### PR TITLE
fix(sm): return KmsKeyId in DescribeSecret and improve ListSecrets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -127,13 +127,18 @@ public class SecretsManagerJsonHandler {
 
         Secret secret = service.updateSecret(secretId, description, kmsKeyId, region);
 
+        String versionId = null;
         if (secretString != null || secretBinary != null) {
-            service.putSecretValue(secretId, secretString, secretBinary, region);
+            SecretVersion version = service.putSecretValue(secretId, secretString, secretBinary, region);
+            versionId = version.getVersionId();
         }
 
         ObjectNode response = objectMapper.createObjectNode();
         response.put("ARN", secret.getArn());
         response.put("Name", secret.getName());
+        if (versionId != null) {
+            response.put("VersionId", versionId);
+        }
         return Response.ok(response).build();
     }
 
@@ -146,6 +151,9 @@ public class SecretsManagerJsonHandler {
         response.put("Name", secret.getName());
         if (secret.getDescription() != null) {
             response.put("Description", secret.getDescription());
+        }
+        if (secret.getKmsKeyId() != null) {
+            response.put("KmsKeyId", secret.getKmsKeyId());
         }
         response.put("RotationEnabled", secret.isRotationEnabled());
         if (secret.getCreatedDate() != null) {
@@ -196,8 +204,18 @@ public class SecretsManagerJsonHandler {
             if (secret.getDescription() != null) {
                 node.put("Description", secret.getDescription());
             }
+            if (secret.getKmsKeyId() != null) {
+                node.put("KmsKeyId", secret.getKmsKeyId());
+            }
+            node.put("RotationEnabled", secret.isRotationEnabled());
+            if (secret.getCreatedDate() != null) {
+                node.put("CreatedDate", secret.getCreatedDate().toEpochMilli() / 1000.0);
+            }
             if (secret.getLastChangedDate() != null) {
                 node.put("LastChangedDate", secret.getLastChangedDate().toEpochMilli() / 1000.0);
+            }
+            if (secret.getLastAccessedDate() != null) {
+                node.put("LastAccessedDate", secret.getLastAccessedDate().toEpochMilli() / 1000.0);
             }
             ArrayNode tagsArray = objectMapper.createArrayNode();
             if (secret.getTags() != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -124,4 +124,36 @@ class SecretsManagerJsonHandlerTest {
         request.put("RequireEachIncludedType", false);
         assertThat(getRandomPassword(request), matchesPattern("[0-9]+"));
     }
+
+    @Test
+    void describeSecretResponseIncludesKmsKeyId() {
+        ObjectNode createReq = MAPPER.createObjectNode();
+        createReq.put("Name", "kms-secret");
+        createReq.put("KmsKeyId", "my-kms-key");
+        handler.handle("CreateSecret", createReq, REGION);
+
+        ObjectNode describeReq = MAPPER.createObjectNode();
+        describeReq.put("SecretId", "kms-secret");
+        Response response = handler.handle("DescribeSecret", describeReq, REGION);
+        
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("KmsKeyId").asText(), is("my-kms-key"));
+    }
+
+    @Test
+    void listSecretsResponseIncludesKmsKeyId() {
+        ObjectNode createReq = MAPPER.createObjectNode();
+        createReq.put("Name", "list-kms-secret");
+        createReq.put("KmsKeyId", "list-kms-key");
+        handler.handle("CreateSecret", createReq, REGION);
+
+        Response response = handler.handle("ListSecrets", MAPPER.createObjectNode(), REGION);
+        
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        ObjectNode secret = (ObjectNode) body.get("SecretList").get(0);
+        assertThat(secret.get("KmsKeyId").asText(), is("list-kms-key"));
+        assertThat(secret.has("CreatedDate"), is(true));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -200,4 +200,21 @@ class SecretsManagerServiceTest {
         SecretVersion fetched = service.getSecretValue("my-secret", v1Id, null, REGION);
         assertEquals("v1", fetched.getSecretString());
     }
+
+    @Test
+    void kmsKeyIdIsPreserved() {
+        String kmsKeyId = "arn:aws:kms:us-east-1:000000000000:key/my-key";
+        // Signature: name, secretString, secretBinary, description, kmsKeyId, tags, region
+        Secret secret = service.createSecret("kms-secret", "value", null,
+                "desc", kmsKeyId, null, REGION);
+
+        assertEquals(kmsKeyId, secret.getKmsKeyId());
+
+        Secret described = service.describeSecret("kms-secret", REGION);
+        assertEquals(kmsKeyId, described.getKmsKeyId());
+
+        service.updateSecret("kms-secret", "new desc", "arn:aws:kms:us-east-1:000000000000:key/other-key", REGION);
+        Secret updated = service.describeSecret("kms-secret", REGION);
+        assertEquals("arn:aws:kms:us-east-1:000000000000:key/other-key", updated.getKmsKeyId());
+    }
 }


### PR DESCRIPTION

## Summary

  This PR resolves compatibility issues in the Secrets Manager service where critical metadata was missing from API responses, causing issues with AWS SDK v2 and IaC tools.

  Key Changes:
   * DescribeSecret: Fixed the handler to include the KmsKeyId field in the JSON response when available.
   * ListSecrets: Enhanced the secret list entries with KmsKeyId, CreatedDate, LastAccessedDate, and RotationEnabled. This ensures that tools listing secrets receive the same
     metadata structure as they would from real AWS.
   * UpdateSecret: Included the VersionId in the response, which is expected by SDKs to track the result of the update operation.


<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


Test https://github.com/hectorvent/floci-compatibility-tests/pull/41

Closes #174
