### PR TITLE
feat: implement GetRandomPassword for Secrets Manager (#76)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,7 @@ public class SecretsManagerJsonHandler {
             case "UntagResource" -> handleUntagResource(request, region);
             case "ListSecretVersionIds" -> handleListSecretVersionIds(request, region);
             case "GetResourcePolicy" -> handleGetResourcePolicy(request, region);
+            case "GetRandomPassword" -> handleGetRandomPassword(request, region);
             case "DeleteResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
             case "PutResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
             default -> Response.status(400)
@@ -298,6 +300,122 @@ public class SecretsManagerJsonHandler {
         ObjectNode response = objectMapper.createObjectNode();
         response.put("ARN", secret.getArn());
         response.put("Name", secret.getName());
+        return Response.ok(response).build();
+    }
+
+    /**
+     * Generates a random password.
+     * <p>
+     * By default uses uppercase and lowercase letters, numbers, and the following special characters:
+     * {@code !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~}
+     *
+     * @param request JSON request body with the following optional fields:
+     *   <ul>
+     *     <li>{@code PasswordLength} (Long) – Length of the password. Default: 32. Min: 1, Max: 4096.</li>
+     *     <li>{@code ExcludeCharacters} (String) – Characters to exclude from the password. Max length: 4096.</li>
+     *     <li>{@code ExcludeLowercase} (Boolean) – Exclude lowercase letters.</li>
+     *     <li>{@code ExcludeUppercase} (Boolean) – Exclude uppercase letters.</li>
+     *     <li>{@code ExcludeNumbers} (Boolean) – Exclude numbers.</li>
+     *     <li>{@code ExcludePunctuation} (Boolean) – Exclude punctuation characters.</li>
+     *     <li>{@code IncludeSpace} (Boolean) – Include the space character.</li>
+     *     <li>{@code RequireEachIncludedType} (Boolean) – Require at least one character from each included type. Default: true.</li>
+     *   </ul>
+     * @param region AWS region (unused for this operation)
+     * @return response containing {@code RandomPassword} string
+     * @see <a href="https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetRandomPassword.html">AWS Secrets Manager – GetRandomPassword</a>
+     */
+    private Response handleGetRandomPassword(JsonNode request, String region) {
+
+        var excludeCharacters = request.get("ExcludeCharacters");
+        var excludeLowerCase = request.get("ExcludeLowercase");
+        var excludeNumbers = request.get("ExcludeNumbers");
+        var excludePunctuation = request.get("ExcludePunctuation");
+        var excludeUpperCase = request.get("ExcludeUppercase");
+        var includeSpace = request.get("IncludeSpace");
+        var passwordLength = request.get("PasswordLength");
+        var requireEachIncludedType = request.get("RequireEachIncludedType");
+
+        int length = (passwordLength != null && !passwordLength.isNull()) ? passwordLength.asInt(32) : 32;
+        if (length < 1 || length > 4096) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("InvalidParameterException", "PasswordLength must be between 1 and 4096."))
+                    .build();
+        }
+
+        StringBuilder charset = new StringBuilder();
+        if (excludeLowerCase == null || excludeLowerCase.isNull() || !excludeLowerCase.asBoolean()) {
+            charset.append("abcdefghijklmnopqrstuvwxyz");
+        }
+        if (excludeUpperCase == null || excludeUpperCase.isNull() || !excludeUpperCase.asBoolean()) {
+            charset.append("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        }
+        if (excludeNumbers == null || excludeNumbers.isNull() || !excludeNumbers.asBoolean()) {
+            charset.append("0123456789");
+        }
+        if (excludePunctuation == null || excludePunctuation.isNull() || !excludePunctuation.asBoolean()) {
+            charset.append("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+        }
+        if (includeSpace != null && !includeSpace.isNull() && includeSpace.asBoolean()) {
+            charset.append(" ");
+        }
+        if (excludeCharacters != null && !excludeCharacters.isNull()) {
+            String excluded = excludeCharacters.asText();
+            for (int i = charset.length() - 1; i >= 0; i--) {
+                if (excluded.indexOf(charset.charAt(i)) >= 0) {
+                    charset.deleteCharAt(i);
+                }
+            }
+        }
+
+        SecureRandom random = new SecureRandom();
+        StringBuilder password = new StringBuilder(length);
+
+        boolean requireEach = requireEachIncludedType == null || requireEachIncludedType.isNull() || requireEachIncludedType.asBoolean();
+        if (requireEach) {
+            List<String> includedTypes = new ArrayList<>();
+            if (excludeLowerCase == null || excludeLowerCase.isNull() || !excludeLowerCase.asBoolean()) {
+                includedTypes.add("abcdefghijklmnopqrstuvwxyz");
+            }
+            if (excludeUpperCase == null || excludeUpperCase.isNull() || !excludeUpperCase.asBoolean()) {
+                includedTypes.add("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            }
+            if (excludeNumbers == null || excludeNumbers.isNull() || !excludeNumbers.asBoolean()) {
+                includedTypes.add("0123456789");
+            }
+            if (excludePunctuation == null || excludePunctuation.isNull() || !excludePunctuation.asBoolean()) {
+                includedTypes.add("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+            }
+            if (includeSpace != null && !includeSpace.isNull() && includeSpace.asBoolean()) {
+                includedTypes.add(" ");
+            }
+            if (excludeCharacters != null && !excludeCharacters.isNull()) {
+                String excluded = excludeCharacters.asText();
+                includedTypes = includedTypes.stream()
+                        .map(t -> t.chars().filter(c -> excluded.indexOf(c) < 0)
+                                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString())
+                        .filter(t -> !t.isEmpty())
+                        .collect(java.util.stream.Collectors.toList());
+            }
+            // Seed one char from each required type
+            for (String type : includedTypes) {
+                password.append(type.charAt(random.nextInt(type.length())));
+            }
+        }
+
+        for (int i = password.length(); i < length; i++) {
+            password.append(charset.charAt(random.nextInt(charset.length())));
+        }
+
+        // Shuffle so required chars aren't always at the start
+        for (int i = length - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            char tmp = password.charAt(i);
+            password.setCharAt(i, password.charAt(j));
+            password.setCharAt(j, tmp);
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("RandomPassword", password.toString());
         return Response.ok(response).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.secretsmanager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class SecretsManagerJsonHandlerTest {
+
+    private static final String REGION = "us-east-1";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private SecretsManagerJsonHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        SecretsManagerService service = new SecretsManagerService(new InMemoryStorage<>(), 30);
+        handler = new SecretsManagerJsonHandler(service, MAPPER);
+    }
+
+    private String getRandomPassword(ObjectNode request) {
+        Response response = handler.handle("GetRandomPassword", request, REGION);
+        assertThat(response.getStatus(), is(200));
+        return ((ObjectNode) response.getEntity()).get("RandomPassword").asText();
+    }
+
+    @Test
+    void defaultLengthIs32() {
+        assertThat(getRandomPassword(MAPPER.createObjectNode()), hasLength(32));
+    }
+
+    @Test
+    void customLength() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("PasswordLength", 20);
+        assertThat(getRandomPassword(request), hasLength(20));
+    }
+
+    @Test
+    void lengthAbove4096Returns400() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("PasswordLength", 4097);
+        assertThat(handler.handle("GetRandomPassword", request, REGION).getStatus(), is(400));
+    }
+
+    @Test
+    void lengthBelowOneReturns400() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("PasswordLength", 0);
+        assertThat(handler.handle("GetRandomPassword", request, REGION).getStatus(), is(400));
+    }
+
+    @Test
+    void excludeLowercase() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludeLowercase", true);
+        assertThat(getRandomPassword(request), not(matchesPattern(".*[a-z].*")));
+    }
+
+    @Test
+    void excludeUppercase() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludeUppercase", true);
+        assertThat(getRandomPassword(request), not(matchesPattern(".*[A-Z].*")));
+    }
+
+    @Test
+    void excludeNumbers() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludeNumbers", true);
+        assertThat(getRandomPassword(request), not(matchesPattern(".*[0-9].*")));
+    }
+
+    @Test
+    void excludePunctuation() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludePunctuation", true);
+        assertThat(getRandomPassword(request), not(matchesPattern(".*[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~].*")));
+    }
+
+    @Test
+    void includeSpace() {
+        // Only spaces are possible, so every char must be a space
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("IncludeSpace", true);
+        request.put("ExcludeLowercase", true);
+        request.put("ExcludeUppercase", true);
+        request.put("ExcludeNumbers", true);
+        request.put("ExcludePunctuation", true);
+        request.put("RequireEachIncludedType", true);
+        request.put("PasswordLength", 5);
+        assertThat(getRandomPassword(request), is("     "));
+    }
+
+    @Test
+    void excludeCharacters() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludeCharacters", "aeiouAEIOU");
+        assertThat(getRandomPassword(request), not(matchesPattern(".*[aeiouAEIOU].*")));
+    }
+
+    @Test
+    void requireEachIncludedTypeDefaultsTrue() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("PasswordLength", 100);
+        String password = getRandomPassword(request);
+        assertThat(password, matchesPattern(".*[a-z].*"));
+        assertThat(password, matchesPattern(".*[A-Z].*"));
+        assertThat(password, matchesPattern(".*[0-9].*"));
+        assertThat(password, hasLength(100));
+    }
+
+    @Test
+    void requireEachIncludedTypeFalse() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("ExcludeLowercase", true);
+        request.put("ExcludeUppercase", true);
+        request.put("ExcludePunctuation", true);
+        request.put("RequireEachIncludedType", false);
+        assertThat(getRandomPassword(request), matchesPattern("[0-9]+"));
+    }
+}


### PR DESCRIPTION
Generates a random password respecting all AWS request parameters: PasswordLength (1–4096), ExcludeCharacters, ExcludeLowercase, ExcludeUppercase, ExcludeNumbers, ExcludePunctuation, IncludeSpace, and RequireEachIncludedType.

Closes #76

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility



## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
