### PR TITLE
docs: clean up named volume examples in docker-compose docs

### DIFF
--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -11,16 +11,9 @@ services:
     ports:
       - "4566:4566"
     volumes:
-      # Local directory bind mount (default)
       - ./data:/app/data
-      
-      # OR named volume (optional):
-      # - floci-data:/app/data
       - ./init/start.d:/etc/floci/init/start.d:ro
       - ./init/stop.d:/etc/floci/init/stop.d:ro
-
-#volumes:
-#  floci-data:
 ```
 
 ## Full Setup (with ElastiCache and RDS)
@@ -36,17 +29,10 @@ services:
       - "6379-6399:6379-6399"  # ElastiCache / Redis proxy ports
       - "7001-7099:7001-7099"  # RDS / PostgreSQL + MySQL proxy ports
     volumes:
-      # Local directory bind mount (default)
-      - ./data:/app/data
-      
-      # OR named volume (optional):
-      # - floci-data:/app/data
       - /var/run/docker.sock:/var/run/docker.sock  # required for Lambda, ElastiCache, RDS
+      - ./data:/app/data
     environment:
       FLOCI_SERVICES_DOCKER_NETWORK: my-project_default  # (1)
-
-#volumes:
-#  floci-data:
 ```
 
 1. Set this to the Docker network name that your compose project creates (usually `<project-name>_default`). Floci uses it to attach spawned Lambda / ElastiCache / RDS containers to the same network.
@@ -82,18 +68,33 @@ services:
     ports:
       - "4566:4566"
     volumes:
-      # Local directory bind mount (default)
       - ./data:/app/data
-      
-      # OR named volume (optional):
-      # - floci-data:/app/data
+    environment:
+      FLOCI_STORAGE_MODE: persistent
+      FLOCI_STORAGE_PERSISTENT_PATH: /app/data
+```
+
+### Using Named Volumes
+
+Instead of bind-mounting a local directory, you can use Docker named volumes to keep your project directory clean:
+
+```yaml
+services:
+  floci:
+    image: hectorvent/floci:latest
+    ports:
+      - "4566:4566"
+    volumes:
+      - floci-data:/app/data
     environment:
       FLOCI_STORAGE_MODE: persistent
       FLOCI_STORAGE_PERSISTENT_PATH: /app/data
 
-#volumes:
-#  floci-data:
+volumes:
+  floci-data:
 ```
+
+Named volumes are managed entirely by Docker and won't create files in your repository. This works with both the JVM and native images.
 
 ## Environment Variables Reference
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -17,12 +17,12 @@ This guide gets Floci running and verifies that AWS CLI commands work against it
         volumes:
           # Local directory bind mount (default)
           - ./data:/app/data
-          
+    
           # OR named volume (optional):
           # - floci-data:/app/data
-
-#    volumes:
-#      floci-data:
+    
+    # volumes:
+    #   floci-data:
     ```
 
     ```bash
@@ -42,12 +42,12 @@ This guide gets Floci running and verifies that AWS CLI commands work against it
         volumes:
           # Local directory bind mount (default)
           - ./data:/app/data
-          
+    
           # OR named volume (optional):
           # - floci-data:/app/data
-
-#    volumes:
-#      floci-data:
+    
+    # volumes:
+    #   floci-data:
     ```
 
     ```bash


### PR DESCRIPTION
## Summary

Follows up on #155 by cleaning up the docker-compose documentation. Closes #154.

- Remove commented-out named volume lines scattered across existing examples (Minimal, Full, Persistence)
- Add a dedicated "Using Named Volumes" section under Persistence with a clean, standalone example

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — documentation only.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)