### PR TITLE
fix: added versionId to S3 notifications for versioning enabled buckets.

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1019,7 +1019,7 @@ public class S3Service {
         }
 
         String region = regionResolver != null ? regionResolver.getDefaultRegion() : "us-east-1";
-        String eventJson = buildS3EventJson(bucketName, key, eventName, obj, region);
+        String eventJson = buildS3EventJson(bucketName, key, eventName, obj, region, bucket.isVersioningEnabled());
 
         for (QueueNotification qn : config.getQueueConfigurations()) {
             if (qn.events().stream().anyMatch(p -> matchesEvent(p, eventName))) {
@@ -1058,7 +1058,7 @@ public class S3Service {
     }
 
     private String buildS3EventJson(String bucketName, String key, String eventName,
-                                    S3Object obj, String region) {
+                                    S3Object obj, String region, boolean isVersionEnabled) {
         try {
             String eventTime = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
             long size = obj != null ? obj.getSize() : 0;
@@ -1073,7 +1073,10 @@ public class S3Service {
             objectNode.put("key", key);
             objectNode.put("size", size);
             objectNode.put("eTag", eTag);
-
+            if(isVersionEnabled) {
+                String versionId = obj !=null && obj.getVersionId()!=null ? obj.getVersionId() : "";
+                objectNode.put("versionId", versionId);
+            }
             ObjectNode s3Node = objectMapper.createObjectNode();
             s3Node.put("s3SchemaVersion", "1.0");
             s3Node.put("configurationId", "emulator");


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix: Added versionId to S3 Notifications for Buckets that have Versioning enabled.`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
 S3 Notification Messages for buckets with versioning enabled were not sending the object's verionId in the notification message.

## Checklist

- [ x] `./mvnw test` passes locally
- [x ] New or updated integration test added
- [ x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
