### PR TITLE
fix(sns): add PublishBatch support to JSON protocol handler

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -44,6 +44,10 @@ public class SnsJsonHandler {
             case "ListSubscriptions" -> handleListSubscriptions(request, region);
             case "ListSubscriptionsByTopic" -> handleListSubscriptionsByTopic(request, region);
             case "Publish" -> handlePublish(request, region);
+            case "PublishBatch" -> handlePublishBatch(request, region);
+            case "GetSubscriptionAttributes" -> handleGetSubscriptionAttributes(request, region);
+            case "SetSubscriptionAttributes" -> handleSetSubscriptionAttributes(request, region);
+            case "ConfirmSubscription" -> handleConfirmSubscription(request, region);
             case "TagResource" -> handleTagResource(request, region);
             case "UntagResource" -> handleUntagResource(request, region);
             case "ListTagsForResource" -> handleListTagsForResource(request, region);
@@ -200,6 +204,84 @@ public class SnsJsonHandler {
             tag.put("Value", entry.getValue());
             tagsArray.add(tag);
         }
+        return Response.ok(response).build();
+    }
+
+    private Response handlePublishBatch(JsonNode request, String region) {
+        String topicArn = request.path("TopicArn").asText(null);
+        List<Map<String, Object>> entries = new ArrayList<>();
+
+        JsonNode entriesNode = request.path("PublishBatchRequestEntries");
+        if (entriesNode.isArray()) {
+            for (JsonNode entryNode : entriesNode) {
+                Map<String, Object> entry = new HashMap<>();
+                entry.put("Id", entryNode.path("Id").asText(null));
+                entry.put("Message", entryNode.path("Message").asText(null));
+                entry.put("Subject", entryNode.path("Subject").asText(null));
+                entry.put("MessageGroupId", entryNode.path("MessageGroupId").asText(null));
+                entry.put("MessageDeduplicationId", entryNode.path("MessageDeduplicationId").asText(null));
+
+                JsonNode attrsNode = entryNode.path("MessageAttributes");
+                if (attrsNode.isObject()) {
+                    Map<String, String> messageAttributes = new HashMap<>();
+                    attrsNode.fields().forEachRemaining(field ->
+                        messageAttributes.put(field.getKey(), field.getValue().path("StringValue").asText())
+                    );
+                    entry.put("MessageAttributes", messageAttributes);
+                }
+
+                entries.add(entry);
+            }
+        }
+
+        SnsService.BatchPublishResult result = snsService.publishBatch(topicArn, entries, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode successful = response.putArray("Successful");
+        for (String[] s : result.successful()) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("Id", s[0]);
+            item.put("MessageId", s[1]);
+            successful.add(item);
+        }
+        ArrayNode failed = response.putArray("Failed");
+        for (String[] f : result.failed()) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("Id", f[0]);
+            item.put("Code", f[1]);
+            item.put("Message", f[2]);
+            item.put("SenderFault", Boolean.parseBoolean(f[3]));
+            failed.add(item);
+        }
+
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetSubscriptionAttributes(JsonNode request, String region) {
+        String subscriptionArn = request.path("SubscriptionArn").asText(null);
+        Map<String, String> attrs = snsService.getSubscriptionAttributes(subscriptionArn, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ObjectNode attrsNode = response.putObject("Attributes");
+        for (var entry : attrs.entrySet()) {
+            attrsNode.put(entry.getKey(), entry.getValue());
+        }
+        return Response.ok(response).build();
+    }
+
+    private Response handleSetSubscriptionAttributes(JsonNode request, String region) {
+        String subscriptionArn = request.path("SubscriptionArn").asText(null);
+        String attributeName = request.path("AttributeName").asText(null);
+        String attributeValue = request.path("AttributeValue").asText(null);
+        snsService.setSubscriptionAttribute(subscriptionArn, attributeName, attributeValue, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleConfirmSubscription(JsonNode request, String region) {
+        String topicArn = request.path("TopicArn").asText(null);
+        String token = request.path("Token").asText(null);
+        String subscriptionArn = snsService.confirmSubscription(topicArn, token, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("SubscriptionArn", subscriptionArn);
         return Response.ok(response).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -1,6 +1,10 @@
 package io.github.hectorvent.floci.services.sns;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,15 @@ import static org.hamcrest.Matchers.*;
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class SnsIntegrationTest {
+
+    private static final String SNS_CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssured.config = RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(SNS_CONTENT_TYPE, ContentType.TEXT));
+    }
 
     private static String topicArn;
     private static String subscriptionArn;
@@ -190,6 +203,53 @@ class SnsIntegrationTest {
     }
 
     @Test
+    @Order(20)
+    void publishBatch_jsonProtocol() {
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.PublishBatch")
+            .body("""
+                {
+                    "TopicArn": "%s",
+                    "PublishBatchRequestEntries": [
+                        {"Id": "json-msg1", "Message": "JSON batch message 1"},
+                        {"Id": "json-msg2", "Message": "JSON batch message 2", "Subject": "Test"}
+                    ]
+                }
+                """.formatted(topicArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Successful.size()", equalTo(2))
+            .body("Successful[0].Id", equalTo("json-msg1"))
+            .body("Successful[0].MessageId", notNullValue())
+            .body("Successful[1].Id", equalTo("json-msg2"))
+            .body("Successful[1].MessageId", notNullValue())
+            .body("Failed.size()", equalTo(0));
+    }
+
+    @Test
+    @Order(21)
+    void publishBatch_jsonProtocol_emptyEntries() {
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.PublishBatch")
+            .body("""
+                {
+                    "TopicArn": "%s",
+                    "PublishBatchRequestEntries": []
+                }
+                """.formatted(topicArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Successful.size()", equalTo(0))
+            .body("Failed.size()", equalTo(0));
+    }
+
+    @Test
     @Order(11)
     void tagResource() {
         given()
@@ -235,7 +295,71 @@ class SnsIntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(22)
+    void getSubscriptionAttributes_jsonProtocol() {
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.GetSubscriptionAttributes")
+            .body("""
+                {"SubscriptionArn": "%s"}
+                """.formatted(subscriptionArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Attributes.SubscriptionArn", equalTo(subscriptionArn))
+            .body("Attributes.Protocol", equalTo("sqs"))
+            .body("Attributes.TopicArn", equalTo(topicArn));
+    }
+
+    @Test
+    @Order(23)
+    void setSubscriptionAttributes_jsonProtocol() {
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.SetSubscriptionAttributes")
+            .body("""
+                {
+                    "SubscriptionArn": "%s",
+                    "AttributeName": "RawMessageDelivery",
+                    "AttributeValue": "true"
+                }
+                """.formatted(subscriptionArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.GetSubscriptionAttributes")
+            .body("""
+                {"SubscriptionArn": "%s"}
+                """.formatted(subscriptionArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Attributes.RawMessageDelivery", equalTo("true"));
+    }
+
+    @Test
+    @Order(24)
+    void getSubscriptionAttributes_jsonProtocol_notFound() {
+        given()
+            .contentType(SNS_CONTENT_TYPE)
+            .header("X-Amz-Target", "SNS_20100331.GetSubscriptionAttributes")
+            .body("""
+                {"SubscriptionArn": "arn:aws:sns:us-east-1:000000000000:nonexistent:fake-id"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(100)
     void unsubscribe() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -258,7 +382,7 @@ class SnsIntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(101)
     void deleteTopic() {
         given()
             .contentType("application/x-www-form-urlencoded")


### PR DESCRIPTION
Add PublishBatch, GetSubscriptionAttributes, SetSubscriptionAttributes, and ConfirmSubscription to the SnsJsonHandler switch statement so modern AWS SDK v2+ clients using the JSON protocol can call these operations.

Includes integration tests verifying PublishBatch via JSON protocol returns Successful entries with MessageIds, plus an empty-entries edge case.

Fixes #51 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
