### PR TITLE
feat(s3): add conditional request headers (If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -372,6 +372,7 @@ public class S3Controller {
                         objectAttributesHeader, maxParts, partNumberMarker);
             }
             if (hasPreconditions(ifMatch, ifNoneMatch, ifModifiedSince, ifUnmodifiedSince)) {
+                // Fetch metadata only to evaluate preconditions, avoiding loading the full object unnecessarily.
                 S3Object metadata = s3Service.headObject(bucket, key, versionId);
                 Response preconditionResponse = checkPreconditions(metadata, ifMatch, ifNoneMatch, ifModifiedSince, ifUnmodifiedSince);
                 if (preconditionResponse != null) {
@@ -1094,18 +1095,6 @@ public class S3Controller {
         return Response.status(e.getHttpStatus()).entity(xml).type(MediaType.APPLICATION_XML).build();
     }
 
-    /**
-     * Evaluates S3 conditional request headers against the target object.
-     * Returns an error/redirect response if a precondition fails, or {@code null} if all pass.
-     * <p>
-     * Evaluation order per HTTP/S3 spec:
-     * <ol>
-     *   <li>If-Match → 412 Precondition Failed when ETag does not match</li>
-     *   <li>If-Unmodified-Since → 412 when object was modified after the date (skipped if If-Match present)</li>
-     *   <li>If-None-Match → 304 Not Modified when ETag matches</li>
-     *   <li>If-Modified-Since → 304 when object was not modified after the date (skipped if If-None-Match present)</li>
-     * </ol>
-     */
     private Response checkPreconditions(S3Object obj, String ifMatch, String ifNoneMatch,
                                          String ifModifiedSince, String ifUnmodifiedSince) {
         String eTag = obj.getETag();
@@ -1153,10 +1142,6 @@ public class S3Controller {
                 "At least one of the pre-conditions you specified did not hold.", 412));
     }
 
-    /**
-     * Checks whether an ETag matches a conditional header value.
-     * Supports the wildcard {@code *} and comma-separated ETag lists per RFC 7232.
-     */
     private boolean eTagMatches(String headerValue, String eTag) {
         if ("*".equals(headerValue.trim())) {
             return true;
@@ -1169,10 +1154,6 @@ public class S3Controller {
         return false;
     }
 
-    /**
-     * Parses an HTTP date string, trying RFC 822 format first, then ISO 8601 as fallback.
-     * Returns {@code null} if the date cannot be parsed.
-     */
     private Instant parseHttpDate(String dateStr) {
         try {
             return RFC_822.parse(dateStr.trim(), Instant::from);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -284,6 +284,55 @@ class S3IntegrationTest {
 
     @Test
     @Order(55)
+    void headObjectIfMatchReturns200() {
+        String eTag = given()
+            .when().head("/test-bucket/greeting.txt")
+            .then().statusCode(200)
+            .extract().header("ETag");
+
+        given()
+            .header("If-Match", eTag)
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(56)
+    void headObjectIfMatchWrongEtagReturns412() {
+        given()
+            .header("If-Match", "\"wrong-etag\"")
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(412);
+    }
+
+    @Test
+    @Order(57)
+    void headObjectIfModifiedSinceReturns304() {
+        given()
+            .header("If-Modified-Since", "Sun, 24 Mar 2030 00:00:00 GMT")
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(304);
+    }
+
+    @Test
+    @Order(58)
+    void headObjectIfUnmodifiedSinceReturns412() {
+        given()
+            .header("If-Unmodified-Since", "Tue, 24 Mar 2020 00:00:00 GMT")
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(412);
+    }
+
+    @Test
+    @Order(61)
     void getObjectIfModifiedSinceReturns304() {
         given()
             .header("If-Modified-Since", "Sun, 24 Mar 2030 00:00:00 GMT")
@@ -294,7 +343,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(56)
+    @Order(62)
     void getObjectIfUnmodifiedSinceReturns412() {
         given()
             .header("If-Unmodified-Since", "Tue, 24 Mar 2020 00:00:00 GMT")
@@ -306,7 +355,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(57)
+    @Order(63)
     void getObjectIfMatchWildcardReturns200() {
         given()
             .header("If-Match", "*")
@@ -318,7 +367,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(58)
+    @Order(64)
     void getObjectIfNoneMatchCommaListReturns304() {
         String eTag = given()
             .when().head("/test-bucket/greeting.txt")
@@ -334,7 +383,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(59)
+    @Order(65)
     void ifNoneMatchTakesPrecedenceOverIfModifiedSince() {
         String eTag = given()
             .when().head("/test-bucket/greeting.txt")
@@ -351,7 +400,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(60)
+    @Order(66)
     void notModifiedResponseIncludesLastModified() {
         String eTag = given()
             .when().head("/test-bucket/greeting.txt")
@@ -369,7 +418,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(100)
+    @Order(70)
     void cleanupAndDeleteBucket() {
         // Delete all objects
         given().delete("/test-bucket/greeting.txt");


### PR DESCRIPTION
Implement precondition evaluation for GetObject and HeadObject per HTTP/S3 spec. Evaluation order: If-Match (412) → If-Unmodified-Since (412, only when If-Match absent) → If-None-Match (304) → If-Modified-Since (304, only when If-None-Match absent). Returns S3-style XML error bodies for 412 responses. Supports comma-separated ETags and wildcard (*) in If-Match/If-None-Match.

Fixes #46

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
