### PR TITLE
fix(cognito): enrich User Pool responses and implement MfaConfig stub (#177)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -36,6 +36,8 @@ public class CognitoJsonHandler {
             case "CreateUserPool" -> handleCreateUserPool(request, region);
             case "DescribeUserPool" -> handleDescribeUserPool(request);
             case "ListUserPools" -> handleListUserPools(request);
+            case "UpdateUserPool" -> handleUpdateUserPool(request, region);
+            case "GetUserPoolMfaConfig" -> handleGetUserPoolMfaConfig(request);
             case "DeleteUserPool" -> handleDeleteUserPool(request);
             case "CreateUserPoolClient" -> handleCreateUserPoolClient(request);
             case "DescribeUserPoolClient" -> handleDescribeUserPoolClient(request);
@@ -76,17 +78,18 @@ public class CognitoJsonHandler {
     }
 
     private Response handleCreateUserPool(JsonNode request, String region) {
-        String poolName = request.path("PoolName").asText();
-        UserPool pool = service.createUserPool(poolName, region);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> reqMap = objectMapper.convertValue(request, Map.class);
+        UserPool pool = service.createUserPool(reqMap, region);
         ObjectNode response = objectMapper.createObjectNode();
-        response.set("UserPool", userPoolToNode(pool));
+        response.set("UserPool", userPoolToFullNode(pool));
         return Response.ok(response).build();
     }
 
     private Response handleDescribeUserPool(JsonNode request) {
         UserPool pool = service.describeUserPool(request.path("UserPoolId").asText());
         ObjectNode response = objectMapper.createObjectNode();
-        response.set("UserPool", userPoolToNode(pool));
+        response.set("UserPool", userPoolToFullNode(pool));
         return Response.ok(response).build();
     }
 
@@ -94,7 +97,23 @@ public class CognitoJsonHandler {
         List<UserPool> pools = service.listUserPools();
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode items = response.putArray("UserPools");
-        pools.forEach(p -> items.add(userPoolToNode(p)));
+        pools.forEach(p -> items.add(userPoolToDescriptionNode(p)));
+        return Response.ok(response).build();
+    }
+
+    private Response handleUpdateUserPool(JsonNode request, String region) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> reqMap = objectMapper.convertValue(request, Map.class);
+        UserPool pool = service.updateUserPool(reqMap, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("UserPool", userPoolToFullNode(pool));
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetUserPoolMfaConfig(JsonNode request) {
+        UserPool pool = service.describeUserPool(request.path("UserPoolId").asText());
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("MfaConfiguration", pool.getMfaConfiguration());
         return Response.ok(response).build();
     }
 
@@ -376,12 +395,54 @@ public class CognitoJsonHandler {
         return Response.ok(response).build();
     }
 
-    private ObjectNode userPoolToNode(UserPool p) {
+    private ObjectNode userPoolToDescriptionNode(UserPool p) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("Id", p.getId());
         node.put("Name", p.getName());
-        node.put("CreationDate", p.getCreationDate());
-        node.put("LastModifiedDate", p.getLastModifiedDate());
+        node.set("LambdaConfig", objectMapper.valueToTree(p.getLambdaConfig() != null ? p.getLambdaConfig() : new HashMap<>()));
+        node.put("Status", p.getStatus());
+        node.put("LastModifiedDate", (double) p.getLastModifiedDate());
+        node.put("CreationDate", (double) p.getCreationDate());
+        return node;
+    }
+
+    private ObjectNode userPoolToFullNode(UserPool p) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Id", p.getId());
+        node.put("Name", p.getName());
+        node.put("Arn", p.getArn());
+        node.put("Status", p.getStatus());
+        node.put("CreationDate", (double) p.getCreationDate());
+        node.put("LastModifiedDate", (double) p.getLastModifiedDate());
+
+        node.set("Policies", objectMapper.valueToTree(p.getPolicies() != null ? p.getPolicies() : new HashMap<>()));
+        node.put("DeletionProtection", p.getDeletionProtection() != null ? p.getDeletionProtection() : "INACTIVE");
+        node.set("LambdaConfig", objectMapper.valueToTree(p.getLambdaConfig() != null ? p.getLambdaConfig() : new HashMap<>()));
+        node.set("SchemaAttributes", objectMapper.valueToTree(p.getSchemaAttributes() != null ? p.getSchemaAttributes() : new java.util.ArrayList<>()));
+        node.set("AutoVerifiedAttributes", objectMapper.valueToTree(p.getAutoVerifiedAttributes() != null ? p.getAutoVerifiedAttributes() : new java.util.ArrayList<>()));
+        node.set("AliasAttributes", objectMapper.valueToTree(p.getAliasAttributes() != null ? p.getAliasAttributes() : new java.util.ArrayList<>()));
+        node.set("UsernameAttributes", objectMapper.valueToTree(p.getUsernameAttributes() != null ? p.getUsernameAttributes() : new java.util.ArrayList<>()));
+        
+        if (p.getSmsVerificationMessage() != null) node.put("SmsVerificationMessage", p.getSmsVerificationMessage());
+        if (p.getEmailVerificationMessage() != null) node.put("EmailVerificationMessage", p.getEmailVerificationMessage());
+        if (p.getEmailVerificationSubject() != null) node.put("EmailVerificationSubject", p.getEmailVerificationSubject());
+        
+        node.set("VerificationMessageTemplate", objectMapper.valueToTree(p.getVerificationMessageTemplate() != null ? p.getVerificationMessageTemplate() : new HashMap<>()));
+        
+        if (p.getSmsAuthenticationMessage() != null) node.put("SmsAuthenticationMessage", p.getSmsAuthenticationMessage());
+        
+        node.put("MfaConfiguration", p.getMfaConfiguration() != null ? p.getMfaConfiguration() : "OFF");
+        node.set("DeviceConfiguration", objectMapper.valueToTree(p.getDeviceConfiguration() != null ? p.getDeviceConfiguration() : new HashMap<>()));
+        node.put("EstimatedNumberOfUsers", p.getEstimatedNumberOfUsers());
+        node.set("EmailConfiguration", objectMapper.valueToTree(p.getEmailConfiguration() != null ? p.getEmailConfiguration() : new HashMap<>()));
+        node.set("SmsConfiguration", objectMapper.valueToTree(p.getSmsConfiguration() != null ? p.getSmsConfiguration() : new HashMap<>()));
+        node.set("UserPoolTags", objectMapper.valueToTree(p.getUserPoolTags() != null ? p.getUserPoolTags() : new HashMap<>()));
+        node.set("AdminCreateUserConfig", objectMapper.valueToTree(p.getAdminCreateUserConfig() != null ? p.getAdminCreateUserConfig() : new HashMap<>()));
+        node.set("UserPoolAddOns", objectMapper.valueToTree(p.getUserPoolAddOns() != null ? p.getUserPoolAddOns() : new HashMap<>()));
+        node.set("UsernameConfiguration", objectMapper.valueToTree(p.getUsernameConfiguration() != null ? p.getUsernameConfiguration() : new HashMap<>()));
+        node.set("AccountRecoverySetting", objectMapper.valueToTree(p.getAccountRecoverySetting() != null ? p.getAccountRecoverySetting() : new HashMap<>()));
+        node.put("UserPoolTier", p.getUserPoolTier() != null ? p.getUserPoolTier() : "ESSENTIALS");
+
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cognito;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -40,9 +41,10 @@ public class CognitoService {
     private final StorageBackend<String, CognitoUser> userStore;
     private final StorageBackend<String, CognitoGroup> groupStore;
     private final String baseUrl;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public CognitoService(StorageFactory storageFactory, EmulatorConfig emulatorConfig) {
+    public CognitoService(StorageFactory storageFactory, EmulatorConfig emulatorConfig, RegionResolver regionResolver) {
         this.poolStore = storageFactory.create("cognito", "cognito-pools.json",
                 new TypeReference<Map<String, UserPool>>() {});
         this.clientStore = storageFactory.create("cognito", "cognito-clients.json",
@@ -54,6 +56,7 @@ public class CognitoService {
         this.groupStore = storageFactory.create("cognito", "cognito-groups.json",
                 new TypeReference<Map<String, CognitoGroup>>() {});
         this.baseUrl = trimTrailingSlash(emulatorConfig.baseUrl());
+        this.regionResolver = regionResolver;
     }
 
     CognitoService(StorageBackend<String, UserPool> poolStore,
@@ -61,26 +64,72 @@ public class CognitoService {
                    StorageBackend<String, ResourceServer> resourceServerStore,
                    StorageBackend<String, CognitoUser> userStore,
                    StorageBackend<String, CognitoGroup> groupStore,
-                   String baseUrl) {
+                   String baseUrl,
+                   RegionResolver regionResolver) {
         this.poolStore = poolStore;
         this.clientStore = clientStore;
         this.resourceServerStore = resourceServerStore;
         this.userStore = userStore;
         this.groupStore = groupStore;
         this.baseUrl = baseUrl;
+        this.regionResolver = regionResolver;
     }
 
     // ──────────────────────────── User Pools ────────────────────────────
 
-    public UserPool createUserPool(String name, String region) {
+    @SuppressWarnings("unchecked")
+    public UserPool createUserPool(Map<String, Object> request, String region) {
+        String name = (String) request.get("PoolName");
         String id = region + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 9);
         UserPool pool = new UserPool();
         pool.setId(id);
         pool.setName(name);
+        pool.setArn(regionResolver.buildArn("cognito-idp", region, "userpool/" + id));
+
+        populateUserPool(pool, request);
+
         ensureJwtSigningKeys(pool);
         poolStore.put(id, pool);
         LOG.infov("Created User Pool: {0}", id);
         return pool;
+    }
+
+    public UserPool updateUserPool(Map<String, Object> request, String region) {
+        String id = (String) request.get("UserPoolId");
+        UserPool pool = describeUserPool(id);
+
+        populateUserPool(pool, request);
+
+        pool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        poolStore.put(id, pool);
+        LOG.infov("Updated User Pool: {0}", id);
+        return pool;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void populateUserPool(UserPool pool, Map<String, Object> request) {
+        if (request.containsKey("Policies")) pool.setPolicies((Map<String, Object>) request.get("Policies"));
+        if (request.containsKey("DeletionProtection")) pool.setDeletionProtection((String) request.get("DeletionProtection"));
+        if (request.containsKey("LambdaConfig")) pool.setLambdaConfig((Map<String, Object>) request.get("LambdaConfig"));
+        if (request.containsKey("Schema")) pool.setSchemaAttributes((List<Map<String, Object>>) request.get("Schema"));
+        if (request.containsKey("AutoVerifiedAttributes")) pool.setAutoVerifiedAttributes((List<String>) request.get("AutoVerifiedAttributes"));
+        if (request.containsKey("AliasAttributes")) pool.setAliasAttributes((List<String>) request.get("AliasAttributes"));
+        if (request.containsKey("UsernameAttributes")) pool.setUsernameAttributes((List<String>) request.get("UsernameAttributes"));
+        if (request.containsKey("SmsVerificationMessage")) pool.setSmsVerificationMessage((String) request.get("SmsVerificationMessage"));
+        if (request.containsKey("EmailVerificationMessage")) pool.setEmailVerificationMessage((String) request.get("EmailVerificationMessage"));
+        if (request.containsKey("EmailVerificationSubject")) pool.setEmailVerificationSubject((String) request.get("EmailVerificationSubject"));
+        if (request.containsKey("VerificationMessageTemplate")) pool.setVerificationMessageTemplate((Map<String, Object>) request.get("VerificationMessageTemplate"));
+        if (request.containsKey("SmsAuthenticationMessage")) pool.setSmsAuthenticationMessage((String) request.get("SmsAuthenticationMessage"));
+        if (request.containsKey("MfaConfiguration")) pool.setMfaConfiguration((String) request.get("MfaConfiguration"));
+        if (request.containsKey("DeviceConfiguration")) pool.setDeviceConfiguration((Map<String, Object>) request.get("DeviceConfiguration"));
+        if (request.containsKey("EmailConfiguration")) pool.setEmailConfiguration((Map<String, Object>) request.get("EmailConfiguration"));
+        if (request.containsKey("SmsConfiguration")) pool.setSmsConfiguration((Map<String, Object>) request.get("SmsConfiguration"));
+        if (request.containsKey("UserPoolTags")) pool.setUserPoolTags((Map<String, String>) request.get("UserPoolTags"));
+        if (request.containsKey("AdminCreateUserConfig")) pool.setAdminCreateUserConfig((Map<String, Object>) request.get("AdminCreateUserConfig"));
+        if (request.containsKey("UserPoolAddOns")) pool.setUserPoolAddOns((Map<String, Object>) request.get("UserPoolAddOns"));
+        if (request.containsKey("UsernameConfiguration")) pool.setUsernameConfiguration((Map<String, Object>) request.get("UsernameConfiguration"));
+        if (request.containsKey("AccountRecoverySetting")) pool.setAccountRecoverySetting((Map<String, Object>) request.get("AccountRecoverySetting"));
+        if (request.containsKey("UserPoolTier")) pool.setUserPoolTier((String) request.get("UserPoolTier"));
     }
 
     public UserPool describeUserPool(String id) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
@@ -2,18 +2,49 @@ package io.github.hectorvent.floci.services.cognito.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserPool {
     private String id;
     private String name;
+    private String arn;
+    private String status = "Enabled";
     private String signingSecret;
     private String signingKeyId;
     private String signingPublicKey;
     private String signingPrivateKey;
     private long creationDate;
     private long lastModifiedDate;
+
+    // Configuration fields
+    private Map<String, Object> policies = new HashMap<>();
+    private String deletionProtection = "INACTIVE";
+    private Map<String, Object> lambdaConfig = new HashMap<>();
+    private List<Map<String, Object>> schemaAttributes = new ArrayList<>();
+    private List<String> autoVerifiedAttributes = new ArrayList<>();
+    private List<String> aliasAttributes = new ArrayList<>();
+    private List<String> usernameAttributes = new ArrayList<>();
+    private String smsVerificationMessage;
+    private String emailVerificationMessage;
+    private String emailVerificationSubject;
+    private Map<String, Object> verificationMessageTemplate = new HashMap<>();
+    private String smsAuthenticationMessage;
+    private String mfaConfiguration = "OFF";
+    private Map<String, Object> deviceConfiguration = new HashMap<>();
+    private int estimatedNumberOfUsers = 0;
+    private Map<String, Object> emailConfiguration = new HashMap<>();
+    private Map<String, Object> smsConfiguration = new HashMap<>();
+    private Map<String, String> userPoolTags = new HashMap<>();
+    private Map<String, Object> adminCreateUserConfig = new HashMap<>();
+    private Map<String, Object> userPoolAddOns = new HashMap<>();
+    private Map<String, Object> usernameConfiguration = new HashMap<>();
+    private Map<String, Object> accountRecoverySetting = new HashMap<>();
+    private String userPoolTier = "ESSENTIALS";
 
     public UserPool() {
         long now = System.currentTimeMillis() / 1000L;
@@ -27,6 +58,12 @@ public class UserPool {
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
 
     public String getSigningSecret() { return signingSecret; }
     public void setSigningSecret(String signingSecret) { this.signingSecret = signingSecret; }
@@ -45,4 +82,73 @@ public class UserPool {
 
     public long getLastModifiedDate() { return lastModifiedDate; }
     public void setLastModifiedDate(long lastModifiedDate) { this.lastModifiedDate = lastModifiedDate; }
+
+    public Map<String, Object> getPolicies() { return policies; }
+    public void setPolicies(Map<String, Object> policies) { this.policies = policies; }
+
+    public String getDeletionProtection() { return deletionProtection; }
+    public void setDeletionProtection(String deletionProtection) { this.deletionProtection = deletionProtection; }
+
+    public Map<String, Object> getLambdaConfig() { return lambdaConfig; }
+    public void setLambdaConfig(Map<String, Object> lambdaConfig) { this.lambdaConfig = lambdaConfig; }
+
+    public List<Map<String, Object>> getSchemaAttributes() { return schemaAttributes; }
+    public void setSchemaAttributes(List<Map<String, Object>> schemaAttributes) { this.schemaAttributes = schemaAttributes; }
+
+    public List<String> getAutoVerifiedAttributes() { return autoVerifiedAttributes; }
+    public void setAutoVerifiedAttributes(List<String> autoVerifiedAttributes) { this.autoVerifiedAttributes = autoVerifiedAttributes; }
+
+    public List<String> getAliasAttributes() { return aliasAttributes; }
+    public void setAliasAttributes(List<String> aliasAttributes) { this.aliasAttributes = aliasAttributes; }
+
+    public List<String> getUsernameAttributes() { return usernameAttributes; }
+    public void setUsernameAttributes(List<String> usernameAttributes) { this.usernameAttributes = usernameAttributes; }
+
+    public String getSmsVerificationMessage() { return smsVerificationMessage; }
+    public void setSmsVerificationMessage(String smsVerificationMessage) { this.smsVerificationMessage = smsVerificationMessage; }
+
+    public String getEmailVerificationMessage() { return emailVerificationMessage; }
+    public void setEmailVerificationMessage(String emailVerificationMessage) { this.emailVerificationMessage = emailVerificationMessage; }
+
+    public String getEmailVerificationSubject() { return emailVerificationSubject; }
+    public void setEmailVerificationSubject(String emailVerificationSubject) { this.emailVerificationSubject = emailVerificationSubject; }
+
+    public Map<String, Object> getVerificationMessageTemplate() { return verificationMessageTemplate; }
+    public void setVerificationMessageTemplate(Map<String, Object> verificationMessageTemplate) { this.verificationMessageTemplate = verificationMessageTemplate; }
+
+    public String getSmsAuthenticationMessage() { return smsAuthenticationMessage; }
+    public void setSmsAuthenticationMessage(String smsAuthenticationMessage) { this.smsAuthenticationMessage = smsAuthenticationMessage; }
+
+    public String getMfaConfiguration() { return mfaConfiguration; }
+    public void setMfaConfiguration(String mfaConfiguration) { this.mfaConfiguration = mfaConfiguration; }
+
+    public Map<String, Object> getDeviceConfiguration() { return deviceConfiguration; }
+    public void setDeviceConfiguration(Map<String, Object> deviceConfiguration) { this.deviceConfiguration = deviceConfiguration; }
+
+    public int getEstimatedNumberOfUsers() { return estimatedNumberOfUsers; }
+    public void setEstimatedNumberOfUsers(int estimatedNumberOfUsers) { this.estimatedNumberOfUsers = estimatedNumberOfUsers; }
+
+    public Map<String, Object> getEmailConfiguration() { return emailConfiguration; }
+    public void setEmailConfiguration(Map<String, Object> emailConfiguration) { this.emailConfiguration = emailConfiguration; }
+
+    public Map<String, Object> getSmsConfiguration() { return smsConfiguration; }
+    public void setSmsConfiguration(Map<String, Object> smsConfiguration) { this.smsConfiguration = smsConfiguration; }
+
+    public Map<String, String> getUserPoolTags() { return userPoolTags; }
+    public void setUserPoolTags(Map<String, String> userPoolTags) { this.userPoolTags = userPoolTags; }
+
+    public Map<String, Object> getAdminCreateUserConfig() { return adminCreateUserConfig; }
+    public void setAdminCreateUserConfig(Map<String, Object> adminCreateUserConfig) { this.adminCreateUserConfig = adminCreateUserConfig; }
+
+    public Map<String, Object> getUserPoolAddOns() { return userPoolAddOns; }
+    public void setUserPoolAddOns(Map<String, Object> userPoolAddOns) { this.userPoolAddOns = userPoolAddOns; }
+
+    public Map<String, Object> getUsernameConfiguration() { return usernameConfiguration; }
+    public void setUsernameConfiguration(Map<String, Object> usernameConfiguration) { this.usernameConfiguration = usernameConfiguration; }
+
+    public Map<String, Object> getAccountRecoverySetting() { return accountRecoverySetting; }
+    public void setAccountRecoverySetting(Map<String, Object> accountRecoverySetting) { this.accountRecoverySetting = accountRecoverySetting; }
+
+    public String getUserPoolTier() { return userPoolTier; }
+    public void setUserPoolTier(String userPoolTier) { this.userPoolTier = userPoolTier; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -1,0 +1,70 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.cognito.model.UserPool;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CognitoJsonHandlerTest {
+
+    private CognitoJsonHandler handler;
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        CognitoService service = new CognitoService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                "http://localhost:4566",
+                regionResolver
+        );
+        handler = new CognitoJsonHandler(service, mapper);
+    }
+
+    @Test
+    void createUserPoolReturnsRichResponse() {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("PoolName", "test-pool");
+        ArrayNode schema = request.putArray("Schema");
+        ObjectNode attr = schema.addObject();
+        attr.put("Name", "email");
+        attr.put("AttributeDataType", "String");
+
+        Response response = handler.handle("CreateUserPool", request, "us-east-1");
+        assertEquals(200, response.getStatus());
+
+        JsonNode body = (JsonNode) response.getEntity();
+        JsonNode pool = body.get("UserPool");
+
+        assertNotNull(pool.get("Id"));
+        assertEquals("test-pool", pool.get("Name").asText());
+        assertTrue(pool.get("Arn").asText().contains("arn:aws:cognito-idp:us-east-1:000000000000:userpool/"));
+        assertEquals("Enabled", pool.get("Status").asText());
+        
+        // Check mandatory blocks for Terraform
+        assertNotNull(pool.get("SchemaAttributes"));
+        assertEquals(1, pool.get("SchemaAttributes").size());
+        assertEquals("email", pool.get("SchemaAttributes").get(0).get("Name").asText());
+
+        assertNotNull(pool.get("Policies"));
+        assertNotNull(pool.get("LambdaConfig"));
+        assertNotNull(pool.get("AdminCreateUserConfig"));
+        assertNotNull(pool.get("AccountRecoverySetting"));
+        assertEquals("ESSENTIALS", pool.get("UserPoolTier").asText());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.cognito;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.cognito.model.CognitoGroup;
 import io.github.hectorvent.floci.services.cognito.model.CognitoUser;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,25 +22,53 @@ class CognitoServiceTest {
 
     private CognitoService service;
     private InMemoryStorage<String, CognitoGroup> groupStore;
+    private RegionResolver regionResolver;
 
     @BeforeEach
     void setUp() {
         groupStore = new InMemoryStorage<>();
+        regionResolver = new RegionResolver("us-east-1", "000000000000");
         service = new CognitoService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 groupStore,
-                "http://localhost:4566"
+                "http://localhost:4566",
+                regionResolver
         );
     }
 
     private UserPool createPoolAndUser() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.adminCreateUser(pool.getId(), "alice", Map.of("email", "alice@example.com"), "TempPass1!");
         service.adminSetUserPassword(pool.getId(), "alice", "Perm1234!", true);
         return pool;
+    }
+
+    @Test
+    void createUserPoolWithFullConfig() {
+        List<Map<String, Object>> schema = List.of(
+                Map.of("Name", "my-attr", "AttributeDataType", "String")
+        );
+        Map<String, Object> policies = Map.of(
+                "PasswordPolicy", Map.of("MinimumLength", 12)
+        );
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("PoolName", "FullConfigPool");
+        request.put("Schema", schema);
+        request.put("Policies", policies);
+        request.put("UsernameAttributes", List.of("email"));
+
+        UserPool pool = service.createUserPool(request, "us-east-1");
+
+        assertNotNull(pool.getId());
+        assertEquals("FullConfigPool", pool.getName());
+        assertEquals("arn:aws:cognito-idp:us-east-1:000000000000:userpool/" + pool.getId(), pool.getArn());
+        assertEquals(schema, pool.getSchemaAttributes());
+        assertEquals(policies, pool.getPolicies());
+        assertEquals(List.of("email"), pool.getUsernameAttributes());
     }
 
     // =========================================================================
@@ -47,7 +77,7 @@ class CognitoServiceTest {
 
     @Test
     void createGroup() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         CognitoGroup group = service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
 
         assertEquals("admins", group.getGroupName());
@@ -61,7 +91,7 @@ class CognitoServiceTest {
 
     @Test
     void createGroupDuplicateThrows() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
 
         assertThrows(AwsException.class, () ->
@@ -70,7 +100,7 @@ class CognitoServiceTest {
 
     @Test
     void getGroup() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
 
         CognitoGroup fetched = service.getGroup(pool.getId(), "admins");
@@ -82,7 +112,7 @@ class CognitoServiceTest {
 
     @Test
     void getGroupNotFoundThrows() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
 
         assertThrows(AwsException.class, () ->
                 service.getGroup(pool.getId(), "nonexistent"));
@@ -90,7 +120,7 @@ class CognitoServiceTest {
 
     @Test
     void listGroups() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
         service.createGroup(pool.getId(), "editors", "Editor group", 2, null);
 
@@ -100,7 +130,7 @@ class CognitoServiceTest {
 
     @Test
     void deleteGroup() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
 
         service.deleteGroup(pool.getId(), "admins");
@@ -200,7 +230,7 @@ class CognitoServiceTest {
 
     @Test
     void adminAddUserToGroupNonexistentUserThrows() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
 
         assertThrows(AwsException.class, () ->
@@ -268,7 +298,7 @@ class CognitoServiceTest {
 
     @Test
     void deleteUserPoolCascadesGroups() {
-        UserPool pool = service.createUserPool("TestPool", "us-east-1");
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         service.createGroup(pool.getId(), "admins", "Admin group", 1, null);
         service.createGroup(pool.getId(), "editors", "Editor group", 2, null);
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
 Resolved Terraform AWS Provider "nil pointer dereference" panic during Cognito User Pool creation.
   - Model: Added comprehensive configuration fields to UserPool to persist full metadata.
   - Service: Updated createUserPool and updateUserPool to handle rich configuration and generate valid ARNs.
   - Handler: Refactored JSON serialization to return complete objects for all User Pool blocks (Policies, Schema, LambdaConfig, etc.), ensuring compatibility with the
     provider's Read logic.
   - API: Implemented GetUserPoolMfaConfig stub to return default string-based MFA configuration.
   - Validation: Successfully validated the fix using the compat-terraform suite with a complex aws_cognito_user_pool resource.

This resolves issue #177


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
