### PR TITLE
fix(s3): prevent S3VirtualHostFilter from hijacking non-S3 requests

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -16,6 +16,21 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         String host = requestContext.getHeaderString("Host");
         if (host == null) return;
 
+        // Do not hijack requests meant for other AWS services
+        String auth = requestContext.getHeaderString("Authorization");
+        if (auth != null && auth.contains("Credential=") && !auth.contains("/s3/aws4_request")) {
+            return;
+        }
+
+        // S3 does not use these content types for bucket/object operations, 
+        // but other AWS services (AwsQuery, JSON protocols) do.
+        String contentType = requestContext.getHeaderString("Content-Type");
+        if (contentType != null && (
+                contentType.startsWith("application/x-www-form-urlencoded") ||
+                contentType.startsWith("application/x-amz-json-"))) {
+            return;
+        }
+
         String bucket = extractBucket(host);
         if (bucket == null) return;
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/CloudFormationHijackTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/CloudFormationHijackTest.java
@@ -1,0 +1,24 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class CloudFormationHijackTest {
+    @Test
+    void testCloudFormationHijack() {
+        // Mock a CloudFormation request sent with Host: cloudformation.us-west-1.amazonaws.com
+        given()
+            .header("Host", "cloudformation.us-west-1.amazonaws.com")
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("Version", "2010-05-15")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DescribeStacksResponse")); // Should be routed to CloudFormation, not S3
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/FilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/FilterTest.java
@@ -1,0 +1,32 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class FilterTest {
+    @Test
+    void testFilterWithQuery() {
+        given()
+            .header("Host", "my-bucket.localhost:4566")
+            .when()
+            .put("/")
+            .then()
+            .statusCode(200);
+
+        String xml = "<Delete><Object><Key>test</Key></Object></Delete>";
+        given()
+            .header("Host", "my-bucket.localhost:4566")
+            .queryParam("delete", "")
+            .contentType("application/xml")
+            .body(xml)
+            .log().all()
+            .when()
+            .post("/")
+            .then()
+            .log().all()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3DumpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3DumpTest.java
@@ -1,0 +1,18 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class S3DumpTest {
+    @Test
+    void dump() {
+        given()
+            .header("Host", "mybucket.s3.amazonaws.com")
+        .when()
+            .post("/?delete")
+        .then()
+            .log().all();
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostTest.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class S3VirtualHostTest {
+
+    @Test
+    void testVirtualHostPostDelete() {
+        given()
+            .header("Host", "mybucket.s3.amazonaws.com")
+        .when()
+            .put("/")
+        .then()
+            .statusCode(200);
+
+        String xml = "<Delete><Object><Key>test</Key></Object></Delete>";
+        given()
+            .header("Host", "mybucket.s3.amazonaws.com")
+            // Empty value adds equal sign in RestAssured: ?delete=
+            .queryParam("delete", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteResult"));
+            
+        // Test with raw query string ?delete
+        given()
+            .header("Host", "mybucket.s3.amazonaws.com")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .post("/?delete")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteResult"));
+            
+        // What about path-style ?delete
+        given()
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .post("/mybucket?delete")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteResult"));
+            
+        // Path style with delete=
+        given()
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .post("/mybucket?delete=")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteResult"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/UriBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/UriBuilderTest.java
@@ -1,0 +1,16 @@
+package io.github.hectorvent.floci.services.s3;
+
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UriBuilderTest {
+    @Test
+    void testUriBuilder() {
+        URI uri = URI.create("http://host/?delete");
+        URI newUri = UriBuilder.fromUri(uri).replacePath("/b/").build();
+        System.out.println("NEW URI: " + newUri.toString());
+        System.out.println("NEW URI QUERY: " + newUri.getQuery());
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
  Resolved a critical regression where S3VirtualHostFilter incorrectly rewrote URIs for other AWS services (like CloudFormation), causing CDK bootstrap failures.
   - Updated the @PreMatching filter to inspect the Authorization header's credential scope and bypass non-S3 services.
   - Added a Content-Type heuristic to immediately skip AwsQuery (application/x-www-form-urlencoded) and JSON protocol requests.
   - Added CloudFormationHijackTest to verify that requests to cloudformation.*.amazonaws.com are properly routed to the CloudFormation controller instead of S3.

  Closes #194


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
