### PR TITLE
feat: implement UploadPartCopy for S3 multipart uploads

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -327,6 +327,9 @@ public class S3Controller {
             }
 
             if (uploadId != null && partNumber != null) {
+                if (copySource != null && !copySource.isEmpty()) {
+                    return handleUploadPartCopy(copySource, bucket, key, uploadId, partNumber, httpHeaders);
+                }
                 byte[] partData = decodeAwsChunked(body, contentEncoding, contentSha256);
                 validateChecksumHeaders(httpHeaders, partData);
                 String eTag = s3Service.uploadPart(bucket, key, uploadId, partNumber, partData);
@@ -1069,6 +1072,28 @@ public class S3Controller {
                 .end("CopyObjectResult")
                 .build();
         return Response.ok(xml).build();
+    }
+
+    private Response handleUploadPartCopy(String copySource, String destBucket, String destKey,
+                                           String uploadId, int partNumber, HttpHeaders httpHeaders) {
+        String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
+        int slashIndex = source.indexOf('/');
+        if (slashIndex < 0) {
+            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
+        }
+        String sourceBucket = source.substring(0, slashIndex);
+        String sourceKey = source.substring(slashIndex + 1);
+        String copySourceRange = httpHeaders.getHeaderString("x-amz-copy-source-range");
+        String eTag = s3Service.uploadPartCopy(destBucket, destKey, uploadId, partNumber,
+                sourceBucket, sourceKey, copySourceRange);
+        String xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("CopyPartResult", AwsNamespaces.S3)
+                .elem("LastModified", ISO_FORMAT.format(java.time.Instant.now()))
+                .elem("ETag", eTag)
+                .end("CopyPartResult")
+                .build();
+        return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
 
     private Response handleGetObjectAttributes(String bucket, String key, String versionId,

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -786,6 +786,26 @@ public class S3Service {
         return eTag;
     }
 
+    public String uploadPartCopy(String destBucket, String destKey, String uploadId, int partNumber,
+                                  String sourceBucket, String sourceKey, String copySourceRange) {
+        S3Object source = getObject(sourceBucket, sourceKey);
+        byte[] data = source.getData();
+
+        if (copySourceRange != null && !copySourceRange.isBlank()) {
+            // format: "bytes=START-END" (inclusive on both ends)
+            String range = copySourceRange.startsWith("bytes=") ? copySourceRange.substring(6) : copySourceRange;
+            int dash = range.indexOf('-');
+            if (dash < 0) {
+                throw new AwsException("InvalidArgument", "Invalid x-amz-copy-source-range: " + copySourceRange, 400);
+            }
+            int start = Integer.parseInt(range.substring(0, dash).trim());
+            int end = Integer.parseInt(range.substring(dash + 1).trim());
+            data = Arrays.copyOfRange(data, start, end + 1);
+        }
+
+        return uploadPart(destBucket, destKey, uploadId, partNumber, data);
+    }
+
     public S3Object completeMultipartUpload(String bucket, String key, String uploadId, List<Integer> partNumbers) {
         MultipartUpload upload = multipartUploads.get(uploadId);
         if (upload == null || !upload.getBucket().equals(bucket) || !upload.getKey().equals(key)) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -178,8 +178,73 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(11)
+    void uploadPartCopy() {
+        // Put a source object
+        given()
+            .body("ABCDEFGHIJ")
+        .when()
+            .put("/" + BUCKET + "/source-for-copy.bin")
+        .then()
+            .statusCode(200);
+
+        // Initiate multipart upload for destination
+        String copyUploadId = given()
+            .when()
+                .post("/" + BUCKET + "/copy-dest.bin?uploads")
+            .then()
+                .statusCode(200)
+                .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        // UploadPartCopy full source
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/source-for-copy.bin")
+        .when()
+            .put("/" + BUCKET + "/copy-dest.bin?uploadId=" + copyUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CopyPartResult"))
+            .body(containsString("<ETag>"));
+
+        // UploadPartCopy with range (bytes 2-5 → "CDEF")
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/source-for-copy.bin")
+            .header("x-amz-copy-source-range", "bytes=2-5")
+        .when()
+            .put("/" + BUCKET + "/copy-dest.bin?uploadId=" + copyUploadId + "&partNumber=2")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CopyPartResult"))
+            .body(containsString("<ETag>"));
+
+        // Complete the upload
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                    <Part><PartNumber>2</PartNumber><ETag>etag2</ETag></Part>
+                </CompleteMultipartUpload>""";
+        given()
+            .contentType("application/xml")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/copy-dest.bin?uploadId=" + copyUploadId)
+        .then()
+            .statusCode(200);
+
+        // Verify contents: full source + ranged slice
+        given()
+        .when()
+            .get("/" + BUCKET + "/copy-dest.bin")
+        .then()
+            .statusCode(200)
+            .body(equalTo("ABCDEFGHIJCDEF"));
+    }
+
+    @Test
+    @Order(12)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/source-for-copy.bin").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/copy-dest.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);
     }
 }


### PR DESCRIPTION
## Summary

Implements `UploadPartCopy` for S3 multipart uploads. When a `PUT /{bucket}/{key}?uploadId=...&partNumber=N` request includes an `x-amz-copy-source` header, the part data is read from the specified source object rather than the request body. An optional `x-amz-copy-source-range: bytes=START-END` header is supported to copy only a byte range of the source.

  ## Type of change

  - [ ] Bug fix (`fix:`)
  - [x] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore

  ## AWS Compatibility

 Verified wire protocol against AWS SDK for Java v2 and AWS CLI v2. The `UploadPartCopy` action is documented in the [S3 API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html). Request routing is handled via the existing `PUT /{bucket}/{key}` endpoint by detecting the `x-amz-copy-source` header. The response body is a `CopyPartResult` XML element containing `LastModified` and `ETag`, matching the AWS wire format.

  ## Checklist

  - [x] `./mvnw test` passes locally
  - [x] New or updated integration test added
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)