### PR TITLE
chore(docker): whitelist java sources for .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 *
 !docker/entrypoint.sh
+!pom.xml
+!src/**
 !target/*.so
 !target/*.properties
 !target/*-runner


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Wasn't able to build `Dockerfile` because `CYOP /src /src` failed as these were blacklisted due to `*` in `.dockerignore`.
Resolved by whitelisting.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `mvn test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)