### PR TITLE
docs: clarify that AI co-author trailers should not be used in commits

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -310,6 +310,8 @@ Conventional commits:
 - `docs:`
 - `chore:`
 
+Do not add `Co-Authored-By` trailers for AI tools in commit messages. Keep attribution limited to human contributors.
+
 ---
 
 ## Release Awareness

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) â
 | `chore:` | Build, CI, dependencies | none |
 | `BREAKING CHANGE:` | Footer or `!` suffix â€” incompatible change | major |
 
+Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution should be limited to human contributors.
+
 **Examples:**
 
 ```


### PR DESCRIPTION
## Summary

 Adds an explicit rule that `Co-Authored-By` trailers for AI tools should not be included in commit messages. Updated both CONTRIBUTING.md and AGENT.md so the expectation is clear for human contributors and AI agents alike.

  This documents a policy that has come up in prior PR reviews:
  - https://github.com/hectorvent/floci/pull/86#pullrequestreview-4056954911
  - https://github.com/hectorvent/floci/pull/175#issuecomment-4183791654

## Type of change

- [x] Docs / chore

## AWS Compatibility
 N/A

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (N/A - docs only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
