### PR TITLE
fix: return versionId in CompleteMultipartUpload response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -481,16 +481,22 @@ public class S3Controller {
                 if (baseUrl.endsWith("/")) {
                     baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
                 }
-                String xml = new XmlBuilder()
+                XmlBuilder xmlBuilder = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("CompleteMultipartUploadResult", AwsNamespaces.S3)
                         .elem("Location", baseUrl + "/" + bucket + "/" + key)
                         .elem("Bucket", bucket)
                         .elem("Key", key)
-                        .elem("ETag", obj.getETag())
-                        .end("CompleteMultipartUploadResult")
-                        .build();
-                return Response.ok(xml).build();
+                        .elem("ETag", obj.getETag());
+                if (obj.getVersionId() != null) {
+                    xmlBuilder.elem("VersionId", obj.getVersionId());
+                }
+                String xml = xmlBuilder.end("CompleteMultipartUploadResult").build();
+                var resp = Response.ok(xml);
+                if (obj.getVersionId() != null) {
+                    resp.header("x-amz-version-id", obj.getVersionId());
+                }
+                return resp.build();
             }
 
             return xmlErrorResponse(new AwsException("InvalidArgument",

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
@@ -123,6 +123,18 @@ class S3MultipartServiceTest {
     }
 
     @Test
+    void completeMultipartUploadVersioned() {
+        s3Service.putBucketVersioning("test-bucket", "Enabled");
+        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "versioned.bin", "text/plain");
+        s3Service.uploadPart("test-bucket", "versioned.bin", upload.getUploadId(), 1, "data".getBytes());
+
+        S3Object result = s3Service.completeMultipartUpload("test-bucket", "versioned.bin",
+                upload.getUploadId(), List.of(1));
+
+        assertNotNull(result.getVersionId(), "Versioned bucket should produce a versionId");
+    }
+
+    @Test
     void completeMultipartUploadCleansUp() {
         MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "file.bin", null);
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 1, "data".getBytes());


### PR DESCRIPTION
 Include VersionId in the CompleteMultipartUploadResult XML body and set the x-amz-version-id response header when the bucket has versioning enabled, matching the behavior of PutObject and other S3 operations.                 
                                            
  Fixes hectorvent/floci#32                                                                                                                                                                                                        
                                                    
  ## Summary                                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  Return `versionId` in `CompleteMultipartUpload` response when bucket versioning is enabled. Adds `<VersionId>` to the XML body and sets the `x-amz-version-id` response header, consistent with how PutObject, GetObject, and    
  HeadObject already handle it. Closes #32          
                                                                                                                                                                                                                                   
  ## Type of change                         
                         
  - [x] Bug fix (`fix:`)                            
  - [ ] New feature (`feat:`)                  
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore                                                                                                                                                                                                               
   
  ## AWS Compatibility                                                                                                                                                                                                             
                                            
  The `CompleteMultipartUpload` response was missing the `<VersionId>` XML element and `x-amz-version-id` header for versioned buckets, despite the object being stored with a version ID. AWS S3 returns both in its response.    
                                                    
  ## Checklist                                                                                                                                                                                                                     
                                            
  - [x] `./mvnw test` passes locally
  - [x] New or updated integration test added       
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
