### PR TITLE
test(dynamodb): add coverage for numeric ExpressionAttributeNames (#0, #1)

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -250,7 +250,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void queryWithNumericExpressionAttributeNames() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")
@@ -277,7 +277,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void queryWithFilterExpression() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")
@@ -303,7 +303,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void queryWithFilterExpressionAndLimitReturnsLastEvaluatedKey() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")
@@ -332,7 +332,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void scan() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Scan")
@@ -349,7 +349,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void deleteItem() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
@@ -389,7 +389,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(16)
     void transactWriteWithNumericExpressionAttributeNames() {
         // PynamoDB-style: attribute_not_exists(#0) where #0 maps to the PK
         given()
@@ -448,7 +448,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(17)
     void deleteTable() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
@@ -477,6 +477,7 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    @Order(18)
     void unsupportedOperation() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateGlobalTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -250,6 +250,33 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    @Order(10)
+    void queryWithNumericExpressionAttributeNames() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "#0 = :0 AND begins_with(#1, :prefix)",
+                    "ExpressionAttributeNames": {
+                        "#0": "pk",
+                        "#1": "sk"
+                    },
+                    "ExpressionAttributeValues": {
+                        ":0": {"S": "user-1"},
+                        ":prefix": {"S": "order"}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(2));
+    }
+
+    @Test
     @Order(11)
     void queryWithFilterExpression() {
         given()
@@ -359,6 +386,65 @@ class DynamoDbIntegrationTest {
         .then()
             .statusCode(200)
             .body("Item", nullValue());
+    }
+
+    @Test
+    @Order(14)
+    void transactWriteWithNumericExpressionAttributeNames() {
+        // PynamoDB-style: attribute_not_exists(#0) where #0 maps to the PK
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.TransactWriteItems")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TransactItems": [{
+                        "Put": {
+                            "TableName": "TestTable",
+                            "Item": {
+                                "pk": {"S": "user-transact"},
+                                "sk": {"S": "profile"},
+                                "name": {"S": "Test User"}
+                            },
+                            "ConditionExpression": "attribute_not_exists(#0)",
+                            "ExpressionAttributeNames": {
+                                "#0": "pk"
+                            }
+                        }
+                    }]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Second attempt — item exists now, condition should fail
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.TransactWriteItems")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TransactItems": [{
+                        "Put": {
+                            "TableName": "TestTable",
+                            "Item": {
+                                "pk": {"S": "user-transact"},
+                                "sk": {"S": "profile"},
+                                "name": {"S": "Duplicate"}
+                            },
+                            "ConditionExpression": "attribute_not_exists(#0)",
+                            "ExpressionAttributeNames": {
+                                "#0": "pk"
+                            }
+                        }
+                    }]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("TransactionCanceledException"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -201,6 +201,29 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void queryWithNumericExpressionAttributeNames() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o1"));
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o2"));
+        service.putItem("Orders", item("customerId", "c2", "orderId", "o1"));
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode pkVal = mapper.createObjectNode(); pkVal.put("S", "c1");
+        exprValues.set(":0", pkVal);
+        ObjectNode skVal = mapper.createObjectNode(); skVal.put("S", "o1");
+        exprValues.set(":1", skVal);
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#0", "customerId");
+        exprNames.put("#1", "orderId");
+
+        // PynamoDB-style: #0 = :0 AND #1 = :1
+        DynamoDbService.QueryResult results = service.query("Orders", null, exprValues,
+                "#0 = :0 AND #1 = :1", null, null, null, null, exprNames, "us-east-1");
+        assertEquals(1, results.items().size());
+    }
+
+    @Test
     void queryWithBeginsWith() {
         createOrdersTable();
         service.putItem("Orders", item("customerId", "c1", "orderId", "2024-01-01"));


### PR DESCRIPTION
Adds unit and integration tests verifying that numeric placeholder aliases in ExpressionAttributeNames are resolved correctly across:

- Query KeyConditionExpression: #0 = :0 AND begins_with(#1, :prefix)
- TransactWriteItems ConditionExpression: attribute_not_exists(#0)

Covers the scenario reported in #127 where PynamoDB-style numeric aliases were not being resolved, causing zero query results and spurious TransactionCanceledExceptions.

Associated to #127

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
