### PR TITLE
fix(sqs): translate Query-protocol error codes to JSON __type equivalents

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsException.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsException.java
@@ -1,10 +1,28 @@
 package io.github.hectorvent.floci.core.common;
 
+import java.util.Map;
+
 /**
  * Base exception for AWS emulator errors.
  * Maps to AWS-style error responses with code, message, and HTTP status.
+ * <p>
+ * Some services use different error code formats for Query (XML) and JSON protocols.
+ * {@link #jsonType()} returns the JSON-protocol {@code __type} value that the AWS SDK v2
+ * uses to instantiate a specific typed exception rather than falling back to a generic one.
  */
 public class AwsException extends RuntimeException {
+
+    /**
+     * Maps Query-protocol error codes to their JSON-protocol {@code __type} equivalents.
+     * Codes absent from this map are used as-is for both protocols.
+     */
+    private static final Map<String, String> JSON_TYPE_BY_QUERY_CODE = Map.of(
+            "AWS.SimpleQueueService.NonExistentQueue", "QueueDoesNotExist",
+            "QueueAlreadyExists",                      "QueueNameExists",
+            "ReceiptHandleIsInvalid",                  "ReceiptHandleIsInvalid",
+            "TooManyEntriesInBatchRequest",            "TooManyEntriesInBatchRequest",
+            "BatchEntryIdNotUnique",                   "BatchEntryIdNotDistinct"
+    );
 
     private final String errorCode;
     private final int httpStatus;
@@ -21,5 +39,13 @@ public class AwsException extends RuntimeException {
 
     public int getHttpStatus() {
         return httpStatus;
+    }
+
+    /**
+     * Returns the JSON-protocol {@code __type} value for this error.
+     * The AWS SDK v2 uses this to map responses to typed exception classes.
+     */
+    public String jsonType() {
+        return JSON_TYPE_BY_QUERY_CODE.getOrDefault(errorCode, errorCode);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsExceptionMapper.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsExceptionMapper.java
@@ -18,8 +18,8 @@ public class AwsExceptionMapper implements ExceptionMapper<AwsException> {
     public Response toResponse(AwsException exception) {
         LOG.debugv("Mapping exception: {0} - {1}", exception.getErrorCode(), exception.getMessage());
         return Response.status(exception.getHttpStatus())
-                .entity(new AwsErrorResponse(exception.getErrorCode(), exception.getMessage()))
                 .type(MediaType.APPLICATION_JSON)
+                .entity(new AwsErrorResponse(exception.jsonType(), exception.getMessage()))
                 .build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
@@ -135,7 +135,7 @@ public class AwsJsonController {
         } catch (AwsException e) {
             return Response.status(e.getHttpStatus())
                     .type(MediaType.APPLICATION_JSON)
-                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .entity(new AwsErrorResponse(e.jsonType(), e.getMessage()))
                     .build();
         } catch (Exception e) {
             LOG.error("Error processing " + serviceName + " JSON request", e);
@@ -329,7 +329,7 @@ public class AwsJsonController {
     private Response cborErrorResponse(AwsException e, String protocolHeader) {
         try {
             byte[] errBytes = CBOR_MAPPER.writeValueAsBytes(
-                    new AwsErrorResponse(e.getErrorCode(), e.getMessage()));
+                    new AwsErrorResponse(e.jsonType(), e.getMessage()));
             return Response.status(e.getHttpStatus())
                     .header(protocolHeader, "rpc-v2-cbor")
                     .type("application/cbor")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -1,6 +1,9 @@
 package io.github.hectorvent.floci.services.sqs;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -214,5 +217,93 @@ class SqsIntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("UnsupportedOperation"));
+    }
+
+    @Test
+    void createQueue_idempotent_sameAttributes() {
+        String queueName = "idempotent-test-queue";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+            .formParam("Attribute.1.Name", "VisibilityTimeout")
+            .formParam("Attribute.1.Value", "60")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(queueName));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+            .formParam("Attribute.1.Name", "VisibilityTimeout")
+            .formParam("Attribute.1.Value", "60")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(queueName));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", "http://localhost:4566/000000000000/" + queueName)
+        .when()
+            .post("/");
+    }
+
+    @Test
+    void createQueue_conflictingAttributes_returns400() {
+        String queueName = "conflict-test-queue";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+            .formParam("Attribute.1.Name", "VisibilityTimeout")
+            .formParam("Attribute.1.Value", "30")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+            .formParam("Attribute.1.Name", "VisibilityTimeout")
+            .formParam("Attribute.1.Value", "60")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("QueueNameExists"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", "http://localhost:4566/000000000000/" + queueName)
+        .when()
+            .post("/");
+    }
+
+    @Test
+    void jsonProtocol_nonExistentQueue_returnsQueueDoesNotExist() {
+        given()
+            .config(RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                    .encodeContentTypeAs("application/x-amz-json-1.0", ContentType.TEXT)))
+            .contentType("application/x-amz-json-1.0")
+            .header("X-Amz-Target", "AmazonSQS.GetQueueUrl")
+            .body("{\"QueueName\": \"no-such-queue-xyz\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("QueueDoesNotExist"))
+            .body(not(containsString("AWS.SimpleQueueService.NonExistentQueue")));
     }
 }


### PR DESCRIPTION
The AWS SDK v2 uses the __type field in JSON error responses to instantiate typed exceptions. Query-protocol codes such as
AWS.SimpleQueueService.NonExistentQueue were being forwarded verbatim into the JSON __type field, causing the SDK to fall back to a generic SqsException instead of QueueDoesNotExistException.

Add a jsonType() method to AwsException that maps Query-protocol codes to their JSON-protocol equivalents (e.g. QueueDoesNotExist, QueueNameExists). Both AwsExceptionMapper and the inline catch in AwsJsonController now call jsonType() so the mapping is applied consistently across all code paths.

Fixes #58 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
