### PR TITLE
fix(s3): increase max HTTP body size to 512MB for S3 uploads

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@ quarkus:
   http:
     port: 4566
     host: 0.0.0.0
+    limits:
+      max-body-size: 512M
   native:
     additional-build-args: "--initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl,--initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32"
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -236,6 +236,30 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(17)
+    void putLargeObject() {
+        // Create a dedicated bucket for the large upload test
+        given().when().put("/large-upload-bucket").then().statusCode(200);
+
+        // Upload a 15MB payload to verify max-body-size is above the old 10MB default
+        byte[] largePayload = new byte[15 * 1024 * 1024];
+        java.util.Arrays.fill(largePayload, (byte) 'A');
+
+        given()
+            .contentType("application/octet-stream")
+            .body(largePayload)
+        .when()
+            .put("/large-upload-bucket/large-file.bin")
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue());
+
+        // Cleanup
+        given().delete("/large-upload-bucket/large-file.bin");
+        given().delete("/large-upload-bucket");
+    }
+
+    @Test
     void getNonExistentBucket() {
         given()
         .when()


### PR DESCRIPTION
## Summary
Quarkus defaults max-body-size to 10MB, causing 413 Content Too Large errors when uploading files larger than ~10MB via S3 PutObject. AWS S3 supports single PUT uploads up to 5GB. Set the limit to 512MB to support realistic local development use cases.

Fixes #19

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
