### PR TITLE
fix(sns): honor RawMessageDelivery attribute for SQS subscriptions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.sns;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.services.sns.model.Subscription;
 import io.github.hectorvent.floci.services.sns.model.Topic;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -154,11 +155,13 @@ public class SnsJsonHandler {
         String message = request.path("Message").asText(null);
         String subject = request.path("Subject").asText(null);
 
-        Map<String, String> attributes = new HashMap<>();
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
         JsonNode attrsNode = request.path("MessageAttributes");
         if (attrsNode.isObject()) {
             attrsNode.fields().forEachRemaining(entry -> {
-                attributes.put(entry.getKey(), entry.getValue().path("StringValue").asText());
+                String dataType = entry.getValue().path("DataType").asText("String");
+                String stringValue = entry.getValue().path("StringValue").asText();
+                attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
             });
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.sns;
 import io.github.hectorvent.floci.core.common.*;
 import io.github.hectorvent.floci.services.sns.model.Subscription;
 import io.github.hectorvent.floci.services.sns.model.Topic;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -181,12 +182,13 @@ public class SnsQueryHandler {
         String messageGroupId = getParam(params, "MessageGroupId");
         String messageDeduplicationId = getParam(params, "MessageDeduplicationId");
 
-        Map<String, String> attributes = new HashMap<>();
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
         for (int i = 1; ; i++) {
             String name = params.getFirst("MessageAttributes.entry." + i + ".Name");
             if (name == null) break;
             String value = params.getFirst("MessageAttributes.entry." + i + ".Value.StringValue");
-            if (value != null) attributes.put(name, value);
+            String dataType = params.getFirst("MessageAttributes.entry." + i + ".Value.DataType");
+            if (value != null) attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
         }
 
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -248,12 +249,12 @@ public class SnsService {
     }
 
     public String publish(String topicArn, String targetArn, String phoneNumber, String message,
-                          String subject, Map<String, String> messageAttributes, String region) {
+                          String subject, Map<String, MessageAttributeValue> messageAttributes, String region) {
         return publish(topicArn, targetArn, phoneNumber, message, subject, messageAttributes, null, null, region);
     }
 
     public String publish(String topicArn, String targetArn, String phoneNumber, String message,
-                          String subject, Map<String, String> messageAttributes,
+                          String subject, Map<String, MessageAttributeValue> messageAttributes,
                           String messageGroupId, String messageDeduplicationId, String region) {
         // Send SMS
         if (phoneNumber != null) {
@@ -362,7 +363,7 @@ public class SnsService {
 
             String messageId = UUID.randomUUID().toString();
             @SuppressWarnings("unchecked")
-            Map<String, String> attrs = (Map<String, String>) entry.get("MessageAttributes");
+            Map<String, MessageAttributeValue> attrs = (Map<String, MessageAttributeValue>) entry.get("MessageAttributes");
             for (Subscription sub : subscriptionsByTopic(topicArn, region)) {
                 if ("true".equals(sub.getAttributes().get("PendingConfirmation"))) continue;
                 if (!matchesFilterPolicy(sub, attrs)) continue;
@@ -412,7 +413,7 @@ public class SnsService {
      * All keys in the policy must match (AND logic). Within each key's rule array,
      * any matching element is sufficient (OR logic).
      */
-    private boolean matchesFilterPolicy(Subscription sub, Map<String, String> messageAttributes) {
+    private boolean matchesFilterPolicy(Subscription sub, Map<String, MessageAttributeValue> messageAttributes) {
         String filterPolicyJson = sub.getAttributes().get("FilterPolicy");
         if (filterPolicyJson == null || filterPolicyJson.isBlank()) {
             return true;
@@ -427,13 +428,14 @@ public class SnsService {
                 LOG.warnv("Invalid FilterPolicy (not a JSON object) for {0}", sub.getSubscriptionArn());
                 return false;
             }
-            Map<String, String> attrs = messageAttributes != null ? messageAttributes : Map.of();
+            Map<String, MessageAttributeValue> attrs = messageAttributes != null ? messageAttributes : Map.of();
             var fields = filterPolicy.fields();
             while (fields.hasNext()) {
                 var entry = fields.next();
                 String key = entry.getKey();
                 JsonNode rules = entry.getValue();
-                String actualValue = attrs.get(key);
+                MessageAttributeValue attr = attrs.get(key);
+                String actualValue = attr != null ? attr.getStringValue() : null;
                 if (!matchesAttributeRules(actualValue, rules)) {
                     return false;
                 }
@@ -560,7 +562,7 @@ public class SnsService {
     }
 
     private void deliverMessage(Subscription sub, String message, String subject,
-                                Map<String, String> messageAttributes, String messageId,
+                                Map<String, MessageAttributeValue> messageAttributes, String messageId,
                                 String topicArn, String messageGroupId) {
         try {
             switch (sub.getProtocol()) {
@@ -576,7 +578,7 @@ public class SnsService {
                             : buildSnsEnvelope(message, subject, messageAttributes, topicArn, messageId);
                     Map<String, MessageAttributeValue> sqsAttributes = rawDelivery
                             ? toSqsMessageAttributes(messageAttributes)
-                            : null;
+                            : Collections.emptyMap();
                     sqsService.sendMessage(queueUrl, body, 0, messageGroupId, null, sqsAttributes, region);
                     LOG.debugv("Delivered SNS message to SQS: {0} ({1}) raw={2}", sub.getEndpoint(), queueUrl, rawDelivery);
                 }
@@ -602,7 +604,7 @@ public class SnsService {
     }
 
     private String buildSnsLambdaEvent(String topicArn, String messageId, String message,
-                                       String subject, Map<String, String> messageAttributes,
+                                       String subject, Map<String, MessageAttributeValue> messageAttributes,
                                        String subscriptionArn) {
         try {
             String timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
@@ -625,8 +627,8 @@ public class SnsService {
             if (messageAttributes != null) {
                 for (var entry : messageAttributes.entrySet()) {
                     ObjectNode attr = attrs.putObject(entry.getKey());
-                    attr.put("Type", "String");
-                    attr.put("Value", entry.getValue());
+                    attr.put("Type", entry.getValue().getDataType());
+                    attr.put("Value", entry.getValue().getStringValue());
                 }
             }
             ObjectNode record = objectMapper.createObjectNode();
@@ -654,22 +656,18 @@ public class SnsService {
     }
 
     /**
-     * Converts SNS message attributes (simple String map) to SQS MessageAttributeValue objects
-     * for forwarding when RawMessageDelivery is enabled.
+     * Forwards SNS message attributes as SQS MessageAttributeValue objects
+     * when RawMessageDelivery is enabled, preserving the original DataType.
      */
-    private Map<String, MessageAttributeValue> toSqsMessageAttributes(Map<String, String> snsAttributes) {
+    private Map<String, MessageAttributeValue> toSqsMessageAttributes(Map<String, MessageAttributeValue> snsAttributes) {
         if (snsAttributes == null || snsAttributes.isEmpty()) {
-            return null;
+            return Collections.emptyMap();
         }
-        Map<String, MessageAttributeValue> sqsAttrs = new java.util.HashMap<>();
-        for (var entry : snsAttributes.entrySet()) {
-            sqsAttrs.put(entry.getKey(), new MessageAttributeValue(entry.getValue(), "String"));
-        }
-        return sqsAttrs;
+        return new java.util.HashMap<>(snsAttributes);
     }
 
     private String buildSnsEnvelope(String message, String subject,
-                                    Map<String, String> messageAttributes,
+                                    Map<String, MessageAttributeValue> messageAttributes,
                                     String topicArn, String messageId) {
         try {
             ObjectNode node = objectMapper.createObjectNode();
@@ -684,8 +682,8 @@ public class SnsService {
             if (messageAttributes != null) {
                 for (var entry : messageAttributes.entrySet()) {
                     ObjectNode attr = attrs.putObject(entry.getKey());
-                    attr.put("Type", "String");
-                    attr.put("Value", entry.getValue());
+                    attr.put("Type", entry.getValue().getDataType());
+                    attr.put("Value", entry.getValue().getStringValue());
                 }
             }
             return objectMapper.writeValueAsString(node);

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.UUID;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -594,19 +596,12 @@ class SnsIntegrationTest {
     @Test
     @Order(50)
     void rawDelivery_createQueuesAndSubscribe() {
-        given().contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DeleteQueue")
-            .formParam("QueueUrl", "http://localhost:4566/000000000000/sns-raw-delivery-queue")
-            .when().post("/");
-        given().contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DeleteQueue")
-            .formParam("QueueUrl", "http://localhost:4566/000000000000/sns-envelope-delivery-queue")
-            .when().post("/");
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
 
         rawDeliveryQueueUrl = given()
             .contentType("application/x-www-form-urlencoded")
             .formParam("Action", "CreateQueue")
-            .formParam("QueueName", "sns-raw-delivery-queue")
+            .formParam("QueueName", "sns-raw-delivery-" + suffix)
         .when()
             .post("/")
         .then()
@@ -616,7 +611,7 @@ class SnsIntegrationTest {
         envelopeQueueUrl = given()
             .contentType("application/x-www-form-urlencoded")
             .formParam("Action", "CreateQueue")
-            .formParam("QueueName", "sns-envelope-delivery-queue")
+            .formParam("QueueName", "sns-envelope-delivery-" + suffix)
         .when()
             .post("/")
         .then()
@@ -708,6 +703,43 @@ class SnsIntegrationTest {
 
     @Test
     @Order(54)
+    void rawDelivery_messageAttributesForwardedOnRawDelivery() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "Attribute forwarding test")
+            .formParam("MessageAttributes.entry.1.Name", "color")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "String")
+            .formParam("MessageAttributes.entry.1.Value.StringValue", "blue")
+            .formParam("MessageAttributes.entry.2.Name", "count")
+            .formParam("MessageAttributes.entry.2.Value.DataType", "Number")
+            .formParam("MessageAttributes.entry.2.Value.StringValue", "42")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", rawDeliveryQueueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+            .formParam("MessageAttributeNames.member.1", "All")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("Attribute forwarding test"))
+            .body(containsString("color"))
+            .body(containsString("blue"))
+            .body(containsString("count"))
+            .body(containsString("Number"));
+    }
+
+    @Test
+    @Order(55)
     void rawDelivery_cleanup() {
         given()
             .contentType("application/x-www-form-urlencoded")


### PR DESCRIPTION
The `RawMessageDelivery` subscription attribute was already accepted via `SetSubscriptionAttributes` and returned via `GetSubscriptionAttributes`, but the delivery path always wrapped messages in the SNS JSON envelope regardless. This caused SQS consumers expecting raw payloads to receive the envelope wrapper, breaking JSON deserialization.

 Fixes #50
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
