### PR TITLE
fix(s3): parse S3 notification filter rules instead of failing on nested XML

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
@@ -153,8 +153,7 @@ public final class XmlParser {
                         current = new LinkedHashMap<>();
                         depth = 1;
                     } else if (current != null && depth == 1) {
-                        String text = r.getElementText();
-                        current.computeIfAbsent(local, k -> new ArrayList<>()).add(text);
+                        readElementIntoMultiMap(r, local, current);
                     } else if (current != null) {
                         depth++;
                     }
@@ -201,8 +200,7 @@ public final class XmlParser {
                         current = new LinkedHashMap<>();
                         depth = 1;
                     } else if (current != null && depth == 1) {
-                        String text = r.getElementText();
-                        current.put(local, text);
+                        readElementIntoMap(r, local, current);
                     } else if (current != null) {
                         depth++;
                     }
@@ -219,5 +217,84 @@ public final class XmlParser {
             r.close();
         } catch (XMLStreamException ignored) {}
         return result;
+    }
+
+    /**
+     * Reads a depth-1 child element and stores its content into a multi-value map.
+     * Text-only elements are stored as {@code elementName → [text]}.
+     * Nested elements (e.g. {@code <Filter>}) are traversed and any leaf
+     * {@code <Name>}/{@code <Value>} pairs found inside are stored directly
+     * into the map (e.g. {@code prefix → [images/]}).
+     */
+    private static void readElementIntoMultiMap(XMLStreamReader r, String elementName,
+                                                 Map<String, List<String>> map) throws XMLStreamException {
+        StringBuilder text = new StringBuilder();
+        boolean textOnly = true;
+        String pendingName = null;
+        int nested = 1;
+        while (r.hasNext()) {
+            int ev = r.next();
+            if (ev == XMLStreamConstants.START_ELEMENT) {
+                if (nested == 1) textOnly = false;
+                nested++;
+                String local = r.getLocalName();
+                if ("Name".equals(local)) {
+                    pendingName = r.getElementText();
+                    nested--;
+                } else if ("Value".equals(local) && pendingName != null) {
+                    String value = r.getElementText();
+                    nested--;
+                    map.computeIfAbsent(pendingName, k -> new ArrayList<>()).add(value);
+                    pendingName = null;
+                }
+            } else if (ev == XMLStreamConstants.END_ELEMENT) {
+                nested--;
+                if (nested == 0) break;
+            } else if (textOnly && (ev == XMLStreamConstants.CHARACTERS || ev == XMLStreamConstants.CDATA)) {
+                text.append(r.getText());
+            }
+        }
+        if (textOnly) {
+            map.computeIfAbsent(elementName, k -> new ArrayList<>()).add(text.toString());
+        }
+    }
+
+    /**
+     * Reads a depth-1 child element and stores its content into a single-value map.
+     * Text-only elements are stored as {@code elementName → text}.
+     * Nested elements are traversed and any leaf {@code <Name>}/{@code <Value>}
+     * pairs are stored directly (e.g. {@code prefix → images/}).
+     */
+    private static void readElementIntoMap(XMLStreamReader r, String elementName,
+                                            Map<String, String> map) throws XMLStreamException {
+        StringBuilder text = new StringBuilder();
+        boolean textOnly = true;
+        String pendingName = null;
+        int nested = 1;
+        while (r.hasNext()) {
+            int ev = r.next();
+            if (ev == XMLStreamConstants.START_ELEMENT) {
+                if (nested == 1) textOnly = false;
+                nested++;
+                String local = r.getLocalName();
+                if ("Name".equals(local)) {
+                    pendingName = r.getElementText();
+                    nested--;
+                } else if ("Value".equals(local) && pendingName != null) {
+                    String value = r.getElementText();
+                    nested--;
+                    map.put(pendingName, value);
+                    pendingName = null;
+                }
+            } else if (ev == XMLStreamConstants.END_ELEMENT) {
+                nested--;
+                if (nested == 0) break;
+            } else if (textOnly && (ev == XMLStreamConstants.CHARACTERS || ev == XMLStreamConstants.CDATA)) {
+                text.append(r.getText());
+            }
+        }
+        if (textOnly) {
+            map.put(elementName, text.toString());
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -778,6 +778,7 @@ public class S3Controller {
                 for (String event : qn.events()) {
                     xml.elem("Event", event);
                 }
+                appendFilterXml(xml, qn.filterPrefix(), qn.filterSuffix());
                 xml.end("QueueConfiguration");
             }
             for (TopicNotification tn : config.getTopicConfigurations()) {
@@ -787,6 +788,7 @@ public class S3Controller {
                 for (String event : tn.events()) {
                     xml.elem("Event", event);
                 }
+                appendFilterXml(xml, tn.filterPrefix(), tn.filterSuffix());
                 xml.end("TopicConfiguration");
             }
             xml.end("NotificationConfiguration");
@@ -807,7 +809,10 @@ public class S3Controller {
                 List<String> queueArns = group.get("Queue");
                 List<String> events = group.get("Event");
                 if (queueArns != null && !queueArns.isEmpty() && events != null && !events.isEmpty()) {
-                    config.getQueueConfigurations().add(new QueueNotification(id, queueArns.get(0), events));
+                    String prefix = group.containsKey("prefix") ? group.get("prefix").get(0) : null;
+                    String suffix = group.containsKey("suffix") ? group.get("suffix").get(0) : null;
+                    config.getQueueConfigurations().add(
+                            new QueueNotification(id, queueArns.get(0), events, prefix, suffix));
                 }
             }
 
@@ -817,7 +822,10 @@ public class S3Controller {
                 List<String> topicArns = group.get("Topic");
                 List<String> events = group.get("Event");
                 if (topicArns != null && !topicArns.isEmpty() && events != null && !events.isEmpty()) {
-                    config.getTopicConfigurations().add(new TopicNotification(id, topicArns.get(0), events));
+                    String prefix = group.containsKey("prefix") ? group.get("prefix").get(0) : null;
+                    String suffix = group.containsKey("suffix") ? group.get("suffix").get(0) : null;
+                    config.getTopicConfigurations().add(
+                            new TopicNotification(id, topicArns.get(0), events, prefix, suffix));
                 }
             }
 
@@ -826,6 +834,20 @@ public class S3Controller {
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
+    }
+
+    private static void appendFilterXml(XmlBuilder xml, String prefix, String suffix) {
+        if (prefix == null && suffix == null) {
+            return;
+        }
+        xml.start("Filter").start("S3Key");
+        if (prefix != null) {
+            xml.start("FilterRule").elem("Name", "prefix").elem("Value", prefix).end("FilterRule");
+        }
+        if (suffix != null) {
+            xml.start("FilterRule").elem("Name", "suffix").elem("Value", suffix).end("FilterRule");
+        }
+        xml.end("S3Key").end("Filter");
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1090,7 +1090,8 @@ public class S3Service {
         String eventJson = buildS3EventJson(bucketName, key, eventName, obj, region, bucket.isVersioningEnabled());
 
         for (QueueNotification qn : config.getQueueConfigurations()) {
-            if (qn.events().stream().anyMatch(p -> matchesEvent(p, eventName))) {
+            if (qn.events().stream().anyMatch(p -> matchesEvent(p, eventName))
+                    && matchesFilter(key, qn.filterPrefix(), qn.filterSuffix())) {
                 try {
                     sqsService.sendMessage(sqsUrlFromArn(qn.queueArn()), eventJson, 0);
                     LOG.debugv("Fired S3 event {0} to SQS {1}", eventName, qn.queueArn());
@@ -1101,7 +1102,8 @@ public class S3Service {
         }
 
         for (TopicNotification tn : config.getTopicConfigurations()) {
-            if (tn.events().stream().anyMatch(p -> matchesEvent(p, eventName))) {
+            if (tn.events().stream().anyMatch(p -> matchesEvent(p, eventName))
+                    && matchesFilter(key, tn.filterPrefix(), tn.filterSuffix())) {
                 try {
                     snsService.publish(tn.topicArn(), null, eventJson, "Amazon S3 Notification", region);
                     LOG.debugv("Fired S3 event {0} to SNS {1}", eventName, tn.topicArn());
@@ -1118,6 +1120,12 @@ public class S3Service {
             return full.startsWith(pattern.substring(0, pattern.length() - 1));
         }
         return full.equals(pattern);
+    }
+
+    private static boolean matchesFilter(String key, String prefix, String suffix) {
+        if (prefix != null && !key.startsWith(prefix)) return false;
+        if (suffix != null && !key.endsWith(suffix)) return false;
+        return true;
     }
 
     private String sqsUrlFromArn(String arn) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/QueueNotification.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/QueueNotification.java
@@ -5,4 +5,5 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 
 @RegisterForReflection
-public record QueueNotification(String id, String queueArn, List<String> events) {}
+public record QueueNotification(String id, String queueArn, List<String> events,
+                                String filterPrefix, String filterSuffix) {}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/TopicNotification.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/TopicNotification.java
@@ -5,4 +5,5 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 
 @RegisterForReflection
-public record TopicNotification(String id, String topicArn, List<String> events) {}
+public record TopicNotification(String id, String topicArn, List<String> events,
+                                String filterPrefix, String filterSuffix) {}

--- a/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
@@ -1,0 +1,159 @@
+package io.github.hectorvent.floci.core.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XmlParserTest {
+
+    @Test
+    void extractGroupsMultiParsesFilterRules() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>notif1</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:my-queue</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.jpg</Value>
+                        </FilterRule>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>images/</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        List<Map<String, List<String>>> groups =
+                XmlParser.extractGroupsMulti(xml, "QueueConfiguration");
+
+        assertEquals(1, groups.size());
+        Map<String, List<String>> group = groups.get(0);
+        assertEquals(List.of("notif1"), group.get("Id"));
+        assertEquals(List.of("arn:aws:sqs:us-east-1:000000000000:my-queue"), group.get("Queue"));
+        assertEquals(List.of("s3:ObjectCreated:*"), group.get("Event"));
+        assertEquals(List.of(".jpg"), group.get("suffix"));
+        assertEquals(List.of("images/"), group.get("prefix"));
+    }
+
+    @Test
+    void extractGroupsParsesFilterRules() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:my-queue</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>logs/</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        List<Map<String, String>> groups =
+                XmlParser.extractGroups(xml, "QueueConfiguration");
+
+        assertEquals(1, groups.size());
+        Map<String, String> group = groups.get(0);
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:my-queue", group.get("Queue"));
+        assertEquals("s3:ObjectCreated:*", group.get("Event"));
+        assertEquals("logs/", group.get("prefix"));
+    }
+
+    @Test
+    void extractGroupsMultiWithMultipleEventsAndNoFilter() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:q1</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Event>s3:ObjectRemoved:*</Event>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        List<Map<String, List<String>>> groups =
+                XmlParser.extractGroupsMulti(xml, "QueueConfiguration");
+
+        assertEquals(1, groups.size());
+        assertEquals(List.of("s3:ObjectCreated:*", "s3:ObjectRemoved:*"),
+                groups.get(0).get("Event"));
+        assertNull(groups.get(0).get("prefix"));
+        assertNull(groups.get(0).get("suffix"));
+    }
+
+    @Test
+    void extractGroupsMultiWithFilterBetweenTextElements() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:q1</Queue>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule><Name>suffix</Name><Value>.png</Value></FilterRule>
+                      </S3Key>
+                    </Filter>
+                    <Event>s3:ObjectCreated:Put</Event>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        List<Map<String, List<String>>> groups =
+                XmlParser.extractGroupsMulti(xml, "QueueConfiguration");
+
+        assertEquals(1, groups.size());
+        Map<String, List<String>> group = groups.get(0);
+        assertEquals(List.of("arn:aws:sqs:us-east-1:000000000000:q1"), group.get("Queue"));
+        assertEquals(List.of("s3:ObjectCreated:Put"), group.get("Event"));
+        assertEquals(List.of(".png"), group.get("suffix"));
+    }
+
+    @Test
+    void extractGroupsMultiMultipleConfigsWithDifferentFilters() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:q1</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule><Name>prefix</Name><Value>images/</Value></FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                  <QueueConfiguration>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:q2</Queue>
+                    <Event>s3:ObjectRemoved:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule><Name>suffix</Name><Value>.log</Value></FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        List<Map<String, List<String>>> groups =
+                XmlParser.extractGroupsMulti(xml, "QueueConfiguration");
+
+        assertEquals(2, groups.size());
+        assertEquals(List.of("images/"), groups.get(0).get("prefix"));
+        assertNull(groups.get(0).get("suffix"));
+        assertNull(groups.get(1).get("prefix"));
+        assertEquals(List.of(".log"), groups.get(1).get("suffix"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3NotificationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3NotificationIntegrationTest.java
@@ -1,0 +1,384 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3NotificationIntegrationTest {
+
+    private static final String BUCKET = "notif-test-bucket";
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getNotificationReturnsEmptyByDefault() {
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("NotificationConfiguration"))
+            .body(not(containsString("QueueConfiguration")))
+            .body(not(containsString("TopicConfiguration")));
+    }
+
+    @Test
+    @Order(3)
+    void putQueueNotificationWithoutFilter() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>no-filter</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:plain-queue</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>no-filter</Id>"))
+            .body(containsString("plain-queue"))
+            .body(containsString("s3:ObjectCreated:*"))
+            .body(not(containsString("<Filter>")));
+    }
+
+    @Test
+    @Order(4)
+    void putQueueNotificationWithPrefixFilter() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>prefix-only</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:prefix-queue</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>images/</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>prefix-only</Id>"))
+            .body(containsString("<Filter>"))
+            .body(containsString("<Name>prefix</Name>"))
+            .body(containsString("<Value>images/</Value>"))
+            .body(not(containsString("<Name>suffix</Name>")));
+    }
+
+    @Test
+    @Order(5)
+    void putQueueNotificationWithSuffixFilter() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>suffix-only</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:suffix-queue</Queue>
+                    <Event>s3:ObjectRemoved:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.jpg</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>suffix-only</Id>"))
+            .body(containsString("<Name>suffix</Name>"))
+            .body(containsString("<Value>.jpg</Value>"))
+            .body(not(containsString("<Name>prefix</Name>")));
+    }
+
+    @Test
+    @Order(6)
+    void putQueueNotificationWithBothPrefixAndSuffix() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>both-filters</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:both-queue</Queue>
+                    <Event>s3:ObjectCreated:Put</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>uploads/</Value>
+                        </FilterRule>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.png</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>both-filters</Id>"))
+            .body(containsString("<Name>prefix</Name>"))
+            .body(containsString("<Value>uploads/</Value>"))
+            .body(containsString("<Name>suffix</Name>"))
+            .body(containsString("<Value>.png</Value>"));
+    }
+
+    @Test
+    @Order(7)
+    void putMultipleQueueConfigsWithDifferentFilters() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>config-a</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:queue-a</Queue>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>logs/</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                  <QueueConfiguration>
+                    <Id>config-b</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:queue-b</Queue>
+                    <Event>s3:ObjectRemoved:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.csv</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        String body = given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("config-a"))
+            .body(containsString("config-b"))
+            .body(containsString("queue-a"))
+            .body(containsString("queue-b"))
+            .extract().body().asString();
+
+        // Verify both configs are present with their respective filters
+        assert body.contains("logs/") : "Expected prefix filter logs/";
+        assert body.contains(".csv") : "Expected suffix filter .csv";
+    }
+
+    @Test
+    @Order(8)
+    void putTopicNotificationWithFilter() {
+        String xml = """
+                <NotificationConfiguration>
+                  <TopicConfiguration>
+                    <Id>topic-filter</Id>
+                    <Topic>arn:aws:sns:us-east-1:000000000000:my-topic</Topic>
+                    <Event>s3:ObjectCreated:*</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>data/</Value>
+                        </FilterRule>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.json</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </TopicConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<TopicConfiguration>"))
+            .body(containsString("<Id>topic-filter</Id>"))
+            .body(containsString("my-topic"))
+            .body(containsString("<Name>prefix</Name>"))
+            .body(containsString("<Value>data/</Value>"))
+            .body(containsString("<Name>suffix</Name>"))
+            .body(containsString("<Value>.json</Value>"));
+    }
+
+    @Test
+    @Order(9)
+    void putNotificationWithFilterBetweenOtherElements() {
+        String xml = """
+                <NotificationConfiguration>
+                  <QueueConfiguration>
+                    <Id>interleaved</Id>
+                    <Queue>arn:aws:sqs:us-east-1:000000000000:interleaved-queue</Queue>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.txt</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                    <Event>s3:ObjectCreated:Put</Event>
+                  </QueueConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>interleaved</Id>"))
+            .body(containsString("interleaved-queue"))
+            .body(containsString("s3:ObjectCreated:Put"))
+            .body(containsString("<Name>suffix</Name>"))
+            .body(containsString("<Value>.txt</Value>"));
+    }
+
+    @Test
+    @Order(10)
+    void putEmptyNotificationClearsConfig() {
+        String xml = """
+                <NotificationConfiguration>
+                </NotificationConfiguration>
+                """;
+        given()
+            .queryParam("notification", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(not(containsString("QueueConfiguration")))
+            .body(not(containsString("TopicConfiguration")));
+    }
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        given().delete("/" + BUCKET);
+    }
+}


### PR DESCRIPTION
## Summary

Fix `XmlParser.extractGroupsMulti()` and `extractGroups()` to handle nested elements like `<Filter>` instead of calling `getElementText()` which throws on non-text children. Add `filterPrefix`/`filterSuffix` fields to notification records and apply prefix/suffix matching in `fireNotifications()`.

Closes #179

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`PutBucketNotificationConfiguration` with `<Filter><S3Key><FilterRule>` elements was silently dropping the entire notification config. The config is now parsed correctly, persisted with prefix/suffix filters, serialized back in `GetBucketNotificationConfiguration` responses, and applied during event delivery.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)