### PR TITLE
feat: add Kinesis ListShards operation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.kinesis;
 
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisRecord;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisShard;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisStream;
@@ -53,6 +54,7 @@ public class KinesisJsonHandler {
             case "PutRecords" -> handlePutRecords(request, region);
             case "GetShardIterator" -> handleGetShardIterator(request, region);
             case "GetRecords" -> handleGetRecords(request, region);
+            case "ListShards" -> handleListShards(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -323,6 +325,62 @@ public class KinesisJsonHandler {
         }
         response.put("NextShardIterator", (String) result.get("NextShardIterator"));
         response.put("MillisBehindLatest", ((Number) result.get("MillisBehindLatest")).longValue());
+        return Response.ok(response).build();
+    }
+
+    private Response handleListShards(JsonNode request, String region) {
+        String streamName = request.has("StreamName") ? request.path("StreamName").asText(null) : null;
+        String streamArn = request.has("StreamARN") ? request.path("StreamARN").asText(null) : null;
+
+        String resolvedStreamName = streamName;
+        if (resolvedStreamName == null && streamArn != null) {
+            int idx = streamArn.lastIndexOf("/");
+            if (idx >= 0) {
+                resolvedStreamName = streamArn.substring(idx + 1);
+            }
+        }
+        if (resolvedStreamName == null) {
+            throw new AwsException("InvalidArgumentException",
+                    "StreamName or StreamARN must be provided", 400);
+        }
+
+        KinesisStream stream = service.describeStream(resolvedStreamName, region);
+
+        List<KinesisShard> shards = stream.getShards();
+        if (request.has("ShardFilter")) {
+            JsonNode filter = request.path("ShardFilter");
+            String filterType = filter.path("Type").asText(null);
+            if ("AT_LATEST".equals(filterType)) {
+                shards = shards.stream().filter(s -> !s.isClosed()).toList();
+            }
+        }
+
+        int maxResults = request.has("MaxResults") ? request.path("MaxResults").asInt(1000) : 1000;
+        List<KinesisShard> page = shards.size() > maxResults ? shards.subList(0, maxResults) : shards;
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode shardsArray = response.putArray("Shards");
+        for (KinesisShard shard : page) {
+            ObjectNode sNode = shardsArray.addObject();
+            sNode.put("ShardId", shard.getShardId());
+            if (shard.getParentShardId() != null) {
+                sNode.put("ParentShardId", shard.getParentShardId());
+            }
+            if (shard.getAdjacentParentShardId() != null) {
+                sNode.put("AdjacentParentShardId", shard.getAdjacentParentShardId());
+            }
+            sNode.putObject("HashKeyRange")
+                    .put("StartingHashKey", shard.getHashKeyRange().startingHashKey())
+                    .put("EndingHashKey", shard.getHashKeyRange().endingHashKey());
+            ObjectNode seqRange = sNode.putObject("SequenceNumberRange");
+            seqRange.put("StartingSequenceNumber", shard.getSequenceNumberRange().startingSequenceNumber());
+            if (shard.getSequenceNumberRange().endingSequenceNumber() != null) {
+                seqRange.put("EndingSequenceNumber", shard.getSequenceNumberRange().endingSequenceNumber());
+            }
+        }
+
+        response.putNull("NextToken");
+
         return Response.ok(response).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -1,0 +1,166 @@
+package io.github.hectorvent.floci.services.kinesis;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class KinesisIntegrationTest {
+
+    private static final String KINESIS_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssured.config = RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(KINESIS_CONTENT_TYPE, ContentType.TEXT));
+    }
+
+    @Test
+    @Order(1)
+    void createStream() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "list-shards-test", "ShardCount": 2}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void listShardsByStreamName() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "list-shards-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Shards.size()", equalTo(2))
+            .body("Shards[0].ShardId", equalTo("shardId-000000000000"))
+            .body("Shards[1].ShardId", equalTo("shardId-000000000001"))
+            .body("Shards[0].HashKeyRange.StartingHashKey", notNullValue())
+            .body("Shards[0].HashKeyRange.EndingHashKey", equalTo("340282366920938463463374607431768211455"))
+            .body("Shards[0].SequenceNumberRange.StartingSequenceNumber", notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void listShardsByStreamArn() {
+        String streamArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "list-shards-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("StreamDescriptionSummary.StreamARN");
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Shards.size()", equalTo(2));
+    }
+
+    @Test
+    @Order(4)
+    void listShardsAfterSplitReturnsAllShards() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.SplitShard")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {
+                    "StreamName": "list-shards-test",
+                    "ShardToSplit": "shardId-000000000000",
+                    "NewStartingHashKey": "170141183460469231731687303715884105728"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "list-shards-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Shards.size()", equalTo(4));
+    }
+
+    @Test
+    @Order(5)
+    void listShardsWithShardFilterAtLatestExcludesClosedShards() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "list-shards-test", "ShardFilter": {"Type": "AT_LATEST"}}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Shards.size()", equalTo(3))
+            .body("Shards.findAll { !it.SequenceNumberRange.containsKey('EndingSequenceNumber') }.size()", equalTo(3));
+    }
+
+    @Test
+    @Order(6)
+    void listShardsWithoutStreamNameOrArn() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(7)
+    void listShardsForNonExistentStream() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListShards")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "non-existent-stream"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+}


### PR DESCRIPTION
## Summary

Add support for the Kinesis `ListShards` operation.

Closes #60

## Type of Change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New action: `Kinesis.ListShards`

- AWS API Reference: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html
- Tested with AWS SDK for Java v2 (via KCL v3.x)

Supported parameters:
- `StreamName`
- `StreamARN`
- `ShardFilter` (`AT_LATEST` type)
- `MaxResults`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
