### PR TITLE
fix: extract region from ARN for cross-region SQS delivery

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -418,8 +418,9 @@ public class EventBridgeService {
                 lambdaService.invoke(fnRegion, fnName, payload.getBytes(), InvocationType.Event);
                 LOG.debugv("EventBridge delivered to Lambda: {0}", arn);
             } else if (arn.contains(":sqs:")) {
+                String sqsRegion = extractRegionFromArn(arn, region);
                 String queueUrl = sqsArnToUrl(arn);
-                sqsService.sendMessage(queueUrl, payload, 0);
+                sqsService.sendMessage(queueUrl, payload, 0, null, null, sqsRegion);
                 LOG.debugv("EventBridge delivered to SQS: {0}", arn);
             } else if (arn.contains(":sns:")) {
                 String topicRegion = extractRegionFromArn(arn, region);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -71,6 +71,16 @@ public class S3Service {
                 new ObjectMapper());
     }
 
+    /**
+     * Package-private constructor for testing with SQS integration.
+     */
+    S3Service(StorageBackend<String, Bucket> bucketStore,
+              StorageBackend<String, S3Object> objectStore,
+              Path dataRoot, SqsService sqsService, RegionResolver regionResolver) {
+        this(bucketStore, objectStore, dataRoot, sqsService, null, regionResolver, "http://localhost:4566",
+                new ObjectMapper());
+    }
+
     private S3Service(StorageBackend<String, Bucket> bucketStore,
                       StorageBackend<String, S3Object> objectStore,
                       Path dataRoot, SqsService sqsService, SnsService snsService,
@@ -1024,7 +1034,8 @@ public class S3Service {
         for (QueueNotification qn : config.getQueueConfigurations()) {
             if (qn.events().stream().anyMatch(p -> matchesEvent(p, eventName))) {
                 try {
-                    sqsService.sendMessage(sqsUrlFromArn(qn.queueArn()), eventJson, 0);
+                    String queueRegion = extractRegionFromArn(qn.queueArn(), region);
+                    sqsService.sendMessage(sqsUrlFromArn(qn.queueArn()), eventJson, 0, null, null, queueRegion);
                     LOG.debugv("Fired S3 event {0} to SQS {1}", eventName, qn.queueArn());
                 } catch (Exception e) {
                     LOG.warnv("Failed to deliver S3 event to SQS {0}: {1}", qn.queueArn(), e.getMessage());
@@ -1050,6 +1061,11 @@ public class S3Service {
             return full.startsWith(pattern.substring(0, pattern.length() - 1));
         }
         return full.equals(pattern);
+    }
+
+    private static String extractRegionFromArn(String arn, String defaultRegion) {
+        String[] parts = arn.split(":");
+        return parts.length >= 4 && !parts[3].isEmpty() ? parts[3] : defaultRegion;
     }
 
     private String sqsUrlFromArn(String arn) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -68,7 +68,7 @@ public class SqsService {
                 new RegionResolver("us-east-1", "000000000000"));
     }
 
-    SqsService(StorageBackend<String, Queue> queueStore, StorageBackend<String, List<Message>> messageStore,
+    public SqsService(StorageBackend<String, Queue> queueStore, StorageBackend<String, List<Message>> messageStore,
                StorageBackend<String, Map<String, Long>> dedupStore,
                int defaultVisibilityTimeout, int maxMessageSize, String baseUrl,
                RegionResolver regionResolver) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -8,6 +8,8 @@ import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.model.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -313,5 +315,80 @@ class EventBridgeServiceTest {
 
         EventBridgeService.PutEventsResult result = service.putEvents(entries, REGION);
         assertEquals(1, result.failedCount());
+    }
+
+    // ──────────────────────────── Cross-Region SQS Delivery ────────────────────────────
+
+    @Test
+    void putEventsDeliversToCrossRegionSqsTarget() {
+        String crossRegion = "eu-west-1";
+        String queueName = "cross-region-queue";
+        String sqsArn = "arn:aws:sqs:" + crossRegion + ":000000000000:" + queueName;
+
+        RegionResolver regionResolver = new RegionResolver(REGION, "000000000000");
+        SqsService sqsService = new SqsService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                30, 262144, "http://localhost:4566", regionResolver);
+
+        sqsService.createQueue(queueName, null, crossRegion);
+
+        EventBridgeService ebWithSqs = new EventBridgeService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                regionResolver, null, sqsService, null, new ObjectMapper());
+
+        ebWithSqs.putRule("test-rule", null,
+                "{\"source\":[\"my.app\"]}", null, RuleState.ENABLED,
+                null, null, null, REGION);
+
+        Target target = new Target();
+        target.setId("sqs-target");
+        target.setArn(sqsArn);
+        ebWithSqs.putTargets("test-rule", null, List.of(target), REGION);
+
+        List<Map<String, Object>> entries = List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{\"key\":\"value\"}")
+        );
+        EventBridgeService.PutEventsResult result = ebWithSqs.putEvents(entries, REGION);
+        assertEquals(0, result.failedCount());
+
+        String queueUrl = "http://localhost:4566/000000000000/" + queueName;
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, crossRegion);
+        assertEquals(1, messages.size());
+    }
+
+    @Test
+    void putEventsDeliversToSameRegionSqsTarget() {
+        String queueName = "same-region-queue";
+        String sqsArn = "arn:aws:sqs:" + REGION + ":000000000000:" + queueName;
+
+        RegionResolver regionResolver = new RegionResolver(REGION, "000000000000");
+        SqsService sqsService = new SqsService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                30, 262144, "http://localhost:4566", regionResolver);
+
+        sqsService.createQueue(queueName, null, REGION);
+
+        EventBridgeService ebWithSqs = new EventBridgeService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                regionResolver, null, sqsService, null, new ObjectMapper());
+
+        ebWithSqs.putRule("test-rule", null,
+                "{\"source\":[\"my.app\"]}", null, RuleState.ENABLED,
+                null, null, null, REGION);
+
+        Target target = new Target();
+        target.setId("sqs-target");
+        target.setArn(sqsArn);
+        ebWithSqs.putTargets("test-rule", null, List.of(target), REGION);
+
+        List<Map<String, Object>> entries = List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{}")
+        );
+        EventBridgeService.PutEventsResult result = ebWithSqs.putEvents(entries, REGION);
+        assertEquals(0, result.failedCount());
+
+        String queueUrl = "http://localhost:4566/000000000000/" + queueName;
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(1, messages.size());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -1,11 +1,16 @@
 package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
+import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
 import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
+import io.github.hectorvent.floci.services.s3.model.QueueNotification;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.model.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -277,5 +282,77 @@ class S3ServiceTest {
         assertEquals("application/json", copy.getContentType());
         assertEquals("STANDARD_IA", copy.getStorageClass());
         assertEquals("dest", copy.getMetadata().get("owner"));
+    }
+
+    // ──────────────────────────── S3 → SQS Cross-Region Notification ────────────────────────────
+
+    @Test
+    void s3NotificationDeliveresToCrossRegionSqsQueue() {
+        String defaultRegion = "us-east-1";
+        String crossRegion = "eu-west-1";
+        String queueName = "s3-notification-queue";
+        String sqsArn = "arn:aws:sqs:" + crossRegion + ":000000000000:" + queueName;
+
+        RegionResolver regionResolver = new RegionResolver(defaultRegion, "000000000000");
+        SqsService sqsService = new SqsService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                30, 262144, "http://localhost:4566", regionResolver);
+
+        sqsService.createQueue(queueName, null, crossRegion);
+
+        Path dataRoot = tempDir.resolve("s3-cross-region");
+        S3Service s3WithSqs = new S3Service(
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                dataRoot, sqsService, regionResolver);
+
+        s3WithSqs.createBucket("notify-bucket", defaultRegion);
+
+        NotificationConfiguration notifConfig = new NotificationConfiguration();
+        notifConfig.setQueueConfigurations(List.of(
+                new QueueNotification("notif-1", sqsArn, List.of("s3:ObjectCreated:*"))
+        ));
+        s3WithSqs.putBucketNotificationConfiguration("notify-bucket", notifConfig);
+
+        s3WithSqs.putObject("notify-bucket", "test-key.txt", "hello".getBytes(StandardCharsets.UTF_8),
+                "text/plain", null, "STANDARD", null, null, null);
+
+        String queueUrl = "http://localhost:4566/000000000000/" + queueName;
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, crossRegion);
+        assertEquals(1, messages.size());
+        assertTrue(messages.getFirst().getBody().contains("test-key.txt"));
+    }
+
+    @Test
+    void s3NotificationDeliveresToSameRegionSqsQueue() {
+        String region = "us-east-1";
+        String queueName = "s3-same-region-queue";
+        String sqsArn = "arn:aws:sqs:" + region + ":000000000000:" + queueName;
+
+        RegionResolver regionResolver = new RegionResolver(region, "000000000000");
+        SqsService sqsService = new SqsService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                30, 262144, "http://localhost:4566", regionResolver);
+
+        sqsService.createQueue(queueName, null, region);
+
+        Path dataRoot = tempDir.resolve("s3-same-region");
+        S3Service s3WithSqs = new S3Service(
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                dataRoot, sqsService, regionResolver);
+
+        s3WithSqs.createBucket("same-region-bucket", region);
+
+        NotificationConfiguration notifConfig = new NotificationConfiguration();
+        notifConfig.setQueueConfigurations(List.of(
+                new QueueNotification("notif-1", sqsArn, List.of("s3:ObjectCreated:*"))
+        ));
+        s3WithSqs.putBucketNotificationConfiguration("same-region-bucket", notifConfig);
+
+        s3WithSqs.putObject("same-region-bucket", "file.txt", "data".getBytes(StandardCharsets.UTF_8),
+                "text/plain", null, "STANDARD", null, null, null);
+
+        String queueUrl = "http://localhost:4566/000000000000/" + queueName;
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, region);
+        assertEquals(1, messages.size());
     }
 }


### PR DESCRIPTION
## Summary

EventBridge and S3 were ignoring the region in SQS target ARNs when delivering messages, always using the emulator's default region. This caused cross-region SQS delivery to fail with `NonExistentQueue` errors.

Both services now extract the region from the ARN and pass it to the region-aware `sendMessage` overload, consistent with how Lambda and SNS targets are already handled.

**Affected code paths:**
- `EventBridgeService.invokeTarget` — SQS branch (line 420)
- `S3Service.fireNotifications` — queue notification loop (line 1027)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `EventBridgeService.invokeTarget` and `S3Service.fireNotifications` called `sqsService.sendMessage(queueUrl, payload, 0)` (3-arg overload), which internally defaults to `regionResolver.getDefaultRegion()`. When the SQS target ARN specified a different region (e.g. `arn:aws:sqs:eu-west-1:...`), the message was sent to the wrong regional queue store, resulting in `NonExistentQueue` errors.

Other service integrations (SNS→SQS, EventBridge→Lambda, EventBridge→SNS) already extract the region correctly — only the two SQS paths were missing this.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)