### PR TITLE
Remove `private` modifier on injected field

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunnerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/inithook/InitializationHooksRunnerIntegrationTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 class InitializationHooksRunnerIntegrationTest {
 
     @Inject
-    private InitializationHooksRunner initializationHooksRunner;
+    InitializationHooksRunner initializationHooksRunner;
 
     @TempDir
     private Path hookScriptsDirectory;


### PR DESCRIPTION
Injecting `private` fields is supported by Quarkus, but it's [discouraged](https://quarkus.io/guides/cdi-reference#native-executables-and-private-members)