### PR TITLE
fix: return stable cursor tokens in GetLogEvents to fix SDK paginatio…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -153,9 +153,10 @@ public class CloudWatchLogsHandler {
         Long endTime = request.has("endTime") ? request.path("endTime").asLong() : null;
         int limit = request.path("limit").asInt(0);
         boolean startFromHead = request.path("startFromHead").asBoolean(false);
+        String nextToken = request.has("nextToken") ? request.path("nextToken").asText(null) : null;
 
         CloudWatchLogsService.LogEventsResult result =
-                logsService.getLogEvents(groupName, streamName, startTime, endTime, limit, startFromHead, region);
+                logsService.getLogEvents(groupName, streamName, startTime, endTime, limit, startFromHead, nextToken, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         response.set("events", buildEventsArray(result.events()));

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -272,7 +272,7 @@ public class CloudWatchLogsService {
 
     public LogEventsResult getLogEvents(String groupName, String streamName,
                                         Long startTime, Long endTime,
-                                        int limit, boolean startFromHead, String region) {
+                                        int limit, boolean startFromHead, String nextToken, String region) {
         int maxEvents = Math.min(limit > 0 ? limit : Integer.MAX_VALUE,
                 maxEventsPerQuery);
 
@@ -285,16 +285,36 @@ public class CloudWatchLogsService {
                         && (endTime == null || e.getTimestamp() <= endTime))
                 .toList();
 
-        List<LogEvent> page;
-        if (!startFromHead && filtered.size() > maxEvents) {
-            page = filtered.subList(filtered.size() - maxEvents, filtered.size());
+        int total = filtered.size();
+        int pageStart;
+        int pageEnd;
+
+        if (nextToken != null && nextToken.startsWith("f/")) {
+            int offset = parseTokenIndex(nextToken, 2);
+            pageStart = Math.min(offset, total);
+            pageEnd = Math.min(pageStart + maxEvents, total);
+        } else if (nextToken != null && nextToken.startsWith("b/")) {
+            int end = parseTokenIndex(nextToken, 2);
+            pageEnd = Math.min(end, total);
+            pageStart = Math.max(pageEnd - maxEvents, 0);
+        } else if (!startFromHead) {
+            pageEnd = total;
+            pageStart = Math.max(total - maxEvents, 0);
         } else {
-            page = filtered.size() > maxEvents ? filtered.subList(0, maxEvents) : filtered;
+            pageStart = 0;
+            pageEnd = Math.min(maxEvents, total);
         }
 
-        String forwardToken = "f/" + UUID.randomUUID();
-        String backwardToken = "b/" + UUID.randomUUID();
-        return new LogEventsResult(page, forwardToken, backwardToken);
+        List<LogEvent> page = filtered.subList(pageStart, pageEnd);
+        return new LogEventsResult(page, "f/" + pageEnd, "b/" + pageStart);
+    }
+
+    private int parseTokenIndex(String token, int prefixLen) {
+        try {
+            return Integer.parseInt(token.substring(prefixLen));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     public record FilteredLogEventsResult(List<LogEvent> events, String nextToken) {}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -166,7 +166,7 @@ class CloudWatchLogsServiceTest {
         ), REGION);
 
         CloudWatchLogsService.LogEventsResult result = service.getLogEvents(
-                "/app/logs", "stream-1", null, null, 100, true, REGION);
+                "/app/logs", "stream-1", null, null, 100, true, null, REGION);
         assertEquals(2, result.events().size());
         assertEquals("first", result.events().get(0).getMessage());
         assertEquals("second", result.events().get(1).getMessage());
@@ -184,7 +184,7 @@ class CloudWatchLogsServiceTest {
         ), REGION);
 
         CloudWatchLogsService.LogEventsResult result = service.getLogEvents(
-                "/app/logs", "stream-1", base + 5000, null, 100, true, REGION);
+                "/app/logs", "stream-1", base + 5000, null, 100, true, null, REGION);
         assertEquals(1, result.events().size());
         assertEquals("new", result.events().getFirst().getMessage());
     }
@@ -260,7 +260,95 @@ class CloudWatchLogsServiceTest {
         ), REGION);
 
         CloudWatchLogsService.LogEventsResult result = limitedService.getLogEvents(
-                "/app/logs", "stream-1", null, null, 100, true, REGION);
+                "/app/logs", "stream-1", null, null, 100, true, null, REGION);
         assertEquals(2, result.events().size());
+    }
+
+    // ──────────────────────────── GetLogEvents pagination (issue #90) ────────────────────────────
+
+    private void putEvents(String group, String stream, long baseTs, int count) {
+        List<Map<String, Object>> events = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            events.add(Map.of("timestamp", baseTs + i, "message", "msg-" + i));
+        }
+        service.putLogEvents(group, stream, events, REGION);
+    }
+
+    @Test
+    void getLogEventsInitialTokensEncodePosition() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 5);
+
+        CloudWatchLogsService.LogEventsResult result =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 100, true, null, REGION);
+
+        assertEquals(5, result.events().size());
+        assertEquals("f/5", result.nextForwardToken());
+        assertEquals("b/0", result.nextBackwardToken());
+    }
+
+    @Test
+    void getLogEventsForwardPaginationContinues() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        long base = System.currentTimeMillis();
+        putEvents("/app/logs", "stream-1", base, 5);
+
+        CloudWatchLogsService.LogEventsResult page1 =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 3, true, null, REGION);
+        assertEquals(3, page1.events().size());
+        assertEquals("msg-0", page1.events().get(0).getMessage());
+        assertEquals("f/3", page1.nextForwardToken());
+
+        CloudWatchLogsService.LogEventsResult page2 =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 3, true, page1.nextForwardToken(), REGION);
+        assertEquals(2, page2.events().size());
+        assertEquals("msg-3", page2.events().get(0).getMessage());
+        assertEquals("f/5", page2.nextForwardToken());
+    }
+
+    @Test
+    void getLogEventsAtEndOfStreamEchosToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        // Simulate the SDK sending back the last returned forward token
+        CloudWatchLogsService.LogEventsResult atEnd =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, "f/3", REGION);
+
+        assertEquals(0, atEnd.events().size());
+        assertEquals("f/3", atEnd.nextForwardToken(), "token must echo back to signal end of stream");
+    }
+
+    @Test
+    void getLogEventsStartFromTailWithNoToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 5);
+
+        CloudWatchLogsService.LogEventsResult result =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 3, false, null, REGION);
+
+        assertEquals(3, result.events().size());
+        assertEquals("msg-2", result.events().get(0).getMessage());
+        assertEquals("msg-4", result.events().get(2).getMessage());
+        assertEquals("b/2", result.nextBackwardToken());
+        assertEquals("f/5", result.nextForwardToken());
+    }
+
+    @Test
+    void getLogEventsBackwardPaginationEchosTokenAtStart() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        // b/0 means we are already at the start — echoed back
+        CloudWatchLogsService.LogEventsResult atStart =
+                service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, "b/0", REGION);
+
+        assertEquals(0, atStart.events().size());
+        assertEquals("b/0", atStart.nextBackwardToken(), "token must echo back to signal start of stream");
     }
 }


### PR DESCRIPTION
…n loop (#90)

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Details

 - `GetLogEvents` was generating random UUID tokens on every call, causing SDK paginators to loop infinitely (they stop only when `returnedToken == sentToken`)
  - Replaced random tokens with cursor-based tokens (`f/<index>`, `b/<index>`) encoding the event position in the sorted stream
  - End-of-stream is signaled naturally: when the cursor is past the last event, the same token is returned — matching the SDK paginator's stop condition


Close #90 