### PR TITLE
fix: add S3 GetObjectAttributes and metadata parity

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -8,7 +8,7 @@
 | Category | Operations |
 |---|---|
 | **Buckets** | ListBuckets, CreateBucket, HeadBucket, DeleteBucket, GetBucketLocation |
-| **Objects** | PutObject, GetObject, HeadObject, DeleteObject, DeleteObjects, CopyObject |
+| **Objects** | PutObject, GetObject, GetObjectAttributes, HeadObject, DeleteObject, DeleteObjects, CopyObject |
 | **Listing** | ListObjects, ListObjectsV2, ListObjectVersions |
 | **Multipart** | CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListMultipartUploads |
 | **Versioning** | PutBucketVersioning, GetBucketVersioning |
@@ -51,6 +51,13 @@ echo '{"hello":"world"}' | aws s3 cp - s3://my-bucket/data.json --endpoint-url $
 
 # Download
 aws s3 cp s3://my-bucket/data.json ./data.json --endpoint-url $AWS_ENDPOINT
+
+# Inspect object attributes without downloading the body
+aws s3api get-object-attributes \
+  --bucket my-bucket \
+  --key data.json \
+  --object-attributes ETag ObjectSize StorageClass \
+  --endpoint-url $AWS_ENDPOINT
 
 # List
 aws s3 ls s3://my-bucket --endpoint-url $AWS_ENDPOINT
@@ -107,3 +114,17 @@ When using the AWS SDK, enable path-style mode:
         endpoint_url="http://localhost:4566",
         config=Config(s3={"addressing_style": "path"}))
     ```
+
+## Object Attribute Notes
+
+Floci now persists and returns the following object attribute state on S3 object APIs:
+
+- user metadata from `x-amz-meta-*`
+- storage class from `x-amz-storage-class`
+- checksum metadata for object reads and `GetObjectAttributes`
+- multipart part manifests for `GetObjectAttributes(ObjectParts)`
+
+Current limitations:
+
+- checksum responses focus on SHA-1 and SHA-256
+- copy-based metadata updates support `x-amz-metadata-directive: REPLACE` for user metadata and content type, but do not yet cover every AWS copy header

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -6,10 +6,15 @@ import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
+import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesParts;
+import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
 import io.github.hectorvent.floci.services.s3.model.MultipartUpload;
 import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
+import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.QueueNotification;
 import io.github.hectorvent.floci.services.s3.model.ObjectLockRetention;
+import io.github.hectorvent.floci.services.s3.model.Part;
+import io.github.hectorvent.floci.services.s3.model.S3Checksum;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import io.github.hectorvent.floci.services.s3.model.TopicNotification;
 import jakarta.inject.Inject;
@@ -24,9 +29,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.logging.Logger;
 
@@ -259,7 +266,7 @@ public class S3Controller {
                    .elem("LastModified", ISO_FORMAT.format(obj.getLastModified()))
                    .elem("ETag", obj.getETag())
                    .elem("Size", obj.getSize())
-                   .elem("StorageClass", "STANDARD")
+                   .elem("StorageClass", obj.getStorageClass())
                    .end("Contents");
             }
             xml.end("ListBucketResult");
@@ -304,12 +311,13 @@ public class S3Controller {
 
             if (uploadId != null && partNumber != null) {
                 byte[] partData = decodeAwsChunked(body, contentEncoding, contentSha256);
+                validateChecksumHeaders(httpHeaders, partData);
                 String eTag = s3Service.uploadPart(bucket, key, uploadId, partNumber, partData);
                 return Response.ok().header("ETag", eTag).build();
             }
 
             if (copySource != null && !copySource.isEmpty()) {
-                return handleCopyObject(copySource, bucket, key);
+                return handleCopyObject(copySource, bucket, key, contentType, httpHeaders);
             }
 
             String lockMode = httpHeaders.getHeaderString("x-amz-object-lock-mode");
@@ -318,12 +326,15 @@ public class S3Controller {
             Instant retainUntil = retainUntilStr != null ? Instant.parse(retainUntilStr) : null;
 
             byte[] data = decodeAwsChunked(body, contentEncoding, contentSha256);
-            S3Object obj = s3Service.putObject(bucket, key, data, contentType, null,
+            validateChecksumHeaders(httpHeaders, data);
+            S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
+                    httpHeaders.getHeaderString("x-amz-storage-class"),
                     lockMode, retainUntil, legalHold);
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
+            appendObjectHeaders(resp, obj);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -335,6 +346,9 @@ public class S3Controller {
     public Response getObject(@PathParam("bucket") String bucket,
                               @PathParam("key") String key,
                               @QueryParam("versionId") String versionId,
+                              @HeaderParam("x-amz-object-attributes") String objectAttributesHeader,
+                              @HeaderParam("x-amz-max-parts") Integer maxParts,
+                              @HeaderParam("x-amz-part-number-marker") Integer partNumberMarker,
                               @Context UriInfo uriInfo) {
         try {
             if (hasQueryParam(uriInfo, "tagging")) {
@@ -349,6 +363,10 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "acl")) {
                 return Response.ok(s3Service.getObjectAcl(bucket, key, versionId)).build();
             }
+            if (hasQueryParam(uriInfo, "attributes")) {
+                return handleGetObjectAttributes(bucket, key, versionId,
+                        objectAttributesHeader, maxParts, partNumberMarker);
+            }
             S3Object obj = s3Service.getObject(bucket, key, versionId);
             var resp = Response.ok(obj.getData())
                     .header("Content-Type", obj.getContentType())
@@ -358,7 +376,7 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendLockHeaders(resp, obj);
+            appendObjectHeaders(resp, obj);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -380,7 +398,7 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendLockHeaders(resp, obj);
+            appendObjectHeaders(resp, obj);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -445,11 +463,13 @@ public class S3Controller {
                                          @QueryParam("uploadId") String uploadId,
                                          @QueryParam("versionId") String versionId,
                                          @HeaderParam("Content-Type") String contentType,
+                                         @Context HttpHeaders httpHeaders,
                                          @Context UriInfo uriInfo,
                                          byte[] body) {
         try {
             if (hasQueryParam(uriInfo, "uploads")) {
-                MultipartUpload upload = s3Service.initiateMultipartUpload(bucket, key, contentType);
+                MultipartUpload upload = s3Service.initiateMultipartUpload(bucket, key, contentType,
+                        extractUserMetadata(httpHeaders), httpHeaders.getHeaderString("x-amz-storage-class"));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("InitiateMultipartUploadResult", AwsNamespaces.S3)
@@ -614,7 +634,7 @@ public class S3Controller {
                    .elem("LastModified", ISO_FORMAT.format(obj.getLastModified()))
                    .elem("ETag", obj.getETag())
                    .elem("Size", obj.getSize())
-                   .elem("StorageClass", "STANDARD")
+                   .elem("StorageClass", obj.getStorageClass())
                    .end("Version");
             }
         }
@@ -882,6 +902,19 @@ public class S3Controller {
         return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
 
+    private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj) {
+        if (obj.getStorageClass() != null) {
+            resp.header("x-amz-storage-class", obj.getStorageClass());
+        }
+        if (obj.getMetadata() != null) {
+            for (Map.Entry<String, String> entry : obj.getMetadata().entrySet()) {
+                resp.header("x-amz-meta-" + entry.getKey(), entry.getValue());
+            }
+        }
+        appendChecksumHeaders(resp, obj.getChecksum());
+        appendLockHeaders(resp, obj);
+    }
+
     private void appendLockHeaders(Response.ResponseBuilder resp, S3Object obj) {
         if (obj.getObjectLockMode() != null) {
             resp.header("x-amz-object-lock-mode", obj.getObjectLockMode());
@@ -897,7 +930,8 @@ public class S3Controller {
 
     // --- Helpers ---
 
-    private Response handleCopyObject(String copySource, String destBucket, String destKey) {
+    private Response handleCopyObject(String copySource, String destBucket, String destKey,
+                                      String contentType, HttpHeaders httpHeaders) {
         String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
         int slashIndex = source.indexOf('/');
         if (slashIndex < 0) {
@@ -906,7 +940,11 @@ public class S3Controller {
         String sourceBucket = source.substring(0, slashIndex);
         String sourceKey = source.substring(slashIndex + 1);
 
-        S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey);
+        S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
+                httpHeaders.getHeaderString("x-amz-metadata-directive"),
+                extractUserMetadata(httpHeaders),
+                httpHeaders.getHeaderString("x-amz-storage-class"),
+                contentType);
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyObjectResult", AwsNamespaces.S3)
@@ -915,6 +953,114 @@ public class S3Controller {
                 .end("CopyObjectResult")
                 .build();
         return Response.ok(xml).build();
+    }
+
+    private Response handleGetObjectAttributes(String bucket, String key, String versionId,
+                                               String objectAttributesHeader, Integer maxParts,
+                                               Integer partNumberMarker) {
+        Set<ObjectAttributeName> attributes = ObjectAttributeName.parseHeader(objectAttributesHeader);
+        GetObjectAttributesResult result = s3Service.getObjectAttributes(bucket, key, versionId,
+                attributes, maxParts, partNumberMarker);
+
+        XmlBuilder xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("GetObjectAttributesResponse", AwsNamespaces.S3)
+                .elem("ETag", result.getETag());
+        appendChecksum(xml, result.getChecksum());
+        appendObjectParts(xml, result.getObjectParts());
+        if (result.getStorageClass() != null) {
+            xml.elem("StorageClass", result.getStorageClass());
+        }
+        if (result.getObjectSize() != null) {
+            xml.elem("ObjectSize", result.getObjectSize());
+        }
+        xml.end("GetObjectAttributesResponse");
+
+        Response.ResponseBuilder response = Response.ok(xml.build()).type(MediaType.APPLICATION_XML);
+        if (result.getLastModified() != null) {
+            response.header("Last-Modified", RFC_822.format(result.getLastModified()));
+        }
+        if (result.getVersionId() != null) {
+            response.header("x-amz-version-id", result.getVersionId());
+        }
+        return response.build();
+    }
+
+    private void appendChecksum(XmlBuilder xml, S3Checksum checksum) {
+        if (checksum == null || !checksum.hasAnyValue()) {
+            return;
+        }
+        xml.start("Checksum")
+                .elem("ChecksumCRC32", checksum.getChecksumCRC32())
+                .elem("ChecksumCRC32C", checksum.getChecksumCRC32C())
+                .elem("ChecksumCRC64NVME", checksum.getChecksumCRC64NVME())
+                .elem("ChecksumSHA1", checksum.getChecksumSHA1())
+                .elem("ChecksumSHA256", checksum.getChecksumSHA256())
+                .elem("ChecksumType", checksum.getChecksumType())
+                .end("Checksum");
+    }
+
+    private void appendObjectParts(XmlBuilder xml, GetObjectAttributesParts objectParts) {
+        if (objectParts == null) {
+            return;
+        }
+        xml.start("ObjectParts")
+                .elem("IsTruncated", objectParts.isTruncated())
+                .elem("MaxParts", objectParts.getMaxParts())
+                .elem("NextPartNumberMarker", objectParts.getNextPartNumberMarker())
+                .elem("PartNumberMarker", objectParts.getPartNumberMarker());
+        for (Part part : objectParts.getParts()) {
+            xml.start("Part")
+                    .elem("ChecksumCRC32", part.getChecksum().getChecksumCRC32())
+                    .elem("ChecksumCRC32C", part.getChecksum().getChecksumCRC32C())
+                    .elem("ChecksumCRC64NVME", part.getChecksum().getChecksumCRC64NVME())
+                    .elem("ChecksumSHA1", part.getChecksum().getChecksumSHA1())
+                    .elem("ChecksumSHA256", part.getChecksum().getChecksumSHA256())
+                    .elem("PartNumber", part.getPartNumber())
+                    .elem("Size", part.getSize())
+                    .end("Part");
+        }
+        xml.elem("PartsCount", objectParts.getPartsCount())
+                .end("ObjectParts");
+    }
+
+    private void appendChecksumHeaders(Response.ResponseBuilder resp, S3Checksum checksum) {
+        if (checksum == null) {
+            return;
+        }
+        if (checksum.getChecksumSHA1() != null) {
+            resp.header("x-amz-checksum-sha1", checksum.getChecksumSHA1());
+        }
+        if (checksum.getChecksumSHA256() != null) {
+            resp.header("x-amz-checksum-sha256", checksum.getChecksumSHA256());
+        }
+    }
+
+    private Map<String, String> extractUserMetadata(HttpHeaders httpHeaders) {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : httpHeaders.getRequestHeaders().entrySet()) {
+            String headerName = entry.getKey().toLowerCase(Locale.ROOT);
+            if (!headerName.startsWith("x-amz-meta-")) {
+                continue;
+            }
+            String key = headerName.substring("x-amz-meta-".length());
+            if (!key.isBlank() && !entry.getValue().isEmpty()) {
+                metadata.put(key, entry.getValue().get(0));
+            }
+        }
+        return metadata;
+    }
+
+    private void validateChecksumHeaders(HttpHeaders httpHeaders, byte[] data) {
+        String sha1 = httpHeaders.getHeaderString("x-amz-checksum-sha1");
+        if (sha1 != null && !sha1.equals(S3Checksum.sha1Base64(data))) {
+            throw new AwsException("BadDigest", "The SHA1 checksum you specified did not match the payload.", 400);
+        }
+
+        String sha256 = httpHeaders.getHeaderString("x-amz-checksum-sha256");
+        if (sha256 != null && !sha256.equals(S3Checksum.sha256Base64(data))) {
+            throw new AwsException("BadDigest", "The SHA256 checksum you specified did not match the payload.", 400);
+        }
     }
 
     private Response xmlErrorResponse(AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -125,13 +125,20 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
-        S3Object object = storeObject(bucketName, key, data, contentType, metadata,
+        return putObject(bucketName, key, data, contentType, metadata, null,
+                objectLockMode, retainUntilDate, legalHoldStatus);
+    }
+
+    public S3Object putObject(String bucketName, String key, byte[] data,
+                              String contentType, Map<String, String> metadata, String storageClass,
+                              String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
+        S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
                 objectLockMode, retainUntilDate, legalHoldStatus);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
@@ -142,11 +149,13 @@ public class S3Service {
      */
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
-        return storeObject(bucketName, key, data, contentType, metadata, null, null, null);
+        return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
+                null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
-                                 String contentType, Map<String, String> metadata,
+                                 String contentType, Map<String, String> metadata, String storageClass,
+                                 S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
@@ -156,6 +165,9 @@ public class S3Service {
         if (metadata != null) {
             object.getMetadata().putAll(metadata);
         }
+        object.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
+        object.setChecksum(checksum != null ? copyChecksum(checksum) : buildChecksum(data, parts, false));
+        object.setParts(copyParts(parts));
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();
@@ -238,23 +250,7 @@ public class S3Service {
     }
 
     public S3Object getObject(String bucketName, String key, String versionId) {
-        ensureBucketExists(bucketName);
-
-        String storeKey;
-        if (versionId != null) {
-            storeKey = versionedKey(bucketName, key, versionId);
-        } else {
-            storeKey = objectKey(bucketName, key);
-        }
-
-        S3Object obj = objectStore.get(storeKey)
-                .orElseThrow(() -> versionId != null
-                        ? new AwsException("NoSuchVersion", "The specified version does not exist.", 404)
-                        : new AwsException("NoSuchKey", "The specified key does not exist.", 404));
-
-        if (obj.isDeleteMarker()) {
-            throw new AwsException("NoSuchKey", "The specified key does not exist.", 404);
-        }
+        S3Object obj = getObjectMetadata(bucketName, key, versionId);
 
         // Read from versioned file if available, otherwise from latest
         if (versionId != null) {
@@ -270,7 +266,79 @@ public class S3Service {
     }
 
     public S3Object headObject(String bucketName, String key, String versionId) {
-        return getObject(bucketName, key, versionId);
+        return getObjectMetadata(bucketName, key, versionId);
+    }
+
+    public S3Object getObjectMetadata(String bucketName, String key, String versionId) {
+        S3Object copy = copyObject(getStoredObject(bucketName, key, versionId));
+        copy.setData(null);
+        return copy;
+    }
+
+    public GetObjectAttributesResult getObjectAttributes(String bucketName, String key, String versionId,
+                                                         Set<ObjectAttributeName> attributes,
+                                                         Integer maxParts, Integer partNumberMarker) {
+        S3Object object = getObjectMetadata(bucketName, key, versionId);
+
+        GetObjectAttributesResult result = new GetObjectAttributesResult();
+        result.setLastModified(object.getLastModified());
+        result.setVersionId(object.getVersionId());
+
+        if (attributes.contains(ObjectAttributeName.E_TAG)) {
+            result.setETag(object.getETag());
+        }
+        if (attributes.contains(ObjectAttributeName.STORAGE_CLASS)) {
+            result.setStorageClass(object.getStorageClass());
+        }
+        if (attributes.contains(ObjectAttributeName.OBJECT_SIZE)) {
+            result.setObjectSize(object.getSize());
+        }
+        if (attributes.contains(ObjectAttributeName.CHECKSUM)) {
+            result.setChecksum(copyChecksum(object.getChecksum()));
+        }
+        if (attributes.contains(ObjectAttributeName.OBJECT_PARTS)) {
+            result.setObjectParts(buildObjectParts(object, maxParts, partNumberMarker));
+        }
+
+        return result;
+    }
+
+    private S3Object getStoredObject(String bucketName, String key, String versionId) {
+        ensureBucketExists(bucketName);
+
+        String storeKey = versionId != null ? versionedKey(bucketName, key, versionId) : objectKey(bucketName, key);
+        S3Object object = objectStore.get(storeKey)
+                .orElseThrow(() -> versionId != null
+                        ? new AwsException("NoSuchVersion", "The specified version does not exist.", 404)
+                        : new AwsException("NoSuchKey", "The specified key does not exist.", 404));
+        if (object.isDeleteMarker()) {
+            throw new AwsException("NoSuchKey", "The specified key does not exist.", 404);
+        }
+        return object;
+    }
+
+    private GetObjectAttributesParts buildObjectParts(S3Object object, Integer maxParts, Integer partNumberMarker) {
+        List<Part> sortedParts = new ArrayList<>(copyParts(object.getParts()));
+        sortedParts.sort(Comparator.comparingInt(Part::getPartNumber));
+
+        int max = (maxParts == null || maxParts <= 0) ? 1000 : maxParts;
+        int marker = Math.max(partNumberMarker != null ? partNumberMarker : 0, 0);
+
+        List<Part> visibleParts = sortedParts.stream()
+                .filter(part -> part.getPartNumber() > marker)
+                .toList();
+        List<Part> returnedParts = visibleParts.stream().limit(max).toList();
+
+        GetObjectAttributesParts result = new GetObjectAttributesParts();
+        result.setMaxParts(max);
+        result.setPartNumberMarker(marker);
+        result.setParts(returnedParts);
+        result.setPartsCount(sortedParts.size());
+        result.setTruncated(visibleParts.size() > returnedParts.size());
+        result.setNextPartNumberMarker(returnedParts.isEmpty()
+                ? marker
+                : returnedParts.get(returnedParts.size() - 1).getPartNumber());
+        return result;
     }
 
     public S3Object deleteObject(String bucketName, String key) {
@@ -374,15 +442,28 @@ public class S3Service {
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey) {
+        return copyObject(sourceBucket, sourceKey, destBucket, destKey,
+                null, null, null, null);
+    }
+
+    public S3Object copyObject(String sourceBucket, String sourceKey,
+                               String destBucket, String destKey,
+                               String metadataDirective, Map<String, String> replacementMetadata,
+                               String storageClass, String contentType) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
 
-        S3Object copy = new S3Object(destBucket, destKey, source.getData(), source.getContentType());
-        copy.getMetadata().putAll(source.getMetadata());
+        boolean replaceMetadata = "REPLACE".equalsIgnoreCase(metadataDirective);
+        Map<String, String> metadata = replaceMetadata ? new LinkedHashMap<>() : new LinkedHashMap<>(source.getMetadata());
+        if (replaceMetadata && replacementMetadata != null) {
+            metadata.putAll(replacementMetadata);
+        }
 
-        String objectKey = objectKey(destBucket, destKey);
-        objectStore.put(objectKey, copy);
-        writeFile(destBucket, destKey, source.getData());
+        String effectiveContentType = replaceMetadata && contentType != null ? contentType : source.getContentType();
+        String effectiveStorageClass = storageClass != null ? storageClass : source.getStorageClass();
+        S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
+                effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null);
+        copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
         return copy;
@@ -636,8 +717,17 @@ public class S3Service {
     // --- Multipart Upload Operations ---
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType) {
+        return initiateMultipartUpload(bucket, key, contentType, null, null);
+    }
+
+    public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
+                                                   Map<String, String> metadata, String storageClass) {
         ensureBucketExists(bucket);
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
+        if (metadata != null) {
+            upload.getMetadata().putAll(metadata);
+        }
+        upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
 
         try {
             Files.createDirectories(dataRoot.resolve(".multipart").resolve(upload.getUploadId()));
@@ -670,7 +760,9 @@ public class S3Service {
         }
 
         String eTag = computeETag(data);
-        upload.getParts().put(partNumber, new Part(partNumber, eTag, data.length));
+        Part part = new Part(partNumber, eTag, data.length);
+        part.setChecksum(buildChecksum(data, List.of(part), true));
+        upload.getParts().put(partNumber, part);
         LOG.debugv("Uploaded part {0} for upload {1} ({2} bytes)", partNumber, uploadId, data.length);
         return eTag;
     }
@@ -708,7 +800,12 @@ public class S3Service {
             // Composite ETag: MD5 of concatenated part MD5s, suffixed with part count
             String compositeETag = "\"" + bytesToHex(md.digest()) + "-" + partNumbers.size() + "\"";
 
-            S3Object object = storeObject(bucket, key, allData, upload.getContentType(), null);
+            List<Part> completedParts = partNumbers.stream()
+                    .map(num -> copyPart(upload.getParts().get(num)))
+                    .toList();
+            S3Checksum checksum = buildChecksum(allData, completedParts, true);
+            S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
+                    upload.getStorageClass(), checksum, completedParts, null, null, null);
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);
@@ -1005,6 +1102,74 @@ public class S3Service {
     private void cleanupMultipart(String uploadId) {
         multipartUploads.remove(uploadId);
         deleteDirectory(dataRoot.resolve(".multipart").resolve(uploadId));
+    }
+
+    private static S3Checksum buildChecksum(byte[] data, List<Part> parts, boolean multipartUpload) {
+        S3Checksum checksum = new S3Checksum();
+        checksum.setChecksumSHA1(S3Checksum.sha1Base64(data));
+        checksum.setChecksumSHA256(S3Checksum.sha256Base64(data));
+        checksum.setChecksumType(multipartUpload || (parts != null && parts.size() > 1)
+                ? "COMPOSITE"
+                : "FULL_OBJECT");
+        return checksum;
+    }
+
+    private static S3Object copyObject(S3Object source) {
+        S3Object copy = new S3Object();
+        copy.setBucketName(source.getBucketName());
+        copy.setKey(source.getKey());
+        copy.setData(source.getData() != null ? Arrays.copyOf(source.getData(), source.getData().length) : null);
+        copy.setMetadata(new HashMap<>(source.getMetadata()));
+        copy.setContentType(source.getContentType());
+        copy.setSize(source.getSize());
+        copy.setLastModified(source.getLastModified());
+        copy.setETag(source.getETag());
+        copy.setStorageClass(source.getStorageClass());
+        copy.setChecksum(copyChecksum(source.getChecksum()));
+        copy.setParts(copyParts(source.getParts()));
+        copy.setVersionId(source.getVersionId());
+        copy.setDeleteMarker(source.isDeleteMarker());
+        copy.setLatest(source.isLatest());
+        copy.setTags(new HashMap<>(source.getTags()));
+        copy.setObjectLockMode(source.getObjectLockMode());
+        copy.setRetainUntilDate(source.getRetainUntilDate());
+        copy.setLegalHoldStatus(source.getLegalHoldStatus());
+        copy.setAcl(source.getAcl());
+        return copy;
+    }
+
+    private static S3Checksum copyChecksum(S3Checksum source) {
+        if (source == null) {
+            return null;
+        }
+        S3Checksum copy = new S3Checksum();
+        copy.setChecksumCRC32(source.getChecksumCRC32());
+        copy.setChecksumCRC32C(source.getChecksumCRC32C());
+        copy.setChecksumCRC64NVME(source.getChecksumCRC64NVME());
+        copy.setChecksumSHA1(source.getChecksumSHA1());
+        copy.setChecksumSHA256(source.getChecksumSHA256());
+        copy.setChecksumType(source.getChecksumType());
+        return copy;
+    }
+
+    private static List<Part> copyParts(List<Part> sourceParts) {
+        if (sourceParts == null) {
+            return new ArrayList<>();
+        }
+        return sourceParts.stream().map(S3Service::copyPart).toList();
+    }
+
+    private static Part copyPart(Part source) {
+        if (source == null) {
+            return null;
+        }
+        Part copy = new Part();
+        copy.setPartNumber(source.getPartNumber());
+        copy.setETag(source.getETag());
+        copy.setSize(source.getSize());
+        copy.setChecksum(copyChecksum(source.getChecksum()));
+        copy.setLastModified(source.getLastModified());
+        return copy;
     }
 
     private static String computeETag(byte[] data) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/GetObjectAttributesParts.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/GetObjectAttributesParts.java
@@ -1,0 +1,35 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+public class GetObjectAttributesParts {
+
+    private boolean isTruncated;
+    private int maxParts;
+    private int nextPartNumberMarker;
+    private int partNumberMarker;
+    private int partsCount;
+    private List<Part> parts = new ArrayList<>();
+
+    public boolean isTruncated() { return isTruncated; }
+    public void setTruncated(boolean truncated) { isTruncated = truncated; }
+
+    public int getMaxParts() { return maxParts; }
+    public void setMaxParts(int maxParts) { this.maxParts = maxParts; }
+
+    public int getNextPartNumberMarker() { return nextPartNumberMarker; }
+    public void setNextPartNumberMarker(int nextPartNumberMarker) { this.nextPartNumberMarker = nextPartNumberMarker; }
+
+    public int getPartNumberMarker() { return partNumberMarker; }
+    public void setPartNumberMarker(int partNumberMarker) { this.partNumberMarker = partNumberMarker; }
+
+    public int getPartsCount() { return partsCount; }
+    public void setPartsCount(int partsCount) { this.partsCount = partsCount; }
+
+    public List<Part> getParts() { return parts; }
+    public void setParts(List<Part> parts) { this.parts = parts; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/GetObjectAttributesResult.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/GetObjectAttributesResult.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+public class GetObjectAttributesResult {
+
+    private String eTag;
+    private S3Checksum checksum;
+    private GetObjectAttributesParts objectParts;
+    private String storageClass;
+    private Long objectSize;
+    private Instant lastModified;
+    private String versionId;
+
+    public String getETag() { return eTag; }
+    public void setETag(String eTag) { this.eTag = eTag; }
+
+    public S3Checksum getChecksum() { return checksum; }
+    public void setChecksum(S3Checksum checksum) { this.checksum = checksum; }
+
+    public GetObjectAttributesParts getObjectParts() { return objectParts; }
+    public void setObjectParts(GetObjectAttributesParts objectParts) { this.objectParts = objectParts; }
+
+    public String getStorageClass() { return storageClass; }
+    public void setStorageClass(String storageClass) { this.storageClass = storageClass; }
+
+    public Long getObjectSize() { return objectSize; }
+    public void setObjectSize(Long objectSize) { this.objectSize = objectSize; }
+
+    public Instant getLastModified() { return lastModified; }
+    public void setLastModified(Instant lastModified) { this.lastModified = lastModified; }
+
+    public String getVersionId() { return versionId; }
+    public void setVersionId(String versionId) { this.versionId = versionId; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.s3.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,16 +15,23 @@ public class MultipartUpload {
     private String bucket;
     private String key;
     private String contentType;
+    private String storageClass;
+    private Map<String, String> metadata;
     private Instant initiated;
     private final Map<Integer, Part> parts = new ConcurrentHashMap<>();
 
-    public MultipartUpload() {}
+    public MultipartUpload() {
+        this.storageClass = "STANDARD";
+        this.metadata = new HashMap<>();
+    }
 
     public MultipartUpload(String bucket, String key, String contentType) {
         this.uploadId = UUID.randomUUID().toString();
         this.bucket = bucket;
         this.key = key;
         this.contentType = contentType != null ? contentType : "application/octet-stream";
+        this.storageClass = "STANDARD";
+        this.metadata = new HashMap<>();
         this.initiated = Instant.now();
     }
 
@@ -38,6 +46,12 @@ public class MultipartUpload {
 
     public String getContentType() { return contentType; }
     public void setContentType(String contentType) { this.contentType = contentType; }
+
+    public String getStorageClass() { return storageClass; }
+    public void setStorageClass(String storageClass) { this.storageClass = storageClass; }
+
+    public Map<String, String> getMetadata() { return metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
 
     public Instant getInitiated() { return initiated; }
     public void setInitiated(Instant initiated) { this.initiated = initiated; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/ObjectAttributeName.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/ObjectAttributeName.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public enum ObjectAttributeName {
+    E_TAG("ETag"),
+    CHECKSUM("Checksum"),
+    OBJECT_PARTS("ObjectParts"),
+    STORAGE_CLASS("StorageClass"),
+    OBJECT_SIZE("ObjectSize");
+
+    private final String wireValue;
+
+    ObjectAttributeName(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String wireValue() {
+        return wireValue;
+    }
+
+    public static Set<ObjectAttributeName> parseHeader(String headerValue) {
+        if (headerValue == null || headerValue.isBlank()) {
+            throw new AwsException("InvalidRequest",
+                    "Missing required header for this request: x-amz-object-attributes", 400);
+        }
+
+        Set<ObjectAttributeName> attributes = new LinkedHashSet<>();
+        for (String token : headerValue.split(",")) {
+            String normalized = token.trim();
+            if (normalized.isEmpty()) {
+                continue;
+            }
+            attributes.add(fromWireValue(normalized));
+        }
+
+        if (attributes.isEmpty()) {
+            throw new AwsException("InvalidRequest",
+                    "Missing required header for this request: x-amz-object-attributes", 400);
+        }
+        return attributes;
+    }
+
+    public static ObjectAttributeName fromWireValue(String value) {
+        for (ObjectAttributeName attribute : values()) {
+            if (attribute.wireValue.equalsIgnoreCase(value)) {
+                return attribute;
+            }
+        }
+        throw new AwsException("InvalidArgument",
+                "Unsupported object attribute: " + value, 400);
+    }
+
+    public static String normalizeStorageClass(String value) {
+        if (value == null || value.isBlank()) {
+            return "STANDARD";
+        }
+
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "STANDARD", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING",
+                    "GLACIER", "DEEP_ARCHIVE", "REDUCED_REDUNDANCY",
+                    "GLACIER_IR", "OUTPOSTS", "SNOW", "EXPRESS_ONEZONE" -> normalized;
+            default -> throw new AwsException("InvalidStorageClass",
+                    "The storage class you specified is not valid", 400);
+        };
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Part.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Part.java
@@ -11,14 +11,18 @@ public class Part {
     private int partNumber;
     private String eTag;
     private long size;
+    private S3Checksum checksum;
     private Instant lastModified;
 
-    public Part() {}
+    public Part() {
+        this.checksum = new S3Checksum();
+    }
 
     public Part(int partNumber, String eTag, long size) {
         this.partNumber = partNumber;
         this.eTag = eTag;
         this.size = size;
+        this.checksum = new S3Checksum();
         this.lastModified = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     }
 
@@ -30,6 +34,9 @@ public class Part {
 
     public long getSize() { return size; }
     public void setSize(long size) { this.size = size; }
+
+    public S3Checksum getChecksum() { return checksum; }
+    public void setChecksum(S3Checksum checksum) { this.checksum = checksum; }
 
     public Instant getLastModified() { return lastModified; }
     public void setLastModified(Instant lastModified) { this.lastModified = lastModified; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Checksum.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Checksum.java
@@ -1,0 +1,58 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+@RegisterForReflection
+public class S3Checksum {
+
+    private String checksumCRC32;
+    private String checksumCRC32C;
+    private String checksumCRC64NVME;
+    private String checksumSHA1;
+    private String checksumSHA256;
+    private String checksumType;
+
+    public String getChecksumCRC32() { return checksumCRC32; }
+    public void setChecksumCRC32(String checksumCRC32) { this.checksumCRC32 = checksumCRC32; }
+
+    public String getChecksumCRC32C() { return checksumCRC32C; }
+    public void setChecksumCRC32C(String checksumCRC32C) { this.checksumCRC32C = checksumCRC32C; }
+
+    public String getChecksumCRC64NVME() { return checksumCRC64NVME; }
+    public void setChecksumCRC64NVME(String checksumCRC64NVME) { this.checksumCRC64NVME = checksumCRC64NVME; }
+
+    public String getChecksumSHA1() { return checksumSHA1; }
+    public void setChecksumSHA1(String checksumSHA1) { this.checksumSHA1 = checksumSHA1; }
+
+    public String getChecksumSHA256() { return checksumSHA256; }
+    public void setChecksumSHA256(String checksumSHA256) { this.checksumSHA256 = checksumSHA256; }
+
+    public String getChecksumType() { return checksumType; }
+    public void setChecksumType(String checksumType) { this.checksumType = checksumType; }
+
+    public boolean hasAnyValue() {
+        return checksumCRC32 != null || checksumCRC32C != null || checksumCRC64NVME != null
+                || checksumSHA1 != null || checksumSHA256 != null;
+    }
+
+    public static String sha256Base64(byte[] data) {
+        return digestBase64("SHA-256", data);
+    }
+
+    public static String sha1Base64(byte[] data) {
+        return digestBase64("SHA-1", data);
+    }
+
+    private static String digestBase64(String algorithm, byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            return Base64.getEncoder().encodeToString(digest.digest(data));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Missing digest algorithm: " + algorithm, e);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -6,7 +6,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RegisterForReflection
@@ -22,6 +24,9 @@ public class S3Object {
     private long size;
     private Instant lastModified;
     private String eTag;
+    private String storageClass;
+    private S3Checksum checksum;
+    private List<Part> parts;
     private String versionId;
     private boolean deleteMarker;
     private boolean isLatest = true;
@@ -34,6 +39,9 @@ public class S3Object {
 
     public S3Object() {
         this.metadata = new HashMap<>();
+        this.storageClass = "STANDARD";
+        this.checksum = new S3Checksum();
+        this.parts = new ArrayList<>();
         this.tags = new HashMap<>();
     }
 
@@ -46,6 +54,11 @@ public class S3Object {
         this.lastModified = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         this.eTag = computeETag(data);
         this.metadata = new HashMap<>();
+        this.storageClass = "STANDARD";
+        this.checksum = new S3Checksum();
+        this.checksum.setChecksumSHA256(S3Checksum.sha256Base64(data));
+        this.checksum.setChecksumType("FULL_OBJECT");
+        this.parts = new ArrayList<>();
         this.tags = new HashMap<>();
     }
 
@@ -72,6 +85,15 @@ public class S3Object {
 
     public String getETag() { return eTag; }
     public void setETag(String eTag) { this.eTag = eTag; }
+
+    public String getStorageClass() { return storageClass; }
+    public void setStorageClass(String storageClass) { this.storageClass = storageClass; }
+
+    public S3Checksum getChecksum() { return checksum; }
+    public void setChecksum(S3Checksum checksum) { this.checksum = checksum; }
+
+    public List<Part> getParts() { return parts; }
+    public void setParts(List<Part> parts) { this.parts = parts; }
 
     public String getVersionId() { return versionId; }
     public void setVersionId(String versionId) { this.versionId = versionId; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -50,6 +50,8 @@ class S3IntegrationTest {
     void putObject() {
         given()
             .contentType("text/plain")
+            .header("x-amz-meta-owner", "team-a")
+            .header("x-amz-storage-class", "STANDARD_IA")
             .body("Hello World from S3!")
         .when()
             .put("/test-bucket/greeting.txt")
@@ -68,11 +70,29 @@ class S3IntegrationTest {
             .statusCode(200)
             .header("ETag", notNullValue())
             .header("Content-Length", notNullValue())
+            .header("x-amz-meta-owner", equalTo("team-a"))
+            .header("x-amz-storage-class", equalTo("STANDARD_IA"))
+            .header("x-amz-checksum-sha256", notNullValue())
             .body(equalTo("Hello World from S3!"));
     }
 
     @Test
     @Order(6)
+    void getObjectAttributes() {
+        given()
+            .header("x-amz-object-attributes", "ETag,ObjectSize,StorageClass,Checksum")
+        .when()
+            .get("/test-bucket/greeting.txt?attributes")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GetObjectAttributesResponse"))
+            .body(containsString("<StorageClass>STANDARD_IA</StorageClass>"))
+            .body(containsString("<ObjectSize>20</ObjectSize>"))
+            .body(containsString("<ChecksumSHA256>"));
+    }
+
+    @Test
+    @Order(7)
     void headObject() {
         given()
         .when()
@@ -80,11 +100,14 @@ class S3IntegrationTest {
         .then()
             .statusCode(200)
             .header("ETag", notNullValue())
-            .header("Content-Length", notNullValue());
+            .header("Content-Length", notNullValue())
+            .header("x-amz-meta-owner", equalTo("team-a"))
+            .header("x-amz-storage-class", equalTo("STANDARD_IA"))
+            .header("x-amz-checksum-sha256", notNullValue());
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void getObjectNotFound() {
         given()
         .when()
@@ -95,7 +118,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void putAnotherObject() {
         given()
             .contentType("application/json")
@@ -107,7 +130,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void listObjects() {
         given()
         .when()
@@ -119,7 +142,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void listObjectsWithPrefix() {
         given()
             .queryParam("prefix", "data/")
@@ -132,10 +155,14 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void copyObject() {
         given()
             .header("x-amz-copy-source", "/test-bucket/greeting.txt")
+            .header("x-amz-metadata-directive", "REPLACE")
+            .header("x-amz-meta-owner", "team-b")
+            .header("x-amz-storage-class", "GLACIER")
+            .contentType("application/json")
         .when()
             .put("/test-bucket/greeting-copy.txt")
         .then()
@@ -148,11 +175,13 @@ class S3IntegrationTest {
             .get("/test-bucket/greeting-copy.txt")
         .then()
             .statusCode(200)
+            .header("x-amz-meta-owner", equalTo("team-b"))
+            .header("x-amz-storage-class", equalTo("GLACIER"))
             .body(equalTo("Hello World from S3!"));
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void deleteObject() {
         given()
         .when()
@@ -169,7 +198,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void deleteNonEmptyBucketFails() {
         given()
         .when()
@@ -180,7 +209,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(16)
     void cleanupAndDeleteBucket() {
         // Delete all objects
         given().delete("/test-bucket/greeting.txt");
@@ -192,6 +221,18 @@ class S3IntegrationTest {
             .delete("/test-bucket")
         .then()
             .statusCode(204);
+    }
+
+    @Test
+    @Order(15)
+    void getObjectAttributesRejectsUnknownSelector() {
+        given()
+            .header("x-amz-object-attributes", "ETag,UnknownThing")
+        .when()
+            .get("/test-bucket/greeting.txt?attributes")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -30,6 +30,8 @@ class S3MultipartIntegrationTest {
     void initiateMultipartUpload() {
         uploadId = given()
             .contentType("application/octet-stream")
+            .header("x-amz-meta-owner", "team-a")
+            .header("x-amz-storage-class", "STANDARD_IA")
         .when()
             .post("/" + BUCKET + "/" + KEY + "?uploads")
         .then()
@@ -106,11 +108,30 @@ class S3MultipartIntegrationTest {
             .get("/" + BUCKET + "/" + KEY)
         .then()
             .statusCode(200)
+            .header("x-amz-meta-owner", equalTo("team-a"))
+            .header("x-amz-storage-class", equalTo("STANDARD_IA"))
             .body(equalTo("Part1Data-HelloPart2Data-World"));
     }
 
     @Test
     @Order(8)
+    void getMultipartObjectAttributes() {
+        given()
+            .header("x-amz-object-attributes", "ObjectParts,Checksum,StorageClass")
+            .header("x-amz-max-parts", 1)
+        .when()
+            .get("/" + BUCKET + "/" + KEY + "?attributes")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GetObjectAttributesResponse"))
+            .body(containsString("<StorageClass>STANDARD_IA</StorageClass>"))
+            .body(containsString("<ObjectParts>"))
+            .body(containsString("<PartsCount>2</PartsCount>"))
+            .body(containsString("<ChecksumSHA256>"));
+    }
+
+    @Test
+    @Order(9)
     void multipartUploadNoLongerListed() {
         given()
         .when()
@@ -121,7 +142,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void abortMultipartUpload() {
         // Initiate new upload
         String newUploadId = given()
@@ -156,7 +177,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
@@ -2,7 +2,9 @@ package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
 import io.github.hectorvent.floci.services.s3.model.MultipartUpload;
+import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,6 +13,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -69,7 +73,8 @@ class S3MultipartServiceTest {
 
     @Test
     void completeMultipartUpload() {
-        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "file.bin", "text/plain");
+        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "file.bin", "text/plain",
+                Map.of("owner", "team-a"), "STANDARD_IA");
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 1, "part1".getBytes());
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 2, "part2".getBytes());
 
@@ -78,11 +83,15 @@ class S3MultipartServiceTest {
 
         assertNotNull(result);
         assertEquals("text/plain", result.getContentType());
+        assertEquals("STANDARD_IA", result.getStorageClass());
+        assertEquals("team-a", result.getMetadata().get("owner"));
+        assertEquals(2, result.getParts().size());
         // Verify the data is concatenated
         S3Object fetched = s3Service.getObject("test-bucket", "file.bin");
         assertEquals("part1part2", new String(fetched.getData()));
         // Composite ETag should end with -2 (number of parts)
         assertTrue(result.getETag().endsWith("-2\""), "ETag should be composite: " + result.getETag());
+        assertEquals("COMPOSITE", result.getChecksum().getChecksumType());
     }
 
     @Test
@@ -143,5 +152,26 @@ class S3MultipartServiceTest {
         // Should no longer be in active uploads
         List<MultipartUpload> uploads = s3Service.listMultipartUploads("test-bucket");
         assertTrue(uploads.isEmpty());
+    }
+
+    @Test
+    void getObjectAttributesReturnsMultipartParts() {
+        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "parts.bin", "application/octet-stream");
+        s3Service.uploadPart("test-bucket", "parts.bin", upload.getUploadId(), 1, "abc".getBytes(StandardCharsets.UTF_8));
+        s3Service.uploadPart("test-bucket", "parts.bin", upload.getUploadId(), 2, "def".getBytes(StandardCharsets.UTF_8));
+        s3Service.completeMultipartUpload("test-bucket", "parts.bin", upload.getUploadId(), List.of(1, 2));
+
+        GetObjectAttributesResult attributes = s3Service.getObjectAttributes("test-bucket", "parts.bin", null,
+                Set.of(ObjectAttributeName.OBJECT_PARTS, ObjectAttributeName.CHECKSUM),
+                1, 0);
+
+        assertNotNull(attributes.getChecksum());
+        assertEquals("COMPOSITE", attributes.getChecksum().getChecksumType());
+        assertNotNull(attributes.getObjectParts());
+        assertEquals(2, attributes.getObjectParts().getPartsCount());
+        assertEquals(1, attributes.getObjectParts().getParts().size());
+        assertTrue(attributes.getObjectParts().isTruncated());
+        assertEquals(1, attributes.getObjectParts().getNextPartNumberMarker());
+        assertNotNull(attributes.getObjectParts().getParts().get(0).getChecksum().getChecksumSHA256());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -2,6 +2,8 @@ package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
+import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -212,6 +216,7 @@ class S3ServiceTest {
         S3Object head = s3Service.headObject("test-bucket", "file.txt");
         assertEquals(5, head.getSize());
         assertEquals("text/plain", head.getContentType());
+        assertNull(head.getData());
     }
 
     @Test
@@ -222,5 +227,55 @@ class S3ServiceTest {
 
         S3Object obj = s3Service.getObject("test-bucket", "file.txt");
         assertArrayEquals("v2".getBytes(), obj.getData());
+    }
+
+    @Test
+    void putObjectPersistsMetadataStorageClassAndChecksum() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+
+        S3Object stored = s3Service.putObject("test-bucket", "docs/file.txt", "payload".getBytes(StandardCharsets.UTF_8),
+                "text/plain", Map.of("owner", "team-a"), "STANDARD_IA", null, null, null);
+
+        S3Object head = s3Service.headObject("test-bucket", "docs/file.txt");
+        assertEquals("STANDARD_IA", head.getStorageClass());
+        assertEquals("team-a", head.getMetadata().get("owner"));
+        assertNotNull(head.getChecksum());
+        assertNotNull(head.getChecksum().getChecksumSHA256());
+        assertEquals("FULL_OBJECT", head.getChecksum().getChecksumType());
+        assertEquals(stored.getETag(), head.getETag());
+    }
+
+    @Test
+    void getObjectAttributesReturnsRequestedFields() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        s3Service.putObject("test-bucket", "report.txt", "payload".getBytes(StandardCharsets.UTF_8),
+                "text/plain", Map.of("env", "dev"), "GLACIER", null, null, null);
+
+        GetObjectAttributesResult attributes = s3Service.getObjectAttributes("test-bucket", "report.txt", null,
+                Set.of(ObjectAttributeName.E_TAG, ObjectAttributeName.OBJECT_SIZE,
+                        ObjectAttributeName.STORAGE_CLASS, ObjectAttributeName.CHECKSUM),
+                null, null);
+
+        assertNotNull(attributes.getETag());
+        assertEquals(7L, attributes.getObjectSize());
+        assertEquals("GLACIER", attributes.getStorageClass());
+        assertNotNull(attributes.getChecksum());
+        assertNotNull(attributes.getChecksum().getChecksumSHA256());
+        assertNull(attributes.getObjectParts());
+    }
+
+    @Test
+    void copyObjectCanReplaceMetadata() {
+        s3Service.createBucket("source-bucket", "us-east-1");
+        s3Service.createBucket("dest-bucket", "us-east-1");
+        s3Service.putObject("source-bucket", "original.txt", "content".getBytes(StandardCharsets.UTF_8),
+                "text/plain", Map.of("owner", "source"), "STANDARD", null, null, null);
+
+        S3Object copy = s3Service.copyObject("source-bucket", "original.txt", "dest-bucket", "copy.txt",
+                "REPLACE", Map.of("owner", "dest"), "STANDARD_IA", "application/json");
+
+        assertEquals("application/json", copy.getContentType());
+        assertEquals("STANDARD_IA", copy.getStorageClass());
+        assertEquals("dest", copy.getMetadata().get("owner"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -115,6 +115,21 @@ class S3VersioningIntegrationTest {
 
     @Test
     @Order(9)
+    void getObjectAttributesSpecificVersion() {
+        given()
+            .header("x-amz-object-attributes", "ETag,ObjectSize,StorageClass")
+        .when()
+            .get("/" + BUCKET + "/test.txt?attributes&versionId=" + versionId1)
+        .then()
+            .statusCode(200)
+            .header("x-amz-version-id", versionId1)
+            .body(containsString("<GetObjectAttributesResponse"))
+            .body(containsString("<ObjectSize>17</ObjectSize>"))
+            .body(containsString("<StorageClass>STANDARD</StorageClass>"));
+    }
+
+    @Test
+    @Order(10)
     void listObjectVersions() {
         given()
         .when()
@@ -128,7 +143,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void deleteCreatesMarker() {
         given()
         .when()
@@ -139,7 +154,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void getAfterDeleteReturns404() {
         given()
         .when()
@@ -149,7 +164,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void getSpecificVersionAfterDelete() {
         // Specific version should still be accessible
         given()
@@ -161,7 +176,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void listVersionsShowsDeleteMarker() {
         given()
         .when()
@@ -172,7 +187,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void cleanUp() {
         // Delete specific versions permanently
         given().when().delete("/" + BUCKET + "/test.txt?versionId=" + versionId1).then().statusCode(204);


### PR DESCRIPTION
Implement GetObjectAttributes on the S3 GET path and persist object metadata such as storage class, checksums, and multipart part manifests so GET and HEAD behave closer to AWS and LocalStack.

Also add service and integration coverage for metadata headers, copy-based metadata replacement, multipart attributes, and versioned object attribute reads.

## Summary

Add S3 `GetObjectAttributes` support on the GET object path and improve object attribute parity across GET and HEAD responses.

This change persists and surfaces object metadata including storage class, checksum fields, user metadata headers, and completed multipart part manifests. It also extends copy and multipart flows so those attributes are preserved and exposed consistently, with new service and integration coverage for multipart attributes, metadata replacement, and versioned reads.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This fixes missing S3 compatibility on the object GET path.

Previously, `GET /{bucket}/{key}?attributes` was not implemented, object metadata like `x-amz-meta-*` and storage class were not surfaced consistently on GET/HEAD, and completed multipart uploads did not retain enough state to serve `ObjectParts` responses. This change aligns behavior more closely with AWS S3 and LocalStack by implementing `GetObjectAttributes`, returning requested attribute fields in AWS-style XML, and propagating object attribute state through put, copy, head, get, versioned, and multipart flows.

Validated locally with:
- `./mvnw test`
- focused S3 coverage for `S3ServiceTest`, `S3MultipartServiceTest`, `S3IntegrationTest`, `S3MultipartIntegrationTest`, and `S3VersioningIntegrationTest`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)