### PR TITLE
fix(core): inject x-amz-request-id headers globally to properly support SDK ResponseMetadata

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsRequestIdFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsRequestIdFilter.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.core.common;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.UUID;
+
+/**
+ * Adds AWS request-id response headers to every HTTP response.
+ *
+ * <p>Real AWS services always return a request identifier so that SDKs can
+ * populate {@code $metadata.requestId}.  The header name varies by protocol:
+ * <ul>
+ *   <li>{@code x-amz-request-id} — REST XML (S3), REST JSON (Lambda), Query protocol</li>
+ *   <li>{@code x-amzn-RequestId}  — JSON 1.0 / 1.1 services (DynamoDB, SSM, …)</li>
+ *   <li>{@code x-amz-id-2}        — S3 extended request ID</li>
+ * </ul>
+ *
+ * <p>This filter emits all three so that every AWS SDK variant can find the
+ * header it expects.  If a controller already set {@code x-amz-request-id}
+ * (e.g. Lambda invoke), the existing value is preserved.
+ */
+@Provider
+public class AwsRequestIdFilter implements ContainerResponseFilter {
+
+    private static final String AMZ_REQUEST_ID = "x-amz-request-id";
+    private static final String AMZN_REQUEST_ID = "x-amzn-RequestId";
+    private static final String AMZ_ID_2 = "x-amz-id-2";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+        var headers = responseContext.getHeaders();
+
+        // Reuse the same ID across all header variants for this response
+        String requestId = UUID.randomUUID().toString();
+
+        if (!headers.containsKey(AMZ_REQUEST_ID)) {
+            headers.putSingle(AMZ_REQUEST_ID, requestId);
+        }
+        if (!headers.containsKey(AMZN_REQUEST_ID)) {
+            headers.putSingle(AMZN_REQUEST_ID, requestId);
+        }
+        if (!headers.containsKey(AMZ_ID_2)) {
+            headers.putSingle(AMZ_ID_2, requestId);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsRequestIdFilterIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsRequestIdFilterIntegrationTest.java
@@ -1,0 +1,156 @@
+package io.github.hectorvent.floci.core.common;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Verifies that {@link AwsRequestIdFilter} injects {@code x-amz-request-id} and
+ * {@code x-amzn-RequestId} headers on every response, across all three AWS wire
+ * protocols supported by Floci: REST XML (S3), JSON 1.0 (DynamoDB), and Query (SQS).
+ *
+ * <p>These headers are the source from which the AWS SDK v3 populates
+ * {@code $metadata.requestId} and {@code $metadata.httpStatusCode} on every
+ * command output.
+ */
+@QuarkusTest
+class AwsRequestIdFilterIntegrationTest {
+
+    private static final String SSM_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssured.config = RestAssured.config().encoderConfig(
+                EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(SSM_CONTENT_TYPE, ContentType.TEXT)
+                        .encodeContentTypeAs(DYNAMODB_CONTENT_TYPE, ContentType.TEXT));
+    }
+
+    // --- REST XML protocol (S3) ---
+
+    @Test
+    void s3SuccessResponseContainsRequestIdHeaders() {
+        // Create a temporary bucket, verify headers, then clean it up
+        String bucket = "request-id-test-bucket";
+
+        given()
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+
+        given().delete("/" + bucket);
+    }
+
+    @Test
+    void s3ErrorResponseContainsRequestIdHeaders() {
+        // Requesting a non-existent bucket produces a 404 error response —
+        // the headers must still be present so the SDK can surface the request ID.
+        given()
+        .when()
+            .get("/no-such-bucket-floci-test")
+        .then()
+            .statusCode(404)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+    }
+
+    @Test
+    void s3CopyObjectResponseContainsRequestIdHeaders() {
+        String bucket = "request-id-copy-bucket";
+        given().put("/" + bucket).then().statusCode(200);
+
+        given()
+            .contentType("text/plain")
+            .body("hello")
+        .when()
+            .put("/" + bucket + "/src.txt")
+        .then()
+            .statusCode(200);
+
+        // CopyObject is the operation the user reported as missing $metadata.requestId
+        given()
+            .header("x-amz-copy-source", "/" + bucket + "/src.txt")
+        .when()
+            .put("/" + bucket + "/dst.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+
+        given().delete("/" + bucket + "/src.txt");
+        given().delete("/" + bucket + "/dst.txt");
+        given().delete("/" + bucket);
+    }
+
+    // --- JSON 1.0 protocol (DynamoDB) ---
+
+    @Test
+    void dynamoDbSuccessResponseContainsRequestIdHeaders() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ListTables")
+            .contentType("application/x-amz-json-1.0")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+    }
+
+    @Test
+    void dynamoDbErrorResponseContainsRequestIdHeaders() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType("application/x-amz-json-1.0")
+            .body("{\"TableName\": \"NonExistentTable\", \"Key\": {\"id\": {\"S\": \"1\"}}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+    }
+
+    // --- Query protocol (SQS) ---
+
+    @Test
+    void sqsSuccessResponseContainsRequestIdHeaders() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListQueues")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+    }
+
+    // --- JSON 1.1 protocol (SSM) ---
+
+    @Test
+    void ssmSuccessResponseContainsRequestIdHeaders() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribeParameters")
+            .contentType("application/x-amz-json-1.1")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .header("x-amz-request-id", notNullValue())
+            .header("x-amzn-RequestId", notNullValue());
+    }
+}


### PR DESCRIPTION
## Summary

This PR establishes a JAX-RS `AwsRequestIdFilter` (`ContainerResponseFilter`) to globally inject the necessary request identifier HTTP headers into all outgoing Floci responses regardless of the underlying controller or AWS wire protocol.

Closes #145 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect Behavior:** When Floci answered generic REST HTTP responses, it omitted the structural request IDs natively used by AWS SDK middlewares. This lead to the SDK `ResponseMetadata` block being inherently incomplete, with `requestId` (and `extendedRequestId` for S3) perpetually returning as `undefined` in client applications.

**Verification:** By explicitly appending `x-amz-request-id` (REST XML / Query shapes), `x-amzn-RequestId` (JSON 1.0/1.1 shapes), and `x-amz-id-2` (S3 extended) via a single shared UUID, we guarantee identical parsing compatibility as AWS servers. The SDK utilizes these headers to unequivocally populate `requestId` on the output envelope. Preexisting intentional headers (such as `x-amz-request-id` established by Lambda `Invoke` contexts) are respected and bypassed proactively to preserve contextual fidelity. Verified successfully against AWS SDK for JavaScript v3.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New integration test added (`AwsRequestIdFilterIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
