### PR TITLE
fix(s3): list part for multipart upload

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -368,6 +368,9 @@ public class S3Controller {
     public Response getObject(@PathParam("bucket") String bucket,
                               @PathParam("key") String key,
                               @QueryParam("versionId") String versionId,
+                              @QueryParam("uploadId") String uploadId,
+                              @QueryParam("max-parts") Integer maxPartsQuery,
+                              @QueryParam("part-number-marker") String partNumberMarkerQuery,
                               @HeaderParam("x-amz-object-attributes") String objectAttributesHeader,
                               @HeaderParam("x-amz-max-parts") Integer maxParts,
                               @HeaderParam("x-amz-part-number-marker") Integer partNumberMarker,
@@ -379,6 +382,9 @@ public class S3Controller {
                               @Context UriInfo uriInfo,
                               @Context HttpHeaders httpHeaders) {
         try {
+            if (uploadId != null) {
+                return handleListParts(bucket, key, uploadId, maxPartsQuery, partNumberMarkerQuery);
+            }
             if (hasQueryParam(uriInfo, "tagging")) {
                 return handleGetObjectTagging(bucket, key);
             }
@@ -677,6 +683,63 @@ public class S3Controller {
         }
         builder.end("DeleteResult");
         return Response.ok(builder.build()).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private Response handleListParts(String bucket, String key, String uploadId,
+                                      Integer maxPartsParam, String partNumberMarkerParam) {
+        MultipartUpload upload = s3Service.listParts(bucket, key, uploadId);
+        int maxPartsLimit = (maxPartsParam != null && maxPartsParam > 0) ? maxPartsParam : 1000;
+        int markerValue = 0;
+        if (partNumberMarkerParam != null && !partNumberMarkerParam.isBlank()) {
+            try {
+                markerValue = Integer.parseInt(partNumberMarkerParam.trim());
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        final int marker = markerValue;
+
+        List<Part> sortedParts = upload.getParts().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .filter(e -> e.getKey() > marker)
+                .limit(maxPartsLimit + 1L)
+                .map(Map.Entry::getValue)
+                .toList();
+
+        boolean truncated = sortedParts.size() > maxPartsLimit;
+        List<Part> page = truncated ? sortedParts.subList(0, maxPartsLimit) : sortedParts;
+        String nextMarker = truncated ? String.valueOf(page.getLast().getPartNumber()) : null;
+
+        XmlBuilder xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("ListPartsResult", AwsNamespaces.S3)
+                .elem("Bucket", bucket)
+                .elem("Key", key)
+                .elem("UploadId", uploadId)
+                .elem("PartNumberMarker", String.valueOf(marker))
+                .elem("MaxParts", maxPartsLimit)
+                .elem("IsTruncated", truncated);
+        if (truncated) {
+            xml.elem("NextPartNumberMarker", nextMarker);
+        }
+        for (Part part : page) {
+            xml.start("Part")
+               .elem("PartNumber", part.getPartNumber())
+               .elem("LastModified", ISO_FORMAT.format(part.getLastModified()))
+               .elem("ETag", part.getETag())
+               .elem("Size", part.getSize())
+               .end("Part");
+        }
+        xml.start("Initiator")
+           .elem("ID", "owner")
+           .elem("DisplayName", "owner")
+           .end("Initiator")
+           .start("Owner")
+           .elem("ID", "owner")
+           .elem("DisplayName", "owner")
+           .end("Owner")
+           .elem("StorageClass", upload.getStorageClass());
+        xml.end("ListPartsResult");
+        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
     }
 
     private Response handleListMultipartUploads(String bucket) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -908,6 +908,15 @@ public class S3Service {
                 .toList();
     }
 
+    public MultipartUpload listParts(String bucket, String key, String uploadId) {
+        MultipartUpload upload = multipartUploads.get(uploadId);
+        if (upload == null || !upload.getBucket().equals(bucket) || !upload.getKey().equals(key)) {
+            throw new AwsException("NoSuchUpload",
+                    "The specified multipart upload does not exist.", 404);
+        }
+        return upload;
+    }
+
     // --- Notification Configuration ---
 
     public void putBucketNotificationConfiguration(String bucketName, NotificationConfiguration config) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -69,6 +69,23 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(5)
+    void listParts() {
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + KEY + "?uploadId=" + uploadId)
+        .then()
+            .statusCode(200)
+            .body(containsString("<ListPartsResult"))
+            .body(containsString("<Bucket>" + BUCKET + "</Bucket>"))
+            .body(containsString("<Key>" + KEY + "</Key>"))
+            .body(containsString("<UploadId>" + uploadId + "</UploadId>"))
+            .body(containsString("<PartNumber>1</PartNumber>"))
+            .body(containsString("<PartNumber>2</PartNumber>"))
+            .body(containsString("<IsTruncated>false</IsTruncated>"));
+    }
+
+    @Test
+    @Order(6)
     void listMultipartUploads() {
         given()
         .when()
@@ -80,7 +97,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     void completeMultipartUpload() {
         String completeXml = """
                 <CompleteMultipartUpload>
@@ -101,7 +118,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(9)
     void getCompletedObject() {
         given()
         .when()
@@ -114,7 +131,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(10)
     void getMultipartObjectAttributes() {
         given()
             .header("x-amz-object-attributes", "ObjectParts,Checksum,StorageClass")
@@ -131,7 +148,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     void multipartUploadNoLongerListed() {
         given()
         .when()
@@ -142,7 +159,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(12)
     void abortMultipartUpload() {
         // Initiate new upload
         String newUploadId = given()
@@ -177,7 +194,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(13)
     void uploadPartCopy() {
         // Put a source object
         given()
@@ -240,7 +257,7 @@ class S3MultipartIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(14)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/source-for-copy.bin").then().statusCode(204);


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


## Details

Implement S3 ListParts operation (GET /{bucket}/{key}?uploadId=...) with pagination support (max-parts, part-number-marker), enabling SDK TransferManager to resume interrupted multipart uploads. 


Closes #47