### PR TITLE
fix(sns): enforce FilterPolicy on message delivery

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -12,12 +12,14 @@ import io.github.hectorvent.floci.services.sns.model.Subscription;
 import io.github.hectorvent.floci.services.sns.model.Topic;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -284,6 +286,9 @@ public class SnsService {
                 LOG.debugv("Skipping delivery to pending subscription {0}", sub.getSubscriptionArn());
                 continue;
             }
+            if (!matchesFilterPolicy(sub, messageAttributes)) {
+                continue;
+            }
             deliverMessage(sub, message, subject, messageAttributes, messageId, effectiveArn, messageGroupId);
         }
         LOG.infov("Published message {0} to topic {1}", messageId, effectiveArn);
@@ -352,6 +357,7 @@ public class SnsService {
             Map<String, String> attrs = (Map<String, String>) entry.get("MessageAttributes");
             for (Subscription sub : subscriptionsByTopic(topicArn, region)) {
                 if ("true".equals(sub.getAttributes().get("PendingConfirmation"))) continue;
+                if (!matchesFilterPolicy(sub, attrs)) continue;
                 deliverMessage(sub, message, subject, attrs, messageId, topicArn, messageGroupId);
             }
             LOG.debugv("Batch published message {0} (id={1}) to {2}", messageId, id, topicArn);
@@ -384,6 +390,140 @@ public class SnsService {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Resource does not exist.", 404));
         return new java.util.LinkedHashMap<>(topic.getTags());
+    }
+
+    /**
+     * Evaluates whether a message satisfies the subscription's filter policy.
+     * Returns {@code true} if no filter policy is set.
+     * Returns {@code false} for malformed filter policies (fail closed).
+     * <p>
+     * Only {@code FilterPolicyScope=MessageAttributes} is supported. When scope is
+     * {@code MessageBody}, filtering is skipped and the message is delivered (to avoid
+     * incorrectly dropping messages for an unsupported scope).
+     * <p>
+     * All keys in the policy must match (AND logic). Within each key's rule array,
+     * any matching element is sufficient (OR logic).
+     */
+    private boolean matchesFilterPolicy(Subscription sub, Map<String, String> messageAttributes) {
+        String filterPolicyJson = sub.getAttributes().get("FilterPolicy");
+        if (filterPolicyJson == null || filterPolicyJson.isBlank()) {
+            return true;
+        }
+        String scope = sub.getAttributes().getOrDefault("FilterPolicyScope", "MessageAttributes");
+        if ("MessageBody".equals(scope)) {
+            return true;
+        }
+        try {
+            JsonNode filterPolicy = objectMapper.readTree(filterPolicyJson);
+            if (!filterPolicy.isObject()) {
+                LOG.warnv("Invalid FilterPolicy (not a JSON object) for {0}", sub.getSubscriptionArn());
+                return false;
+            }
+            Map<String, String> attrs = messageAttributes != null ? messageAttributes : Map.of();
+            var fields = filterPolicy.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                String key = entry.getKey();
+                JsonNode rules = entry.getValue();
+                String actualValue = attrs.get(key);
+                if (!matchesAttributeRules(actualValue, rules)) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.warnv("Failed to parse filter policy for {0}: {1}", sub.getSubscriptionArn(), e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Checks if an attribute value matches a single filter policy rule set.
+     * Rules must be a JSON array where ANY element matching means the rule passes (OR logic).
+     * Non-array rules are treated as non-matching.
+     */
+    private boolean matchesAttributeRules(String actualValue, JsonNode rules) {
+        if (!rules.isArray()) {
+            return false;
+        }
+        for (JsonNode rule : rules) {
+            if (rule.isTextual() && rule.asText().equals(actualValue)) {
+                return true;
+            }
+            if (rule.isNumber() && actualValue != null) {
+                try {
+                    if (new BigDecimal(actualValue).compareTo(rule.decimalValue()) == 0) {
+                        return true;
+                    }
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            if (rule.isObject() && matchesObjectRule(rule, actualValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Evaluates a single object-type filter rule (exists, prefix, anything-but, numeric)
+     * against the actual attribute value.
+     */
+    private boolean matchesObjectRule(JsonNode rule, String actualValue) {
+        if (rule.has("exists")) {
+            boolean shouldExist = rule.get("exists").asBoolean();
+            return shouldExist ? actualValue != null : actualValue == null;
+        }
+        if (rule.has("prefix") && actualValue != null) {
+            return actualValue.startsWith(rule.get("prefix").asText());
+        }
+        if (rule.has("anything-but") && actualValue != null) {
+            return !containsValue(rule.get("anything-but"), actualValue);
+        }
+        if (rule.has("numeric") && actualValue != null) {
+            try {
+                return evaluateNumericCondition(new BigDecimal(actualValue), rule.get("numeric"));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return false;
+    }
+
+    private boolean containsValue(JsonNode node, String value) {
+        if (node.isArray()) {
+            for (JsonNode element : node) {
+                if (element.asText().equals(value)) return true;
+            }
+            return false;
+        }
+        LOG.warnv("FilterPolicy 'anything-but' expected an array but got a scalar; treating as single-value list");
+        return node.asText().equals(value);
+    }
+
+    /**
+     * Evaluates a numeric condition array against a value.
+     * The conditions array contains alternating operator-target pairs (e.g. [">=", 100, "<", 200]).
+     * All pairs must match for the condition to pass (AND logic).
+     */
+    private boolean evaluateNumericCondition(BigDecimal value, JsonNode conditions) {
+        if (!conditions.isArray() || conditions.size() % 2 != 0) {
+            return false;
+        }
+        for (int i = 0; i < conditions.size(); i += 2) {
+            String op = conditions.get(i).asText();
+            BigDecimal target = conditions.get(i + 1).decimalValue();
+            int cmp = value.compareTo(target);
+            boolean matches = switch (op) {
+                case "=" -> cmp == 0;
+                case ">" -> cmp > 0;
+                case ">=" -> cmp >= 0;
+                case "<" -> cmp < 0;
+                case "<=" -> cmp <= 0;
+                default -> false;
+            };
+            if (!matches) return false;
+        }
+        return true;
     }
 
     private boolean isDuplicate(String topicArn, String deduplicationId) {

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -294,6 +294,11 @@ class SnsIntegrationTest {
             .statusCode(200);
     }
 
+    private static String filterQueueUrlA;
+    private static String filterQueueUrlB;
+    private static String filterSubArnA;
+    private static String filterSubArnB;
+
     @Test
     @Order(22)
     void getSubscriptionAttributes_jsonProtocol() {
@@ -359,6 +364,230 @@ class SnsIntegrationTest {
     }
 
     @Test
+    @Order(13)
+    void filterPolicy_createQueuesAndSubscribe() {
+        filterQueueUrlA = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "filter-queue-sports")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        filterQueueUrlB = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "filter-queue-weather")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        String sportsQueueArn = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueAttributes")
+            .formParam("QueueUrl", filterQueueUrlA)
+            .formParam("AttributeName.1", "QueueArn")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("**.find { it.Name == 'QueueArn' }.Value");
+
+        String weatherQueueArn = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueAttributes")
+            .formParam("QueueUrl", filterQueueUrlB)
+            .formParam("AttributeName.1", "QueueArn")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("**.find { it.Name == 'QueueArn' }.Value");
+
+        filterSubArnA = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "sqs")
+            .formParam("Endpoint", sportsQueueArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("SubscribeResponse.SubscribeResult.SubscriptionArn");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SetSubscriptionAttributes")
+            .formParam("SubscriptionArn", filterSubArnA)
+            .formParam("AttributeName", "FilterPolicy")
+            .formParam("AttributeValue", "{\"category\":[\"sports\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        filterSubArnB = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "sqs")
+            .formParam("Endpoint", weatherQueueArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("SubscribeResponse.SubscribeResult.SubscriptionArn");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SetSubscriptionAttributes")
+            .formParam("SubscriptionArn", filterSubArnB)
+            .formParam("AttributeName", "FilterPolicy")
+            .formParam("AttributeValue", "{\"category\":[\"weather\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(14)
+    void filterPolicy_routesMessageToMatchingSubscription() {
+        drainQueue(filterQueueUrlA);
+        drainQueue(filterQueueUrlB);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "Goal scored!")
+            .formParam("MessageAttributes.entry.1.Name", "category")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "String")
+            .formParam("MessageAttributes.entry.1.Value.StringValue", "sports")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", filterQueueUrlA)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("Goal scored!"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", filterQueueUrlB)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Message>")));
+    }
+
+    @Test
+    @Order(15)
+    void filterPolicy_noFilterPolicyReceivesAllMessages() {
+        drainQueue(sqsQueueUrl);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "Unfiltered broadcast")
+            .formParam("MessageAttributes.entry.1.Name", "category")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "String")
+            .formParam("MessageAttributes.entry.1.Value.StringValue", "weather")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", sqsQueueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("Unfiltered broadcast"));
+    }
+
+    @Test
+    @Order(16)
+    void filterPolicy_nonMatchingMessageNotDelivered() {
+        drainQueue(filterQueueUrlA);
+        drainQueue(filterQueueUrlB);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "Stock update")
+            .formParam("MessageAttributes.entry.1.Name", "category")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "String")
+            .formParam("MessageAttributes.entry.1.Value.StringValue", "finance")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", filterQueueUrlA)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Message>")));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", filterQueueUrlB)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Message>")));
+    }
+
+    @Test
+    @Order(17)
+    void filterPolicy_cleanup() {
+        given().contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Unsubscribe").formParam("SubscriptionArn", filterSubArnA)
+            .when().post("/");
+        given().contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Unsubscribe").formParam("SubscriptionArn", filterSubArnB)
+            .when().post("/");
+        given().contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue").formParam("QueueUrl", filterQueueUrlA)
+            .when().post("/");
+        given().contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue").formParam("QueueUrl", filterQueueUrlB)
+            .when().post("/");
+    }
+
+    @Test
     @Order(100)
     void unsubscribe() {
         given()
@@ -404,7 +633,7 @@ class SnsIntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(102)
     void unsupportedAction_returns400() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -414,5 +643,19 @@ class SnsIntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("UnsupportedOperation"));
+    }
+
+    /**
+     * Drains all pending messages from the given SQS queue using PurgeQueue.
+     */
+    private void drainQueue(String queueUrl) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "PurgeQueue")
+            .formParam("QueueUrl", queueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
     }
 }


### PR DESCRIPTION
FilterPolicy subscription attribute was accepted and stored but never evaluated during publish. Messages were delivered to all confirmed subscriptions regardless of filter rules. Now evaluates filter policies supporting exact string matching, numeric comparisons, prefix matching, exists operator, and anything-but operator per SNS specification.

Fixes #49

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
