### PR TITLE
ci: scope workflow triggers to relevant file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - '.github/workflows/ci.yml'
   pull_request:
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -2,6 +2,19 @@ name: Compatibility Tests
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - 'Dockerfile'
+      - 'Dockerfile.jvm-package'
+      - 'Dockerfile.native'
+      - 'Dockerfile.native-package'
+      - 'docker-compose.yml'
+      - 'docker-compose-test.yml'
+      - '.github/workflows/compatibility.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,8 @@ on:
       - main
       - develop
     paths:
-      - "docs/**"
-      - "mkdocs.yml"
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -12,6 +12,20 @@ on:
     branches:
       - 'release/[0-9]+.x'
       - 'release/[0-9]+.[0-9]+.x'
+    paths:
+      - 'src/**'
+      - 'pom.xml'
+      - '.mvn/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - 'Dockerfile'
+      - 'Dockerfile.jvm-package'
+      - 'Dockerfile.native'
+      - 'Dockerfile.native-package'
+      - 'docker-compose.yml'
+      - 'docker-compose-test.yml'
+      - '.releaserc.json'
+      - '.github/workflows/semver.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- scope CI, compatibility, docs, and semantic-release workflows to prevent running on every repository change
- prevent docs-only pull requests and release-branch documentation updates from triggering heavyweight test and release automation

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
