### PR TITLE
fix: align S3 CreateBucket and HeadBucket region behavior with AWS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -98,8 +98,12 @@ public class S3Controller {
     public Response headBucket(@PathParam("bucket") String bucket) {
         try {
             s3Service.headBucket(bucket);
+            String bucketRegion = s3Service.getBucketRegion(bucket);
+            if (bucketRegion == null || bucketRegion.isBlank()) {
+                bucketRegion = regionResolver.getDefaultRegion();
+            }
             return Response.ok()
-                    .header("x-amz-bucket-region", regionResolver.getDefaultRegion())
+                    .header("x-amz-bucket-region", bucketRegion)
                     .build();
         } catch (AwsException e) {
             return Response.status(e.getHttpStatus()).build();
@@ -151,14 +155,25 @@ public class S3Controller {
                 locationConstraint = XmlParser.extractFirst(new String(body, StandardCharsets.UTF_8),
                         "LocationConstraint", null);
             }
-            String region = locationConstraint != null ? locationConstraint : regionResolver.getDefaultRegion();
+            if (locationConstraint != null) {
+                locationConstraint = locationConstraint.trim();
+                if (locationConstraint.isEmpty()) {
+                    locationConstraint = null;
+                } else if ("us-east-1".equalsIgnoreCase(locationConstraint)) {
+                    throw new AwsException("InvalidLocationConstraint",
+                            "The specified location-constraint is not valid.", 400);
+                }
+            }
+            String region = locationConstraint != null ? locationConstraint : regionResolver.resolveRegion(httpHeaders);
             s3Service.createBucket(bucket, region);
             String lockEnabled = httpHeaders.getHeaderString("x-amz-bucket-object-lock-enabled");
             if ("true".equalsIgnoreCase(lockEnabled)) {
                 s3Service.putBucketVersioning(bucket, "Enabled");
                 s3Service.setBucketObjectLockEnabled(bucket);
             }
-            return Response.ok().build();
+            return Response.ok()
+                    .header("Location", "/" + bucket)
+                    .build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -20,7 +20,8 @@ class S3IntegrationTest {
         .when()
             .put("/test-bucket")
         .then()
-            .statusCode(200);
+            .statusCode(200)
+            .header("Location", equalTo("/test-bucket"));
     }
 
     @Test
@@ -243,5 +244,85 @@ class S3IntegrationTest {
         .then()
             .statusCode(404)
             .body(containsString("NoSuchBucket"));
+    }
+
+    @Test
+    @Order(17)
+    void headBucketReturnsStoredRegionForLocationConstraintBucket() {
+        String bucket = "eu-head-bucket";
+        String createBucketConfiguration = """
+                <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <LocationConstraint>eu-central-1</LocationConstraint>
+                </CreateBucketConfiguration>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .body(createBucketConfiguration)
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200)
+            .header("Location", equalTo("/" + bucket));
+
+        given()
+        .when()
+            .head("/" + bucket)
+        .then()
+            .statusCode(200)
+            .header("x-amz-bucket-region", equalTo("eu-central-1"));
+
+        given()
+        .when()
+            .delete("/" + bucket)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(18)
+    void createBucketUsesSigningRegionWhenBodyEmpty() {
+        String bucket = "signed-region-bucket";
+
+        given()
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260325/eu-west-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=test")
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200)
+            .header("Location", equalTo("/" + bucket));
+
+        given()
+        .when()
+            .head("/" + bucket)
+        .then()
+            .statusCode(200)
+            .header("x-amz-bucket-region", equalTo("eu-west-1"));
+
+        given()
+        .when()
+            .delete("/" + bucket)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(19)
+    void createBucketRejectsUsEast1LocationConstraint() {
+        String createBucketConfiguration = """
+                <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <LocationConstraint>us-east-1</LocationConstraint>
+                </CreateBucketConfiguration>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .body(createBucketConfiguration)
+        .when()
+            .put("/invalid-location-bucket")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidLocationConstraint"));
     }
 }


### PR DESCRIPTION
## Summary

Align S3 bucket-creation parity with AWS by fixing the `CreateBucket` success response and related region behavior. This update adds the missing `Location` header, makes empty-body bucket creation follow the request/signing region, returns the stored bucket region from `HeadBucket`, and rejects an explicit `LocationConstraint=us-east-1` with `InvalidLocationConstraint`.

Related issue: use the bug report from this branch or replace with `Closes #N` when the issue exists.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, Floci diverged from AWS S3 in several observable ways:

- `CreateBucket` returned `200 OK` without the `Location` response header, so SDKs observed `CreateBucketOutput.Location === undefined`
- `HeadBucket` always returned the default region instead of the bucket's stored region
- empty-body `CreateBucket` ignored the request/signing region and defaulted to `us-east-1`
- explicit `LocationConstraint=us-east-1` was incorrectly accepted instead of returning `InvalidLocationConstraint`

Verification performed for this fix:

- AWS `CreateBucket` API documentation was used to confirm the expected `Location: /<bucket>` success header and invalid `us-east-1` `LocationConstraint` handling
- in-repo Floci integration tests were updated and run locally
- local `floci-compatibility-tests` Node S3 coverage was updated and run against a live Floci instance
- manual QA was run with raw HTTP requests and AWS SDK for JavaScript v3 calls against a local `mvn quarkus:dev` instance

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
