### PR TITLE
fix: load storage after backend is created in StorageFactory

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
@@ -65,6 +65,9 @@ public class StorageFactory {
             default -> throw new IllegalArgumentException("Unknown storage mode: " + mode);
         };
 
+        // load because loadAll() may run before the service is initialized
+        backend.load();
+
         allBackends.add(backend);
         return backend;
     }


### PR DESCRIPTION
## Summary

In Floci 1.0.11, I cannot load json file into the storage even if I chose persistent/hybrid storage mode. (test kms, secretsmanager only)
I found that `StorageFactory.loadAll()` may run before the service's(e.g. KmsService) constructor is executed.

So I run `load()` after backend is created because `loadAll()` may run before the service is initialized.

Maybe it is better to review the storage loading stategy, but it is the smallest change in my opinion.
If there is better solution, I can close pullrequest and just raise the issue.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

> For bug fixes: what was the incorrect behavior? 
- In Floci 1.0.11, I cannot load json file into the storage even if I chose persistent/hybrid storage mode. (test kms, secretsmanager only)


## Checklist

- [x] `./mvnw test` passes locally
- [] New or updated integration test added
  - There are not related test classes so I did not add any tests.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
