### PR TITLE
fix: defer startup hooks until HTTP server is ready

### DIFF
--- a/docs/configuration/initialization-hooks.md
+++ b/docs/configuration/initialization-hooks.md
@@ -5,7 +5,7 @@ environment (creating buckets, populating data, configuring resources, etc.) or 
 
 Hook scripts ending with `.sh` are discovered in the following directories:
 
-- **Startup hooks** (`/etc/floci/init/start.d`) run after Floci services are initialized, but before the environment is marked as ready.
+- **Startup hooks** (`/etc/floci/init/start.d`) run after the HTTP server is ready and accepting connections on port 4566. This means hooks can safely make HTTP calls back to Floci (e.g. using the AWS CLI).
 - **Shutdown hooks** (`/etc/floci/init/stop.d`) run when Floci is shutting down, after `destroy()` is triggered.
 
 If a hook directory does not exist or contains no `.sh` scripts, Floci skips it and continues normally.
@@ -22,8 +22,15 @@ Hooks run:
 - With access to configured services and their endpoints
 - With the same environment variables as Floci
 
-Hooks can call Floci service endpoints directly from inside the container. If a hook depends on additional CLI tools,
-make sure those tools are available in the runtime image.
+Hooks can call Floci service endpoints directly from inside the container (e.g. `http://localhost:4566`).
+The published Docker image does not include the AWS CLI. If your hooks require it, extend the image:
+
+```dockerfile
+FROM ghcr.io/hectorvent/floci:latest
+RUN apk add --no-cache aws-cli
+```
+
+If a hook depends on additional CLI tools, make sure those tools are available in the runtime image.
 
 ### Execution Behavior
 
@@ -38,7 +45,8 @@ Execution uses a fail-fast strategy:
 
 - If a script exits with a non-zero status, remaining hooks are not executed.
 - If a script exceeds the configured timeout, it is terminated and remaining hooks are not executed.
-- A hook failure marks the corresponding startup or shutdown phase as **failed**.
+- A startup hook failure triggers application shutdown.
+- A shutdown hook failure is logged but does not prevent the shutdown from completing.
 
 ## Examples
 

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -15,11 +16,17 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 
 @ApplicationScoped
 public class EmulatorLifecycle {
 
     private static final Logger LOG = Logger.getLogger(EmulatorLifecycle.class);
+    private static final int HTTP_PORT = 4566;
+    private static final int PORT_POLL_TIMEOUT_MS = 100;
+    private static final int PORT_POLL_INTERVAL_MS = 50;
+    private static final int PORT_POLL_MAX_RETRIES = 100;
 
     private final StorageFactory storageFactory;
     private final ServiceRegistry serviceRegistry;
@@ -40,16 +47,44 @@ public class EmulatorLifecycle {
         this.initializationHooksRunner = initializationHooksRunner;
     }
 
-    void onStart(@Observes StartupEvent ignored) throws IOException, InterruptedException {
+    void onStart(@Observes StartupEvent ignored) throws IOException {
         LOG.info("=== AWS Local Emulator Starting ===");
         LOG.infov("Storage mode: {0}", config.storage().mode());
         LOG.infov("Persistent path: {0}", config.storage().persistentPath());
 
         serviceRegistry.logEnabledServices();
         storageFactory.loadAll();
-        initializationHooksRunner.run(InitializationHook.START);
 
-        LOG.info("=== AWS Local Emulator Ready ===");
+        if (initializationHooksRunner.hasHooks(InitializationHook.START)) {
+            LOG.info("Startup hooks detected — deferring execution until HTTP server is ready");
+            Thread.ofVirtual().name("init-hooks-runner").start(this::runStartupHooksAfterReady);
+        } else {
+            LOG.info("=== AWS Local Emulator Ready ===");
+        }
+    }
+
+    private void runStartupHooksAfterReady() {
+        try {
+            waitForHttpPort();
+            initializationHooksRunner.run(InitializationHook.START);
+            LOG.info("=== AWS Local Emulator Ready ===");
+        } catch (Exception e) {
+            LOG.error("Startup hook execution failed — shutting down", e);
+            Quarkus.asyncExit();
+        }
+    }
+
+    private static void waitForHttpPort() throws InterruptedException {
+        for (int attempt = 1; attempt <= PORT_POLL_MAX_RETRIES; attempt++) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress("localhost", HTTP_PORT), PORT_POLL_TIMEOUT_MS);
+                LOG.debugv("HTTP port {0} is ready (attempt {1})", HTTP_PORT, attempt);
+                return;
+            } catch (IOException ignored) {
+                Thread.sleep(PORT_POLL_INTERVAL_MS);
+            }
+        }
+        throw new IllegalStateException("HTTP port " + HTTP_PORT + " did not become ready in time");
     }
 
     void onStop(@Observes ShutdownEvent ignored) throws IOException, InterruptedException {

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunner.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunner.java
@@ -44,6 +44,10 @@ public class InitializationHooksRunner {
         return scriptFileNames;
     }
 
+    public boolean hasHooks(final InitializationHook hook) {
+        return findScriptFileNames(hook.getName(), hook.getPath()).length > 0;
+    }
+
     public void run(final InitializationHook hook) throws IOException, InterruptedException {
         final String hookName = hook.getName();
         final File hookDirectory = hook.getPath();

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.ServiceRegistry;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
+import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
+import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
+import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import io.quarkus.runtime.StartupEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmulatorLifecycleTest {
+
+    @Mock private StorageFactory storageFactory;
+    @Mock private ServiceRegistry serviceRegistry;
+    @Mock private EmulatorConfig config;
+    @Mock private EmulatorConfig.StorageConfig storageConfig;
+    @Mock private ElastiCacheProxyManager elastiCacheProxyManager;
+    @Mock private RdsProxyManager rdsProxyManager;
+    @Mock private InitializationHooksRunner initializationHooksRunner;
+
+    private EmulatorLifecycle emulatorLifecycle;
+
+    @BeforeEach
+    void setUp() {
+        when(config.storage()).thenReturn(storageConfig);
+        when(storageConfig.mode()).thenReturn("in-memory");
+        when(storageConfig.persistentPath()).thenReturn("/app/data");
+        emulatorLifecycle = new EmulatorLifecycle(
+                storageFactory, serviceRegistry, config,
+                elastiCacheProxyManager, rdsProxyManager, initializationHooksRunner);
+    }
+
+    @Test
+    @DisplayName("Should log Ready immediately when no startup hooks exist")
+    void shouldLogReadyImmediatelyWhenNoHooksExist() throws IOException, InterruptedException {
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        verify(storageFactory).loadAll();
+        verify(initializationHooksRunner).hasHooks(InitializationHook.START);
+        verify(initializationHooksRunner, never()).run(InitializationHook.START);
+    }
+
+    @Test
+    @DisplayName("Should defer hook execution when startup hooks exist")
+    void shouldDeferHookExecutionWhenHooksExist() throws IOException, InterruptedException {
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(true);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        verify(storageFactory).loadAll();
+        verify(initializationHooksRunner).hasHooks(InitializationHook.START);
+        // run() is NOT called synchronously — it will be called by the virtual thread
+        verify(initializationHooksRunner, never()).run(InitializationHook.START);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunnerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunnerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -12,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 @ExtendWith(MockitoExtension.class)
 class InitializationHooksRunnerTest {
@@ -150,6 +153,37 @@ class InitializationHooksRunnerTest {
 
         Mockito.verify(hookScriptExecutorMock).run(hookDirectory, "10-bootstrap.sh");
         Assertions.assertSame(interruptedException, exception);
+    }
+
+    @Test
+    @DisplayName("hasHooks should return true when scripts exist in hook directory")
+    void hasHooksShouldReturnTrueWhenScriptsExist(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("01-setup.sh"));
+        InitializationHook hook = Mockito.mock(InitializationHook.class);
+        Mockito.when(hook.getName()).thenReturn("startup");
+        Mockito.when(hook.getPath()).thenReturn(tempDir.toFile());
+
+        Assertions.assertTrue(initializationHooksRunner.hasHooks(hook));
+    }
+
+    @Test
+    @DisplayName("hasHooks should return false when hook directory is empty")
+    void hasHooksShouldReturnFalseWhenDirectoryIsEmpty(@TempDir Path tempDir) {
+        InitializationHook hook = Mockito.mock(InitializationHook.class);
+        Mockito.when(hook.getName()).thenReturn("startup");
+        Mockito.when(hook.getPath()).thenReturn(tempDir.toFile());
+
+        Assertions.assertFalse(initializationHooksRunner.hasHooks(hook));
+    }
+
+    @Test
+    @DisplayName("hasHooks should return false when hook directory does not exist")
+    void hasHooksShouldReturnFalseWhenDirectoryDoesNotExist() {
+        InitializationHook hook = Mockito.mock(InitializationHook.class);
+        Mockito.when(hook.getName()).thenReturn("startup");
+        Mockito.when(hook.getPath()).thenReturn(new File("/nonexistent/path"));
+
+        Assertions.assertFalse(initializationHooksRunner.hasHooks(hook));
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #157 — init hooks that make HTTP calls back to floci (e.g. `aws --endpoint-url http://localhost:4566 ...`) deadlocked because they ran synchronously during Quarkus `StartupEvent`, before the HTTP server bound to port 4566.

- **Deferred execution**: when startup hooks are detected, a virtual thread (`Thread.ofVirtual()`) polls TCP port 4566 until reachable, then executes hooks
- **No-hooks path unchanged**: when no `.sh` scripts exist in `/etc/floci/init/start.d`, behavior is identical to before (synchronous "Ready" log)
- **Failure handling**: hook failure logs the error and calls `Quarkus.asyncExit()` for graceful shutdown
- **`hasHooks()` guard**: avoids spawning a thread + polling when no hooks are configured (the common case)
- **Docs updated**: startup hooks now documented as running after HTTP server is ready; added AWS CLI extension instructions

## Changes

| File | What |
|------|------|
| `EmulatorLifecycle.java` | Defer hook execution to virtual thread with TCP port polling |
| `InitializationHooksRunner.java` | Add `hasHooks(InitializationHook)` method |
| `EmulatorLifecycleTest.java` | New: 2 tests (no-hooks sync path, hooks deferred path) |
| `InitializationHooksRunnerTest.java` | 3 new tests for `hasHooks()` |
| `initialization-hooks.md` | Updated timing, failure behavior, AWS CLI guidance |

## Test plan

- [x] `InitializationHooksRunnerTest` — 11/11 pass (8 existing + 3 new `hasHooks` tests)
- [x] `EmulatorLifecycleTest` — 2/2 pass (new)
- [x] Full suite — 1020/1022 pass (2 pre-existing failures in `S3MultipartIntegrationTest`, unrelated)
- [x] Docker integration — verified with hook running `aws ssm put-parameter`, `aws dynamodb create-table`, `aws s3 mb` back to `localhost:4566` — no deadlock, completes in ~5s