### PR TITLE
fix(sqs): support binary message attributes and fix MD5OfMessageAttri…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,8 +137,14 @@ public class SqsJsonHandler {
                 String name = entry.getKey();
                 String dataType = entry.getValue().path("DataType").asText(null);
                 String stringValue = entry.getValue().path("StringValue").asText(null);
-                if (dataType != null && stringValue != null) {
-                    messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                String binaryValueBase64 = entry.getValue().path("BinaryValue").asText(null);
+                if (dataType != null) {
+                    if (binaryValueBase64 != null) {
+                        byte[] binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                        messageAttributes.put(name, new MessageAttributeValue(binaryValue, dataType));
+                    } else if (stringValue != null) {
+                        messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                    }
                 }
             });
         }
@@ -196,7 +203,11 @@ public class SqsJsonHandler {
                 for (var entry : msg.getMessageAttributes().entrySet()) {
                     ObjectNode valNode = msgAttrs.putObject(entry.getKey());
                     valNode.put("DataType", entry.getValue().getDataType());
-                    valNode.put("StringValue", entry.getValue().getStringValue());
+                    if (entry.getValue().getBinaryValue() != null) {
+                        valNode.put("BinaryValue", Base64.getEncoder().encodeToString(entry.getValue().getBinaryValue()));
+                    } else {
+                        valNode.put("StringValue", entry.getValue().getStringValue());
+                    }
                 }
             }
 
@@ -277,8 +288,14 @@ public class SqsJsonHandler {
                         String name = attrEntry.getKey();
                         String dataType = attrEntry.getValue().path("DataType").asText(null);
                         String stringValue = attrEntry.getValue().path("StringValue").asText(null);
-                        if (dataType != null && stringValue != null) {
-                            messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                        String binaryValueBase64 = attrEntry.getValue().path("BinaryValue").asText(null);
+                        if (dataType != null) {
+                            if (binaryValueBase64 != null) {
+                                byte[] binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                                messageAttributes.put(name, new MessageAttributeValue(binaryValue, dataType));
+                            } else if (stringValue != null) {
+                                messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                            }
                         }
                     });
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,8 +132,14 @@ public class SqsQueryHandler {
             if (name == null) break;
             String dataType = getParam(params, "MessageAttribute." + i + ".Value.DataType");
             String stringValue = getParam(params, "MessageAttribute." + i + ".Value.StringValue");
-            if (dataType != null && stringValue != null) {
-                messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+            String binaryValueBase64 = getParam(params, "MessageAttribute." + i + ".Value.BinaryValue");
+            if (dataType != null) {
+                if (binaryValueBase64 != null) {
+                    byte[] binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                    messageAttributes.put(name, new MessageAttributeValue(binaryValue, dataType));
+                } else if (stringValue != null) {
+                    messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                }
             }
         }
 
@@ -189,9 +196,13 @@ public class SqsQueryHandler {
                     xml.start("MessageAttribute")
                        .elem("Name", entry.getKey())
                        .start("Value")
-                       .elem("DataType", entry.getValue().getDataType())
-                       .elem("StringValue", entry.getValue().getStringValue())
-                       .end("Value")
+                       .elem("DataType", entry.getValue().getDataType());
+                    if (entry.getValue().getBinaryValue() != null) {
+                        xml.elem("BinaryValue", Base64.getEncoder().encodeToString(entry.getValue().getBinaryValue()));
+                    } else {
+                        xml.elem("StringValue", entry.getValue().getStringValue());
+                    }
+                    xml.end("Value")
                        .end("MessageAttribute");
                 }
             }
@@ -257,8 +268,14 @@ public class SqsQueryHandler {
                 if (name == null) break;
                 String dataType = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageAttribute." + j + ".Value.DataType");
                 String stringValue = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageAttribute." + j + ".Value.StringValue");
-                if (dataType != null && stringValue != null) {
-                    messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                String binaryValueBase64 = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageAttribute." + j + ".Value.BinaryValue");
+                if (dataType != null) {
+                    if (binaryValueBase64 != null) {
+                        byte[] binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                        messageAttributes.put(name, new MessageAttributeValue(binaryValue, dataType));
+                    } else if (stringValue != null) {
+                        messageAttributes.put(name, new MessageAttributeValue(stringValue, dataType));
+                    }
                 }
             }
 
@@ -268,6 +285,9 @@ public class SqsQueryHandler {
                    .elem("Id", id)
                    .elem("MessageId", msg.getMessageId())
                    .elem("MD5OfMessageBody", msg.getMd5OfBody());
+                if (msg.getMd5OfMessageAttributes() != null) {
+                    xml.elem("MD5OfMessageAttributes", msg.getMd5OfMessageAttributes());
+                }
                 if (msg.getSequenceNumber() > 0) {
                     xml.elem("SequenceNumber", msg.getSequenceNumber());
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -109,13 +109,10 @@ public class Message {
                 dos.writeInt(typeBytes.length);
                 dos.write(typeBytes);
 
-                if ("Binary".equals(val.getDataType()) || val.getDataType().startsWith("Binary.")) {
-                    dos.write(2);
-                    // For now, emulator assumes string values for simplicity, but if it were binary we'd decode it.
-                    // Actually, the SDK encodes Binary attributes as base64 in StringValue if sent via JSON.
-                    byte[] valBytes = java.util.Base64.getDecoder().decode(val.getStringValue());
-                    dos.writeInt(valBytes.length);
-                    dos.write(valBytes);
+                if (val.getBinaryValue() != null) {
+                    dos.write(2); // Binary type
+                    dos.writeInt(val.getBinaryValue().length);
+                    dos.write(val.getBinaryValue());
                 } else {
                     dos.write(1); // String or Number
                     byte[] valBytes = val.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8);

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/MessageAttributeValue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/MessageAttributeValue.java
@@ -8,6 +8,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public class MessageAttributeValue {
 
     private String stringValue;
+    private byte[] binaryValue;
     private String dataType;
 
     public MessageAttributeValue() {}
@@ -17,8 +18,16 @@ public class MessageAttributeValue {
         this.dataType = dataType;
     }
 
+    public MessageAttributeValue(byte[] binaryValue, String dataType) {
+        this.binaryValue = binaryValue;
+        this.dataType = dataType;
+    }
+
     public String getStringValue() { return stringValue; }
     public void setStringValue(String stringValue) { this.stringValue = stringValue; }
+
+    public byte[] getBinaryValue() { return binaryValue; }
+    public void setBinaryValue(byte[] binaryValue) { this.binaryValue = binaryValue; }
 
     public String getDataType() { return dataType; }
     public void setDataType(String dataType) { this.dataType = dataType; }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -64,6 +64,7 @@ class SqsIntegrationTest {
     @Test
     @Order(4)
     void sendMessage() {
+        // MD5 of "Hello from integration test!" = 72077a684c89bfbf51991620feedff61
         given()
             .contentType("application/x-www-form-urlencoded")
             .formParam("Action", "SendMessage")
@@ -74,7 +75,7 @@ class SqsIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<MessageId>"))
-            .body(containsString("<MD5OfMessageBody>"));
+            .body(containsString("<MD5OfMessageBody>72077a684c89bfbf51991620feedff61</MD5OfMessageBody>"));
     }
 
     @Test
@@ -170,6 +171,48 @@ class SqsIntegrationTest {
 
     @Test
     @Order(9)
+    void sendMessageWithStringAttribute() {
+        // MD5 of body "attr-test" = 6eee3c38f0022ec400be5d6eb6f22709
+        // MD5 of attributes {color=red (String)} = 20ca9041878c8c65d5a4bf6eaf446c21
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SendMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MessageBody", "attr-test")
+            .formParam("MessageAttribute.1.Name", "color")
+            .formParam("MessageAttribute.1.Value.DataType", "String")
+            .formParam("MessageAttribute.1.Value.StringValue", "red")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MD5OfMessageBody>6eee3c38f0022ec400be5d6eb6f22709</MD5OfMessageBody>"))
+            .body(containsString("<MD5OfMessageAttributes>20ca9041878c8c65d5a4bf6eaf446c21</MD5OfMessageAttributes>"));
+    }
+
+    @Test
+    @Order(10)
+    void sendMessageWithBinaryAttribute() {
+        // body "binary-attr-test" MD5 = c090a04ce0c88aea830b4bf78051e834
+        // attribute data=bytes[1,2,3] (Binary), base64=AQID
+        // MD5 of attributes {data=[1,2,3] (Binary)} = 922637243eb93fabf39f19417c7e2b43
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SendMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MessageBody", "binary-attr-test")
+            .formParam("MessageAttribute.1.Name", "data")
+            .formParam("MessageAttribute.1.Value.DataType", "Binary")
+            .formParam("MessageAttribute.1.Value.BinaryValue", "AQID")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MD5OfMessageAttributes>922637243eb93fabf39f19417c7e2b43</MD5OfMessageAttributes>"));
+    }
+
+    @Test
+    @Order(11)
     void getQueueAttributes() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -185,7 +228,7 @@ class SqsIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(12)
     void deleteQueue() {
         given()
             .contentType("application/x-www-form-urlencoded")


### PR DESCRIPTION
…butes

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


## Summary 

SQS binary message attributes were silently dropped in both Query and JSON protocol handlers, causing `MD5OfMessageAttributes` to be absent from `SendMessage/SendMessageBatch` responses. SDKs that validate MD5 client-side (Java, Go, .NET, etc.) would throw "MD5 hash mismatch" when binary attributes were sent.

  - Read BinaryValue from Query protocol (MessageAttribute.N.Value.BinaryValue) and JSON protocol (BinaryValue field)
  - Add binaryValue (byte[]) field to MessageAttributeValue model
  - Fix updateMd5OfMessageAttributes() to detect binary vs string using value presence (binaryValue != null), matching the AWS SDK algorithm exactly
  - Return <BinaryValue> (base64-encoded) in ReceiveMessage responses for binary attributes
  - Add MD5OfMessageAttributes to SendMessageBatch response (was missing)

Fixes #141 
