### PR TITLE
fix: DynamoDB expression evaluation, UpdateExpression paths, and ConsumedCapacity

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -253,8 +253,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
+                    <!-- Include *Tests.java to also run DynamoDbScanConditionTests, EcsTests,
+                         Ec2Tests, etc. that were silently skipped by the original pattern -->
                     <includes>
                         <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
                     </includes>
                     <environmentVariables>
                         <FLOCI_ENDPOINT>${env.FLOCI_ENDPOINT}</FLOCI_ENDPOINT>

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
@@ -1,0 +1,334 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for DynamoDB expression evaluation:
+ * - Filter expressions with BOOL, IN, OR, NOT, nested parens
+ * - Dotted paths in UpdateExpression SET/REMOVE
+ * - ConsumedCapacity in responses
+ * - Parenthesized BETWEEN in KeyConditionExpression
+ */
+@DisplayName("DynamoDB Expression & Capacity Tests")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbExpressionTests {
+
+    private static DynamoDbClient ddb;
+    private static final String FILTER_TABLE = "expr-filter-test";
+    private static final String BETWEEN_TABLE = "expr-between-test";
+
+    @BeforeAll
+    static void setup() {
+        ddb = TestFixtures.dynamoDbClient();
+
+        // Table for filter expression tests (hash-only)
+        ddb.createTable(CreateTableRequest.builder()
+                .tableName(FILTER_TABLE)
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .build());
+
+        // Table for BETWEEN / key-condition tests (hash + range)
+        ddb.createTable(CreateTableRequest.builder()
+                .tableName(BETWEEN_TABLE)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build(),
+                        KeySchemaElement.builder().attributeName("sk").keyType(KeyType.RANGE).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("sk").attributeType(ScalarAttributeType.S).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .build());
+
+        // Seed filter table
+        ddb.putItem(PutItemRequest.builder().tableName(FILTER_TABLE).item(Map.of(
+                "pk", AttributeValue.fromS("u1"),
+                "deleted", AttributeValue.fromBool(false),
+                "status", AttributeValue.fromN("1"),
+                "category", AttributeValue.fromS("A")
+        )).build());
+        ddb.putItem(PutItemRequest.builder().tableName(FILTER_TABLE).item(Map.of(
+                "pk", AttributeValue.fromS("u2"),
+                "deleted", AttributeValue.fromBool(true),
+                "status", AttributeValue.fromN("2"),
+                "category", AttributeValue.fromS("B")
+        )).build());
+        ddb.putItem(PutItemRequest.builder().tableName(FILTER_TABLE).item(Map.of(
+                "pk", AttributeValue.fromS("u3"),
+                "deleted", AttributeValue.fromBool(false),
+                "status", AttributeValue.fromN("1"),
+                "category", AttributeValue.fromS("A")
+        )).build());
+        // u4 has no "deleted" attribute
+        ddb.putItem(PutItemRequest.builder().tableName(FILTER_TABLE).item(Map.of(
+                "pk", AttributeValue.fromS("u4"),
+                "status", AttributeValue.fromN("3"),
+                "category", AttributeValue.fromS("C")
+        )).build());
+
+        // Seed between table
+        for (String sk : new String[]{"2026-01-01T00:00:00Z#a", "2026-06-15T00:00:00Z#b", "2026-12-31T00:00:00Z#c"}) {
+            ddb.putItem(PutItemRequest.builder().tableName(BETWEEN_TABLE).item(Map.of(
+                    "pk", AttributeValue.fromS("r1"),
+                    "sk", AttributeValue.fromS(sk)
+            )).build());
+        }
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (ddb != null) {
+            try { ddb.deleteTable(DeleteTableRequest.builder().tableName(FILTER_TABLE).build()); } catch (Exception ignored) {}
+            try { ddb.deleteTable(DeleteTableRequest.builder().tableName(BETWEEN_TABLE).build()); } catch (Exception ignored) {}
+            ddb.close();
+        }
+    }
+
+    // ---- BOOL comparison ----
+
+    @Test
+    @Order(1)
+    @DisplayName("Filter: BOOL not-equal excludes deleted items")
+    void filterBoolNotEqual() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("deleted <> :d")
+                .expressionAttributeValues(Map.of(":d", AttributeValue.fromBool(true)))
+                .build());
+        // u1 (false), u3 (false), u4 (missing → <> true is true)
+        assertThat(resp.count()).isEqualTo(3);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Filter: BOOL equal matches false")
+    void filterBoolEqual() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("deleted = :d")
+                .expressionAttributeValues(Map.of(":d", AttributeValue.fromBool(false)))
+                .build());
+        assertThat(resp.count()).isEqualTo(2);
+    }
+
+    // ---- IN operator ----
+
+    @Test
+    @Order(3)
+    @DisplayName("Filter: IN operator with single value")
+    void filterInSingle() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("status IN (:v0)")
+                .expressionAttributeValues(Map.of(":v0", AttributeValue.fromN("1")))
+                .build());
+        assertThat(resp.count()).isEqualTo(2);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Filter: IN operator with multiple values")
+    void filterInMultiple() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("status IN (:v0, :v1)")
+                .expressionAttributeValues(Map.of(
+                        ":v0", AttributeValue.fromN("1"),
+                        ":v1", AttributeValue.fromN("3")))
+                .build());
+        assertThat(resp.count()).isEqualTo(3);
+    }
+
+    // ---- OR operator ----
+
+    @Test
+    @Order(5)
+    @DisplayName("Filter: OR operator")
+    void filterOr() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("status = :v1 OR status = :v2")
+                .expressionAttributeValues(Map.of(
+                        ":v1", AttributeValue.fromN("1"),
+                        ":v2", AttributeValue.fromN("2")))
+                .build());
+        assertThat(resp.count()).isEqualTo(3);
+    }
+
+    // ---- NOT operator ----
+
+    @Test
+    @Order(6)
+    @DisplayName("Filter: NOT operator")
+    void filterNot() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("NOT deleted = :d")
+                .expressionAttributeValues(Map.of(":d", AttributeValue.fromBool(true)))
+                .build());
+        assertThat(resp.count()).isEqualTo(3);
+    }
+
+    // ---- Nested parentheses with AND + OR ----
+
+    @Test
+    @Order(7)
+    @DisplayName("Filter: parenthesized AND + OR")
+    void filterParenthesizedAndOr() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .filterExpression("(status = :v1 OR status = :v3) AND category = :catA")
+                .expressionAttributeValues(Map.of(
+                        ":v1", AttributeValue.fromN("1"),
+                        ":v3", AttributeValue.fromN("3"),
+                        ":catA", AttributeValue.fromS("A")))
+                .build());
+        assertThat(resp.count()).isEqualTo(2);
+    }
+
+    // ---- Dotted path in UpdateExpression ----
+
+    @Test
+    @Order(8)
+    @DisplayName("UpdateExpression: SET with dotted nested path")
+    void updateDottedPath() {
+        // Put an item with a nested map
+        String pk = "dotted-test";
+        ddb.putItem(PutItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .item(Map.of(
+                        "pk", AttributeValue.fromS(pk),
+                        "details", AttributeValue.builder().m(Map.of(
+                                "name", AttributeValue.fromS("original")
+                        )).build()))
+                .build());
+
+        // Update nested attribute via dotted path
+        ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .key(Map.of("pk", AttributeValue.fromS(pk)))
+                .updateExpression("SET details.#sub = :val")
+                .expressionAttributeNames(Map.of("#sub", "name"))
+                .expressionAttributeValues(Map.of(":val", AttributeValue.fromS("updated")))
+                .build());
+
+        GetItemResponse get = ddb.getItem(GetItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .key(Map.of("pk", AttributeValue.fromS(pk)))
+                .build());
+
+        assertThat(get.item().get("details").m().get("name").s()).isEqualTo("updated");
+
+        // Clean up
+        ddb.deleteItem(DeleteItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .key(Map.of("pk", AttributeValue.fromS(pk)))
+                .build());
+    }
+
+    // ---- ConsumedCapacity ----
+
+    @Test
+    @Order(9)
+    @DisplayName("ConsumedCapacity: TOTAL returns capacity in Scan")
+    void consumedCapacityTotal() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+                .build());
+
+        assertThat(resp.consumedCapacity()).isNotNull();
+        assertThat(resp.consumedCapacity().tableName()).isEqualTo(FILTER_TABLE);
+        assertThat(resp.consumedCapacity().capacityUnits()).isGreaterThan(0);
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("ConsumedCapacity: NONE omits capacity")
+    void consumedCapacityNone() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(FILTER_TABLE)
+                .returnConsumedCapacity(ReturnConsumedCapacity.NONE)
+                .build());
+
+        assertThat(resp.consumedCapacity()).isNull();
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("ConsumedCapacity: TOTAL in GetItem")
+    void consumedCapacityGetItem() {
+        GetItemResponse resp = ddb.getItem(GetItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .key(Map.of("pk", AttributeValue.fromS("u1")))
+                .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+                .build());
+
+        assertThat(resp.consumedCapacity()).isNotNull();
+        assertThat(resp.consumedCapacity().capacityUnits()).isGreaterThan(0);
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("ConsumedCapacity: TOTAL in PutItem")
+    void consumedCapacityPutItem() {
+        PutItemResponse resp = ddb.putItem(PutItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .item(Map.of(
+                        "pk", AttributeValue.fromS("cap-test"),
+                        "data", AttributeValue.fromS("v")))
+                .returnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+                .build());
+
+        assertThat(resp.consumedCapacity()).isNotNull();
+        assertThat(resp.consumedCapacity().capacityUnits()).isGreaterThan(0);
+
+        // Clean up
+        ddb.deleteItem(DeleteItemRequest.builder()
+                .tableName(FILTER_TABLE)
+                .key(Map.of("pk", AttributeValue.fromS("cap-test")))
+                .build());
+    }
+
+    // ---- Parenthesized BETWEEN in KeyConditionExpression ----
+
+    @Test
+    @Order(13)
+    @DisplayName("Query: parenthesized BETWEEN in KeyConditionExpression")
+    void queryParenthesizedBetween() {
+        QueryResponse resp = ddb.query(QueryRequest.builder()
+                .tableName(BETWEEN_TABLE)
+                .keyConditionExpression("pk = :pk AND (sk BETWEEN :start AND :end)")
+                .expressionAttributeValues(Map.of(
+                        ":pk", AttributeValue.fromS("r1"),
+                        ":start", AttributeValue.fromS("2026-01-01T00:00:00Z#"),
+                        ":end", AttributeValue.fromS("2026-12-31T23:59:59Z#")))
+                .build());
+
+        assertThat(resp.count()).isEqualTo(3);
+    }
+
+    @Test
+    @Order(14)
+    @DisplayName("Query: compact format BETWEEN — no spaces around AND")
+    void queryCompactBetween() {
+        QueryResponse resp = ddb.query(QueryRequest.builder()
+                .tableName(BETWEEN_TABLE)
+                .keyConditionExpression("(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)")
+                .expressionAttributeNames(Map.of("#f0", "pk", "#f1", "sk"))
+                .expressionAttributeValues(Map.of(
+                        ":v0", AttributeValue.fromS("r1"),
+                        ":v1", AttributeValue.fromS("2026-01-01T00:00:00Z#"),
+                        ":v2", AttributeValue.fromS("2026-12-31T23:59:59Z#z")))
+                .build());
+
+        assertThat(resp.count()).isEqualTo(3);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -226,6 +226,7 @@ public class DynamoDbJsonHandler {
         if ("ALL_OLD" .equals(returnValues) && oldItem != null) {
             response.set("Attributes", oldItem);
         }
+        addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
     }
 
@@ -239,6 +240,7 @@ public class DynamoDbJsonHandler {
         if (item != null) {
             response.set("Item", item);
         }
+        addConsumedCapacity(response, request, tableName, item != null ? 1 : 0, false);
         return Response.ok(response).build();
     }
 
@@ -260,6 +262,7 @@ public class DynamoDbJsonHandler {
         if ("ALL_OLD" .equals(returnValues) && oldItem != null) {
             response.set("Attributes", oldItem);
         }
+        addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
     }
 
@@ -289,6 +292,7 @@ public class DynamoDbJsonHandler {
         } else if ("ALL_OLD" .equals(returnValues) && result.oldItem() != null) {
             response.set("Attributes", result.oldItem());
         }
+        addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
     }
 
@@ -323,6 +327,7 @@ public class DynamoDbJsonHandler {
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
+        addConsumedCapacity(response, request, tableName, result.items().size(), false);
         return Response.ok(response).build();
     }
 
@@ -352,6 +357,7 @@ public class DynamoDbJsonHandler {
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
+        addConsumedCapacity(response, request, tableName, result.items().size(), false);
         return Response.ok(response).build();
     }
 
@@ -376,6 +382,7 @@ public class DynamoDbJsonHandler {
 
         ObjectNode response = objectMapper.createObjectNode();
         response.set("UnprocessedItems", objectMapper.createObjectNode());
+        addBatchConsumedCapacity(response, request, items, true);
         return Response.ok(response).build();
     }
 
@@ -405,6 +412,7 @@ public class DynamoDbJsonHandler {
         }
         response.set("Responses", responses);
         response.set("UnprocessedKeys", objectMapper.createObjectNode());
+        addBatchConsumedCapacity(response, request, items, false);
         return Response.ok(response).build();
     }
 
@@ -741,6 +749,64 @@ public class DynamoDbJsonHandler {
         }
         response.set("KinesisDataStreamDestinations", destinations);
         return Response.ok(response).build();
+    }
+
+    /**
+     * Builds a ConsumedCapacity node if the request includes ReturnConsumedCapacity.
+     * Uses simple estimates: 0.5 RCU per item read, 1.0 WCU per item written.
+     */
+    private void addConsumedCapacity(ObjectNode response, JsonNode request, String tableName,
+                                      int itemCount, boolean isWrite) {
+        String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");
+        if ("NONE".equals(returnCC)) return;
+
+        double cu = isWrite ? Math.max(1.0, itemCount) : Math.max(0.5, itemCount * 0.5);
+
+        ObjectNode cc = objectMapper.createObjectNode();
+        cc.put("TableName", tableName);
+        cc.put("CapacityUnits", cu);
+
+        if ("INDEXES".equals(returnCC)) {
+            ObjectNode tableCap = objectMapper.createObjectNode();
+            String indexName = request.path("IndexName").asText(null);
+            if (indexName != null) {
+                tableCap.put("CapacityUnits", 0.0);
+                cc.set("Table", tableCap);
+                ObjectNode gsiCaps = objectMapper.createObjectNode();
+                ObjectNode indexCap = objectMapper.createObjectNode();
+                indexCap.put("CapacityUnits", cu);
+                gsiCaps.set(indexName, indexCap);
+                cc.set("GlobalSecondaryIndexes", gsiCaps);
+            } else {
+                tableCap.put("CapacityUnits", cu);
+                cc.set("Table", tableCap);
+            }
+        }
+
+        response.set("ConsumedCapacity", cc);
+    }
+
+    /**
+     * Builds a list-style ConsumedCapacity for batch operations.
+     */
+    private void addBatchConsumedCapacity(ObjectNode response, JsonNode request,
+                                           Map<String, ?> tableItems, boolean isWrite) {
+        String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");
+        if ("NONE".equals(returnCC)) return;
+
+        ArrayNode ccArray = objectMapper.createArrayNode();
+        for (String tableName : tableItems.keySet()) {
+            ObjectNode cc = objectMapper.createObjectNode();
+            cc.put("TableName", tableName);
+            cc.put("CapacityUnits", isWrite ? 1.0 : 0.5);
+            if ("INDEXES".equals(returnCC)) {
+                ObjectNode tableCap = objectMapper.createObjectNode();
+                tableCap.put("CapacityUnits", isWrite ? 1.0 : 0.5);
+                cc.set("Table", tableCap);
+            }
+            ccArray.add(cc);
+        }
+        response.set("ConsumedCapacity", ccArray);
     }
 
     private ObjectNode tableToNode(TableDefinition table) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1318,7 +1318,7 @@ public class DynamoDbService {
     }
 
     String resolveAttributeName(String nameOrPlaceholder, JsonNode exprAttrNames) {
-        nameOrPlaceholder = trimBalancedOuterParens(nameOrPlaceholder).trim();
+        nameOrPlaceholder = nameOrPlaceholder.trim();
         if (nameOrPlaceholder.startsWith("#") && exprAttrNames != null) {
             JsonNode resolved = exprAttrNames.get(nameOrPlaceholder);
             if (resolved != null) {
@@ -1659,7 +1659,6 @@ public class DynamoDbService {
                                                 String expression,
                                                 JsonNode expressionAttrValues,
                                                 JsonNode exprAttrNames) {
-        expression = trimBalancedOuterParens(expression);
         List<JsonNode> results = new ArrayList<>();
 
         // Use token-based splitting that correctly handles BETWEEN...AND and compact format

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -466,10 +466,15 @@ public class DynamoDbService {
                                           expressionAttrValues, exprAttrNames);
         }
 
-        // Filter out items without GSI key if querying GSI (sparse index)
+        // Filter out items without GSI key attributes (sparse index behavior).
+        // DynamoDB excludes items from a GSI if any key attribute is null/missing.
         if (indexName != null) {
             String finalPkName = pkName;
-            results = results.stream().filter(item -> item.has(finalPkName)).toList();
+            String finalSkName = skName;
+            results = results.stream()
+                    .filter(item -> item.has(finalPkName) && hasNonNullAttribute(item, finalPkName))
+                    .filter(item -> finalSkName == null || (item.has(finalSkName) && hasNonNullAttribute(item, finalSkName)))
+                    .toList();
         }
 
         // Filter out TTL-expired items
@@ -1504,243 +1509,29 @@ public class DynamoDbService {
 
     private boolean matchesFilterExpression(JsonNode item, String filterExpression,
                                              JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        filterExpression = trimBalancedOuterParens(filterExpression);
-        // Handle AND/OR combined expressions
-        // Split on AND first (simple approach — handles most common cases)
-        String[] andParts = filterExpression.split("\\s+[Aa][Nn][Dd]\\s+");
-        for (String part : andParts) {
-            if (!evaluateSingleCondition(item, part.trim(), exprAttrNames, exprAttrValues)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean evaluateSingleCondition(JsonNode item, String condition,
-                                             JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        condition = trimBalancedOuterParens(condition);
-        // Parse: "attrPath = :val", "attrPath <> :val", "attrPath > :val", etc.
-        // Also: "attribute_exists(attrPath)", "attribute_not_exists(attrPath)",
-        //        "begins_with(attrPath, :val)", "contains(attrPath, :val)"
-        String condLower = condition.toLowerCase();
-
-        if (condLower.startsWith("attribute_exists")) {
-            String attr = extractFunctionArg(condition);
-            String resolvedPath = resolveAttributePath(attr, exprAttrNames);
-            return item != null && resolveNestedAttribute(item, resolvedPath) != null;
-        }
-        if (condLower.startsWith("attribute_not_exists")) {
-            String attr = extractFunctionArg(condition);
-            String resolvedPath = resolveAttributePath(attr, exprAttrNames);
-            return item == null || resolveNestedAttribute(item, resolvedPath) == null;
-        }
-        if (condLower.startsWith("begins_with")) {
-            String[] args = extractFunctionArgs(condition);
-            if (args.length == 2) {
-                String attrName = resolveAttributeName(args[0], exprAttrNames);
-                String prefix = resolveExprValue(args[1], exprAttrValues);
-                String actual = item != null ? extractScalarValue(item.get(attrName)) : null;
-                return actual != null && prefix != null && actual.startsWith(prefix);
-            }
-            return false;
-        }
-        if (condLower.startsWith("contains")) {
-            String[] args = extractFunctionArgs(condition);
-            if (args.length == 2) {
-                String attrName = resolveAttributeName(args[0], exprAttrNames);
-                if (item == null) return false;
-                JsonNode attrNode = item.get(attrName);
-                if (attrNode == null) return false;
-                // Resolve the raw AttributeValue node for type-aware comparisons
-                JsonNode searchAttrValue = exprAttrValues != null
-                        ? exprAttrValues.get(args[1].trim()) : null;
-                if (searchAttrValue == null) return false;
-                // List type: type-aware element membership check
-                if (attrNode.has("L")) {
-                    for (JsonNode element : attrNode.get("L")) {
-                        if (attributeValuesEqual(element, searchAttrValue)) return true;
-                    }
-                    return false;
-                }
-                // SS (String Set): operand must be S type
-                if (attrNode.has("SS")) {
-                    if (!searchAttrValue.has("S")) return false;
-                    String target = searchAttrValue.get("S").asText();
-                    for (JsonNode element : attrNode.get("SS")) {
-                        if (target.equals(element.asText())) return true;
-                    }
-                    return false;
-                }
-                // NS (Number Set): operand must be N type, compare numerically
-                if (attrNode.has("NS")) {
-                    if (!searchAttrValue.has("N")) return false;
-                    try {
-                        java.math.BigDecimal target = new java.math.BigDecimal(searchAttrValue.get("N").asText());
-                        for (JsonNode element : attrNode.get("NS")) {
-                            if (target.compareTo(new java.math.BigDecimal(element.asText())) == 0) return true;
-                        }
-                    } catch (NumberFormatException ignored) {}
-                    return false;
-                }
-                // BS (Binary Set): operand must be B type
-                if (attrNode.has("BS")) {
-                    if (!searchAttrValue.has("B")) return false;
-                    String target = searchAttrValue.get("B").asText();
-                    for (JsonNode element : attrNode.get("BS")) {
-                        if (target.equals(element.asText())) return true;
-                    }
-                    return false;
-                }
-                // String type: operand must be S type, check substring
-                if (attrNode.has("S") && searchAttrValue.has("S")) {
-                    return attrNode.get("S").asText().contains(searchAttrValue.get("S").asText());
-                }
-                return false;
-            }
-            return false;
-        }
-
-        // Comparison operators: =, <>, <, <=, >, >=
-        String[] operators = {"<>", "<=", ">=", "=", "<", ">"};
-        for (String op : operators) {
-            int opIdx = condition.indexOf(op);
-            if (opIdx > 0) {
-                String left = condition.substring(0, opIdx).trim();
-                String right = condition.substring(opIdx + op.length()).trim();
-
-                String attrName = resolveAttributeName(left, exprAttrNames);
-                String expected = resolveExprValue(right, exprAttrValues);
-                String actual = item != null ? extractScalarValue(item.get(attrName)) : null;
-
-                if (actual == null || expected == null) return false;
-
-                return switch (op) {
-                    case "=" -> actual.equals(expected);
-                    case "<>" -> !actual.equals(expected);
-                    case "<" -> compareValues(actual, expected) < 0;
-                    case "<=" -> compareValues(actual, expected) <= 0;
-                    case ">" -> compareValues(actual, expected) > 0;
-                    case ">=" -> compareValues(actual, expected) >= 0;
-                    default -> false;
-                };
-            }
-        }
-
-        return true; // Unknown condition — pass through
-    }
-
-    private String resolveExprValue(String placeholder, JsonNode exprAttrValues) {
-        placeholder = trimBalancedOuterParens(placeholder).trim();
-        if (placeholder.startsWith(":") && exprAttrValues != null) {
-            return extractScalarValue(exprAttrValues.get(placeholder));
-        }
-        return placeholder;
+        return ExpressionEvaluator.matches(filterExpression, item, exprAttrNames, exprAttrValues);
     }
 
     private boolean attributeValuesEqual(JsonNode a, JsonNode b) {
-        if (a == null || b == null) return a == b;
-        // Scalar types: S, B, BOOL, NULL
-        for (String type : new String[]{"S", "B", "BOOL", "NULL"}) {
-            if (a.has(type) && b.has(type)) {
-                return a.get(type).asText().equals(b.get(type).asText());
-            }
-            if (a.has(type) || b.has(type)) return false; // type mismatch
-        }
-        // Numeric comparison with normalization
-        if (a.has("N") && b.has("N")) {
-            try {
-                return new java.math.BigDecimal(a.get("N").asText())
-                        .compareTo(new java.math.BigDecimal(b.get("N").asText())) == 0;
-            } catch (NumberFormatException e) {
-                return false;
-            }
-        }
-        if (a.has("N") || b.has("N")) return false;
-        // Map type: compare all entries recursively
-        if (a.has("M") && b.has("M")) {
-            JsonNode aMap = a.get("M");
-            JsonNode bMap = b.get("M");
-            if (aMap.size() != bMap.size()) return false;
-            var fields = aMap.fields();
-            while (fields.hasNext()) {
-                var entry = fields.next();
-                if (!bMap.has(entry.getKey())) return false;
-                if (!attributeValuesEqual(entry.getValue(), bMap.get(entry.getKey()))) return false;
-            }
-            return true;
-        }
-        // List type: compare element by element
-        if (a.has("L") && b.has("L")) {
-            JsonNode aList = a.get("L");
-            JsonNode bList = b.get("L");
-            if (aList.size() != bList.size()) return false;
-            for (int i = 0; i < aList.size(); i++) {
-                if (!attributeValuesEqual(aList.get(i), bList.get(i))) return false;
-            }
-            return true;
-        }
-        // Different types are never equal
-        return false;
+        return ExpressionEvaluator.attributeValuesEqual(a, b);
+    }
+
+    /**
+     * Returns true if the item has the given attribute with a non-null DynamoDB value.
+     * An attribute is considered null if it is the DynamoDB NULL type ({@code {"NULL": true}}).
+     */
+    private static boolean hasNonNullAttribute(JsonNode item, String attrName) {
+        JsonNode attr = item.get(attrName);
+        if (attr == null) return false;
+        return !attr.has("NULL");
     }
 
     private int compareValues(String a, String b) {
-        // Try numeric comparison first
         try {
             return Double.compare(Double.parseDouble(a), Double.parseDouble(b));
         } catch (NumberFormatException e) {
             return a.compareTo(b);
         }
-    }
-
-    private static final String DOT_ESCAPE = "\uFF0E";
-
-    private String resolveAttributePath(String path, JsonNode exprAttrNames) {
-        // Resolve each segment of a dotted path, e.g. "passengerInformation.#name"
-        // ExpressionAttributeNames may resolve to names containing dots (e.g. "#a" -> "foo.bar").
-        // Escape those dots so resolveNestedAttribute treats them as single keys.
-        String[] segments = path.split("\\.");
-        StringBuilder resolved = new StringBuilder();
-        for (int i = 0; i < segments.length; i++) {
-            if (i > 0) resolved.append(".");
-            String original = segments[i];
-            String resolvedSegment = resolveAttributeName(original, exprAttrNames);
-            if (original.startsWith("#") && resolvedSegment != null) {
-                resolvedSegment = resolvedSegment.replace(".", DOT_ESCAPE);
-            }
-            resolved.append(resolvedSegment);
-        }
-        return resolved.toString();
-    }
-
-    private JsonNode resolveNestedAttribute(JsonNode item, String path) {
-        // Navigate a dotted path through DynamoDB's {"M": {...}} structure
-        String[] segments = path.split("\\.");
-        JsonNode current = item;
-        for (int i = 0; i < segments.length; i++) {
-            if (current == null) return null;
-            String segment = segments[i].replace(DOT_ESCAPE, ".");
-            if (i == 0) {
-                // First segment: resolve against the top-level item map
-                current = current.get(segment);
-            } else {
-                // Subsequent segments: descend into DynamoDB Map type
-                if (current.has("M")) {
-                    current = current.get("M").get(segment);
-                } else {
-                    current = current.get(segment);
-                }
-            }
-        }
-        return current;
-    }
-
-    private String extractFunctionArg(String funcCall) {
-        int open = funcCall.indexOf('(');
-        int close = funcCall.lastIndexOf(')');
-        if (open >= 0 && close > open) {
-            return funcCall.substring(open + 1, close).trim();
-        }
-        return funcCall;
     }
 
     private String[] extractFunctionArgs(String funcCall) {
@@ -1871,17 +1662,30 @@ public class DynamoDbService {
         expression = trimBalancedOuterParens(expression);
         List<JsonNode> results = new ArrayList<>();
 
-        // Parse simple expressions: "pk = :val" or "pk = :val AND sk begins_with :prefix"
-        String[] parts = expression.split("\\s+[Aa][Nn][Dd]\\s+", 2);
-        String pkExpression = trimBalancedOuterParens(parts[0].trim());
-        String skExpression = parts.length > 1 ? trimBalancedOuterParens(parts[1].trim()) : null;
+        // Use token-based splitting that correctly handles BETWEEN...AND and compact format
+        String[] keyParts = ExpressionEvaluator.splitKeyCondition(expression);
+        String pkExpression = keyParts[0];
+        String skExpression = keyParts[1];
 
         // Extract pk attr name from expression (may use #alias)
-        String pkAttrInExpr = pkExpression.split("\\s*=\\s*")[0].trim();
+        // Strip outer parens for PK extraction (e.g. "(#f0 = :v0)" → "#f0 = :v0")
+        String pkExprStripped = pkExpression.trim();
+        while (pkExprStripped.startsWith("(") && pkExprStripped.endsWith(")")) {
+            pkExprStripped = pkExprStripped.substring(1, pkExprStripped.length() - 1).trim();
+        }
+        String pkAttrInExpr = pkExprStripped.split("\\s*=\\s*")[0].trim();
         String resolvedPkName = resolveAttributeName(pkAttrInExpr, exprAttrNames);
 
-        // Extract pk value
-        String pkPlaceholder = extractPlaceholder(pkExpression);
+        // Extract pk value placeholder
+        int colonIdx = pkExprStripped.indexOf(':');
+        String pkPlaceholder = null;
+        if (colonIdx >= 0) {
+            int end = colonIdx + 1;
+            while (end < pkExprStripped.length() && (Character.isLetterOrDigit(pkExprStripped.charAt(end)) || pkExprStripped.charAt(end) == '_')) {
+                end++;
+            }
+            pkPlaceholder = pkExprStripped.substring(colonIdx, end);
+        }
         String pkValue = pkPlaceholder != null && expressionAttrValues != null
                 ? extractScalarValue(expressionAttrValues.get(pkPlaceholder))
                 : null;
@@ -1893,7 +1697,7 @@ public class DynamoDbService {
             }
 
             if (skExpression != null && skName != null) {
-                if (!matchesSkExpression(item.get(skName), skExpression, expressionAttrValues)) {
+                if (!ExpressionEvaluator.matches(skExpression, item, exprAttrNames, expressionAttrValues)) {
                     continue;
                 }
             }
@@ -1902,100 +1706,6 @@ public class DynamoDbService {
         }
 
         return results;
-    }
-
-    private boolean matchesSkExpression(JsonNode skValue, String expression, JsonNode exprValues) {
-        expression = trimBalancedOuterParens(expression);
-        String actual = extractScalarValue(skValue);
-        if (actual == null) return false;
-
-        String exprLower = expression.toLowerCase();
-        if (exprLower.contains("begins_with")) {
-            String placeholder = extractPlaceholder(expression);
-            String prefix = placeholder != null && exprValues != null
-                    ? extractScalarValue(exprValues.get(placeholder)) : null;
-            return prefix != null && actual.startsWith(prefix);
-        }
-
-        if (exprLower.contains(" between ")) {
-            int betweenIdx = exprLower.indexOf(" between ");
-            int andIdx = exprLower.indexOf(" and ", betweenIdx + " between ".length());
-            if (andIdx < 0) return false;
-
-            String lowerExpr = expression.substring(betweenIdx + " between ".length(), andIdx).trim();
-            String upperExpr = expression.substring(andIdx + " and ".length()).trim();
-            String lowerPlaceholder = lowerExpr.startsWith(":") ? lowerExpr.split("\\s+")[0] : null;
-            String upperPlaceholder = upperExpr.startsWith(":") ? upperExpr.split("\\s+")[0] : null;
-            String lower = lowerPlaceholder != null && exprValues != null
-                    ? extractScalarValue(exprValues.get(lowerPlaceholder)) : null;
-            String upper = upperPlaceholder != null && exprValues != null
-                    ? extractScalarValue(exprValues.get(upperPlaceholder)) : null;
-            if (lower == null || upper == null) return false;
-            return compareValues(actual, lower) >= 0 && compareValues(actual, upper) <= 0;
-        }
-
-        // Detect comparison operator
-        String[] operators = {"<>", "<=", ">=", "=", "<", ">"};
-        for (String op : operators) {
-            int opIdx = expression.indexOf(op);
-            if (opIdx > 0) {
-                String right = expression.substring(opIdx + op.length()).trim();
-                String placeholder = right.startsWith(":") ? right.split("\\s+")[0] : null;
-                String expected = placeholder != null && exprValues != null
-                        ? extractScalarValue(exprValues.get(placeholder)) : null;
-                if (expected == null) return false;
-                return switch (op) {
-                    case "=" -> actual.equals(expected);
-                    case "<>" -> !actual.equals(expected);
-                    case ">=" -> actual.compareTo(expected) >= 0;
-                    case "<=" -> actual.compareTo(expected) <= 0;
-                    case ">" -> actual.compareTo(expected) > 0;
-                    case "<" -> actual.compareTo(expected) < 0;
-                    default -> true;
-                };
-            }
-        }
-        return true;
-    }
-
-    private String extractPlaceholder(String expression) {
-        // Find :placeholder in expression
-        int idx = expression.indexOf(':');
-        if (idx < 0) return null;
-        int end = idx + 1;
-        while (end < expression.length() && (Character.isLetterOrDigit(expression.charAt(end)) || expression.charAt(end) == '_')) {
-            end++;
-        }
-        return expression.substring(idx, end);
-    }
-
-    private String trimBalancedOuterParens(String expression) {
-        if (expression == null) return null;
-        String trimmed = expression.trim();
-        while (trimmed.length() >= 2 && trimmed.startsWith("(") && trimmed.endsWith(")")
-                && hasBalancedOuterParens(trimmed)) {
-            trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
-        }
-        return trimmed;
-    }
-
-    private boolean hasBalancedOuterParens(String expression) {
-        int depth = 0;
-        for (int i = 0; i < expression.length(); i++) {
-            char c = expression.charAt(i);
-            if (c == '(') {
-                depth++;
-            } else if (c == ')') {
-                depth--;
-                if (depth == 0 && i < expression.length() - 1) {
-                    return false;
-                }
-                if (depth < 0) {
-                    return false;
-                }
-            }
-        }
-        return depth == 0;
     }
 
     private AwsException resourceNotFoundException(String tableName) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -1,0 +1,746 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Proper tokenizer/parser/evaluator for DynamoDB filter expressions and key condition expressions.
+ * Replaces the regex-based splitting approach that breaks on compact formats like
+ * {@code (#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)}.
+ */
+final class ExpressionEvaluator {
+
+    private ExpressionEvaluator() {}
+
+    // ── Token types ──
+
+    enum TokenType {
+        // Literals / identifiers
+        IDENTIFIER,      // plain name like "pk", "info"
+        NAME_REF,        // #name
+        VALUE_REF,       // :value
+        // Keywords
+        AND, OR, NOT, IN, BETWEEN,
+        // Comparators
+        EQ,    // =
+        NE,    // <>
+        LT,    // <
+        LE,    // <=
+        GT,    // >
+        GE,    // >=
+        // Punctuation
+        LPAREN, RPAREN, COMMA, DOT,
+        // Functions
+        FUNCTION,        // attribute_exists, attribute_not_exists, begins_with, contains, size
+        // End
+        EOF
+    }
+
+    record Token(TokenType type, String value, int pos) {}
+
+    // ── Tokenizer ──
+
+    static List<Token> tokenize(String expression) {
+        var tokens = new ArrayList<Token>();
+        int i = 0;
+        int len = expression.length();
+
+        while (i < len) {
+            char c = expression.charAt(i);
+
+            // Skip whitespace
+            if (Character.isWhitespace(c)) {
+                i++;
+                continue;
+            }
+
+            // Punctuation
+            if (c == '(') { tokens.add(new Token(TokenType.LPAREN, "(", i)); i++; continue; }
+            if (c == ')') { tokens.add(new Token(TokenType.RPAREN, ")", i)); i++; continue; }
+            if (c == ',') { tokens.add(new Token(TokenType.COMMA, ",", i)); i++; continue; }
+            if (c == '.') { tokens.add(new Token(TokenType.DOT, ".", i)); i++; continue; }
+
+            // Comparators (must check <> and <= before <, >= before >)
+            if (c == '<') {
+                if (i + 1 < len && expression.charAt(i + 1) == '>') {
+                    tokens.add(new Token(TokenType.NE, "<>", i)); i += 2;
+                } else if (i + 1 < len && expression.charAt(i + 1) == '=') {
+                    tokens.add(new Token(TokenType.LE, "<=", i)); i += 2;
+                } else {
+                    tokens.add(new Token(TokenType.LT, "<", i)); i++;
+                }
+                continue;
+            }
+            if (c == '>') {
+                if (i + 1 < len && expression.charAt(i + 1) == '=') {
+                    tokens.add(new Token(TokenType.GE, ">=", i)); i += 2;
+                } else {
+                    tokens.add(new Token(TokenType.GT, ">", i)); i++;
+                }
+                continue;
+            }
+            if (c == '=') { tokens.add(new Token(TokenType.EQ, "=", i)); i++; continue; }
+
+            // Value reference :name
+            if (c == ':') {
+                int start = i;
+                i++; // skip ':'
+                while (i < len && isNameChar(expression.charAt(i))) i++;
+                tokens.add(new Token(TokenType.VALUE_REF, expression.substring(start, i), start));
+                continue;
+            }
+
+            // Name reference #name
+            if (c == '#') {
+                int start = i;
+                i++; // skip '#'
+                while (i < len && isNameChar(expression.charAt(i))) i++;
+                tokens.add(new Token(TokenType.NAME_REF, expression.substring(start, i), start));
+                continue;
+            }
+
+            // Identifier or keyword
+            if (isNameStartChar(c)) {
+                int start = i;
+                while (i < len && isNameChar(expression.charAt(i))) i++;
+                // Check for function names that contain underscores (attribute_exists, etc.)
+                // and multi-word function names
+                String word = expression.substring(start, i);
+
+                // Handle "attribute_exists", "attribute_not_exists" — need to consume underscores and following parts
+                // Actually the loop above already handles underscores via isNameChar.
+                // Check for known functions
+                String wordLower = word.toLowerCase();
+                switch (wordLower) {
+                    case "and" -> tokens.add(new Token(TokenType.AND, word, start));
+                    case "or" -> tokens.add(new Token(TokenType.OR, word, start));
+                    case "not" -> tokens.add(new Token(TokenType.NOT, word, start));
+                    case "in" -> tokens.add(new Token(TokenType.IN, word, start));
+                    case "between" -> tokens.add(new Token(TokenType.BETWEEN, word, start));
+                    case "attribute_exists", "attribute_not_exists", "begins_with", "contains", "size" ->
+                        tokens.add(new Token(TokenType.FUNCTION, word, start));
+                    default -> tokens.add(new Token(TokenType.IDENTIFIER, word, start));
+                }
+                continue;
+            }
+
+            throw new IllegalArgumentException(
+                    "Unexpected character '%c' at position %d in expression: %s".formatted(c, i, expression));
+        }
+
+        tokens.add(new Token(TokenType.EOF, "", len));
+        return tokens;
+    }
+
+    private static boolean isNameStartChar(char c) {
+        return Character.isLetter(c) || c == '_';
+    }
+
+    private static boolean isNameChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+
+    // ── AST nodes ──
+
+    sealed interface Expr {}
+
+    record AndExpr(List<Expr> operands) implements Expr {}
+    record OrExpr(List<Expr> operands) implements Expr {}
+    record NotExpr(Expr operand) implements Expr {}
+    record CompareExpr(Operand left, TokenType op, Operand right) implements Expr {}
+    record BetweenExpr(Operand value, Operand low, Operand high) implements Expr {}
+    record InExpr(Operand value, List<Operand> candidates) implements Expr {}
+    record FunctionCallExpr(String functionName, List<Operand> args) implements Expr {}
+
+    sealed interface Operand {}
+    record PathOperand(List<String> segments) implements Operand {}      // e.g. ["info", "#name"] or ["pk"]
+    record PlaceholderOperand(String name) implements Operand {}         // e.g. ":val"
+    record FunctionOperand(String functionName, List<Operand> args) implements Operand {} // e.g. size(path)
+
+    // ── Parser ──
+
+    static final class Parser {
+        private final List<Token> tokens;
+        private int pos;
+
+        Parser(List<Token> tokens) {
+            this.tokens = tokens;
+            this.pos = 0;
+        }
+
+        private Token peek() { return tokens.get(pos); }
+        private Token advance() { return tokens.get(pos++); }
+
+        private Token expect(TokenType type) {
+            Token t = advance();
+            if (t.type() != type) {
+                throw new IllegalArgumentException(
+                        "Expected %s but got %s ('%s') at position %d".formatted(type, t.type(), t.value(), t.pos()));
+            }
+            return t;
+        }
+
+        Expr parseExpression() {
+            Expr expr = parseOrExpr();
+            // Don't require EOF here — caller may stop before consuming all tokens (e.g. splitKeyCondition)
+            return expr;
+        }
+
+        private Expr parseOrExpr() {
+            var operands = new ArrayList<Expr>();
+            operands.add(parseAndExpr());
+            while (peek().type() == TokenType.OR) {
+                advance(); // consume OR
+                operands.add(parseAndExpr());
+            }
+            return operands.size() == 1 ? operands.getFirst() : new OrExpr(operands);
+        }
+
+        private Expr parseAndExpr() {
+            var operands = new ArrayList<Expr>();
+            operands.add(parseNotExpr());
+            while (peek().type() == TokenType.AND) {
+                advance(); // consume AND
+                operands.add(parseNotExpr());
+            }
+            return operands.size() == 1 ? operands.getFirst() : new AndExpr(operands);
+        }
+
+        private Expr parseNotExpr() {
+            if (peek().type() == TokenType.NOT) {
+                advance(); // consume NOT
+                return new NotExpr(parseNotExpr());
+            }
+            return parsePrimary();
+        }
+
+        private Expr parsePrimary() {
+            Token current = peek();
+
+            // Parenthesized expression
+            if (current.type() == TokenType.LPAREN) {
+                advance(); // consume (
+                Expr inner = parseOrExpr();
+                expect(TokenType.RPAREN);
+                return inner;
+            }
+
+            // Function call as condition (attribute_exists, attribute_not_exists, begins_with, contains, size)
+            if (current.type() == TokenType.FUNCTION) {
+                String funcName = advance().value();
+                expect(TokenType.LPAREN);
+                var args = parseOperandList();
+                expect(TokenType.RPAREN);
+
+                // If followed by a comparator, this is "size(path) = :val" — treat as comparison
+                if (isComparator(peek().type())) {
+                    TokenType op = advance().type();
+                    Operand right = parseOperand();
+                    return new CompareExpr(new FunctionOperand(funcName, args), op, right);
+                }
+
+                return new FunctionCallExpr(funcName, args);
+            }
+
+            // Operand followed by comparator, IN, or BETWEEN
+            Operand left = parseOperand();
+
+            Token next = peek();
+            if (next.type() == TokenType.IN) {
+                advance(); // consume IN
+                expect(TokenType.LPAREN);
+                var candidates = parseOperandList();
+                expect(TokenType.RPAREN);
+                return new InExpr(left, candidates);
+            }
+            if (next.type() == TokenType.BETWEEN) {
+                advance(); // consume BETWEEN
+                Operand low = parseOperand();
+                expect(TokenType.AND); // BETWEEN ... AND ...
+                Operand high = parseOperand();
+                return new BetweenExpr(left, low, high);
+            }
+            if (isComparator(next.type())) {
+                TokenType op = advance().type();
+                Operand right = parseOperand();
+                return new CompareExpr(left, op, right);
+            }
+
+            throw new IllegalArgumentException(
+                    "Expected comparator, IN, or BETWEEN after operand, but got %s ('%s') at position %d"
+                            .formatted(next.type(), next.value(), next.pos()));
+        }
+
+        private Operand parseOperand() {
+            Token current = peek();
+
+            // Function as operand (e.g. size(path))
+            if (current.type() == TokenType.FUNCTION) {
+                String funcName = advance().value();
+                expect(TokenType.LPAREN);
+                var args = parseOperandList();
+                expect(TokenType.RPAREN);
+                return new FunctionOperand(funcName, args);
+            }
+
+            // Placeholder :value
+            if (current.type() == TokenType.VALUE_REF) {
+                return new PlaceholderOperand(advance().value());
+            }
+
+            // Path: identifier or #name, possibly dotted
+            if (current.type() == TokenType.IDENTIFIER || current.type() == TokenType.NAME_REF) {
+                var segments = new ArrayList<String>();
+                segments.add(advance().value());
+                while (peek().type() == TokenType.DOT) {
+                    advance(); // consume dot
+                    Token seg = peek();
+                    if (seg.type() == TokenType.IDENTIFIER || seg.type() == TokenType.NAME_REF) {
+                        segments.add(advance().value());
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Expected identifier after '.' at position %d".formatted(seg.pos()));
+                    }
+                }
+                return new PathOperand(segments);
+            }
+
+            throw new IllegalArgumentException(
+                    "Expected operand but got %s ('%s') at position %d"
+                            .formatted(current.type(), current.value(), current.pos()));
+        }
+
+        private List<Operand> parseOperandList() {
+            var list = new ArrayList<Operand>();
+            list.add(parseOperand());
+            while (peek().type() == TokenType.COMMA) {
+                advance(); // consume comma
+                list.add(parseOperand());
+            }
+            return list;
+        }
+
+        private static boolean isComparator(TokenType type) {
+            return type == TokenType.EQ || type == TokenType.NE ||
+                   type == TokenType.LT || type == TokenType.LE ||
+                   type == TokenType.GT || type == TokenType.GE;
+        }
+    }
+
+    // ── Parse helper ──
+
+    static Expr parse(String expression) {
+        if (expression == null || expression.isBlank()) return null;
+        var tokens = tokenize(expression.trim());
+        var parser = new Parser(tokens);
+        Expr expr = parser.parseExpression();
+        if (parser.peek().type() != TokenType.EOF) {
+            throw new IllegalArgumentException(
+                    "Unexpected token '%s' at position %d after parsing complete expression"
+                            .formatted(parser.peek().value(), parser.peek().pos()));
+        }
+        return expr;
+    }
+
+    // ── Key condition splitting ──
+
+    /**
+     * Splits a key condition expression into [pkCondition, skCondition].
+     * Finds the top-level AND that is NOT part of a BETWEEN...AND.
+     * Returns a 2-element array; the second element is null if there is no SK condition.
+     */
+    static String[] splitKeyCondition(String expression) {
+        if (expression == null || expression.isBlank()) return new String[]{expression, null};
+
+        var tokens = tokenize(expression.trim());
+        // Find the top-level AND that separates PK from SK.
+        // We need to skip AND tokens that are part of BETWEEN...AND.
+        // Strategy: walk through tokens tracking parenthesis depth and BETWEEN state.
+
+        int depth = 0;
+        boolean inBetween = false;
+
+        for (int i = 0; i < tokens.size(); i++) {
+            Token t = tokens.get(i);
+            switch (t.type()) {
+                case LPAREN -> depth++;
+                case RPAREN -> depth--;
+                case BETWEEN -> { if (depth == 0) inBetween = true; }
+                case AND -> {
+                    if (depth == 0) {
+                        if (inBetween) {
+                            // This AND belongs to BETWEEN...AND — skip it
+                            inBetween = false;
+                        } else {
+                            // This is the top-level AND separating PK from SK
+                            int splitCharPos = t.pos();
+                            // Find end of AND keyword in source
+                            String trimmed = expression.trim();
+                            String pk = trimmed.substring(0, splitCharPos).trim();
+                            // The AND keyword is at splitCharPos, length varies (could be "AND" = 3 chars)
+                            // But we need to find the actual end in the original string.
+                            // Token value is the literal text, and pos is position in original.
+                            int andEnd = splitCharPos + t.value().length();
+                            String sk = trimmed.substring(andEnd).trim();
+                            return new String[]{pk, sk};
+                        }
+                    }
+                }
+                default -> {}
+            }
+        }
+
+        // No top-level AND found — expression is PK-only
+        return new String[]{expression.trim(), null};
+    }
+
+    // ── Evaluator ──
+
+    private static final String DOT_ESCAPE = "\uFF0E";
+
+    /**
+     * Evaluates a parsed expression against a DynamoDB item.
+     *
+     * @param expr           the parsed expression (may be null for "no filter")
+     * @param item           the DynamoDB item (JsonNode map of attribute names to typed values)
+     * @param exprAttrNames  expression attribute names mapping (#name -> actual name), may be null
+     * @param exprAttrValues expression attribute values mapping (:val -> DynamoDB typed value), may be null
+     * @return true if the item matches the expression
+     */
+    static boolean evaluate(Expr expr, JsonNode item, JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        if (expr == null) return true;
+
+        return switch (expr) {
+            case AndExpr and -> {
+                for (Expr op : and.operands()) {
+                    if (!evaluate(op, item, exprAttrNames, exprAttrValues)) yield false;
+                }
+                yield true;
+            }
+            case OrExpr or -> {
+                for (Expr op : or.operands()) {
+                    if (evaluate(op, item, exprAttrNames, exprAttrValues)) yield true;
+                }
+                yield false;
+            }
+            case NotExpr not -> !evaluate(not.operand(), item, exprAttrNames, exprAttrValues);
+
+            case CompareExpr cmp -> evaluateComparison(cmp, item, exprAttrNames, exprAttrValues);
+            case BetweenExpr bet -> evaluateBetween(bet, item, exprAttrNames, exprAttrValues);
+            case InExpr in -> evaluateIn(in, item, exprAttrNames, exprAttrValues);
+            case FunctionCallExpr func -> evaluateFunction(func, item, exprAttrNames, exprAttrValues);
+        };
+    }
+
+    /**
+     * Convenience: parse and evaluate in one call.
+     */
+    static boolean matches(String expression, JsonNode item, JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        return evaluate(parse(expression), item, exprAttrNames, exprAttrValues);
+    }
+
+    // ── Comparison evaluation ──
+
+    private static boolean evaluateComparison(CompareExpr cmp, JsonNode item,
+                                               JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        String leftVal = resolveScalar(cmp.left(), item, exprAttrNames, exprAttrValues);
+        String rightVal = resolveScalar(cmp.right(), item, exprAttrNames, exprAttrValues);
+
+        // DynamoDB: comparing a missing attribute with <> returns true
+        if (leftVal == null && cmp.op() == TokenType.NE) return true;
+        if (rightVal == null && cmp.op() == TokenType.NE) return true;
+        if (leftVal == null || rightVal == null) return false;
+
+        return switch (cmp.op()) {
+            case EQ -> leftVal.equals(rightVal);
+            case NE -> !leftVal.equals(rightVal);
+            case LT -> compareValues(leftVal, rightVal) < 0;
+            case LE -> compareValues(leftVal, rightVal) <= 0;
+            case GT -> compareValues(leftVal, rightVal) > 0;
+            case GE -> compareValues(leftVal, rightVal) >= 0;
+            default -> false;
+        };
+    }
+
+    private static boolean evaluateBetween(BetweenExpr bet, JsonNode item,
+                                            JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        String val = resolveScalar(bet.value(), item, exprAttrNames, exprAttrValues);
+        String low = resolveScalar(bet.low(), item, exprAttrNames, exprAttrValues);
+        String high = resolveScalar(bet.high(), item, exprAttrNames, exprAttrValues);
+        if (val == null || low == null || high == null) return false;
+        return compareValues(val, low) >= 0 && compareValues(val, high) <= 0;
+    }
+
+    private static boolean evaluateIn(InExpr in, JsonNode item,
+                                       JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        // For IN, we use type-aware equality via the raw attribute value nodes
+        JsonNode leftAttrValue = resolveAttributeValue(in.value(), item, exprAttrNames, exprAttrValues);
+        if (leftAttrValue == null) return false;
+
+        for (Operand candidate : in.candidates()) {
+            JsonNode candidateValue = resolveAttributeValue(candidate, item, exprAttrNames, exprAttrValues);
+            if (candidateValue != null && attributeValuesEqual(leftAttrValue, candidateValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean evaluateFunction(FunctionCallExpr func, JsonNode item,
+                                             JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        String funcLower = func.functionName().toLowerCase();
+        return switch (funcLower) {
+            case "attribute_exists" -> {
+                if (func.args().isEmpty()) yield false;
+                String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                yield item != null && resolveNestedAttribute(item, path) != null;
+            }
+            case "attribute_not_exists" -> {
+                if (func.args().isEmpty()) yield false;
+                String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                yield item == null || resolveNestedAttribute(item, path) == null;
+            }
+            case "begins_with" -> {
+                if (func.args().size() < 2) yield false;
+                String path = resolveAttributePath(func.args().get(0), exprAttrNames);
+                JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
+                String actual = extractScalarValue(attrNode);
+                String prefix = resolveScalar(func.args().get(1), item, exprAttrNames, exprAttrValues);
+                yield actual != null && prefix != null && actual.startsWith(prefix);
+            }
+            case "contains" -> {
+                if (func.args().size() < 2) yield false;
+                yield evaluateContains(func.args().get(0), func.args().get(1),
+                        item, exprAttrNames, exprAttrValues);
+            }
+            default -> false;
+        };
+    }
+
+    private static boolean evaluateContains(Operand pathOperand, Operand searchOperand,
+                                             JsonNode item, JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        if (item == null) return false;
+        String path = resolveAttributePath(pathOperand, exprAttrNames);
+        JsonNode attrNode = resolveNestedAttribute(item, path);
+        if (attrNode == null) return false;
+
+        JsonNode searchAttrValue = resolveAttributeValue(searchOperand, item, exprAttrNames, exprAttrValues);
+        if (searchAttrValue == null) return false;
+
+        // List membership
+        if (attrNode.has("L")) {
+            for (JsonNode element : attrNode.get("L")) {
+                if (attributeValuesEqual(element, searchAttrValue)) return true;
+            }
+            return false;
+        }
+        // String set
+        if (attrNode.has("SS")) {
+            if (!searchAttrValue.has("S")) return false;
+            String target = searchAttrValue.get("S").asText();
+            for (JsonNode element : attrNode.get("SS")) {
+                if (target.equals(element.asText())) return true;
+            }
+            return false;
+        }
+        // Number set
+        if (attrNode.has("NS")) {
+            if (!searchAttrValue.has("N")) return false;
+            try {
+                BigDecimal target = new BigDecimal(searchAttrValue.get("N").asText());
+                for (JsonNode element : attrNode.get("NS")) {
+                    if (target.compareTo(new BigDecimal(element.asText())) == 0) return true;
+                }
+            } catch (NumberFormatException ignored) {}
+            return false;
+        }
+        // Binary set
+        if (attrNode.has("BS")) {
+            if (!searchAttrValue.has("B")) return false;
+            String target = searchAttrValue.get("B").asText();
+            for (JsonNode element : attrNode.get("BS")) {
+                if (target.equals(element.asText())) return true;
+            }
+            return false;
+        }
+        // String contains (substring)
+        if (attrNode.has("S") && searchAttrValue.has("S")) {
+            return attrNode.get("S").asText().contains(searchAttrValue.get("S").asText());
+        }
+        return false;
+    }
+
+    // ── Operand resolution ──
+
+    /**
+     * Resolves an operand to a scalar string value (for comparisons and BETWEEN).
+     */
+    private static String resolveScalar(Operand operand, JsonNode item,
+                                         JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        return switch (operand) {
+            case PlaceholderOperand p -> {
+                if (exprAttrValues != null) {
+                    yield extractScalarValue(exprAttrValues.get(p.name()));
+                }
+                yield null;
+            }
+            case PathOperand path -> {
+                String resolvedPath = resolvePathString(path, exprAttrNames);
+                JsonNode attrNode = item != null ? resolveNestedAttribute(item, resolvedPath) : null;
+                yield extractScalarValue(attrNode);
+            }
+            case FunctionOperand func -> {
+                // size() returns a number
+                if ("size".equalsIgnoreCase(func.functionName()) && !func.args().isEmpty()) {
+                    String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                    JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
+                    yield attrNode != null ? String.valueOf(computeSize(attrNode)) : null;
+                }
+                yield null;
+            }
+        };
+    }
+
+    /**
+     * Resolves an operand to its raw DynamoDB attribute value node (for IN and contains).
+     */
+    private static JsonNode resolveAttributeValue(Operand operand, JsonNode item,
+                                                    JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        return switch (operand) {
+            case PlaceholderOperand p -> exprAttrValues != null ? exprAttrValues.get(p.name()) : null;
+            case PathOperand path -> {
+                String resolvedPath = resolvePathString(path, exprAttrNames);
+                yield item != null ? resolveNestedAttribute(item, resolvedPath) : null;
+            }
+            case FunctionOperand _ -> null;
+        };
+    }
+
+    // ── Attribute path resolution ──
+
+    private static String resolveAttributePath(Operand operand, JsonNode exprAttrNames) {
+        if (operand instanceof PathOperand path) {
+            return resolvePathString(path, exprAttrNames);
+        }
+        return operand.toString();
+    }
+
+    private static String resolvePathString(PathOperand path, JsonNode exprAttrNames) {
+        var sb = new StringBuilder();
+        for (int i = 0; i < path.segments().size(); i++) {
+            if (i > 0) sb.append(".");
+            String segment = path.segments().get(i);
+            String resolved = resolveAttributeName(segment, exprAttrNames);
+            // If the resolved name contains dots, escape them so resolveNestedAttribute treats it as one key
+            if (segment.startsWith("#") && resolved != null) {
+                resolved = resolved.replace(".", DOT_ESCAPE);
+            }
+            sb.append(resolved);
+        }
+        return sb.toString();
+    }
+
+    // ── Helpers (self-contained, replicated from DynamoDbService) ──
+
+    private static String resolveAttributeName(String nameOrPlaceholder, JsonNode exprAttrNames) {
+        if (nameOrPlaceholder.startsWith("#") && exprAttrNames != null) {
+            JsonNode resolved = exprAttrNames.get(nameOrPlaceholder);
+            if (resolved != null) {
+                return resolved.asText();
+            }
+        }
+        return nameOrPlaceholder;
+    }
+
+    private static String extractScalarValue(JsonNode attrValue) {
+        if (attrValue == null) return null;
+        if (attrValue.has("S")) return attrValue.get("S").asText();
+        if (attrValue.has("N")) return attrValue.get("N").asText();
+        if (attrValue.has("B")) return attrValue.get("B").asText();
+        if (attrValue.has("BOOL")) return attrValue.get("BOOL").asText();
+        return attrValue.asText();
+    }
+
+    private static JsonNode resolveNestedAttribute(JsonNode item, String path) {
+        String[] segments = path.split("\\.");
+        JsonNode current = item;
+        for (int i = 0; i < segments.length; i++) {
+            if (current == null) return null;
+            String segment = segments[i].replace(DOT_ESCAPE, ".");
+            if (i == 0) {
+                current = current.get(segment);
+            } else {
+                if (current.has("M")) {
+                    current = current.get("M").get(segment);
+                } else {
+                    current = current.get(segment);
+                }
+            }
+        }
+        return current;
+    }
+
+    static boolean attributeValuesEqual(JsonNode a, JsonNode b) {
+        if (a == null || b == null) return a == b;
+        for (String type : new String[]{"S", "B", "BOOL", "NULL"}) {
+            if (a.has(type) && b.has(type)) {
+                return a.get(type).asText().equals(b.get(type).asText());
+            }
+            if (a.has(type) || b.has(type)) return false;
+        }
+        if (a.has("N") && b.has("N")) {
+            try {
+                return new BigDecimal(a.get("N").asText())
+                        .compareTo(new BigDecimal(b.get("N").asText())) == 0;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        if (a.has("N") || b.has("N")) return false;
+        if (a.has("M") && b.has("M")) {
+            JsonNode aMap = a.get("M");
+            JsonNode bMap = b.get("M");
+            if (aMap.size() != bMap.size()) return false;
+            var fields = aMap.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                if (!bMap.has(entry.getKey())) return false;
+                if (!attributeValuesEqual(entry.getValue(), bMap.get(entry.getKey()))) return false;
+            }
+            return true;
+        }
+        if (a.has("L") && b.has("L")) {
+            JsonNode aList = a.get("L");
+            JsonNode bList = b.get("L");
+            if (aList.size() != bList.size()) return false;
+            for (int i = 0; i < aList.size(); i++) {
+                if (!attributeValuesEqual(aList.get(i), bList.get(i))) return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static int compareValues(String a, String b) {
+        try {
+            return Double.compare(Double.parseDouble(a), Double.parseDouble(b));
+        } catch (NumberFormatException e) {
+            return a.compareTo(b);
+        }
+    }
+
+    private static int computeSize(JsonNode attrNode) {
+        if (attrNode.has("S")) return attrNode.get("S").asText().length();
+        if (attrNode.has("B")) return attrNode.get("B").asText().length(); // base64 length
+        if (attrNode.has("L")) return attrNode.get("L").size();
+        if (attrNode.has("M")) return attrNode.get("M").size();
+        if (attrNode.has("SS")) return attrNode.get("SS").size();
+        if (attrNode.has("NS")) return attrNode.get("NS").size();
+        if (attrNode.has("BS")) return attrNode.get("BS").size();
+        if (attrNode.has("N")) return attrNode.get("N").asText().length();
+        return 0;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
@@ -1,0 +1,370 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for DynamoDB filter expression evaluation via the HTTP API.
+ * Covers comparison operators on BOOL types, IN operator, and OR logical operator.
+ */
+@QuarkusTest
+class DynamoDbFilterExpressionIntegrationTest {
+
+    private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String TABLE_NAME = "FilterExprTestTable";
+    private static boolean tableCreated = false;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @BeforeEach
+    void ensureTableAndData() {
+        if (tableCreated) return;
+
+        // Create table
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}]
+                }
+                """.formatted(TABLE_NAME))
+        .when().post("/").then().statusCode(200);
+
+        // Insert items
+        putItem("""
+            {"pk": {"S": "u1"}, "deleted": {"BOOL": false}, "status": {"N": "1"}, "category": {"S": "A"}}
+            """);
+        putItem("""
+            {"pk": {"S": "u2"}, "deleted": {"BOOL": true}, "status": {"N": "2"}, "category": {"S": "B"}}
+            """);
+        putItem("""
+            {"pk": {"S": "u3"}, "deleted": {"BOOL": false}, "status": {"N": "1"}, "category": {"S": "A"}}
+            """);
+        // u4 has no "deleted" attribute — tests attribute_not_exists semantics
+        putItem("""
+            {"pk": {"S": "u4"}, "status": {"N": "3"}, "category": {"S": "C"}}
+            """);
+
+        tableCreated = true;
+    }
+
+    // ---- BOOL not-equal (<>) ----
+
+    @Test
+    void scanFilterBoolNotEqual_excludesDeletedItems() {
+        // deleted <> true should return u1 (false), u3 (false), u4 (missing — <> true is true for missing)
+        scanWithFilter(
+                "deleted <> :d",
+                """
+                {":d": {"BOOL": true}}
+                """,
+                null,
+                3);
+    }
+
+    @Test
+    void scanFilterBoolEqual_matchesFalse() {
+        // deleted = false should return u1, u3
+        scanWithFilter(
+                "deleted = :d",
+                """
+                {":d": {"BOOL": false}}
+                """,
+                null,
+                2);
+    }
+
+    // ---- IN operator ----
+
+    @Test
+    void scanFilterInOperator_singleValue() {
+        // status IN (:v0) where v0=1 should return u1, u3
+        scanWithFilter(
+                "status IN (:v0)",
+                """
+                {":v0": {"N": "1"}}
+                """,
+                null,
+                2);
+    }
+
+    @Test
+    void scanFilterInOperator_multipleValues() {
+        // status IN (:v0, :v1) where v0=1, v1=3 should return u1, u3, u4
+        scanWithFilter(
+                "status IN (:v0, :v1)",
+                """
+                {":v0": {"N": "1"}, ":v1": {"N": "3"}}
+                """,
+                null,
+                3);
+    }
+
+    @Test
+    void scanFilterInOperator_withExpressionAttributeNames() {
+        // #cat IN (:v0) where #cat=category, v0="A" should return u1, u3
+        scanWithFilter(
+                "#cat IN (:v0)",
+                """
+                {":v0": {"S": "A"}}
+                """,
+                """
+                {"#cat": "category"}
+                """,
+                2);
+    }
+
+    // ---- OR logical operator ----
+
+    @Test
+    void scanFilterOrOperator() {
+        // status = :v1 OR status = :v2 should return u1, u2, u3 (status 1 or 2)
+        scanWithFilter(
+                "status = :v1 OR status = :v2",
+                """
+                {":v1": {"N": "1"}, ":v2": {"N": "2"}}
+                """,
+                null,
+                3);
+    }
+
+    @Test
+    void scanFilterOrWithAttributeNotExists() {
+        // attribute_not_exists(deleted) OR deleted = :false — should match u1, u3, u4
+        scanWithFilter(
+                "attribute_not_exists(deleted) OR deleted = :notDel",
+                """
+                {":notDel": {"BOOL": false}}
+                """,
+                null,
+                3);
+    }
+
+    // ---- Combined AND + OR ----
+
+    @Test
+    void scanFilterAndWithOr() {
+        // (status = :v1 OR status = :v3) AND category = :catA
+        // status=1 OR status=3 → u1,u3,u4; AND category=A → u1,u3
+        scanWithFilter(
+                "(status = :v1 OR status = :v3) AND category = :catA",
+                """
+                {":v1": {"N": "1"}, ":v3": {"N": "3"}, ":catA": {"S": "A"}}
+                """,
+                null,
+                2);
+    }
+
+    // ---- NOT operator ----
+
+    @Test
+    void scanFilterNotOperator() {
+        // NOT deleted = :true should return u1, u3, u4
+        scanWithFilter(
+                "NOT deleted = :d",
+                """
+                {":d": {"BOOL": true}}
+                """,
+                null,
+                3);
+    }
+
+    // ---- Nested parentheses and complex expressions ----
+
+    @Test
+    void scanFilterNestedParentheses() {
+        // ((status = :v1 OR status = :v3) AND category = :catA) OR deleted = :del
+        // (status 1 or 3) AND category A → u1,u3; OR deleted=true → u2
+        // Total: u1, u2, u3
+        scanWithFilter(
+                "((status = :v1 OR status = :v3) AND category = :catA) OR deleted = :del",
+                """
+                {":v1": {"N": "1"}, ":v3": {"N": "3"}, ":catA": {"S": "A"}, ":del": {"BOOL": true}}
+                """,
+                null,
+                3);
+    }
+
+    @Test
+    void scanFilterNotWithParenthesizedAnd() {
+        // NOT (deleted = :true AND status = :v2) — negate (u2 only) → u1, u3, u4
+        scanWithFilter(
+                "NOT (deleted = :d AND status = :v2)",
+                """
+                {":d": {"BOOL": true}, ":v2": {"N": "2"}}
+                """,
+                null,
+                3);
+    }
+
+    @Test
+    void scanFilterDoubleNestedParens() {
+        // ((category = :a)) should work like category = :a → u1, u3
+        scanWithFilter(
+                "((category = :a))",
+                """
+                {":a": {"S": "A"}}
+                """,
+                null,
+                2);
+    }
+
+    // ---- Parenthesized BETWEEN in KeyConditionExpression ----
+
+    @Test
+    void queryWithParenthesizedBetweenInKeyCondition() {
+        // Create a table with partition + sort key for this test
+        String tbl = "BetweenTestTable";
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"}
+                    ]
+                }
+                """.formatted(tbl))
+        .when().post("/").then().statusCode(200);
+
+        // Insert items
+        for (String sk : new String[]{"2026-01-01T00:00:00Z#a", "2026-06-15T00:00:00Z#b", "2026-12-31T00:00:00Z#c"}) {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                    {"TableName": "%s", "Item": {"pk": {"S": "r1"}, "sk": {"S": "%s"}}}
+                    """.formatted(tbl, sk))
+            .when().post("/").then().statusCode(200);
+        }
+
+        // Query with parenthesized BETWEEN — this is what the AWS SDK commonly generates
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk AND (sk BETWEEN :start AND :end)",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "r1"},
+                        ":start": {"S": "2026-01-01T00:00:00Z#"},
+                        ":end": {"S": "2026-12-31T23:59:59Z#"}
+                    }
+                }
+                """.formatted(tbl))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3));
+    }
+
+    @Test
+    void queryWithCompactAndBetweenInKeyCondition() {
+        // EfficientDynamoDb compact format: "(pk = :v0)AND(sk BETWEEN :v1 AND :v2)" — no spaces around AND
+        String tbl = "CompactBetweenTestTable";
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"}
+                    ]
+                }
+                """.formatted(tbl))
+        .when().post("/").then().statusCode(200);
+
+        for (String sk : new String[]{"2026-01-01Z#a", "2026-06-15Z#b", "2026-12-31Z#c"}) {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                    {"TableName": "%s", "Item": {"pk": {"S": "r1"}, "sk": {"S": "%s"}}}
+                    """.formatted(tbl, sk))
+            .when().post("/").then().statusCode(200);
+        }
+
+        // Compact format: no spaces around AND, parens wrapping each sub-expression
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)",
+                    "ExpressionAttributeNames": {"#f0": "pk", "#f1": "sk"},
+                    "ExpressionAttributeValues": {
+                        ":v0": {"S": "r1"},
+                        ":v1": {"S": "2026-01-01Z#"},
+                        ":v2": {"S": "2026-12-31Z#z"}
+                    }
+                }
+                """.formatted(tbl))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3));
+    }
+
+    // ---- Helpers ----
+
+    private void putItem(String itemJson) {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s", "Item": %s}
+                """.formatted(TABLE_NAME, itemJson))
+        .when().post("/").then().statusCode(200);
+    }
+
+    private void scanWithFilter(String filterExpression, String exprAttrValuesJson,
+                                 String exprAttrNamesJson, int expectedCount) {
+        var body = new StringBuilder();
+        body.append("{");
+        body.append("\"TableName\": \"").append(TABLE_NAME).append("\",");
+        body.append("\"FilterExpression\": \"").append(filterExpression).append("\",");
+        body.append("\"ExpressionAttributeValues\": ").append(exprAttrValuesJson);
+        if (exprAttrNamesJson != null) {
+            body.append(",\"ExpressionAttributeNames\": ").append(exprAttrNamesJson);
+        }
+        body.append("}");
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body(body.toString())
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(expectedCount));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -802,6 +802,114 @@ class DynamoDbIntegrationTest {
             .body("__type", equalTo("ResourceNotFoundException"));
     }
 
+    // --- ConsumedCapacity tests ---
+    // These use a dedicated table to avoid ordering dependencies.
+
+    @Test
+    void getItem_withReturnConsumedCapacityTotal_returnsCapacity() {
+        // Create a dedicated table
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "CapacityTest",
+                    "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
+                    "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5}
+                }
+                """)
+        .when().post("/").then().statusCode(200);
+
+        // Put an item
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "CapacityTest", "Item": {"id": {"S": "a"}, "val": {"S": "hello"}}}
+                """)
+        .when().post("/").then().statusCode(200);
+
+        // GetItem with TOTAL
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "CapacityTest",
+                    "Key": {"id": {"S": "a"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.val.S", equalTo("hello"))
+            .body("ConsumedCapacity.TableName", equalTo("CapacityTest"))
+            .body("ConsumedCapacity.CapacityUnits", notNullValue());
+    }
+
+    @Test
+    void getItem_withoutReturnConsumedCapacity_omitsCapacity() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "CapacityTest",
+                    "Key": {"id": {"S": "a"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity", nullValue());
+    }
+
+    @Test
+    void putItem_withReturnConsumedCapacityTotal_returnsCapacity() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "CapacityTest",
+                    "Item": {"id": {"S": "b"}, "val": {"S": "world"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.TableName", equalTo("CapacityTest"))
+            .body("ConsumedCapacity.CapacityUnits", notNullValue());
+    }
+
+    @Test
+    void query_withReturnConsumedCapacityIndexes_returnsTableBreakdown() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "CapacityTest",
+                    "KeyConditionExpression": "id = :id",
+                    "ExpressionAttributeValues": {":id": {"S": "a"}},
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.TableName", equalTo("CapacityTest"))
+            .body("ConsumedCapacity.CapacityUnits", notNullValue())
+            .body("ConsumedCapacity.Table.CapacityUnits", notNullValue());
+    }
+
     @Test
     @Order(28)
     void updateItemListAppend() {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -1426,4 +1426,82 @@ class DynamoDbServiceTest {
                 "(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)", null, null, null, null, null, exprNames, "us-east-1");
         assertEquals(2, result.items().size(), "compact AND with BETWEEN should work");
     }
+
+    @Test
+    void updateItemWithNestedDottedPathSetAndRemove() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o1"));
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#details", "details");
+        exprNames.put("#status", "status");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":val", attributeValue("S", "hello"));
+        exprValues.set(":s", attributeValue("S", "active"));
+
+        // SET a nested map field via dotted path: #details.subkey = :val, #status = :s
+        ObjectNode key = mapper.createObjectNode();
+        key.set("customerId", attributeValue("S", "c1"));
+        key.set("orderId", attributeValue("S", "o1"));
+
+        var result = service.updateItem("Orders", key, null,
+                "SET #details.subkey = :val, #status = :s", exprNames, exprValues, "ALL_NEW", null, "us-east-1");
+
+        JsonNode updated = result.newItem();
+        assertNotNull(updated);
+        // status should be set at top level
+        assertEquals("active", updated.get("status").get("S").asText());
+        // details.subkey should be set in a nested map
+        assertNotNull(updated.get("details"), "details map should exist");
+        assertTrue(updated.get("details").has("M"), "details should be a DynamoDB Map");
+        assertEquals("hello", updated.get("details").get("M").get("subkey").get("S").asText());
+
+        // Now REMOVE the nested field
+        result = service.updateItem("Orders", key, null,
+                "REMOVE #details.subkey", exprNames, null, "ALL_NEW", null, "us-east-1");
+
+        updated = result.newItem();
+        // The subkey should be removed from the nested map
+        assertFalse(updated.get("details").get("M").has("subkey"), "subkey should be removed");
+        // status should still be there
+        assertEquals("active", updated.get("status").get("S").asText());
+    }
+
+    @Test
+    void updateItemSetFollowedByRemovePreservesAllAssignments() {
+        // Reproduces the bug where SET's last assignment was lost because findNextComma
+        // consumed into the REMOVE clause's comma-separated list.
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o1"));
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#a", "fieldA");
+        exprNames.put("#b", "fieldB");
+        exprNames.put("#c", "fieldC");
+        exprNames.put("#d", "fieldD");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v1", attributeValue("S", "val1"));
+        exprValues.set(":v2", attributeValue("S", "val2"));
+
+        ObjectNode key = mapper.createObjectNode();
+        key.set("customerId", attributeValue("S", "c1"));
+        key.set("orderId", attributeValue("S", "o1"));
+
+        // First, set all four fields
+        service.updateItem("Orders", key, null,
+                "SET #a = :v1, #b = :v1, #c = :v1, #d = :v1", exprNames, exprValues, "NONE", null, "us-east-1");
+
+        // SET last two assignments, then REMOVE two fields (comma-separated)
+        var result = service.updateItem("Orders", key, null,
+                "SET #a = :v1, #b = :v2 REMOVE #c, #d", exprNames, exprValues, "ALL_NEW", null, "us-east-1");
+
+        JsonNode updated = result.newItem();
+        assertNotNull(updated);
+        assertEquals("val1", updated.get("fieldA").get("S").asText(), "fieldA should be set");
+        assertEquals("val2", updated.get("fieldB").get("S").asText(), "fieldB should be set (last SET before REMOVE)");
+        assertNull(updated.get("fieldC"), "fieldC should be removed");
+        assertNull(updated.get("fieldD"), "fieldD should be removed");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -858,7 +858,6 @@ class DynamoDbServiceTest {
         assertTrue(tagValues.containsAll(Arrays.asList("a", "b")));
     }
 
-
     /**
      * Test update with SET and REMOVE in the same expression.
      * This mimics how the DynamoDB Enhanced Client generates expressions
@@ -1392,4 +1391,39 @@ class DynamoDbServiceTest {
         assertEquals("two", stored.get("other").get("S").asText());
     }
 
+    @Test
+    void queryWithParenthesizedBetweenKeyCondition() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "2026-01-01Z#a"));
+        service.putItem("Orders", item("customerId", "c1", "orderId", "2026-06-15Z#b"));
+        service.putItem("Orders", item("customerId", "c1", "orderId", "2026-12-31Z#c"));
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":pk", attributeValue("S", "c1"));
+        exprValues.set(":start", attributeValue("S", "2026-01-01Z#"));
+        exprValues.set(":end", attributeValue("S", "2026-12-31Z#z"));
+
+        var result = service.query("Orders", null, exprValues,
+                "customerId = :pk AND (orderId BETWEEN :start AND :end)", null, null);
+        assertEquals(3, result.items().size(), "parenthesized BETWEEN should work");
+    }
+
+    @Test
+    void queryWithCompactAndBetweenKeyCondition() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "2026-01-01Z#a"));
+        service.putItem("Orders", item("customerId", "c1", "orderId", "2026-06-15Z#b"));
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#f0", "customerId");
+        exprNames.put("#f1", "orderId");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v0", attributeValue("S", "c1"));
+        exprValues.set(":v1", attributeValue("S", "2026-01-01Z#"));
+        exprValues.set(":v2", attributeValue("S", "2026-12-31Z#z"));
+
+        var result = service.query("Orders", null, exprValues,
+                "(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)", null, null, null, null, null, exprNames, "us-east-1");
+        assertEquals(2, result.items().size(), "compact AND with BETWEEN should work");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -1,0 +1,574 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExpressionEvaluatorTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // ── Tokenizer tests ──
+
+    @Nested
+    class TokenizerTests {
+
+        @Test
+        void standardExpression() {
+            var tokens = ExpressionEvaluator.tokenize("pk = :pk AND sk BETWEEN :a AND :b");
+            var types = tokens.stream().map(ExpressionEvaluator.Token::type).toList();
+            assertEquals(List.of(
+                    ExpressionEvaluator.TokenType.IDENTIFIER,  // pk
+                    ExpressionEvaluator.TokenType.EQ,          // =
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :pk
+                    ExpressionEvaluator.TokenType.AND,         // AND
+                    ExpressionEvaluator.TokenType.IDENTIFIER,  // sk
+                    ExpressionEvaluator.TokenType.BETWEEN,     // BETWEEN
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :a
+                    ExpressionEvaluator.TokenType.AND,         // AND
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :b
+                    ExpressionEvaluator.TokenType.EOF
+            ), types);
+        }
+
+        @Test
+        void compactFormat() {
+            var tokens = ExpressionEvaluator.tokenize("(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)");
+            var types = tokens.stream().map(ExpressionEvaluator.Token::type).toList();
+            assertEquals(List.of(
+                    ExpressionEvaluator.TokenType.LPAREN,
+                    ExpressionEvaluator.TokenType.NAME_REF,    // #f0
+                    ExpressionEvaluator.TokenType.EQ,
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :v0
+                    ExpressionEvaluator.TokenType.RPAREN,
+                    ExpressionEvaluator.TokenType.AND,
+                    ExpressionEvaluator.TokenType.LPAREN,
+                    ExpressionEvaluator.TokenType.NAME_REF,    // #f1
+                    ExpressionEvaluator.TokenType.BETWEEN,
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :v1
+                    ExpressionEvaluator.TokenType.AND,
+                    ExpressionEvaluator.TokenType.VALUE_REF,   // :v2
+                    ExpressionEvaluator.TokenType.RPAREN,
+                    ExpressionEvaluator.TokenType.EOF
+            ), types);
+        }
+
+        @Test
+        void allComparators() {
+            var tokens = ExpressionEvaluator.tokenize("a = b a <> b a < b a <= b a > b a >= b");
+            var comparators = tokens.stream()
+                    .map(ExpressionEvaluator.Token::type)
+                    .filter(t -> t != ExpressionEvaluator.TokenType.IDENTIFIER && t != ExpressionEvaluator.TokenType.EOF)
+                    .toList();
+            assertEquals(List.of(
+                    ExpressionEvaluator.TokenType.EQ,
+                    ExpressionEvaluator.TokenType.NE,
+                    ExpressionEvaluator.TokenType.LT,
+                    ExpressionEvaluator.TokenType.LE,
+                    ExpressionEvaluator.TokenType.GT,
+                    ExpressionEvaluator.TokenType.GE
+            ), comparators);
+        }
+
+        @Test
+        void functionTokens() {
+            var tokens = ExpressionEvaluator.tokenize("attribute_exists(a) AND begins_with(b, :v) AND contains(c, :w) AND size(d) > :x AND attribute_not_exists(e)");
+            var functions = tokens.stream()
+                    .filter(t -> t.type() == ExpressionEvaluator.TokenType.FUNCTION)
+                    .map(ExpressionEvaluator.Token::value)
+                    .toList();
+            assertEquals(List.of("attribute_exists", "begins_with", "contains", "size", "attribute_not_exists"), functions);
+        }
+
+        @Test
+        void inAndBetweenKeywords() {
+            var tokens = ExpressionEvaluator.tokenize("x IN (:a, :b) AND y BETWEEN :c AND :d");
+            assertTrue(tokens.stream().anyMatch(t -> t.type() == ExpressionEvaluator.TokenType.IN));
+            assertTrue(tokens.stream().anyMatch(t -> t.type() == ExpressionEvaluator.TokenType.BETWEEN));
+        }
+
+        @Test
+        void dottedPath() {
+            var tokens = ExpressionEvaluator.tokenize("info.nested = :v");
+            var types = tokens.stream().map(ExpressionEvaluator.Token::type).toList();
+            assertEquals(List.of(
+                    ExpressionEvaluator.TokenType.IDENTIFIER,  // info
+                    ExpressionEvaluator.TokenType.DOT,
+                    ExpressionEvaluator.TokenType.IDENTIFIER,  // nested
+                    ExpressionEvaluator.TokenType.EQ,
+                    ExpressionEvaluator.TokenType.VALUE_REF,
+                    ExpressionEvaluator.TokenType.EOF
+            ), types);
+        }
+    }
+
+    // ── Parser tests ──
+
+    @Nested
+    class ParserTests {
+
+        @Test
+        void simpleComparison() {
+            var expr = ExpressionEvaluator.parse("pk = :pk");
+            assertInstanceOf(ExpressionEvaluator.CompareExpr.class, expr);
+        }
+
+        @Test
+        void andExpression() {
+            var expr = ExpressionEvaluator.parse("a = :a AND b = :b");
+            assertInstanceOf(ExpressionEvaluator.AndExpr.class, expr);
+            assertEquals(2, ((ExpressionEvaluator.AndExpr) expr).operands().size());
+        }
+
+        @Test
+        void orExpression() {
+            var expr = ExpressionEvaluator.parse("a = :a OR b = :b");
+            assertInstanceOf(ExpressionEvaluator.OrExpr.class, expr);
+            assertEquals(2, ((ExpressionEvaluator.OrExpr) expr).operands().size());
+        }
+
+        @Test
+        void notExpression() {
+            var expr = ExpressionEvaluator.parse("NOT a = :a");
+            assertInstanceOf(ExpressionEvaluator.NotExpr.class, expr);
+        }
+
+        @Test
+        void nestedParens() {
+            var expr = ExpressionEvaluator.parse("(a = :a OR b = :b) AND c = :c");
+            assertInstanceOf(ExpressionEvaluator.AndExpr.class, expr);
+            var and = (ExpressionEvaluator.AndExpr) expr;
+            assertInstanceOf(ExpressionEvaluator.OrExpr.class, and.operands().get(0));
+            assertInstanceOf(ExpressionEvaluator.CompareExpr.class, and.operands().get(1));
+        }
+
+        @Test
+        void betweenAndNotConfusedWithLogicalAnd() {
+            var expr = ExpressionEvaluator.parse("sk BETWEEN :a AND :b");
+            assertInstanceOf(ExpressionEvaluator.BetweenExpr.class, expr);
+        }
+
+        @Test
+        void betweenInsideAnd() {
+            var expr = ExpressionEvaluator.parse("pk = :pk AND sk BETWEEN :a AND :b");
+            assertInstanceOf(ExpressionEvaluator.AndExpr.class, expr);
+            var and = (ExpressionEvaluator.AndExpr) expr;
+            assertInstanceOf(ExpressionEvaluator.CompareExpr.class, and.operands().get(0));
+            assertInstanceOf(ExpressionEvaluator.BetweenExpr.class, and.operands().get(1));
+        }
+
+        @Test
+        void inOperator() {
+            var expr = ExpressionEvaluator.parse("status IN (:a, :b, :c)");
+            assertInstanceOf(ExpressionEvaluator.InExpr.class, expr);
+            assertEquals(3, ((ExpressionEvaluator.InExpr) expr).candidates().size());
+        }
+
+        @Test
+        void inOperatorSingleValue() {
+            var expr = ExpressionEvaluator.parse("status IN (:a)");
+            assertInstanceOf(ExpressionEvaluator.InExpr.class, expr);
+            assertEquals(1, ((ExpressionEvaluator.InExpr) expr).candidates().size());
+        }
+
+        @Test
+        void functionCallCondition() {
+            var expr = ExpressionEvaluator.parse("attribute_exists(myAttr)");
+            assertInstanceOf(ExpressionEvaluator.FunctionCallExpr.class, expr);
+        }
+
+        @Test
+        void sizeComparison() {
+            var expr = ExpressionEvaluator.parse("size(myList) > :val");
+            assertInstanceOf(ExpressionEvaluator.CompareExpr.class, expr);
+            var cmp = (ExpressionEvaluator.CompareExpr) expr;
+            assertInstanceOf(ExpressionEvaluator.FunctionOperand.class, cmp.left());
+        }
+
+        @Test
+        void compactFormatParsesCorrectly() {
+            var expr = ExpressionEvaluator.parse("(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)");
+            assertInstanceOf(ExpressionEvaluator.AndExpr.class, expr);
+            var and = (ExpressionEvaluator.AndExpr) expr;
+            assertInstanceOf(ExpressionEvaluator.CompareExpr.class, and.operands().get(0));
+            assertInstanceOf(ExpressionEvaluator.BetweenExpr.class, and.operands().get(1));
+        }
+    }
+
+    // ── splitKeyCondition tests ──
+
+    @Nested
+    class SplitKeyConditionTests {
+
+        @Test
+        void pkAndSkEquals() {
+            var result = ExpressionEvaluator.splitKeyCondition("pk = :pk AND sk = :sk");
+            assertEquals("pk = :pk", result[0]);
+            assertEquals("sk = :sk", result[1]);
+        }
+
+        @Test
+        void pkAndSkBetweenParenthesized() {
+            var result = ExpressionEvaluator.splitKeyCondition("pk = :pk AND (sk BETWEEN :a AND :b)");
+            assertEquals("pk = :pk", result[0]);
+            assertEquals("(sk BETWEEN :a AND :b)", result[1]);
+        }
+
+        @Test
+        void compactFormat() {
+            var result = ExpressionEvaluator.splitKeyCondition("(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)");
+            assertEquals("(#f0 = :v0)", result[0]);
+            assertEquals("(#f1 BETWEEN :v1 AND :v2)", result[1]);
+        }
+
+        @Test
+        void pkOnly() {
+            var result = ExpressionEvaluator.splitKeyCondition("pk = :pk");
+            assertEquals("pk = :pk", result[0]);
+            assertNull(result[1]);
+        }
+
+        @Test
+        void pkAndSkBeginsWith() {
+            var result = ExpressionEvaluator.splitKeyCondition("pk = :pk AND begins_with(sk, :prefix)");
+            assertEquals("pk = :pk", result[0]);
+            assertEquals("begins_with(sk, :prefix)", result[1]);
+        }
+
+        @Test
+        void pkAndSkBetweenNoParen() {
+            var result = ExpressionEvaluator.splitKeyCondition("pk = :pk AND sk BETWEEN :a AND :b");
+            assertEquals("pk = :pk", result[0]);
+            assertEquals("sk BETWEEN :a AND :b", result[1]);
+        }
+    }
+
+    // ── Evaluator (matches) tests ──
+
+    @Nested
+    class EvaluatorTests {
+
+        private JsonNode item(String json) throws Exception {
+            return mapper.readTree(json);
+        }
+
+        private JsonNode values(String json) throws Exception {
+            return mapper.readTree(json);
+        }
+
+        private JsonNode names(String json) throws Exception {
+            return mapper.readTree(json);
+        }
+
+        // AND, OR, NOT logic
+
+        @Test
+        void andBothTrue() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}, \"b\": {\"S\": \"2\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"},\n\":b\": {\"S\": \"2\"}}");
+            assertTrue(ExpressionEvaluator.matches("a = :a AND b = :b", i, null, v));
+        }
+
+        @Test
+        void andOneFalse() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}, \"b\": {\"S\": \"3\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"},\n\":b\": {\"S\": \"2\"}}");
+            assertFalse(ExpressionEvaluator.matches("a = :a AND b = :b", i, null, v));
+        }
+
+        @Test
+        void orOneTrue() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}, \"b\": {\"S\": \"3\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"},\n\":b\": {\"S\": \"2\"}}");
+            assertTrue(ExpressionEvaluator.matches("a = :a OR b = :b", i, null, v));
+        }
+
+        @Test
+        void orBothFalse() throws Exception {
+            var i = item("{\"a\": {\"S\": \"X\"}, \"b\": {\"S\": \"Y\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"},\n\":b\": {\"S\": \"2\"}}");
+            assertFalse(ExpressionEvaluator.matches("a = :a OR b = :b", i, null, v));
+        }
+
+        @Test
+        void notTrue() throws Exception {
+            var i = item("{\"a\": {\"S\": \"X\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"}}");
+            assertTrue(ExpressionEvaluator.matches("NOT a = :a", i, null, v));
+        }
+
+        @Test
+        void notFalse() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}}");
+            var v = values("{\n\":a\": {\"S\": \"1\"}}");
+            assertFalse(ExpressionEvaluator.matches("NOT a = :a", i, null, v));
+        }
+
+        // Comparison operators on strings
+
+        @Test
+        void stringEquals() throws Exception {
+            var i = item("{\"name\": {\"S\": \"Alice\"}}");
+            var v = values("{\n\":v\": {\"S\": \"Alice\"}}");
+            assertTrue(ExpressionEvaluator.matches("name = :v", i, null, v));
+        }
+
+        @Test
+        void stringNotEquals() throws Exception {
+            var i = item("{\"name\": {\"S\": \"Alice\"}}");
+            var v = values("{\n\":v\": {\"S\": \"Bob\"}}");
+            assertTrue(ExpressionEvaluator.matches("name <> :v", i, null, v));
+        }
+
+        @Test
+        void stringLessThan() throws Exception {
+            var i = item("{\"name\": {\"S\": \"Alice\"}}");
+            var v = values("{\n\":v\": {\"S\": \"Bob\"}}");
+            assertTrue(ExpressionEvaluator.matches("name < :v", i, null, v));
+        }
+
+        // Comparison operators on numbers
+
+        @Test
+        void numberEquals() throws Exception {
+            var i = item("{\"age\": {\"N\": \"25\"}}");
+            var v = values("{\n\":v\": {\"N\": \"25\"}}");
+            assertTrue(ExpressionEvaluator.matches("age = :v", i, null, v));
+        }
+
+        @Test
+        void numberGreaterThan() throws Exception {
+            var i = item("{\"age\": {\"N\": \"30\"}}");
+            var v = values("{\n\":v\": {\"N\": \"25\"}}");
+            assertTrue(ExpressionEvaluator.matches("age > :v", i, null, v));
+        }
+
+        @Test
+        void numberLessThanOrEqual() throws Exception {
+            var i = item("{\"age\": {\"N\": \"25\"}}");
+            var v = values("{\n\":v\": {\"N\": \"25\"}}");
+            assertTrue(ExpressionEvaluator.matches("age <= :v", i, null, v));
+        }
+
+        // <> on BOOL and missing attributes
+
+        @Test
+        void boolNotEqualFalse() throws Exception {
+            var i = item("{\"active\": {\"BOOL\": \"false\"}}");
+            var v = values("{\n\":v\": {\"BOOL\": \"true\"}}");
+            assertTrue(ExpressionEvaluator.matches("active <> :v", i, null, v));
+        }
+
+        @Test
+        void boolNotEqualTrue() throws Exception {
+            var i = item("{\"active\": {\"BOOL\": \"true\"}}");
+            var v = values("{\n\":v\": {\"BOOL\": \"true\"}}");
+            assertFalse(ExpressionEvaluator.matches("active <> :v", i, null, v));
+        }
+
+        @Test
+        void missingAttributeNotEqual() throws Exception {
+            // DynamoDB: missing <> val → true
+            var i = item("{\"other\": {\"S\": \"x\"}}");
+            var v = values("{\n\":v\": {\"BOOL\": \"true\"}}");
+            assertTrue(ExpressionEvaluator.matches("active <> :v", i, null, v));
+        }
+
+        @Test
+        void missingAttributeEquals() throws Exception {
+            // DynamoDB: missing = val → false
+            var i = item("{\"other\": {\"S\": \"x\"}}");
+            var v = values("{\n\":v\": {\"S\": \"hello\"}}");
+            assertFalse(ExpressionEvaluator.matches("name = :v", i, null, v));
+        }
+
+        // IN operator
+
+        @Test
+        void inWithNumbers() throws Exception {
+            var i = item("{\"status\": {\"N\": \"2\"}}");
+            var v = values("{\n\":a\": {\"N\": \"1\"},\n\":b\": {\"N\": \"2\"},\n\":c\": {\"N\": \"3\"}}");
+            assertTrue(ExpressionEvaluator.matches("status IN (:a, :b, :c)", i, null, v));
+        }
+
+        @Test
+        void inWithStrings() throws Exception {
+            var i = item("{\"color\": {\"S\": \"red\"}}");
+            var v = values("{\n\":a\": {\"S\": \"red\"},\n\":b\": {\"S\": \"blue\"}}");
+            assertTrue(ExpressionEvaluator.matches("color IN (:a, :b)", i, null, v));
+        }
+
+        @Test
+        void inNotMatching() throws Exception {
+            var i = item("{\"color\": {\"S\": \"green\"}}");
+            var v = values("{\n\":a\": {\"S\": \"red\"},\n\":b\": {\"S\": \"blue\"}}");
+            assertFalse(ExpressionEvaluator.matches("color IN (:a, :b)", i, null, v));
+        }
+
+        @Test
+        void inSingleValue() throws Exception {
+            var i = item("{\"status\": {\"S\": \"active\"}}");
+            var v = values("{\n\":a\": {\"S\": \"active\"}}");
+            assertTrue(ExpressionEvaluator.matches("status IN (:a)", i, null, v));
+        }
+
+        // BETWEEN
+
+        @Test
+        void betweenStrings() throws Exception {
+            var i = item("{\"sk\": {\"S\": \"B\"}}");
+            var v = values("{\n\":low\": {\"S\": \"A\"},\n\":high\": {\"S\": \"C\"}}");
+            assertTrue(ExpressionEvaluator.matches("sk BETWEEN :low AND :high", i, null, v));
+        }
+
+        @Test
+        void betweenOutOfRange() throws Exception {
+            var i = item("{\"sk\": {\"S\": \"D\"}}");
+            var v = values("{\n\":low\": {\"S\": \"A\"},\n\":high\": {\"S\": \"C\"}}");
+            assertFalse(ExpressionEvaluator.matches("sk BETWEEN :low AND :high", i, null, v));
+        }
+
+        // attribute_exists / attribute_not_exists
+
+        @Test
+        void attributeExistsPresent() throws Exception {
+            var i = item("{\"name\": {\"S\": \"Alice\"}}");
+            assertTrue(ExpressionEvaluator.matches("attribute_exists(name)", i, null, null));
+        }
+
+        @Test
+        void attributeExistsMissing() throws Exception {
+            var i = item("{\"other\": {\"S\": \"x\"}}");
+            assertFalse(ExpressionEvaluator.matches("attribute_exists(name)", i, null, null));
+        }
+
+        @Test
+        void attributeNotExistsPresent() throws Exception {
+            var i = item("{\"name\": {\"S\": \"Alice\"}}");
+            assertFalse(ExpressionEvaluator.matches("attribute_not_exists(name)", i, null, null));
+        }
+
+        @Test
+        void attributeNotExistsMissing() throws Exception {
+            var i = item("{\"other\": {\"S\": \"x\"}}");
+            assertTrue(ExpressionEvaluator.matches("attribute_not_exists(name)", i, null, null));
+        }
+
+        @Test
+        void attributeExistsNested() throws Exception {
+            var i = item("{\"info\": {\"M\": {\"email\": {\"S\": \"a@b.com\"}}}}");
+            assertTrue(ExpressionEvaluator.matches("attribute_exists(info.email)", i, null, null));
+        }
+
+        @Test
+        void attributeExistsNestedMissing() throws Exception {
+            var i = item("{\"info\": {\"M\": {\"name\": {\"S\": \"Alice\"}}}}");
+            assertFalse(ExpressionEvaluator.matches("attribute_exists(info.email)", i, null, null));
+        }
+
+        // begins_with
+
+        @Test
+        void beginsWithMatch() throws Exception {
+            var i = item("{\"sk\": {\"S\": \"USER#123\"}}");
+            var v = values("{\n\":prefix\": {\"S\": \"USER#\"}}");
+            assertTrue(ExpressionEvaluator.matches("begins_with(sk, :prefix)", i, null, v));
+        }
+
+        @Test
+        void beginsWithNoMatch() throws Exception {
+            var i = item("{\"sk\": {\"S\": \"ORDER#123\"}}");
+            var v = values("{\n\":prefix\": {\"S\": \"USER#\"}}");
+            assertFalse(ExpressionEvaluator.matches("begins_with(sk, :prefix)", i, null, v));
+        }
+
+        // contains
+
+        @Test
+        void containsString() throws Exception {
+            var i = item("{\"desc\": {\"S\": \"hello world\"}}");
+            var v = values("{\n\":sub\": {\"S\": \"world\"}}");
+            assertTrue(ExpressionEvaluator.matches("contains(desc, :sub)", i, null, v));
+        }
+
+        @Test
+        void containsList() throws Exception {
+            var i = item("{\"tags\": {\"L\": [{\"S\": \"a\"}, {\"S\": \"b\"}, {\"S\": \"c\"}]}}");
+            var v = values("{\n\":val\": {\"S\": \"b\"}}");
+            assertTrue(ExpressionEvaluator.matches("contains(tags, :val)", i, null, v));
+        }
+
+        @Test
+        void containsStringSet() throws Exception {
+            var i = item("{\"tags\": {\"SS\": [\"a\", \"b\", \"c\"]}}");
+            var v = values("{\n\":val\": {\"S\": \"b\"}}");
+            assertTrue(ExpressionEvaluator.matches("contains(tags, :val)", i, null, v));
+        }
+
+        @Test
+        void containsNumberSet() throws Exception {
+            var i = item("{\"nums\": {\"NS\": [\"1\", \"2\", \"3\"]}}");
+            var v = values("{\n\":val\": {\"N\": \"2\"}}");
+            assertTrue(ExpressionEvaluator.matches("contains(nums, :val)", i, null, v));
+        }
+
+        // Expression attribute names
+
+        @Test
+        void expressionAttributeNames() throws Exception {
+            var i = item("{\"status\": {\"S\": \"active\"}}");
+            var v = values("{\n\":v\": {\"S\": \"active\"}}");
+            var n = names("{\"#s\": \"status\"}");
+            assertTrue(ExpressionEvaluator.matches("#s = :v", i, n, v));
+        }
+
+        // Nested parentheses
+
+        @Test
+        void nestedParentheses() throws Exception {
+            // ((a = :1 OR b = :2) AND c = :3) OR d = :4
+            var i = item("{\"a\": {\"S\": \"X\"}, \"b\": {\"S\": \"Y\"}, \"c\": {\"S\": \"3\"}, \"d\": {\"S\": \"4\"}}");
+            var v = values("{\n\":1\": {\"S\": \"1\"},\n\":2\": {\"S\": \"2\"},\n\":3\": {\"S\": \"3\"},\n\":4\": {\"S\": \"4\"}}");
+            // a!=1, b!=2 so inner OR is false, AND c=3 doesn't matter (false AND true = false)
+            // d=4 so outer OR is true
+            assertTrue(ExpressionEvaluator.matches("((a = :1 OR b = :2) AND c = :3) OR d = :4", i, null, v));
+        }
+
+        @Test
+        void nestedParenthesesAllFalse() throws Exception {
+            var i = item("{\"a\": {\"S\": \"X\"}, \"b\": {\"S\": \"Y\"}, \"c\": {\"S\": \"3\"}, \"d\": {\"S\": \"Z\"}}");
+            var v = values("{\n\":1\": {\"S\": \"1\"},\n\":2\": {\"S\": \"2\"},\n\":3\": {\"S\": \"3\"},\n\":4\": {\"S\": \"4\"}}");
+            assertFalse(ExpressionEvaluator.matches("((a = :1 OR b = :2) AND c = :3) OR d = :4", i, null, v));
+        }
+
+        // Compact format end-to-end
+
+        @Test
+        void compactFormatEvaluation() throws Exception {
+            var i = item("{\"pk\": {\"S\": \"USER#1\"}, \"sk\": {\"S\": \"B\"}}");
+            var v = values("{\n\":v0\": {\"S\": \"USER#1\"},\n\":v1\": {\"S\": \"A\"},\n\":v2\": {\"S\": \"C\"}}");
+            var n = names("{\"#f0\": \"pk\", \"#f1\": \"sk\"}");
+            assertTrue(ExpressionEvaluator.matches("(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)", i, n, v));
+        }
+
+        // Null/empty expression
+
+        @Test
+        void nullExpressionMatchesAll() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}}");
+            assertTrue(ExpressionEvaluator.matches(null, i, null, null));
+        }
+
+        @Test
+        void blankExpressionMatchesAll() throws Exception {
+            var i = item("{\"a\": {\"S\": \"1\"}}");
+            assertTrue(ExpressionEvaluator.matches("  ", i, null, null));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes several DynamoDB compatibility issues and adds ConsumedCapacity support:

### 1. Replace regex-based expression evaluation with AST parser (`fix`)

The old regex/string-splitting approach for filter, condition, and key condition expressions broke on several valid DynamoDB patterns:
- `<>` comparisons on BOOL attributes (missing attribute handling)
- `IN` operator (fell through to pass-all)
- `OR` / `NOT` logical operators (only `AND` was implemented)
- Parenthesized BETWEEN: `pk = :pk AND (sk BETWEEN :start AND :end)`
- Compact format without spaces: `(#f0 = :v0)AND(#f1 BETWEEN :v1 AND :v2)`
- Numeric ExpressionAttributeNames (`#0`, `#1`) — relates to #127

Adds `ExpressionEvaluator` with a proper tokenizer → recursive-descent parser → AST evaluator. Also fixes GSI sparse-index semantics: items where any GSI key attribute is null/missing are now excluded from GSI query results, matching real DynamoDB behavior.

### 2. Support dotted paths in UpdateExpression and fix clause boundary parsing (`fix`)

Two bugs in `applyUpdateExpression`:

- **Dotted paths** (e.g. `#details.subkey = :val`) were not resolved segment-by-segment — the entire string was looked up as a single ExpressionAttributeName, failing silently. Now each segment is resolved independently and nested Map nodes are navigated/created as needed.

- **SET/REMOVE clause boundary** — `findNextComma` was checked before `findNextClauseKeyword`, so `SET #a = :v1 REMOVE #b,#c` would treat the comma in the REMOVE list as a SET separator, corrupting both clauses.

### 3. Add ConsumedCapacity in DynamoDB responses (`feat`)

- Returns `ConsumedCapacity` in GetItem, PutItem, DeleteItem, UpdateItem, Query, Scan, BatchGetItem, BatchWriteItem when `ReturnConsumedCapacity` is `TOTAL` or `INDEXES`.
- For `INDEXES` level, includes per-table and per-GSI capacity breakdown.
- Adds `ProvisionedThroughput` to GSI descriptions in DescribeTable (was missing, causing clients that read GSI throughput to fail).
- Simple capacity estimates: 0.5 RCU per item read, 1.0 WCU per write.

## Tests

### Unit & integration tests (main project)

- **ExpressionEvaluatorTest**: 64 tests covering tokenizer, parser, key-condition splitting, and evaluator (logic, comparisons, functions, nested parens, compact format, expression attribute names)
- **DynamoDbServiceTest**: new tests for dotted path SET/REMOVE, SET+REMOVE clause boundary, compact BETWEEN queries
- **DynamoDbIntegrationTest**: 4 new integration tests for ConsumedCapacity (TOTAL, INDEXES, omission when not requested)
- **DynamoDbFilterExpressionIntegrationTest**: 14 new HTTP-level integration tests for BOOL `<>`/`=`, IN operator, OR/NOT operators, nested parentheses, parenthesized BETWEEN, and compact-format key conditions

All 1468 tests pass.

### Compatibility tests (SDK against live Floci)

- **DynamoDbExpressionTests** (new, 14 tests): end-to-end AWS SDK v2 tests covering filter expressions (BOOL, IN, OR, NOT, nested parens), dotted UpdateExpression paths, ConsumedCapacity (TOTAL/NONE for Scan/GetItem/PutItem), and parenthesized BETWEEN in KeyConditionExpression (standard and compact format)
- **Surefire include fix**: added `**/*Tests.java` pattern to `compatibility-tests/sdk-test-java/pom.xml` — several existing test classes (`DynamoDbScanConditionTests`, `EcsTests`, `Ec2Tests`, etc.) were silently skipped because surefire only matched `**/*Test.java`

All 38 DynamoDB compatibility tests pass (18 existing + 6 previously skipped + 14 new).