### PR TITLE
feat(cloudwatch-logs): add ListTagsForResource, TagResource, and UntagResource

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -45,6 +45,9 @@ public class CloudWatchLogsHandler {
             case "TagLogGroup" -> handleTagLogGroup(request, region);
             case "UntagLogGroup" -> handleUntagLogGroup(request, region);
             case "ListTagsLogGroup" -> handleListTagsLogGroup(request, region);
+            case "ListTagsForResource" -> handleListTagsForResource(request, region);
+            case "TagResource" -> handleTagResource(request, region);
+            case "UntagResource" -> handleUntagResource(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -222,6 +225,46 @@ public class CloudWatchLogsHandler {
         tags.forEach(tagsNode::put);
         response.set("tags", tagsNode);
         return Response.ok(response).build();
+    }
+
+    private Response handleListTagsForResource(JsonNode request, String region) {
+        String resourceArn = request.path("resourceArn").asText();
+        String groupName = extractLogGroupNameFromArn(resourceArn);
+        Map<String, String> tags = logsService.listTagsLogGroup(groupName, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ObjectNode tagsNode = objectMapper.createObjectNode();
+        tags.forEach(tagsNode::put);
+        response.set("tags", tagsNode);
+        return Response.ok(response).build();
+    }
+
+    private Response handleTagResource(JsonNode request, String region) {
+        String resourceArn = request.path("resourceArn").asText();
+        String groupName = extractLogGroupNameFromArn(resourceArn);
+        Map<String, String> tags = extractTags(request.path("tags"));
+        logsService.tagLogGroup(groupName, tags, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleUntagResource(JsonNode request, String region) {
+        String resourceArn = request.path("resourceArn").asText();
+        String groupName = extractLogGroupNameFromArn(resourceArn);
+        List<String> tagKeys = new ArrayList<>();
+        request.path("tagKeys").forEach(k -> tagKeys.add(k.asText()));
+        logsService.untagLogGroup(groupName, tagKeys, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private String extractLogGroupNameFromArn(String arn) {
+        if (arn != null && arn.contains(":log-group:")) {
+            String name = arn.substring(arn.indexOf(":log-group:") + ":log-group:".length());
+            if (name.endsWith(":*")) {
+                name = name.substring(0, name.length() - 2);
+            }
+            return name;
+        }
+        return arn;
     }
 
     // ──────────────────────────── Helpers ────────────────────────────


### PR DESCRIPTION
## Summary

Added the resource-based tag operations (`ListTagsForResource`, `TagResource`, `UntagResource`) to the CloudWatch Logs handler. These are the newer AWS API operations that use ARN-based resource identification, replacing the older `ListTagsLogGroup`/`TagLogGroup`/`UntagLogGroup` operations.

## Changes

Updated `CloudWatchLogsHandler.java`:
- Added three new case handlers in the action switch: `ListTagsForResource`, `TagResource`, `UntagResource`
- Added `extractLogGroupNameFromArn()` helper to parse log group names from resource ARNs (format: `arn:aws:logs:region:account:log-group:name`)
- Each new handler delegates to the existing service methods (`listTagsLogGroup`, `tagLogGroup`, `untagLogGroup`) after extracting the group name from the ARN

The response format for `ListTagsForResource` matches the AWS API specification (flat `tags` object), which is the same format the existing `ListTagsLogGroup` handler uses.

## Context

This fixes the `UnsupportedOperation: Operation ListTagsForResource is not supported` error that occurs when creating CloudWatch log groups via Terraform, since Terraform uses the newer resource-based API.

Fixes #77

This contribution was developed with AI assistance (Claude Code).