### PR TITLE
feat(lambda): implement ListVersionsByFunction API (#182)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -274,6 +274,20 @@ public class LambdaController {
         return Response.status(201).entity(buildFunctionConfiguration(version)).build();
     }
 
+    @GET
+    @Path("/functions/{functionName}/versions")
+    public Response listVersionsByFunction(@Context HttpHeaders headers,
+                                           @PathParam("functionName") String functionName) {
+        String region = regionResolver.resolveRegion(headers);
+        List<LambdaFunction> versions = lambdaService.listVersionsByFunction(region, functionName);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("Versions");
+        for (LambdaFunction v : versions) {
+            items.add(objectMapper.valueToTree(buildFunctionConfiguration(v)));
+        }
+        return Response.ok(root).build();
+    }
+
     // ──────────────────────────── Aliases ────────────────────────────
 
     @POST
@@ -384,7 +398,7 @@ public class LambdaController {
         if (fn.getImageUri() != null) node.put("ImageUri", fn.getImageUri());
         node.put("LastModified", String.valueOf(fn.getLastModified()));
         node.put("RevisionId", fn.getRevisionId());
-        node.put("Version", "$LATEST");
+        node.put("Version", fn.getVersion());
 
         if (fn.getEnvironment() != null && !fn.getEnvironment().isEmpty()) {
             ObjectNode envNode = node.putObject("Environment");

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaFunctionStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaFunctionStore.java
@@ -66,14 +66,18 @@ public class LambdaFunctionStore {
 
     public void save(String region, LambdaFunction fn) {
         // Remove old index entry if URL changed or was removed
-        get(region, fn.getFunctionName()).ifPresent(this::deindexFunction);
+        get(region, fn.getFunctionName(), fn.getVersion()).ifPresent(this::deindexFunction);
         
-        backend.put(regionKey(region, fn.getFunctionName()), fn);
+        backend.put(regionKey(region, fn.getFunctionName(), fn.getVersion()), fn);
         indexFunction(fn);
     }
 
     public Optional<LambdaFunction> get(String region, String functionName) {
-        return backend.get(regionKey(region, functionName));
+        return get(region, functionName, "$LATEST");
+    }
+
+    public Optional<LambdaFunction> get(String region, String functionName, String version) {
+        return backend.get(regionKey(region, functionName, version));
     }
 
     public Optional<LambdaFunction> getByUrlId(String urlId) {
@@ -82,6 +86,11 @@ public class LambdaFunctionStore {
 
     public List<LambdaFunction> list(String region) {
         String prefix = "lambda::" + region + "::";
+        return backend.scan(key -> key.startsWith(prefix) && key.endsWith("::$LATEST"));
+    }
+
+    public List<LambdaFunction> listVersions(String region, String functionName) {
+        String prefix = "lambda::" + region + "::" + functionName + "::";
         return backend.scan(key -> key.startsWith(prefix));
     }
 
@@ -90,13 +99,14 @@ public class LambdaFunctionStore {
     }
 
     public void delete(String region, String functionName) {
-        get(region, functionName).ifPresent(fn -> {
+        // Delete all versions
+        listVersions(region, functionName).forEach(fn -> {
             deindexFunction(fn);
-            backend.delete(regionKey(region, functionName));
+            backend.delete(regionKey(region, functionName, fn.getVersion()));
         });
     }
 
-    private static String regionKey(String region, String functionName) {
-        return "lambda::" + region + "::" + functionName;
+    private static String regionKey(String region, String functionName, String version) {
+        return "lambda::" + region + "::" + functionName + "::" + (version != null ? version : "$LATEST");
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -359,6 +359,7 @@ public class LambdaService {
         int version = versionCounters.merge(region + "::" + functionName, 1, Integer::sum);
         LambdaFunction snapshot = new LambdaFunction();
         snapshot.setFunctionName(fn.getFunctionName());
+        snapshot.setVersion(String.valueOf(version));
         snapshot.setFunctionArn(fn.getFunctionArn().replace(":$LATEST", "") + ":" + version);
         snapshot.setRuntime(fn.getRuntime());
         snapshot.setRole(fn.getRole());
@@ -372,7 +373,15 @@ public class LambdaService {
         snapshot.setEnvironment(fn.getEnvironment());
         snapshot.setLastModified(System.currentTimeMillis());
         snapshot.setRevisionId(UUID.randomUUID().toString());
+        
+        functionStore.save(region, snapshot);
+        LOG.infov("Published version {0} for function {1}", version, functionName);
         return snapshot;
+    }
+
+    public List<LambdaFunction> listVersionsByFunction(String region, String functionName) {
+        getFunction(region, functionName); // verify function exists
+        return functionStore.listVersions(region, functionName);
     }
 
     // ──────────────────────────── Aliases ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
@@ -30,6 +30,7 @@ public class LambdaFunction {
     private Map<String, String> tags = new HashMap<>();
     private long lastModified;
     private String revisionId;
+    private String version = "$LATEST";
     private LambdaUrlConfig urlConfig;
 
     @JsonIgnore
@@ -94,6 +95,9 @@ public class LambdaFunction {
 
     public String getRevisionId() { return revisionId; }
     public void setRevisionId(String revisionId) { this.revisionId = revisionId; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
 
     public LambdaUrlConfig getUrlConfig() { return urlConfig; }
     public void setUrlConfig(LambdaUrlConfig urlConfig) { this.urlConfig = urlConfig; }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaVersionIntegrationTest {
+
+    private static final String BASE_PATH = "/2015-03-31";
+    private static final String FUNCTION_NAME = "versioned-function";
+
+    @Test
+    @Order(1)
+    void createFunction() {
+        given()
+            .contentType("application/json")
+            .body(String.format("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Description": "Version test function"
+                }
+                """, FUNCTION_NAME))
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("$LATEST"));
+    }
+
+    @Test
+    @Order(2)
+    void publishVersion() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Description": "First version"
+                }
+                """)
+        .when()
+            .post(BASE_PATH + "/functions/" + FUNCTION_NAME + "/versions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("1"))
+            .body("Description", equalTo("First version"))
+            .body("FunctionArn", containsString(FUNCTION_NAME + ":1"));
+    }
+
+    @Test
+    @Order(3)
+    void publishSecondVersion() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Description": "Second version"
+                }
+                """)
+        .when()
+            .post(BASE_PATH + "/functions/" + FUNCTION_NAME + "/versions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("2"))
+            .body("Description", equalTo("Second version"))
+            .body("FunctionArn", containsString(FUNCTION_NAME + ":2"));
+    }
+
+    @Test
+    @Order(4)
+    void listVersionsByFunction() {
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/" + FUNCTION_NAME + "/versions")
+        .then()
+            .statusCode(200)
+            .body("Versions", hasSize(3)) // $LATEST, 1, 2
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2"))
+            .body("Versions.find { it.Version == '1' }.Description", equalTo("First version"))
+            .body("Versions.find { it.Version == '2' }.Description", equalTo("Second version"));
+    }
+
+    @Test
+    @Order(5)
+    void deleteFunctionDeletesAllVersions() {
+        // Delete function
+        given()
+        .when()
+            .delete(BASE_PATH + "/functions/" + FUNCTION_NAME)
+        .then()
+            .statusCode(204);
+
+        // Verify it's gone
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/" + FUNCTION_NAME)
+        .then()
+            .statusCode(404);
+            
+        // Verify versions are gone (actually listVersionsByFunction should return 404 if function doesn't exist)
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/" + FUNCTION_NAME + "/versions")
+        .then()
+            .statusCode(404);
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Implemented the ListVersionsByFunction API action to improve compatibility with Infrastructure as Code (IaC) tools like Terraform.
   - Model: Added version field to LambdaFunction (defaulting to $LATEST).
   - Storage: Updated LambdaFunctionStore to support persisting and retrieving multiple function versions using version-aware storage keys.
   - Service: Enhanced LambdaService.publishVersion to persist snapshots and added listVersionsByFunction.
   - Controller: Added the GET /2015-03-31/functions/{functionName}/versions endpoint and updated buildFunctionConfiguration to return the correct version.
   - Testing: Added LambdaVersionIntegrationTest covering version publication, listing, and cleanup. Verified with existing SDK compatibility tests.

Closes #182 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
