### PR TITLE
feat: support GSI and LSI in CloudFormation DynamoDB table provisioning

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -3,7 +3,9 @@ package io.github.hectorvent.floci.services.cloudformation;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
+import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
+import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
 import io.github.hectorvent.floci.services.iam.IamService;
 import io.github.hectorvent.floci.services.kms.KmsService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
@@ -190,6 +192,8 @@ public class CloudFormationResourceProvisioner {
 
         List<KeySchemaElement> keySchema = new ArrayList<>();
         List<AttributeDefinition> attrDefs = new ArrayList<>();
+        List<GlobalSecondaryIndex> gsis = new ArrayList<>();
+        List<LocalSecondaryIndex> lsis = new ArrayList<>();
 
         if (props != null && props.has("KeySchema")) {
             for (JsonNode ks : props.get("KeySchema")) {
@@ -206,12 +210,52 @@ public class CloudFormationResourceProvisioner {
             }
         }
 
+        if (props != null && props.has("GlobalSecondaryIndexes")) {
+            for (JsonNode gsiNode : props.get("GlobalSecondaryIndexes")) {
+                String indexName = engine.resolve(gsiNode.get("IndexName"));
+                List<KeySchemaElement> gsiKeySchema = new ArrayList<>();
+                if (gsiNode.has("KeySchema")) {
+                    for (JsonNode ks : gsiNode.get("KeySchema")) {
+                        String attrName = engine.resolve(ks.get("AttributeName"));
+                        String keyType = engine.resolve(ks.get("KeyType"));
+                        gsiKeySchema.add(new KeySchemaElement(attrName, keyType));
+                    }
+                }
+                String projectionType = "ALL";
+                JsonNode projection = gsiNode.get("Projection");
+                if (projection != null && projection.has("ProjectionType")) {
+                    projectionType = engine.resolve(projection.get("ProjectionType"));
+                }
+                gsis.add(new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType));
+            }
+        }
+
+        if (props != null && props.has("LocalSecondaryIndexes")) {
+            for (JsonNode lsiNode : props.get("LocalSecondaryIndexes")) {
+                String indexName = engine.resolve(lsiNode.get("IndexName"));
+                List<KeySchemaElement> lsiKeySchema = new ArrayList<>();
+                if (lsiNode.has("KeySchema")) {
+                    for (JsonNode ks : lsiNode.get("KeySchema")) {
+                        String attrName = engine.resolve(ks.get("AttributeName"));
+                        String keyType = engine.resolve(ks.get("KeyType"));
+                        lsiKeySchema.add(new KeySchemaElement(attrName, keyType));
+                    }
+                }
+                String projectionType = "ALL";
+                JsonNode projection = lsiNode.get("Projection");
+                if (projection != null && projection.has("ProjectionType")) {
+                    projectionType = engine.resolve(projection.get("ProjectionType"));
+                }
+                lsis.add(new LocalSecondaryIndex(indexName, lsiKeySchema, null, projectionType));
+            }
+        }
+
         if (keySchema.isEmpty()) {
             keySchema.add(new KeySchemaElement("id", "HASH"));
             attrDefs.add(new AttributeDefinition("id", "S"));
         }
 
-        var table = dynamoDbService.createTable(tableName, keySchema, attrDefs, null, null, region);
+        var table = dynamoDbService.createTable(tableName, keySchema, attrDefs, null, null, gsis, lsis, region);
         r.setPhysicalId(tableName);
         r.getAttributes().put("Arn", table.getTableArn());
         r.getAttributes().put("StreamArn", table.getTableArn() + "/stream/2024-01-01T00:00:00.000");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1,14 +1,28 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
 class CloudFormationIntegrationTest {
+
+    private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssured.config = RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(DYNAMODB_CONTENT_TYPE, ContentType.TEXT));
+    }
 
     @Test
     void createStack_withS3AndSqs() {
@@ -73,6 +87,79 @@ class CloudFormationIntegrationTest {
             .statusCode(200)
             .body(containsString("<StackName>test-stack</StackName>"))
             .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+    }
+
+    @Test
+    void createStack_withDynamoDbGsiAndLsi() {
+        String template = """
+            {
+                "Resources": {
+                    "MyTable": {
+                        "Type": "AWS::DynamoDB::Table",
+                        "Properties": {
+                            "TableName": "cf-index-table",
+                            "AttributeDefinitions": [
+                                {"AttributeName": "pk", "AttributeType": "S"},
+                                {"AttributeName": "sk", "AttributeType": "S"},
+                                {"AttributeName": "gsiPk", "AttributeType": "S"}
+                            ],
+                            "KeySchema": [
+                                {"AttributeName": "pk", "KeyType": "HASH"},
+                                {"AttributeName": "sk", "KeyType": "RANGE"}
+                            ],
+                            "GlobalSecondaryIndexes": [
+                                {
+                                    "IndexName": "gsi-1",
+                                    "KeySchema": [
+                                        {"AttributeName": "gsiPk", "KeyType": "HASH"},
+                                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                                    ],
+                                    "Projection": {"ProjectionType": "ALL"}
+                                }
+                            ],
+                            "LocalSecondaryIndexes": [
+                                {
+                                    "IndexName": "lsi-1",
+                                    "KeySchema": [
+                                        {"AttributeName": "pk", "KeyType": "HASH"},
+                                        {"AttributeName": "gsiPk", "KeyType": "RANGE"}
+                                    ],
+                                    "Projection": {"ProjectionType": "KEYS_ONLY"}
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+            """;
+
+        // 1. Create Stack
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "test-dynamo-index-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // 2. Verify GSI and LSI via DescribeTable
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "cf-index-table"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.GlobalSecondaryIndexes.size()", equalTo(1))
+            .body("Table.GlobalSecondaryIndexes[0].IndexName", equalTo("gsi-1"))
+            .body("Table.LocalSecondaryIndexes.size()", equalTo(1))
+            .body("Table.LocalSecondaryIndexes[0].IndexName", equalTo("lsi-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -79,6 +79,66 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    void createTableWithGsiAndLsi() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "IndexTable",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"},
+                        {"AttributeName": "gsiPk", "AttributeType": "S"}
+                    ],
+                    "GlobalSecondaryIndexes": [
+                        {
+                            "IndexName": "gsi-1",
+                            "KeySchema": [
+                                {"AttributeName": "gsiPk", "KeyType": "HASH"},
+                                {"AttributeName": "sk", "KeyType": "RANGE"}
+                            ],
+                            "Projection": {"ProjectionType": "ALL"}
+                        }
+                    ],
+                    "LocalSecondaryIndexes": [
+                        {
+                            "IndexName": "lsi-1",
+                            "KeySchema": [
+                                {"AttributeName": "pk", "KeyType": "HASH"},
+                                {"AttributeName": "gsiPk", "KeyType": "RANGE"}
+                            ],
+                            "Projection": {"ProjectionType": "KEYS_ONLY"}
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes.size()", equalTo(1))
+            .body("TableDescription.GlobalSecondaryIndexes[0].IndexName", equalTo("gsi-1"))
+            .body("TableDescription.LocalSecondaryIndexes.size()", equalTo(1))
+            .body("TableDescription.LocalSecondaryIndexes[0].IndexName", equalTo("lsi-1"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "IndexTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     @Order(3)
     void describeTable() {
         given()


### PR DESCRIPTION
## Summary

Add support for GlobalSecondaryIndexes (GSI) and LocalSecondaryIndexes (LSI) when provisioning AWS::DynamoDB::Table resources via CloudFormation.

Closes: #122

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

The CloudFormation provisioner now parses GlobalSecondaryIndexes and LocalSecondaryIndexes properties from the template and passes them to `DynamoDbService.createTable()`. Supports KeySchema and Projection (ProjectionType) for each index.

Verified via DynamoDB_20120810.DescribeTable (JSON 1.0 protocol) that GSI and LSI are correctly returned after stack creation.

For verification, we used `aws-cdk-lib@2.176.0`.

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

> Note: 4 failures in AcmImportExportTest also occur on main and are unrelated to this PR.