### PR TITLE
fix: DynamoDB table creation compatibility with Terraform AWS provider v6

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonController.java
@@ -195,8 +195,9 @@ public class AwsJsonController {
 
     /**
      * Handles AWS smithy-rpc-v2-cbor protocol requests.
-     * Go SDK CloudWatch v1.55.1+ sends to POST /service/{serviceId}/operation/{op}
+     * AWS SDK v2 sends to POST /service/{sdkId}/operation/{op}
      * with Content-Type: application/cbor and no X-Amz-Target header.
+     * Supported services: DynamoDB, SQS, SNS, StepFunctions, CloudWatch.
      */
     @POST
     @Path("service/{serviceId}/operation/{operation}")
@@ -208,11 +209,7 @@ public class AwsJsonController {
             @Context HttpHeaders httpHeaders,
             byte[] body) {
 
-        if (!CLOUDWATCH_SERVICE_ID.equals(serviceId)) {
-            return Response.status(404).build();
-        }
-
-        LOG.debugv("CloudWatch RPC v2 CBOR action: {0}", operation);
+        LOG.debugv("Smithy RPC v2 CBOR: service={0}, operation={1}", serviceId, operation);
 
         try {
             JsonNode request = (body != null && body.length > 0)
@@ -220,28 +217,21 @@ public class AwsJsonController {
                     : objectMapper.createObjectNode();
             String region = regionResolver.resolveRegion(httpHeaders);
 
-            Response delegated = cloudWatchMetricsJsonHandler.handle(operation, request, region);
-            byte[] cborBytes = nodeToSmithyCbor((JsonNode) delegated.getEntity());
+            Response delegated = dispatchCbor(serviceId, operation, request, region);
+            if (delegated == null) {
+                return Response.status(404).build();
+            }
 
+            byte[] cborBytes = nodeToSmithyCbor((JsonNode) delegated.getEntity());
             return Response.status(delegated.getStatus())
                     .header("Smithy-Protocol", "rpc-v2-cbor")
                     .type("application/cbor")
                     .entity(cborBytes)
                     .build();
         } catch (AwsException e) {
-            try {
-                byte[] errBytes = CBOR_MAPPER.writeValueAsBytes(
-                        new AwsErrorResponse(e.getErrorCode(), e.getMessage()));
-                return Response.status(e.getHttpStatus())
-                        .header("Smithy-Protocol", "rpc-v2-cbor")
-                        .type("application/cbor")
-                        .entity(errBytes)
-                        .build();
-            } catch (Exception ex) {
-                return Response.status(e.getHttpStatus()).build();
-            }
+            return cborErrorResponse(e, "Smithy-Protocol");
         } catch (Exception e) {
-            LOG.error("Error processing CloudWatch CBOR request", e);
+            LOG.error("Error processing Smithy CBOR request: " + serviceId + "." + operation, e);
             return Response.status(500).build();
         }
     }
@@ -258,12 +248,37 @@ public class AwsJsonController {
             @Context HttpHeaders httpHeaders,
             byte[] body) {
 
-        if (target == null || !target.startsWith(CLOUDWATCH_TARGET_PREFIX)) {
+        if (target == null) {
             return null;
         }
 
-        String action = target.substring(CLOUDWATCH_TARGET_PREFIX.length());
-        LOG.debugv("CloudWatch CBOR action: {0}", action);
+        String prefix;
+        String serviceName;
+
+        if (target.startsWith(DYNAMODB_STREAMS_TARGET_PREFIX)) {
+            prefix = DYNAMODB_STREAMS_TARGET_PREFIX;
+            serviceName = "DynamoDBStreams";
+        } else if (target.startsWith(DYNAMODB_TARGET_PREFIX)) {
+            prefix = DYNAMODB_TARGET_PREFIX;
+            serviceName = "DynamoDB";
+        } else if (target.startsWith(SQS_TARGET_PREFIX)) {
+            prefix = SQS_TARGET_PREFIX;
+            serviceName = "SQS";
+        } else if (target.startsWith(SNS_TARGET_PREFIX)) {
+            prefix = SNS_TARGET_PREFIX;
+            serviceName = "SNS";
+        } else if (target.startsWith(STEPFUNCTIONS_TARGET_PREFIX)) {
+            prefix = STEPFUNCTIONS_TARGET_PREFIX;
+            serviceName = "StepFunctions";
+        } else if (target.startsWith(CLOUDWATCH_TARGET_PREFIX)) {
+            prefix = CLOUDWATCH_TARGET_PREFIX;
+            serviceName = "CloudWatch";
+        } else {
+            return null;
+        }
+
+        String action = target.substring(prefix.length());
+        LOG.debugv("{0} CBOR action: {1}", serviceName, action);
 
         try {
             JsonNode request = (body != null && body.length > 0)
@@ -271,29 +286,57 @@ public class AwsJsonController {
                     : objectMapper.createObjectNode();
             String region = regionResolver.resolveRegion(httpHeaders);
 
-            Response delegated = cloudWatchMetricsJsonHandler.handle(action, request, region);
-            byte[] cborBytes = nodeToSmithyCbor((JsonNode) delegated.getEntity());
+            Response delegated = switch (serviceName) {
+                case "DynamoDB" -> dynamoDbJsonHandler.handle(action, request, region);
+                case "DynamoDBStreams" -> dynamoDbStreamsJsonHandler.handle(action, request, region);
+                case "SQS" -> sqsJsonHandler.handle(action, request, region);
+                case "SNS" -> snsJsonHandler.handle(action, request, region);
+                case "StepFunctions" -> sfnJsonHandler.handle(action, request, region);
+                case "CloudWatch" -> cloudWatchMetricsJsonHandler.handle(action, request, region);
+                default -> null;
+            };
+            if (delegated == null) {
+                return null;
+            }
 
+            byte[] cborBytes = nodeToSmithyCbor((JsonNode) delegated.getEntity());
             return Response.status(delegated.getStatus())
                     .header("smithy-protocol", "rpc-v2-cbor")
                     .type("application/cbor")
                     .entity(cborBytes)
                     .build();
         } catch (AwsException e) {
-            try {
-                byte[] errBytes = CBOR_MAPPER.writeValueAsBytes(
-                        new AwsErrorResponse(e.getErrorCode(), e.getMessage()));
-                return Response.status(e.getHttpStatus())
-                        .header("smithy-protocol", "rpc-v2-cbor")
-                        .type("application/cbor")
-                        .entity(errBytes)
-                        .build();
-            } catch (Exception ex) {
-                return Response.status(e.getHttpStatus()).build();
-            }
+            return cborErrorResponse(e, "smithy-protocol");
         } catch (Exception e) {
-            LOG.error("Error processing CloudWatch CBOR request", e);
+            LOG.error("Error processing CBOR request: " + serviceName + "." + action, e);
             return Response.status(500).build();
+        }
+    }
+
+    /** Dispatches a CBOR request to the appropriate service handler by SDK service ID. */
+    private Response dispatchCbor(String serviceId, String operation, JsonNode request, String region) throws Exception {
+        return switch (serviceId) {
+            case "DynamoDB" -> dynamoDbJsonHandler.handle(operation, request, region);
+            case "DynamoDB Streams" -> dynamoDbStreamsJsonHandler.handle(operation, request, region);
+            case "SQS" -> sqsJsonHandler.handle(operation, request, region);
+            case "SNS" -> snsJsonHandler.handle(operation, request, region);
+            case "SFN" -> sfnJsonHandler.handle(operation, request, region);
+            case CLOUDWATCH_SERVICE_ID -> cloudWatchMetricsJsonHandler.handle(operation, request, region);
+            default -> null;
+        };
+    }
+
+    private Response cborErrorResponse(AwsException e, String protocolHeader) {
+        try {
+            byte[] errBytes = CBOR_MAPPER.writeValueAsBytes(
+                    new AwsErrorResponse(e.getErrorCode(), e.getMessage()));
+            return Response.status(e.getHttpStatus())
+                    .header(protocolHeader, "rpc-v2-cbor")
+                    .type("application/cbor")
+                    .entity(errBytes)
+                    .build();
+        } catch (Exception ex) {
+            return Response.status(e.getHttpStatus()).build();
         }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -114,8 +114,27 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        String billingMode = request.has("BillingMode")
+                ? request.get("BillingMode").asText() : null;
+
         TableDefinition table = dynamoDbService.createTable(tableName, keySchema, attrDefs,
                 readCapacity, writeCapacity, gsis, lsis, region);
+
+        if ("PAY_PER_REQUEST".equals(billingMode)) {
+            table.setBillingMode("PAY_PER_REQUEST");
+            table.getProvisionedThroughput().setReadCapacityUnits(0L);
+            table.getProvisionedThroughput().setWriteCapacityUnits(0L);
+        } else {
+            table.setBillingMode("PROVISIONED");
+        }
+
+        // Store tags from CreateTable request
+        JsonNode tagsNode = request.path("Tags");
+        if (tagsNode.isArray()) {
+            for (JsonNode tag : tagsNode) {
+                table.getTags().put(tag.path("Key").asText(), tag.path("Value").asText());
+            }
+        }
 
         JsonNode streamSpec = request.path("StreamSpecification");
         if (!streamSpec.isMissingNode() && streamSpec.path("StreamEnabled").asBoolean(false)) {
@@ -375,6 +394,16 @@ public class DynamoDbJsonHandler {
 
         TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity, region);
 
+        String billingMode = request.has("BillingMode")
+                ? request.get("BillingMode").asText() : null;
+        if (billingMode != null) {
+            table.setBillingMode(billingMode);
+            if ("PAY_PER_REQUEST".equals(billingMode)) {
+                table.getProvisionedThroughput().setReadCapacityUnits(0L);
+                table.getProvisionedThroughput().setWriteCapacityUnits(0L);
+            }
+        }
+
         JsonNode streamSpec = request.path("StreamSpecification");
         if (!streamSpec.isMissingNode()) {
             boolean streamEnabled = streamSpec.path("StreamEnabled").asBoolean(false);
@@ -525,6 +554,21 @@ public class DynamoDbJsonHandler {
         node.put("CreationDateTime", table.getCreationDateTime().getEpochSecond());
         node.put("ItemCount", table.getItemCount());
         node.put("TableSizeBytes", table.getTableSizeBytes());
+        node.put("DeletionProtectionEnabled", false);
+
+        if ("PAY_PER_REQUEST".equals(table.getBillingMode())) {
+            ObjectNode billing = objectMapper.createObjectNode();
+            billing.put("BillingMode", "PAY_PER_REQUEST");
+            billing.put("LastUpdateToPayPerRequestDateTime",
+                    table.getCreationDateTime().getEpochSecond());
+            node.set("BillingModeSummary", billing);
+        }
+
+        ObjectNode warmThroughput = objectMapper.createObjectNode();
+        warmThroughput.put("Status", "ACTIVE");
+        warmThroughput.put("ReadUnitsPerSecond", 0);
+        warmThroughput.put("WriteUnitsPerSecond", 0);
+        node.set("WarmThroughput", warmThroughput);
 
         ArrayNode keySchemaArray = objectMapper.createArrayNode();
         for (var ks : table.getKeySchema()) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -29,6 +29,7 @@ public class TableDefinition {
     private Map<String, String> tags;
     private List<GlobalSecondaryIndex> globalSecondaryIndexes;
     private List<LocalSecondaryIndex> localSecondaryIndexes;
+    private String billingMode; // "PROVISIONED" or "PAY_PER_REQUEST"
     private String ttlAttributeName;
     private boolean ttlEnabled;
     private boolean streamEnabled;
@@ -106,6 +107,9 @@ public class TableDefinition {
     public void setLocalSecondaryIndexes(List<LocalSecondaryIndex> localSecondaryIndexes) {
         this.localSecondaryIndexes = localSecondaryIndexes != null ? localSecondaryIndexes : new ArrayList<>();
     }
+
+    public String getBillingMode() { return billingMode; }
+    public void setBillingMode(String billingMode) { this.billingMode = billingMode; }
 
     public String getTtlAttributeName() { return ttlAttributeName; }
     public void setTtlAttributeName(String ttlAttributeName) { this.ttlAttributeName = ttlAttributeName; }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCborIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCborIntegrationTest.java
@@ -1,0 +1,176 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests the smithy-rpc-v2-cbor protocol for DynamoDB.
+ * AWS SDK v2 sends DynamoDB requests as CBOR to /service/DynamoDB/operation/{op}.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbCborIntegrationTest {
+
+    private static final ObjectMapper CBOR_MAPPER = new ObjectMapper(new CBORFactory());
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    @Test
+    @Order(1)
+    void createTableViaCbor() throws Exception {
+        JsonNode request = JSON_MAPPER.readTree("""
+            {
+                "TableName": "CborTable",
+                "KeySchema": [
+                    {"AttributeName": "pk", "KeyType": "HASH"}
+                ],
+                "AttributeDefinitions": [
+                    {"AttributeName": "pk", "AttributeType": "S"}
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": 5,
+                    "WriteCapacityUnits": 5
+                }
+            }
+            """);
+
+        byte[] cborBody = CBOR_MAPPER.writeValueAsBytes(request);
+
+        byte[] responseBytes = given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(cborBody)
+        .when()
+            .post("/service/DynamoDB/operation/CreateTable")
+        .then()
+            .statusCode(200)
+            .contentType("application/cbor")
+            .extract().asByteArray();
+
+        JsonNode response = CBOR_MAPPER.readTree(responseBytes);
+        assertThat(response.path("TableDescription").path("TableName").asText(), equalTo("CborTable"));
+        assertThat(response.path("TableDescription").path("TableStatus").asText(), equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(2)
+    void describeTableViaCbor() throws Exception {
+        JsonNode request = JSON_MAPPER.readTree("""
+            {"TableName": "CborTable"}
+            """);
+
+        byte[] cborBody = CBOR_MAPPER.writeValueAsBytes(request);
+
+        byte[] responseBytes = given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(cborBody)
+        .when()
+            .post("/service/DynamoDB/operation/DescribeTable")
+        .then()
+            .statusCode(200)
+            .contentType("application/cbor")
+            .extract().asByteArray();
+
+        JsonNode response = CBOR_MAPPER.readTree(responseBytes);
+        assertThat(response.path("Table").path("TableName").asText(), equalTo("CborTable"));
+        assertThat(response.path("Table").path("TableStatus").asText(), equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(3)
+    void describeNonExistentTableViaCbor() throws Exception {
+        JsonNode request = JSON_MAPPER.readTree("""
+            {"TableName": "NoSuchTable"}
+            """);
+
+        byte[] cborBody = CBOR_MAPPER.writeValueAsBytes(request);
+
+        byte[] responseBytes = given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(cborBody)
+        .when()
+            .post("/service/DynamoDB/operation/DescribeTable")
+        .then()
+            .statusCode(400)
+            .extract().asByteArray();
+
+        JsonNode response = CBOR_MAPPER.readTree(responseBytes);
+        assertThat(response.path("__type").asText(), equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    @Order(4)
+    void putAndGetItemViaCbor() throws Exception {
+        JsonNode putRequest = JSON_MAPPER.readTree("""
+            {
+                "TableName": "CborTable",
+                "Item": {
+                    "pk": {"S": "cbor-1"},
+                    "data": {"S": "hello cbor"}
+                }
+            }
+            """);
+
+        given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(CBOR_MAPPER.writeValueAsBytes(putRequest))
+        .when()
+            .post("/service/DynamoDB/operation/PutItem")
+        .then()
+            .statusCode(200);
+
+        JsonNode getRequest = JSON_MAPPER.readTree("""
+            {
+                "TableName": "CborTable",
+                "Key": {"pk": {"S": "cbor-1"}}
+            }
+            """);
+
+        byte[] responseBytes = given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(CBOR_MAPPER.writeValueAsBytes(getRequest))
+        .when()
+            .post("/service/DynamoDB/operation/GetItem")
+        .then()
+            .statusCode(200)
+            .extract().asByteArray();
+
+        JsonNode response = CBOR_MAPPER.readTree(responseBytes);
+        assertThat(response.path("Item").path("data").path("S").asText(), equalTo("hello cbor"));
+    }
+
+    @Test
+    @Order(5)
+    void deleteTableViaCbor() throws Exception {
+        JsonNode request = JSON_MAPPER.readTree("""
+            {"TableName": "CborTable"}
+            """);
+
+        byte[] responseBytes = given()
+            .contentType("application/cbor")
+            .accept("application/cbor")
+            .body(CBOR_MAPPER.writeValueAsBytes(request))
+        .when()
+            .post("/service/DynamoDB/operation/DeleteTable")
+        .then()
+            .statusCode(200)
+            .extract().asByteArray();
+
+        JsonNode response = CBOR_MAPPER.readTree(responseBytes);
+        assertThat(response.path("TableDescription").path("TableStatus").asText(), equalTo("DELETING"));
+    }
+}


### PR DESCRIPTION
The Terraform AWS provider v6 calls waitTableWarmThroughputActive after creating a DynamoDB table, which checks DescribeTable for WarmThroughput.Status == "ACTIVE". Without this field the waiter retried for ~2.5 minutes then failed with "couldn't find resource (21 retries)".

## Summary

- Add WarmThroughput with Status ACTIVE to DescribeTable/CreateTable responses
- Add BillingModeSummary for PAY_PER_REQUEST tables
- Parse BillingMode and Tags from CreateTable/UpdateTable requests
- Add DeletionProtectionEnabled field to table responses
- Extend CBOR protocol handlers to support DynamoDB, SQS, SNS, StepFunctions

## compat-terraform output
<details>
```
=== Terraform Compatibility ===
Endpoint: http://localhost:4566

--- Setup: state bucket & lock table ---
{
    "Location": "/tfstate"
}
  INFO  Created S3 state bucket
{
    "TableDescription": {
        "AttributeDefinitions": [
            {
                "AttributeName": "LockID",
                "AttributeType": "S"
            }
        ],
        "TableName": "tflock",
        "KeySchema": [
            {
                "AttributeName": "LockID",
                "KeyType": "HASH"
            }
        ],
        "TableStatus": "ACTIVE",
        "CreationDateTime": "2026-03-27T11:00:46+13:00",
        "ProvisionedThroughput": {
            "NumberOfDecreasesToday": 0,
            "ReadCapacityUnits": 0,
            "WriteCapacityUnits": 0
        },
        "TableSizeBytes": 0,
        "ItemCount": 0,
        "TableArn": "arn:aws:dynamodb:us-east-1:000000000000:table/tflock",
        "BillingModeSummary": {
            "BillingMode": "PAY_PER_REQUEST",
            "LastUpdateToPayPerRequestDateTime": "2026-03-27T11:00:46+13:00"
        },
        "DeletionProtectionEnabled": false,
        "WarmThroughput": {
            "ReadUnitsPerSecond": 0,
            "WriteUnitsPerSecond": 0,
            "Status": "ACTIVE"
        }
    }
}
  INFO  Created DynamoDB lock table

--- terraform init ---
Successfully configured the backend "s3"! Terraform will automatically
  PASS  terraform init

--- terraform validate ---
  PASS  terraform validate

--- terraform plan ---
  PASS  terraform plan (Plan: 13 to add, 0 to change, 0 to destroy.)

--- terraform apply ---
data.aws_iam_policy_document.lambda_assume_role: Reading...
data.aws_iam_policy_document.lambda_assume_role: Read complete after 0s [id=2690255455]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_dynamodb_table.items will be created
  + resource "aws_dynamodb_table" "items" {
      + arn              = (known after apply)
      + billing_mode     = "PAY_PER_REQUEST"
      + hash_key         = "pk"
      + id               = (known after apply)
      + name             = "floci-compat-items"
      + range_key        = "sk"
      + read_capacity    = (known after apply)
      + region           = "us-east-1"
      + stream_arn       = (known after apply)
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)
      + tags             = {
          + "Environment" = "compat-test"
        }
      + tags_all         = {
          + "Environment" = "compat-test"
        }
      + write_capacity   = (known after apply)

      + attribute {
          + name = "pk"
          + type = "S"
        }
      + attribute {
          + name = "sk"
          + type = "S"
        }

      + global_secondary_index (known after apply)

      + global_table_witness (known after apply)

      + point_in_time_recovery (known after apply)

      + server_side_encryption (known after apply)

      + ttl {
          + attribute_name = "expires_at"
          + enabled        = true
        }

      + warm_throughput (known after apply)
    }

  # aws_iam_role.lambda_exec will be created
  + resource "aws_iam_role" "lambda_exec" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "floci-compat-lambda-exec"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_s3_bucket.app will be created
  + resource "aws_s3_bucket" "app" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "floci-compat-app"
      + bucket_domain_name          = (known after apply)
      + bucket_namespace            = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_region               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = "us-east-1"
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule (known after apply)

      + grant (known after apply)

      + lifecycle_rule (known after apply)

      + logging (known after apply)

      + object_lock_configuration (known after apply)

      + replication_configuration (known after apply)

      + server_side_encryption_configuration (known after apply)

      + versioning (known after apply)

      + website (known after apply)
    }

  # aws_s3_bucket_versioning.app will be created
  + resource "aws_s3_bucket_versioning" "app" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + region = "us-east-1"

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

  # aws_secretsmanager_secret.db_creds will be created
  + resource "aws_secretsmanager_secret" "db_creds" {
      + arn                            = (known after apply)
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "floci-compat/db-creds"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + region                         = "us-east-1"
      + tags_all                       = (known after apply)

      + replica (known after apply)
    }

  # aws_secretsmanager_secret_version.db_creds will be created
  + resource "aws_secretsmanager_secret_version" "db_creds" {
      + arn                  = (known after apply)
      + has_secret_string_wo = (known after apply)
      + id                   = (known after apply)
      + region               = "us-east-1"
      + secret_id            = (known after apply)
      + secret_string        = (sensitive value)
      + secret_string_wo     = (write-only attribute)
      + version_id           = (known after apply)
      + version_stages       = (known after apply)
    }

  # aws_sns_topic.events will be created
  + resource "aws_sns_topic" "events" {
      + arn                         = (known after apply)
      + beginning_archive_time      = (known after apply)
      + content_based_deduplication = false
      + fifo_throughput_scope       = (known after apply)
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "floci-compat-events"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + region                      = "us-east-1"
      + signature_version           = (known after apply)
      + tags_all                    = (known after apply)
      + tracing_config              = (known after apply)
    }

  # aws_sns_topic_subscription.events_to_sqs will be created
  + resource "aws_sns_topic_subscription" "events_to_sqs" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + confirmation_was_authenticated  = (known after apply)
      + endpoint                        = (known after apply)
      + endpoint_auto_confirms          = false
      + filter_policy_scope             = (known after apply)
      + id                              = (known after apply)
      + owner_id                        = (known after apply)
      + pending_confirmation            = (known after apply)
      + protocol                        = "sqs"
      + raw_message_delivery            = false
      + region                          = "us-east-1"
      + topic_arn                       = (known after apply)
    }

  # aws_sqs_queue.jobs will be created
  + resource "aws_sqs_queue" "jobs" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 86400
      + name                              = "floci-compat-jobs"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + region                            = "us-east-1"
      + sqs_managed_sse_enabled           = (known after apply)
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # aws_sqs_queue.jobs_dlq will be created
  + resource "aws_sqs_queue" "jobs_dlq" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "floci-compat-jobs-dlq"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + region                            = "us-east-1"
      + sqs_managed_sse_enabled           = (known after apply)
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

  # aws_sqs_queue_redrive_policy.jobs will be created
  + resource "aws_sqs_queue_redrive_policy" "jobs" {
      + id             = (known after apply)
      + queue_url      = (known after apply)
      + redrive_policy = (known after apply)
      + region         = "us-east-1"
    }

  # aws_ssm_parameter.api_key will be created
  + resource "aws_ssm_parameter" "api_key" {
      + arn            = (known after apply)
      + data_type      = (known after apply)
      + has_value_wo   = (known after apply)
      + id             = (known after apply)
      + insecure_value = (known after apply)
      + key_id         = (known after apply)
      + name           = "/floci-compat/api-key"
      + region         = "us-east-1"
      + tags_all       = (known after apply)
      + tier           = (known after apply)
      + type           = "SecureString"
      + value          = (sensitive value)
      + value_wo       = (write-only attribute)
      + version        = (known after apply)
    }

  # aws_ssm_parameter.db_url will be created
  + resource "aws_ssm_parameter" "db_url" {
      + arn            = (known after apply)
      + data_type      = (known after apply)
      + has_value_wo   = (known after apply)
      + id             = (known after apply)
      + insecure_value = (known after apply)
      + key_id         = (known after apply)
      + name           = "/floci-compat/db-url"
      + region         = "us-east-1"
      + tags_all       = (known after apply)
      + tier           = (known after apply)
      + type           = "String"
      + value          = (sensitive value)
      + value_wo       = (write-only attribute)
      + version        = (known after apply)
    }

Plan: 13 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_id  = (known after apply)
  + queue_url  = (known after apply)
  + secret_arn = (known after apply)
  + table_name = "floci-compat-items"
  + topic_arn  = (known after apply)
aws_iam_role.lambda_exec: Creating...
aws_ssm_parameter.db_url: Creating...
aws_secretsmanager_secret.db_creds: Creating...
aws_ssm_parameter.api_key: Creating...
aws_sqs_queue.jobs_dlq: Creating...
aws_sqs_queue.jobs: Creating...
aws_sns_topic.events: Creating...
aws_s3_bucket.app: Creating...
aws_secretsmanager_secret.db_creds: Creation complete after 0s [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX]
aws_ssm_parameter.db_url: Creation complete after 0s [id=/floci-compat/db-url]
aws_ssm_parameter.api_key: Creation complete after 0s [id=/floci-compat/api-key]
aws_secretsmanager_secret_version.db_creds: Creating...
aws_dynamodb_table.items: Creating...
aws_secretsmanager_secret_version.db_creds: Creation complete after 0s [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX|07972681-84d4-457e-bf63-f4bba4177e6b]
aws_iam_role.lambda_exec: Creation complete after 0s [id=floci-compat-lambda-exec]
aws_sns_topic.events: Creation complete after 0s [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events]
aws_s3_bucket.app: Creation complete after 0s [id=floci-compat-app]
aws_s3_bucket_versioning.app: Creating...
aws_dynamodb_table.items: Creation complete after 1s [id=floci-compat-items]
aws_s3_bucket_versioning.app: Creation complete after 2s [id=floci-compat-app]
aws_sqs_queue.jobs: Still creating... [00m10s elapsed]
aws_sqs_queue.jobs_dlq: Still creating... [00m10s elapsed]
aws_sqs_queue.jobs_dlq: Still creating... [00m20s elapsed]
aws_sqs_queue.jobs: Still creating... [00m20s elapsed]
aws_sqs_queue.jobs: Creation complete after 25s [id=http://localhost:4566/000000000000/floci-compat-jobs]
aws_sqs_queue.jobs_dlq: Creation complete after 25s [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq]
aws_sqs_queue_redrive_policy.jobs: Creating...
aws_sns_topic_subscription.events_to_sqs: Creating...
aws_sns_topic_subscription.events_to_sqs: Creation complete after 0s [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events:3890875b-deea-422b-9973-9b580f5967c6]
aws_sqs_queue_redrive_policy.jobs: Still creating... [00m10s elapsed]
aws_sqs_queue_redrive_policy.jobs: Still creating... [00m20s elapsed]
aws_sqs_queue_redrive_policy.jobs: Creation complete after 25s [id=http://localhost:4566/000000000000/floci-compat-jobs]

Apply complete! Resources: 13 added, 0 changed, 0 destroyed.

Outputs:

bucket_id = "floci-compat-app"
queue_url = "http://localhost:4566/000000000000/floci-compat-jobs"
secret_arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX"
table_name = "floci-compat-items"
topic_arn = "arn:aws:sns:us-east-1:000000000000:floci-compat-events"
  PASS  terraform apply (Apply complete! Resources: 13 added, 0 changed, 0 destroyed.)

--- Spot checks ---
{
    "BucketRegion": "us-east-1"
}
  PASS  S3 bucket created
  PASS  SQS queue created
  PASS  SNS topic created
  PASS  DynamoDB table created
  PASS  SSM parameter created
  PASS  Secrets Manager secret created

--- terraform destroy ---
data.aws_iam_policy_document.lambda_assume_role: Reading...
aws_secretsmanager_secret.db_creds: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX]
aws_ssm_parameter.db_url: Refreshing state... [id=/floci-compat/db-url]
aws_ssm_parameter.api_key: Refreshing state... [id=/floci-compat/api-key]
aws_sqs_queue.jobs_dlq: Refreshing state... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq]
aws_sns_topic.events: Refreshing state... [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events]
aws_s3_bucket.app: Refreshing state... [id=floci-compat-app]
aws_sqs_queue.jobs: Refreshing state... [id=http://localhost:4566/000000000000/floci-compat-jobs]
aws_dynamodb_table.items: Refreshing state... [id=floci-compat-items]
data.aws_iam_policy_document.lambda_assume_role: Read complete after 0s [id=2690255455]
aws_iam_role.lambda_exec: Refreshing state... [id=floci-compat-lambda-exec]
aws_secretsmanager_secret_version.db_creds: Refreshing state... [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX|07972681-84d4-457e-bf63-f4bba4177e6b]
aws_sqs_queue_redrive_policy.jobs: Refreshing state... [id=http://localhost:4566/000000000000/floci-compat-jobs]
aws_sns_topic_subscription.events_to_sqs: Refreshing state... [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events:3890875b-deea-422b-9973-9b580f5967c6]
aws_s3_bucket_versioning.app: Refreshing state... [id=floci-compat-app]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # aws_dynamodb_table.items will be destroyed
  - resource "aws_dynamodb_table" "items" {
      - arn                         = "arn:aws:dynamodb:us-east-1:000000000000:table/floci-compat-items" -> null
      - billing_mode                = "PAY_PER_REQUEST" -> null
      - deletion_protection_enabled = false -> null
      - hash_key                    = "pk" -> null
      - id                          = "floci-compat-items" -> null
      - name                        = "floci-compat-items" -> null
      - range_key                   = "sk" -> null
      - read_capacity               = 0 -> null
      - region                      = "us-east-1" -> null
      - stream_enabled              = false -> null
      - table_class                 = "STANDARD" -> null
      - tags                        = {
          - "Environment" = "compat-test"
        } -> null
      - tags_all                    = {
          - "Environment" = "compat-test"
        } -> null
      - write_capacity              = 0 -> null
        # (3 unchanged attributes hidden)

      - attribute {
          - name = "pk" -> null
          - type = "S" -> null
        }
      - attribute {
          - name = "sk" -> null
          - type = "S" -> null
        }

      - point_in_time_recovery {
          - enabled                 = false -> null
          - recovery_period_in_days = 0 -> null
        }

      - ttl {
          - attribute_name = "expires_at" -> null
          - enabled        = true -> null
        }
    }

  # aws_iam_role.lambda_exec will be destroyed
  - resource "aws_iam_role" "lambda_exec" {
      - arn                   = "arn:aws:iam::000000000000:role/floci-compat-lambda-exec" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Effect    = "Allow"
                      - Principal = {
                          - Service = "lambda.amazonaws.com"
                        }
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2026-03-26T22:01:03Z" -> null
      - force_detach_policies = false -> null
      - id                    = "floci-compat-lambda-exec" -> null
      - managed_policy_arns   = [] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "floci-compat-lambda-exec" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {} -> null
      - unique_id             = "AROAIHBHOBBSAHHUGL0M" -> null
        # (3 unchanged attributes hidden)
    }

  # aws_s3_bucket.app will be destroyed
  - resource "aws_s3_bucket" "app" {
      - arn                         = "arn:aws:s3:::floci-compat-app" -> null
      - bucket                      = "floci-compat-app" -> null
      - bucket_domain_name          = "floci-compat-app.s3.amazonaws.com" -> null
      - bucket_namespace            = "global" -> null
      - bucket_region               = "us-east-1" -> null
      - bucket_regional_domain_name = "floci-compat-app.s3.us-east-1.amazonaws.com" -> null
      - force_destroy               = false -> null
      - hosted_zone_id              = "Z3AQBSTGFYJSTF" -> null
      - id                          = "floci-compat-app" -> null
      - object_lock_enabled         = true -> null
      - region                      = "us-east-1" -> null
      - tags                        = {} -> null
      - tags_all                    = {} -> null
        # (4 unchanged attributes hidden)

      - grant {
          - id          = "000000000000" -> null
          - permissions = [
              - "FULL_CONTROL",
            ] -> null
          - type        = "CanonicalUser" -> null
            # (1 unchanged attribute hidden)
        }

      - object_lock_configuration {
          - object_lock_enabled = "Enabled" -> null
        }

      - replication_configuration {
        }

      - versioning {
          - enabled    = true -> null
          - mfa_delete = false -> null
        }
    }

  # aws_s3_bucket_versioning.app will be destroyed
  - resource "aws_s3_bucket_versioning" "app" {
      - bucket                = "floci-compat-app" -> null
      - id                    = "floci-compat-app" -> null
      - region                = "us-east-1" -> null
        # (1 unchanged attribute hidden)

      - versioning_configuration {
          - status     = "Enabled" -> null
            # (1 unchanged attribute hidden)
        }
    }

  # aws_secretsmanager_secret.db_creds will be destroyed
  - resource "aws_secretsmanager_secret" "db_creds" {
      - arn                            = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX" -> null
      - force_overwrite_replica_secret = false -> null
      - id                             = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX" -> null
      - name                           = "floci-compat/db-creds" -> null
      - recovery_window_in_days        = 30 -> null
      - region                         = "us-east-1" -> null
      - tags                           = {} -> null
      - tags_all                       = {} -> null
        # (4 unchanged attributes hidden)
    }

  # aws_secretsmanager_secret_version.db_creds will be destroyed
  - resource "aws_secretsmanager_secret_version" "db_creds" {
      - arn              = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX" -> null
      - id               = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX|07972681-84d4-457e-bf63-f4bba4177e6b" -> null
      - region           = "us-east-1" -> null
      - secret_id        = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX" -> null
      - secret_string    = (sensitive value) -> null
      - secret_string_wo = (write-only attribute) -> null
      - version_id       = "07972681-84d4-457e-bf63-f4bba4177e6b" -> null
      - version_stages   = [
          - "AWSCURRENT",
        ] -> null
        # (1 unchanged attribute hidden)
    }

  # aws_sns_topic.events will be destroyed
  - resource "aws_sns_topic" "events" {
      - application_success_feedback_sample_rate = 0 -> null
      - arn                                      = "arn:aws:sns:us-east-1:000000000000:floci-compat-events" -> null
      - content_based_deduplication              = false -> null
      - fifo_topic                               = false -> null
      - firehose_success_feedback_sample_rate    = 0 -> null
      - http_success_feedback_sample_rate        = 0 -> null
      - id                                       = "arn:aws:sns:us-east-1:000000000000:floci-compat-events" -> null
      - lambda_success_feedback_sample_rate      = 0 -> null
      - name                                     = "floci-compat-events" -> null
      - owner                                    = "000000000000" -> null
      - policy                                   = jsonencode(
            {
              - Id        = "__default_policy_ID"
              - Statement = [
                  - {
                      - Action    = [
                          - "SNS:GetTopicAttributes",
                          - "SNS:SetTopicAttributes",
                          - "SNS:AddPermission",
                          - "SNS:RemovePermission",
                          - "SNS:DeleteTopic",
                          - "SNS:Subscribe",
                          - "SNS:ListSubscriptionsByTopic",
                          - "SNS:Publish",
                        ]
                      - Condition = {
                          - StringEquals = {
                              - "AWS:SourceAccount" = "000000000000"
                            }
                        }
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "*"
                        }
                      - Resource  = "arn:aws:sns:us-east-1:000000000000:floci-compat-events"
                      - Sid       = "__default_statement_ID"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - region                                   = "us-east-1" -> null
      - signature_version                        = 0 -> null
      - sqs_success_feedback_sample_rate         = 0 -> null
      - tags                                     = {} -> null
      - tags_all                                 = {} -> null
        # (18 unchanged attributes hidden)
    }

  # aws_sns_topic_subscription.events_to_sqs will be destroyed
  - resource "aws_sns_topic_subscription" "events_to_sqs" {
      - arn                             = "arn:aws:sns:us-east-1:000000000000:floci-compat-events:3890875b-deea-422b-9973-9b580f5967c6" -> null
      - confirmation_timeout_in_minutes = 1 -> null
      - confirmation_was_authenticated  = false -> null
      - endpoint                        = "arn:aws:sqs:us-east-1:000000000000:floci-compat-jobs" -> null
      - endpoint_auto_confirms          = false -> null
      - filter_policy_scope             = "MessageAttributes" -> null
      - id                              = "arn:aws:sns:us-east-1:000000000000:floci-compat-events:3890875b-deea-422b-9973-9b580f5967c6" -> null
      - owner_id                        = "000000000000" -> null
      - pending_confirmation            = false -> null
      - protocol                        = "sqs" -> null
      - raw_message_delivery            = false -> null
      - region                          = "us-east-1" -> null
      - topic_arn                       = "arn:aws:sns:us-east-1:000000000000:floci-compat-events" -> null
        # (5 unchanged attributes hidden)
    }

  # aws_sqs_queue.jobs will be destroyed
  - resource "aws_sqs_queue" "jobs" {
      - arn                               = "arn:aws:sqs:us-east-1:000000000000:floci-compat-jobs" -> null
      - content_based_deduplication       = false -> null
      - delay_seconds                     = 0 -> null
      - fifo_queue                        = false -> null
      - id                                = "http://localhost:4566/000000000000/floci-compat-jobs" -> null
      - kms_data_key_reuse_period_seconds = 300 -> null
      - max_message_size                  = 262144 -> null
      - message_retention_seconds         = 86400 -> null
      - name                              = "floci-compat-jobs" -> null
      - receive_wait_time_seconds         = 0 -> null
      - redrive_policy                    = jsonencode(
            {
              - deadLetterTargetArn = "arn:aws:sqs:us-east-1:000000000000:floci-compat-jobs-dlq"
              - maxReceiveCount     = 3
            }
        ) -> null
      - region                            = "us-east-1" -> null
      - sqs_managed_sse_enabled           = false -> null
      - tags                              = {} -> null
      - tags_all                          = {} -> null
      - url                               = "http://localhost:4566/000000000000/floci-compat-jobs" -> null
      - visibility_timeout_seconds        = 30 -> null
        # (6 unchanged attributes hidden)
    }

  # aws_sqs_queue.jobs_dlq will be destroyed
  - resource "aws_sqs_queue" "jobs_dlq" {
      - arn                               = "arn:aws:sqs:us-east-1:000000000000:floci-compat-jobs-dlq" -> null
      - content_based_deduplication       = false -> null
      - delay_seconds                     = 0 -> null
      - fifo_queue                        = false -> null
      - id                                = "http://localhost:4566/000000000000/floci-compat-jobs-dlq" -> null
      - kms_data_key_reuse_period_seconds = 300 -> null
      - max_message_size                  = 262144 -> null
      - message_retention_seconds         = 345600 -> null
      - name                              = "floci-compat-jobs-dlq" -> null
      - receive_wait_time_seconds         = 0 -> null
      - region                            = "us-east-1" -> null
      - sqs_managed_sse_enabled           = false -> null
      - tags                              = {} -> null
      - tags_all                          = {} -> null
      - url                               = "http://localhost:4566/000000000000/floci-compat-jobs-dlq" -> null
      - visibility_timeout_seconds        = 30 -> null
        # (7 unchanged attributes hidden)
    }

  # aws_sqs_queue_redrive_policy.jobs will be destroyed
  - resource "aws_sqs_queue_redrive_policy" "jobs" {
      - id             = "http://localhost:4566/000000000000/floci-compat-jobs" -> null
      - queue_url      = "http://localhost:4566/000000000000/floci-compat-jobs" -> null
      - redrive_policy = jsonencode(
            {
              - deadLetterTargetArn = "arn:aws:sqs:us-east-1:000000000000:floci-compat-jobs-dlq"
              - maxReceiveCount     = 3
            }
        ) -> null
      - region         = "us-east-1" -> null
    }

  # aws_ssm_parameter.api_key will be destroyed
  - resource "aws_ssm_parameter" "api_key" {
      - arn             = "arn:aws:ssm:us-east-1:000000000000:parameter/floci-compat/api-key" -> null
      - data_type       = "text" -> null
      - has_value_wo    = false -> null
      - id              = "/floci-compat/api-key" -> null
      - name            = "/floci-compat/api-key" -> null
      - region          = "us-east-1" -> null
      - tags            = {} -> null
      - tags_all        = {} -> null
      - type            = "SecureString" -> null
      - value           = (sensitive value) -> null
      - value_wo        = (write-only attribute) -> null
      - version         = 1 -> null
        # (4 unchanged attributes hidden)
    }

  # aws_ssm_parameter.db_url will be destroyed
  - resource "aws_ssm_parameter" "db_url" {
      - arn             = "arn:aws:ssm:us-east-1:000000000000:parameter/floci-compat/db-url" -> null
      - data_type       = "text" -> null
      - has_value_wo    = false -> null
      - id              = "/floci-compat/db-url" -> null
      - name            = "/floci-compat/db-url" -> null
      - region          = "us-east-1" -> null
      - tags            = {} -> null
      - tags_all        = {} -> null
      - type            = "String" -> null
      - value           = (sensitive value) -> null
      - value_wo        = (write-only attribute) -> null
      - version         = 1 -> null
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 13 to destroy.

Changes to Outputs:
  - bucket_id  = "floci-compat-app" -> null
  - queue_url  = "http://localhost:4566/000000000000/floci-compat-jobs" -> null
  - secret_arn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX" -> null
  - table_name = "floci-compat-items" -> null
  - topic_arn  = "arn:aws:sns:us-east-1:000000000000:floci-compat-events" -> null
aws_sqs_queue_redrive_policy.jobs: Destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs]
aws_ssm_parameter.api_key: Destroying... [id=/floci-compat/api-key]
aws_s3_bucket_versioning.app: Destroying... [id=floci-compat-app]
aws_secretsmanager_secret_version.db_creds: Destroying... [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX|07972681-84d4-457e-bf63-f4bba4177e6b]
aws_ssm_parameter.db_url: Destroying... [id=/floci-compat/db-url]
aws_sns_topic_subscription.events_to_sqs: Destroying... [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events:3890875b-deea-422b-9973-9b580f5967c6]
aws_iam_role.lambda_exec: Destroying... [id=floci-compat-lambda-exec]
aws_dynamodb_table.items: Destroying... [id=floci-compat-items]
aws_ssm_parameter.db_url: Destruction complete after 0s
aws_secretsmanager_secret_version.db_creds: Destruction complete after 0s
aws_s3_bucket_versioning.app: Destruction complete after 0s
aws_ssm_parameter.api_key: Destruction complete after 0s
aws_sns_topic_subscription.events_to_sqs: Destruction complete after 0s
aws_secretsmanager_secret.db_creds: Destroying... [id=arn:aws:secretsmanager:us-east-1:000000000000:secret:floci-compat/db-creds-BEKIVX]
aws_iam_role.lambda_exec: Destruction complete after 0s
aws_dynamodb_table.items: Destruction complete after 0s
aws_sns_topic.events: Destroying... [id=arn:aws:sns:us-east-1:000000000000:floci-compat-events]
aws_s3_bucket.app: Destroying... [id=floci-compat-app]
aws_sns_topic.events: Destruction complete after 0s
aws_secretsmanager_secret.db_creds: Destruction complete after 0s
aws_s3_bucket.app: Destruction complete after 0s
aws_sqs_queue_redrive_policy.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m10s elapsed]
aws_sqs_queue_redrive_policy.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m20s elapsed]
aws_sqs_queue_redrive_policy.jobs: Destruction complete after 25s
aws_sqs_queue.jobs_dlq: Destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq]
aws_sqs_queue.jobs: Destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 00m10s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m10s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 00m20s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m20s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m30s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 00m30s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m40s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 00m40s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 00m50s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 00m50s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m00s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m00s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m10s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m10s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m20s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m20s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m30s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m30s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m40s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m40s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 01m50s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 01m50s elapsed]
aws_sqs_queue.jobs_dlq: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs-dlq, 02m00s elapsed]
aws_sqs_queue.jobs: Still destroying... [id=http://localhost:4566/000000000000/floci-compat-jobs, 02m00s elapsed]
aws_sqs_queue.jobs: Destruction complete after 2m9s
aws_sqs_queue.jobs_dlq: Destruction complete after 2m9s

Destroy complete! Resources: 13 destroyed.
  PASS  terraform destroy (Destroy complete! Resources: 13 destroyed.)

==================================================
Results: 11 passed, 0 failed
```
</details>
