### PR TITLE
fix: add ruby lambda runtime support (#18)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolver.java
@@ -24,6 +24,8 @@ public class ImageResolver {
             Map.entry("nodejs22.x", "public.ecr.aws/lambda/nodejs:22"),
             Map.entry("nodejs20.x", "public.ecr.aws/lambda/nodejs:20"),
             Map.entry("nodejs18.x", "public.ecr.aws/lambda/nodejs:18"),
+            Map.entry("ruby3.3", "public.ecr.aws/lambda/ruby:3.3"),
+            Map.entry("ruby3.2", "public.ecr.aws/lambda/ruby:3.2"),
             Map.entry("provided.al2023", "public.ecr.aws/lambda/provided:al2023"),
             Map.entry("provided.al2", "public.ecr.aws/lambda/provided:al2")
     );

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolverTest.java
@@ -24,6 +24,8 @@ class ImageResolverTest {
             "nodejs22.x, public.ecr.aws/lambda/nodejs:22",
             "nodejs20.x, public.ecr.aws/lambda/nodejs:20",
             "nodejs18.x, public.ecr.aws/lambda/nodejs:18",
+            "ruby3.3, public.ecr.aws/lambda/ruby:3.3",
+            "ruby3.2, public.ecr.aws/lambda/ruby:3.2",
             "provided.al2023, public.ecr.aws/lambda/provided:al2023",
             "provided.al2, public.ecr.aws/lambda/provided:al2"
     })


### PR DESCRIPTION
## Summary

- Added missing Lambda runtime → ECR image mappings to ImageResolver: ruby3.2, ruby3.3

Closes #18 — Lambda functions with Ruby runtimes failed at CreateFunction with The runtime parameter ruby3.3 is not supported because ImageResolver had no entry for them.
