### PR TITLE
fix(sns): make Subscribe idempotent for same topic+protocol+endpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -182,6 +183,14 @@ public class SnsService {
         if (protocol == null || protocol.isBlank()) {
             throw new AwsException("InvalidParameter", "Protocol is required.", 400);
         }
+
+        for (Subscription existing : subscriptionsByTopic(topicArn, region)) {
+            if (protocol.equals(existing.getProtocol())
+                    && Objects.equals(endpoint, existing.getEndpoint())) {
+                return existing;
+            }
+        }
+
         String subscriptionArn = topicArn + ":" + UUID.randomUUID().toString();
         Subscription subscription = new Subscription(subscriptionArn, topicArn, protocol, endpoint,
                 regionResolver.getAccountId());

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -127,6 +127,26 @@ class SnsIntegrationTest {
 
     @Test
     @Order(7)
+    void subscribe_idempotent() {
+        String arn = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "sqs")
+            .formParam("Endpoint", sqsQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath()
+                .getString("SubscribeResponse.SubscribeResult.SubscriptionArn");
+
+        assert arn.equals(subscriptionArn) : "Expected existing subscription ARN but got a new one";
+
+    }
+
+    @Test
+    @Order(7)
     void listSubscriptionsByTopic() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -109,6 +109,27 @@ class SnsServiceTest {
     }
 
     @Test
+    void subscribe_idempotent() {
+        Topic topic = snsService.createTopic("my-topic", null, null, REGION);
+        Subscription sub1 = snsService.subscribe(topic.getTopicArn(), "sqs",
+                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION);
+        Subscription sub2 = snsService.subscribe(topic.getTopicArn(), "sqs",
+                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION);
+        assertEquals(sub1.getSubscriptionArn(), sub2.getSubscriptionArn());
+        assertEquals(1, snsService.listSubscriptions(REGION).size());
+    }
+
+    @Test
+    void subscribe_differentEndpoints_createsSeparateSubscriptions() {
+        Topic topic = snsService.createTopic("my-topic", null, null, REGION);
+        snsService.subscribe(topic.getTopicArn(), "sqs",
+                "arn:aws:sqs:us-east-1:000000000000:queue-1", REGION);
+        snsService.subscribe(topic.getTopicArn(), "sqs",
+                "arn:aws:sqs:us-east-1:000000000000:queue-2", REGION);
+        assertEquals(2, snsService.listSubscriptions(REGION).size());
+    }
+
+    @Test
     void subscribe_throwsForMissingTopic() {
         assertThrows(AwsException.class,
             () -> snsService.subscribe("arn:aws:sns:us-east-1:000000000000:nonexistent",


### PR DESCRIPTION
## Summary

`Subscribe` always created a new subscription, even when one already existed for the same TopicArn+Protocol+Endpoint. This caused duplicate subscriptions to accumulate across test re-runs, leading to duplicate message delivery.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Real AWS `Subscribe` is idempotent — calling it with the same TopicArn, Protocol, and Endpoint returns the existing subscription ARN. Verified against [AWS documentation](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) and [LocalStack implementation](https://github.com/localstack/localstack/blob/master/localstack-core/localstack/services/sns/provider.py).

There are two real AWS behaviors we don't cover:
  - Attribute conflict rejection: If you re-subscribe with different attributes (FilterPolicy, RawMessageDelivery,
  etc.), AWS throws InvalidParameterException.
  - Attribute pass-through: Subscribe accepts Attributes — floci's handlers don't parse them yet.
  
  Both are irrelevant until we add attribute support to the Subscribe handlers.

Companion compatibility test: hectorvent/floci-compatibility-tests#38

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)