### PR TITLE
fix: return NoSuchVersion error for non-existent versionId

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -248,7 +248,9 @@ public class S3Service {
         }
 
         S3Object obj = objectStore.get(storeKey)
-                .orElseThrow(() -> new AwsException("NoSuchKey", "The specified key does not exist.", 404));
+                .orElseThrow(() -> versionId != null
+                        ? new AwsException("NoSuchVersion", "The specified version does not exist.", 404)
+                        : new AwsException("NoSuchKey", "The specified key does not exist.", 404));
 
         if (obj.isDeleteMarker()) {
             throw new AwsException("NoSuchKey", "The specified key does not exist.", 404);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -156,6 +156,17 @@ class S3VersioningServiceTest {
     }
 
     @Test
+    void getObjectWithNonExistentVersionIdThrowsNoSuchVersion() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        s3Service.putObject("versioned-bucket", "test.txt",
+                "data".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                s3Service.getObject("versioned-bucket", "test.txt", "fake-version-id"));
+        assertEquals("NoSuchVersion", ex.getErrorCode());
+    }
+
+    @Test
     void listObjectsExcludesDeleteMarkers() {
         s3Service.putBucketVersioning("versioned-bucket", "Enabled");
         s3Service.putObject("versioned-bucket", "keep.txt",


### PR DESCRIPTION
 When requesting an object with a versionId that doesn't exist, S3 returns NoSuchVersion, not NoSuchKey. Updated getObject to distinguish between a missing key and a missing version.                                            
                                                                                                                                                                                                                                   
  Fixes https://github.com/hectorvent/floci/issues/33                                                                                                                                                                              
                                                                                                                                                                                                                                   
  ## Summary                                                              
                                          14k out:8k
  Return `NoSuchVersion` error code (instead of `NoSuchKey`) when a GetObject request includes a `versionId` that doesn't exist, matching AWS S3 behavior.                                                                         
                                               
  ## Type of change                                                                                                                                                                                                                
                                                                          
  - [x] Bug fix (`fix:`) 
  - [ ] New feature (`feat:`)                       
  - [ ] Breaking change (`feat!:` or `fix!:`)  
  - [ ] Docs / chore

  ## AWS Compatibility

  The incorrect behavior was returning error code `NoSuchKey` with message "The specified key does not exist." when a non-existent `versionId` was requested. AWS S3 returns `NoSuchVersion` with "The specified version does not  
  exist." (HTTP 404).
                                                                                                                                                                                                                                   
  ## Checklist                                                            
                         
  - [x] `./mvnw test` passes locally                
  - [x] New or updated integration test added  
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
