### PR TITLE
fix: cognito well-known endpoints and rs256 signing

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -3,7 +3,7 @@
 **Protocol:** JSON 1.1 (`X-Amz-Target: AWSCognitoIdentityProviderService.*`)
 **Endpoint:** `POST http://localhost:4566/`
 
-Floci also serves OIDC well-known endpoints, making it compatible with JWT validation libraries.
+Floci serves pool-specific discovery and JWKS endpoints so local clients can validate Cognito-like JWTs against RS256 signing keys.
 
 ## Supported Actions
 
@@ -16,12 +16,12 @@ Floci also serves OIDC well-known endpoints, making it compatible with JWT valid
 | **Authentication** | InitiateAuth, AdminInitiateAuth, RespondToAuthChallenge |
 | **User Listing** | ListUsers |
 
-## OIDC Well-Known Endpoints
+## Well-Known Endpoints
 
 | Endpoint | Description |
 |---|---|
-| `GET /.well-known/openid-configuration` | OIDC discovery document |
-| `GET /.well-known/jwks.json` | JSON Web Key Set for JWT validation |
+| `GET /{userPoolId}/.well-known/openid-configuration` | OpenID discovery document |
+| `GET /{userPoolId}/.well-known/jwks.json` | JSON Web Key Set for JWT validation |
 
 ## Examples
 
@@ -63,20 +63,27 @@ aws cognito-idp initiate-auth \
   --client-id $CLIENT_ID \
   --auth-parameters USERNAME=alice@example.com,PASSWORD=Perm1234! \
   --endpoint-url $AWS_ENDPOINT
+
+# Fetch the pool discovery document
+curl -s "$AWS_ENDPOINT/$POOL_ID/.well-known/openid-configuration"
 ```
 
 ## JWT Validation
 
-Tokens issued by Floci can be validated using the JWKS endpoint:
+Tokens issued by Floci can be validated using the discovery and JWKS endpoints:
 
 ```
-http://localhost:4566/.well-known/jwks.json
+http://localhost:4566/$POOL_ID/.well-known/openid-configuration
 ```
 
-The OIDC discovery endpoint returns:
-
 ```
-http://localhost:4566/.well-known/openid-configuration
+http://localhost:4566/$POOL_ID/.well-known/jwks.json
 ```
 
-This allows libraries like `jsonwebtoken`, `jose`, or Spring Security to validate tokens against Floci the same way they would against real Cognito.
+Tokens issued by Cognito auth flows keep the emulator issuer format:
+
+```
+https://cognito-idp.local/$POOL_ID
+```
+
+This allows libraries like `jsonwebtoken`, `jose`, or Spring Security to validate tokens against Floci using the emulator's published issuer, discovery, and JWKS endpoints.

--- a/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.services.cognito.CognitoWellKnownController;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
@@ -15,6 +18,9 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
 
     private static final Pattern AUTH_SERVICE_PATTERN =
             Pattern.compile("Credential=\\S+/\\d{8}/[^/]+/([^/]+)/");
+
+    @Context
+    ResourceInfo resourceInfo;
 
     private final ServiceRegistry serviceRegistry;
 
@@ -48,7 +54,7 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
             }
         }
 
-        return null;
+        return serviceKeyFromMatchedResource();
     }
 
     private String serviceKeyFromTarget(String target) {
@@ -75,12 +81,24 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
         };
     }
 
+    private String serviceKeyFromMatchedResource() {
+        Class<?> resourceClass = resourceInfo != null ? resourceInfo.getResourceClass() : null;
+        if (resourceClass == null) {
+            return null;
+        }
+        if (CognitoWellKnownController.class.equals(resourceClass)) {
+            return "cognito-idp";
+        }
+        return null;
+    }
+
     private Response disabledResponse(ContainerRequestContext ctx, String serviceKey) {
         String message = "Service " + serviceKey + " is not enabled.";
         String target = ctx.getHeaderString("X-Amz-Target");
         String contentType = ctx.getMediaType() != null ? ctx.getMediaType().toString() : "";
+        boolean jsonEndpoint = serviceKeyFromMatchedResource() != null;
 
-        if (target != null || contentType.contains("json")) {
+        if (target != null || contentType.contains("json") || jsonEndpoint) {
             return Response.status(400)
                     .type(MediaType.APPLICATION_JSON)
                     .entity(new AwsErrorResponse("ServiceNotAvailableException", message))

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -11,10 +11,17 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.*;
 
 @ApplicationScoped
@@ -43,14 +50,17 @@ public class CognitoService {
         UserPool pool = new UserPool();
         pool.setId(id);
         pool.setName(name);
+        ensureJwtSigningKeys(pool);
         poolStore.put(id, pool);
         LOG.infov("Created User Pool: {0}", id);
         return pool;
     }
 
     public UserPool describeUserPool(String id) {
-        return poolStore.get(id)
+        UserPool pool = poolStore.get(id)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool not found", 404));
+        ensureJwtSigningKeys(pool);
+        return pool;
     }
 
     public List<UserPool> listUserPools() {
@@ -385,7 +395,9 @@ public class CognitoService {
     }
 
     private String generateSignedJwt(CognitoUser user, UserPool pool, String type) {
-        String headerJson = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+        String headerJson = String.format(
+                "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"kid\":\"%s\"}",
+                escapeJson(getSigningKeyId(pool)));
         String header = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
 
@@ -401,15 +413,14 @@ public class CognitoService {
         );
         String payload = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
-
-        String signingInput = header + "." + payload;
-        String signature = hmacSha256(signingInput, pool.getSigningSecret());
-        return signingInput + "." + signature;
+        return signJwt(header, payload, getSigningPrivateKey(pool));
     }
 
     private String generateTokenString(String type, String username, UserPool pool) {
         long now = System.currentTimeMillis() / 1000L;
-        String headerJson = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+        String headerJson = String.format(
+                "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"kid\":\"%s\"}",
+                escapeJson(getSigningKeyId(pool)));
         String header = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
         String payloadJson = String.format(
@@ -419,19 +430,87 @@ public class CognitoService {
         );
         String payload = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        return signJwt(header, payload, getSigningPrivateKey(pool));
+    }
+
+    private String signJwt(String header, String payload, PrivateKey signingKey) {
         String signingInput = header + "." + payload;
-        String signature = hmacSha256(signingInput, pool.getSigningSecret());
+        String signature = rsaSha256(signingInput, signingKey);
         return signingInput + "." + signature;
     }
 
-    private String hmacSha256(String data, String key) {
+    private String rsaSha256(String data, PrivateKey signingKey) {
         try {
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            byte[] sig = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            signature.initSign(signingKey);
+            signature.update(data.getBytes(StandardCharsets.UTF_8));
+            byte[] sig = signature.sign();
             return Base64.getUrlEncoder().withoutPadding().encodeToString(sig);
         } catch (Exception e) {
             throw new RuntimeException("JWT signing failed", e);
+        }
+    }
+
+    String getSigningKeyId(UserPool pool) {
+        ensureJwtSigningKeys(pool);
+        return pool.getSigningKeyId();
+    }
+
+    RSAPublicKey getSigningPublicKey(UserPool pool) {
+        ensureJwtSigningKeys(pool);
+
+        try {
+            byte[] encoded = Base64.getDecoder().decode(pool.getSigningPublicKey());
+            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(encoded);
+            PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(keySpec);
+            return (RSAPublicKey) publicKey;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load Cognito RSA public key", e);
+        }
+    }
+
+    private PrivateKey getSigningPrivateKey(UserPool pool) {
+        ensureJwtSigningKeys(pool);
+
+        try {
+            byte[] encoded = Base64.getDecoder().decode(pool.getSigningPrivateKey());
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+            return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load Cognito RSA private key", e);
+        }
+    }
+
+    private void ensureJwtSigningKeys(UserPool pool) {
+        synchronized (pool) {
+            boolean changed = false;
+
+            if (pool.getSigningKeyId() == null || pool.getSigningKeyId().isBlank()) {
+                pool.setSigningKeyId(pool.getId());
+                changed = true;
+            }
+
+            if (pool.getSigningPrivateKey() == null || pool.getSigningPrivateKey().isBlank()
+                    || pool.getSigningPublicKey() == null || pool.getSigningPublicKey().isBlank()) {
+                try {
+                    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+                    generator.initialize(2048);
+                    KeyPair keyPair = generator.generateKeyPair();
+
+                    pool.setSigningPrivateKey(
+                            Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
+                    pool.setSigningPublicKey(
+                            Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+                    changed = true;
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to generate Cognito RSA signing keypair", e);
+                }
+            }
+
+            if (changed && pool.getId() != null) {
+                pool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+                poolStore.put(pool.getId(), pool);
+            }
         }
     }
 
@@ -493,5 +572,11 @@ public class CognitoService {
 
     private String userKey(String poolId, String username) {
         return poolId + "::" + username;
+    }
+
+    private String escapeJson(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoWellKnownController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoWellKnownController.java
@@ -6,10 +6,12 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
-import java.nio.charset.StandardCharsets;
+import java.math.BigInteger;
 import java.util.Base64;
 
 /**
@@ -32,14 +34,40 @@ public class CognitoWellKnownController {
     @Path("/{poolId}/.well-known/jwks.json")
     public Response getJwks(@PathParam("poolId") String poolId) {
         UserPool pool = cognitoService.describeUserPool(poolId);
-        String kid = pool.getId();
-        // Encode signing secret bytes as Base64URL (no padding) for the JWK "k" parameter
-        byte[] secretBytes = pool.getSigningSecret().getBytes(StandardCharsets.UTF_8);
-        String k = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        String kid = cognitoService.getSigningKeyId(pool);
+        var publicKey = cognitoService.getSigningPublicKey(pool);
+        String modulus = base64UrlEncodeUnsigned(publicKey.getModulus());
+        String exponent = base64UrlEncodeUnsigned(publicKey.getPublicExponent());
 
         String body = """
-                {"keys":[{"kty":"oct","kid":"%s","alg":"HS256","k":"%s","use":"sig"}]}
-                """.formatted(kid, k).strip();
+                {"keys":[{"kty":"RSA","kid":"%s","alg":"RS256","n":"%s","e":"%s","use":"sig"}]}
+                """.formatted(kid, modulus, exponent).strip();
         return Response.ok(body).build();
+    }
+
+    @GET
+    @Path("/{poolId}/.well-known/openid-configuration")
+    public Response getOpenIdConfiguration(@PathParam("poolId") String poolId, @Context UriInfo uriInfo) {
+        UserPool pool = cognitoService.describeUserPool(poolId);
+        String issuer = "https://cognito-idp.local/" + pool.getId();
+        String jwksUri = uriInfo.getBaseUriBuilder()
+                .path(pool.getId())
+                .path(".well-known")
+                .path("jwks.json")
+                .build()
+                .toString();
+
+        String body = """
+                {"issuer":"%s","jwks_uri":"%s","subject_types_supported":["public"],"response_types_supported":["code","token","id_token"],"id_token_signing_alg_values_supported":["RS256"]}
+                """.formatted(issuer, jwksUri).strip();
+        return Response.ok(body).build();
+    }
+
+    private String base64UrlEncodeUnsigned(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            bytes = java.util.Arrays.copyOfRange(bytes, 1, bytes.length);
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
@@ -9,6 +9,9 @@ public class UserPool {
     private String id;
     private String name;
     private String signingSecret;
+    private String signingKeyId;
+    private String signingPublicKey;
+    private String signingPrivateKey;
     private long creationDate;
     private long lastModifiedDate;
 
@@ -27,6 +30,15 @@ public class UserPool {
 
     public String getSigningSecret() { return signingSecret; }
     public void setSigningSecret(String signingSecret) { this.signingSecret = signingSecret; }
+
+    public String getSigningKeyId() { return signingKeyId; }
+    public void setSigningKeyId(String signingKeyId) { this.signingKeyId = signingKeyId; }
+
+    public String getSigningPublicKey() { return signingPublicKey; }
+    public void setSigningPublicKey(String signingPublicKey) { this.signingPublicKey = signingPublicKey; }
+
+    public String getSigningPrivateKey() { return signingPrivateKey; }
+    public void setSigningPrivateKey(String signingPrivateKey) { this.signingPrivateKey = signingPrivateKey; }
 
     public long getCreationDate() { return creationDate; }
     public void setCreationDate(long creationDate) { this.creationDate = creationDate; }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -1,0 +1,230 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CognitoIntegrationTest {
+
+    private static final String COGNITO_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static String poolId;
+    private static String clientId;
+    private static final String username = "alice+" + UUID.randomUUID() + "@example.com";
+    private static final String password = "Perm1234!";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssured.config = RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(COGNITO_CONTENT_TYPE, ContentType.TEXT));
+    }
+
+    @Test
+    @Order(1)
+    void createPoolClientAndUser() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "JwtPool"
+                }
+                """);
+        poolId = poolResponse.path("UserPool").path("Id").asText();
+
+        JsonNode clientResponse = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "jwt-client"
+                }
+                """.formatted(poolId));
+        clientId = clientResponse.path("UserPoolClient").path("ClientId").asText();
+
+        cognitoAction("AdminCreateUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "%s" }
+                  ]
+                }
+                """.formatted(poolId, username, username))
+                .then()
+                .statusCode(200);
+
+        cognitoAction("AdminSetUserPassword", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s",
+                  "Password": "%s",
+                  "Permanent": true
+                }
+                """.formatted(poolId, username, password))
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void initiateAuthReturnsAuthenticationResult() {
+        cognitoAction("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {
+                    "USERNAME": "%s",
+                    "PASSWORD": "%s"
+                  }
+                }
+                """.formatted(clientId, username, password))
+                .then()
+                .statusCode(200)
+                .body("AuthenticationResult.AccessToken", org.hamcrest.Matchers.notNullValue())
+                .body("AuthenticationResult.IdToken", org.hamcrest.Matchers.notNullValue())
+                .body("AuthenticationResult.RefreshToken", org.hamcrest.Matchers.notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void authTokensAreSignedWithPublishedRsaJwksKey() throws Exception {
+        Response authResponse = cognitoAction("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {
+                    "USERNAME": "%s",
+                    "PASSWORD": "%s"
+                  }
+                }
+                """.formatted(clientId, username, password));
+
+        authResponse.then().statusCode(200);
+
+        String accessToken = authResponse.jsonPath().getString("AuthenticationResult.AccessToken");
+        JsonNode header = decodeJwtHeader(accessToken);
+        JsonNode payload = decodeJwtPayload(accessToken);
+        assertEquals("RS256", header.path("alg").asText());
+        assertEquals(poolId, header.path("kid").asText());
+        assertEquals("https://cognito-idp.local/" + poolId, payload.path("iss").asText());
+        assertEquals(username, payload.path("username").asText());
+        assertEquals("access", payload.path("token_use").asText());
+
+        String jwksResponse = given()
+        .when()
+                .get("/" + poolId + "/.well-known/jwks.json")
+        .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        JsonNode jwks = OBJECT_MAPPER.readTree(jwksResponse);
+        JsonNode key = jwks.path("keys").get(0);
+        assertNotNull(key);
+        assertEquals("RSA", key.path("kty").asText());
+        assertEquals("RS256", key.path("alg").asText());
+        assertEquals("sig", key.path("use").asText());
+        assertEquals(poolId, key.path("kid").asText());
+        assertTrue(key.hasNonNull("n"));
+        assertTrue(key.hasNonNull("e"));
+        assertTrue(verifyJwtSignature(accessToken, key));
+    }
+
+    @Test
+    @Order(4)
+    void openIdConfigurationPublishesIssuerAndJwksUri() throws Exception {
+        String openIdResponse = given()
+        .when()
+                .get("/" + poolId + "/.well-known/openid-configuration")
+        .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        JsonNode document = OBJECT_MAPPER.readTree(openIdResponse);
+        assertEquals("https://cognito-idp.local/" + poolId, document.path("issuer").asText());
+        assertEquals(
+                "http://localhost:" + RestAssured.port + "/" + poolId + "/.well-known/jwks.json",
+                document.path("jwks_uri").asText());
+        assertEquals("public", document.path("subject_types_supported").get(0).asText());
+        assertEquals("RS256", document.path("id_token_signing_alg_values_supported").get(0).asText());
+    }
+
+    private static Response cognitoAction(String action, String body) {
+        return given()
+                .header("X-Amz-Target", "AWSCognitoIdentityProviderService." + action)
+                .contentType(COGNITO_CONTENT_TYPE)
+                .body(body)
+        .when()
+                .post("/");
+    }
+
+    private static JsonNode cognitoJson(String action, String body) throws Exception {
+        String response = cognitoAction(action, body)
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        return OBJECT_MAPPER.readTree(response);
+    }
+
+    private static JsonNode decodeJwtPayload(String token) throws Exception {
+        return decodeJwtPart(token, 1);
+    }
+
+    private static JsonNode decodeJwtHeader(String token) throws Exception {
+        return decodeJwtPart(token, 0);
+    }
+
+    private static JsonNode decodeJwtPart(String token, int partIndex) throws Exception {
+        String[] parts = token.split("\\.");
+        assertEquals(3, parts.length);
+        return OBJECT_MAPPER.readTree(Base64.getUrlDecoder().decode(padBase64(parts[partIndex])));
+    }
+
+    private static boolean verifyJwtSignature(String token, JsonNode jwk) throws Exception {
+        String[] parts = token.split("\\.");
+        assertEquals(3, parts.length);
+
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(padBase64(jwk.path("n").asText())));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(padBase64(jwk.path("e").asText())));
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(modulus, exponent);
+        PublicKey publicKey = KeyFactory.getInstance("RSA").generatePublic(keySpec);
+
+        Signature signature = Signature.getInstance("SHA256withRSA");
+        signature.initVerify(publicKey);
+        signature.update((parts[0] + "." + parts[1]).getBytes(StandardCharsets.UTF_8));
+        return signature.verify(Base64.getUrlDecoder().decode(padBase64(parts[2])));
+    }
+
+    private static String padBase64(String value) {
+        int remainder = value.length() % 4;
+        if (remainder == 0) {
+            return value;
+        }
+        return value + "=".repeat(4 - remainder);
+    }
+}


### PR DESCRIPTION
## Summary

Add Cognito well-known metadata support and switch Cognito JWT signing to RS256.
This PR:
- adds `GET /{userPoolId}/.well-known/openid-configuration`
- adds pool-scoped JWKS publishing at `GET /{userPoolId}/.well-known/jwks.json`
- switches Cognito-issued JWTs from HS256 to RS256 so they can be validated against the published JWKS
- fixes service-enabled filtering so Cognito well-known endpoints are correctly gated by `cognito-idp` without misclassifying unrelated routes
- makes lazy RSA key initialization safe for existing pools

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior before this change:
- Cognito tokens were not published through a proper pool-scoped discovery document
- JWT validation against a public JWKS was not possible because tokens were not signed with RS256
- the new well-known routes were not safely integrated with service enablement checks

After this change, Floci publishes Cognito discovery/JWKS metadata and signs Cognito JWTs with RS256 using the advertised key set.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Closes #64 
