### PR TITLE
fix(s3): truncate LastModified timestamps to second precision

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Part.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Part.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.s3.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @RegisterForReflection
 public class Part {
@@ -18,7 +19,7 @@ public class Part {
         this.partNumber = partNumber;
         this.eTag = eTag;
         this.size = size;
-        this.lastModified = Instant.now();
+        this.lastModified = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     }
 
     public int getPartNumber() { return partNumber; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class S3Object {
         this.data = data;
         this.contentType = contentType != null ? contentType : "application/octet-stream";
         this.size = data.length;
-        this.lastModified = Instant.now();
+        this.lastModified = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         this.eTag = computeETag(data);
         this.metadata = new HashMap<>();
         this.tags = new HashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -70,6 +70,13 @@ class S3ServiceTest {
     }
 
     @Test
+    void putObjectLastModifiedHasSecondPrecision() {
+        s3Service.createBucket("test-bucket");
+        S3Object obj = s3Service.putObject("test-bucket", "file.txt", "data".getBytes(), null, null);
+        assertEquals(0, obj.getLastModified().getNano());
+    }
+
+    @Test
     void putAndGetObject() {
         s3Service.createBucket("test-bucket");
         byte[] data = "Hello World".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
 ## Summary

  - `S3Object` and `Part` stored `lastModified` as `Instant.now()` with nanosecond precision, causing responses like `2026-03-23T11:35:11.676905149Z` instead of the
  AWS-standard `2026-03-23T11:35:11Z`
  - Truncate at the source in both constructors: `Instant.now().truncatedTo(ChronoUnit.SECONDS)`
  - Fixes all emission points at once: `HeadObject`/`GetObject` headers, `ListObjectsV2`, `ListObjectVersions`, and `CopyObject` XML responses

  ## Test plan

  - [ ] New unit test `putObjectLastModifiedHasSecondPrecision` in `S3ServiceTest` asserts `getNano() == 0`
  - [ ] `HeadObject LastModified second precision` assertion added to all 5 SDK compatibility suites (Go, Node.js, Python, Java, Rust) — all passing

  Closes #12
