### PR TITLE
fix(KMS): Allow arn and alias to encrypt

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -183,15 +183,25 @@ public class KmsService {
 
     private KmsKey resolveKey(String keyIdOrArn, String region) {
         String id = keyIdOrArn;
-        if (id.startsWith("arn:aws:kms:")) {
+        // Alias arn
+        if (id.contains(":alias/")) {
+            String aliasName = id.substring(id.lastIndexOf(":") + 1);
+            String aliasKey = region + "::" + aliasName;
+            id = aliasStore.get(aliasKey)
+                    .map(KmsAlias::getTargetKeyId)
+                    .orElseThrow(() -> new AwsException("NotFoundException", "Alias not found: " + keyIdOrArn, 404));
+        } else if (id.startsWith("arn:aws:kms:")) {
+            // Key arn
             id = id.substring(id.lastIndexOf("/") + 1);
         } else if (id.startsWith("alias/")) {
+            // Alias name
             String aliasKey = region + "::" + id;
             id = aliasStore.get(aliasKey)
                     .map(KmsAlias::getTargetKeyId)
                     .orElseThrow(() -> new AwsException("NotFoundException", "Alias not found: " + keyIdOrArn, 404));
         }
 
+        // Key id
         return keyStore.get(region + "::" + id)
                 .orElseThrow(() -> new AwsException("NotFoundException", "Key not found: " + keyIdOrArn, 404));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -149,13 +149,26 @@ class KmsServiceTest {
     }
 
     @Test
-    void encryptAndDecryptWithAlias() {
+    void encryptAndDecryptWithAliasName() {
         KmsKey key = kmsService.createKey(null, REGION);
         String aliasName = "alias/my-alias";
         kmsService.createAlias(aliasName, key.getKeyId(), REGION);
         byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);
 
         byte[] ciphertext = kmsService.encrypt(aliasName, plaintext, REGION);
+        byte[] decrypted = kmsService.decrypt(ciphertext, REGION);
+
+        assertArrayEquals(plaintext, decrypted);
+    }
+
+    @Test
+    void encryptAndDecryptWithAliasArn() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        String aliasName = "alias/my-alias";
+        kmsService.createAlias(aliasName, key.getKeyId(), REGION);
+        byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);
+
+        byte[] ciphertext = kmsService.encrypt("arn:aws:kms:" + REGION + ":000000000000:" + aliasName, plaintext, REGION);
         byte[] decrypted = kmsService.decrypt(ciphertext, REGION);
 
         assertArrayEquals(plaintext, decrypted);


### PR DESCRIPTION
## Summary

In Floci 1.0.11, we can use only key-id to encrypt.
This PR enables to use key-alias, key-arn and alias-arn to encrypt.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- For bug fixes: what was the incorrect behavior?
  - We can use key-id, key-alias, key-arn and alias-arn to encrypt.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
