### PR TITLE
fix(s3): expose inMemory flag in test constructor to fix S3

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -70,8 +70,8 @@ public class S3Service {
      */
     S3Service(StorageBackend<String, Bucket> bucketStore,
               StorageBackend<String, S3Object> objectStore,
-              Path dataRoot) {
-        this(bucketStore, objectStore, dataRoot, true, null, null, null, "http://localhost:4566",
+              Path dataRoot, boolean inMemory) {
+        this(bucketStore, objectStore, dataRoot, inMemory, null, null, null, "http://localhost:4566",
                 new ObjectMapper());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
@@ -27,7 +27,7 @@ class S3MultipartServiceTest {
 
     @BeforeEach
     void setUp() {
-        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir);
+        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir, true);
         s3Service.createBucket("test-bucket", "us-east-1");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -29,7 +29,7 @@ class S3ServiceTest {
     @BeforeEach
     void setUp() {
         Path dataRoot = tempDir.resolve("s3");
-        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot);
+        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -22,7 +22,7 @@ class S3VersioningServiceTest {
 
     @BeforeEach
     void setUp() {
-        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir);
+        s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir, true);
         s3Service.createBucket("versioned-bucket", "us-east-1");
     }
 


### PR DESCRIPTION
I fixed the expose in-memory flag in test constructor to fix S3 disk-persistence tests

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
