### PR TITLE
S3 presigned post policy conditions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -33,14 +33,16 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 
 /**
@@ -55,6 +57,8 @@ public class S3Controller {
     private static final DateTimeFormatter RFC_822 = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final S3Service s3Service;
     private final S3SelectService s3SelectService;
@@ -1555,10 +1559,10 @@ public class S3Controller {
                     "Bucket POST must contain a file field.", 400);
         }
 
-        // Validate content-length-range from policy if present
+        // Validate policy conditions if present
         String policy = fields.get("policy");
         if (policy != null && !policy.isEmpty()) {
-            validateContentLengthRange(policy, fileData.length);
+            validatePolicyConditions(policy, bucket, fields, fileData.length);
         }
 
         // Use Content-Type from form fields, fall back to file part Content-Type
@@ -1588,43 +1592,90 @@ public class S3Controller {
                 .build();
     }
 
-    private void validateContentLengthRange(String policyBase64, int contentLength) {
+    private void validatePolicyConditions(String policyBase64, String bucket,
+                                           Map<String, String> fields, int contentLength) {
         try {
-            String decoded = new String(java.util.Base64.getDecoder().decode(policyBase64), StandardCharsets.UTF_8);
-            // Parse conditions array from the policy JSON to find content-length-range
-            int condIdx = decoded.indexOf("\"conditions\"");
-            if (condIdx < 0) {
+            byte[] decoded = java.util.Base64.getDecoder().decode(policyBase64);
+            JsonNode policy = OBJECT_MAPPER.readTree(decoded);
+            JsonNode conditions = policy.get("conditions");
+            if (conditions == null || !conditions.isArray()) {
                 return;
             }
-            // Look for content-length-range condition: ["content-length-range", min, max]
-            String lower = decoded.toLowerCase(Locale.ROOT);
-            int rangeIdx = lower.indexOf("content-length-range");
-            if (rangeIdx < 0) {
-                return;
-            }
-            // Find the enclosing array bracket
-            int bracketStart = decoded.lastIndexOf('[', rangeIdx);
-            int bracketEnd = decoded.indexOf(']', rangeIdx);
-            if (bracketStart < 0 || bracketEnd < 0) {
-                return;
-            }
-            String rangeArray = decoded.substring(bracketStart, bracketEnd + 1);
-            // Extract min and max values
-            String[] tokens = rangeArray.replaceAll("[\\[\\]\"]", "").split(",");
-            if (tokens.length >= 3) {
-                long min = Long.parseLong(tokens[1].trim());
-                long max = Long.parseLong(tokens[2].trim());
-                if (contentLength < min || contentLength > max) {
-                    throw new AwsException("EntityTooLarge",
-                            "Your proposed upload exceeds the maximum allowed size.", 400);
+            for (JsonNode condition : conditions) {
+                if (condition.isObject()) {
+                    validateExactMatchCondition(condition, bucket, fields);
+                } else if (condition.isArray()) {
+                    validateArrayCondition(condition, bucket, fields, contentLength);
                 }
             }
         } catch (AwsException e) {
             throw e;
         } catch (Exception e) {
-            // If policy parsing fails, skip validation (match AWS lenient behavior for emulator)
             LOG.debugv("Failed to parse presigned POST policy: {0}", e.getMessage());
         }
+    }
+
+    private void validateExactMatchCondition(JsonNode condition, String bucket, Map<String, String> fields) {
+        Iterator<Map.Entry<String, JsonNode>> fieldIter = condition.fields();
+        while (fieldIter.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fieldIter.next();
+            String fieldName = entry.getKey();
+            String expectedValue = entry.getValue().asText();
+            String actualValue;
+            if ("bucket".equals(fieldName)) {
+                actualValue = bucket;
+            } else {
+                actualValue = fields.get(fieldName);
+            }
+            if (actualValue == null || !actualValue.equals(expectedValue)) {
+                throw new AwsException("AccessDenied",
+                        "Invalid according to Policy: Policy Condition failed: "
+                                + "[\"eq\", \"$" + fieldName + "\", \"" + expectedValue + "\"]", 403);
+            }
+        }
+    }
+
+    private void validateArrayCondition(JsonNode condition, String bucket,
+                                        Map<String, String> fields, int contentLength) {
+        if (condition.size() < 3) {
+            return;
+        }
+        String operator = condition.get(0).asText().toLowerCase(Locale.ROOT);
+        if ("content-length-range".equals(operator)) {
+            long min = condition.get(1).asLong();
+            long max = condition.get(2).asLong();
+            if (contentLength < min || contentLength > max) {
+                throw new AwsException("EntityTooLarge",
+                        "Your proposed upload exceeds the maximum allowed size.", 400);
+            }
+        } else if ("eq".equals(operator)) {
+            String fieldRef = condition.get(1).asText();
+            String expectedValue = condition.get(2).asText();
+            String fieldName = fieldRef.startsWith("$") ? fieldRef.substring(1) : fieldRef;
+            String actualValue = resolveFieldValue(fieldName, bucket, fields);
+            if (actualValue == null || !actualValue.equals(expectedValue)) {
+                throw new AwsException("AccessDenied",
+                        "Invalid according to Policy: Policy Condition failed: "
+                                + "[\"eq\", \"$" + fieldName + "\", \"" + expectedValue + "\"]", 403);
+            }
+        } else if ("starts-with".equals(operator)) {
+            String fieldRef = condition.get(1).asText();
+            String prefix = condition.get(2).asText();
+            String fieldName = fieldRef.startsWith("$") ? fieldRef.substring(1) : fieldRef;
+            String actualValue = resolveFieldValue(fieldName, bucket, fields);
+            if (actualValue == null || !actualValue.startsWith(prefix)) {
+                throw new AwsException("AccessDenied",
+                        "Invalid according to Policy: Policy Condition failed: "
+                                + "[\"starts-with\", \"$" + fieldName + "\", \"" + prefix + "\"]", 403);
+            }
+        }
+    }
+
+    private static String resolveFieldValue(String fieldName, String bucket, Map<String, String> fields) {
+        if ("bucket".equals(fieldName)) {
+            return bucket;
+        }
+        return fields.get(fieldName);
     }
 
     private static String extractBoundary(String contentType) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -129,7 +129,10 @@ class S3PresignedPostIntegrationTest {
             .post("/" + BUCKET)
         .then()
             .statusCode(400)
-            .body(containsString("EntityTooLarge"));
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("EntityTooLarge")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Your proposed upload exceeds the maximum allowed size.")));
     }
 
     @Test
@@ -143,7 +146,10 @@ class S3PresignedPostIntegrationTest {
             .post("/" + BUCKET)
         .then()
             .statusCode(400)
-            .body(containsString("InvalidArgument"));
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("InvalidArgument")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Bucket POST must contain a field named 'key'.")));
     }
 
     @Test
@@ -157,7 +163,10 @@ class S3PresignedPostIntegrationTest {
             .post("/" + BUCKET)
         .then()
             .statusCode(400)
-            .body(containsString("InvalidArgument"));
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("InvalidArgument")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Bucket POST must contain a file field.")));
     }
 
     @Test
@@ -227,7 +236,8 @@ class S3PresignedPostIntegrationTest {
             .post("/nonexistent-presigned-bucket")
         .then()
             .statusCode(404)
-            .body(containsString("NoSuchBucket"));
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("NoSuchBucket")));
     }
 
     @Test
@@ -256,6 +266,117 @@ class S3PresignedPostIntegrationTest {
     }
 
     @Test
+    @Order(91)
+    void presignedPostRejectsContentTypeMismatch() {
+        String key = "uploads/ct-mismatch.png";
+        String fileContent = "not a real png";
+
+        String policy = buildPolicy(BUCKET, key, "image/png", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "image/gif")
+            .multiPart("policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "ct-mismatch.png", fileContent.getBytes(StandardCharsets.UTF_8), "image/gif")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(403)
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("AccessDenied")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Invalid according to Policy: Policy Condition failed: "
+                            + "[\"eq\", \"$Content-Type\", \"image/png\"]")));
+    }
+
+    @Test
+    @Order(92)
+    void presignedPostRejectsKeyMismatch() {
+        String key = "uploads/wrong-key.txt";
+        String fileContent = "test content";
+
+        String policy = buildPolicy(BUCKET, "uploads/expected-key.txt", "text/plain", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "text/plain")
+            .multiPart("policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "wrong-key.txt", fileContent.getBytes(StandardCharsets.UTF_8), "text/plain")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(403)
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("AccessDenied")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Invalid according to Policy: Policy Condition failed: "
+                            + "[\"eq\", \"$key\", \"uploads/expected-key.txt\"]")));
+    }
+
+    @Test
+    @Order(93)
+    void presignedPostWithStartsWithCondition() {
+        String key = "uploads/prefix-test.txt";
+        String fileContent = "starts-with test";
+
+        String policy = buildStartsWithPolicy(BUCKET, "uploads/", "text/", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "text/plain")
+            .multiPart("policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "prefix-test.txt", fileContent.getBytes(StandardCharsets.UTF_8), "text/plain")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(94)
+    void presignedPostRejectsStartsWithMismatch() {
+        String key = "other/wrong-prefix.txt";
+        String fileContent = "starts-with mismatch";
+
+        String policy = buildStartsWithPolicy(BUCKET, "uploads/", "text/", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "text/plain")
+            .multiPart("policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "wrong-prefix.txt", fileContent.getBytes(StandardCharsets.UTF_8), "text/plain")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(403)
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("AccessDenied")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Invalid according to Policy: Policy Condition failed: "
+                            + "[\"starts-with\", \"$key\", \"uploads/\"]")));
+    }
+
+    @Test
     @Order(100)
     void cleanupBucket() {
         // Delete all objects
@@ -264,6 +385,7 @@ class S3PresignedPostIntegrationTest {
         given().delete("/" + BUCKET + "/uploads/no-policy.txt");
         given().delete("/" + BUCKET + "/uploads/typed-file.json");
         given().delete("/" + BUCKET + "/uploads/within-range.txt");
+        given().delete("/" + BUCKET + "/uploads/prefix-test.txt");
 
         given()
         .when()
@@ -287,5 +409,23 @@ class S3PresignedPostIntegrationTest {
                   ]
                 }
                 """.formatted(expiration, bucket, key, contentType, minSize, maxSize);
+    }
+
+    private String buildStartsWithPolicy(String bucket, String keyPrefix, String contentTypePrefix,
+                                         long minSize, long maxSize) {
+        String expiration = Instant.now().plusSeconds(3600)
+                .atZone(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+        return """
+                {
+                  "expiration": "%s",
+                  "conditions": [
+                    {"bucket": "%s"},
+                    ["starts-with", "$key", "%s"],
+                    ["starts-with", "$Content-Type", "%s"],
+                    ["content-length-range", %d, %d]
+                  ]
+                }
+                """.formatted(expiration, bucket, keyPrefix, contentTypePrefix, minSize, maxSize);
     }
 }


### PR DESCRIPTION
## Summary

Presigned POST uploads only validated `content-length-range` policy conditions. All other conditions (`bucket`, `key`, `Content-Type`, etc.) were silently ignored, allowing uploads that violate the policy. Real AWS S3 rejects with `403 AccessDenied` when any condition is not met.

This PR replaces the narrow `validateContentLengthRange` method with `validatePolicyConditions`, which enforces:

- **Object-form exact match**: `{"bucket": "X"}`, `{"key": "X"}`, `{"Content-Type": "X"}`
- **Array-form `eq`**: `["eq", "$Content-Type", "image/png"]`
- **Array-form `starts-with`**: `["starts-with", "$key", "uploads/"]`
- **Array-form `content-length-range`**: `["content-length-range", min, max]` (existing, preserved)

Policy violations return `403 AccessDenied` with AWS-compatible error messages:
```
Invalid according to Policy: Policy Condition failed: ["eq", "$Content-Type", "image/png"]
```

Policy JSON is parsed via Jackson `ObjectMapper.readTree()` → `JsonNode`, matching the pattern used elsewhere in the codebase (e.g. `AwsJsonController`).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Floci accepted presigned POST uploads regardless of policy conditions (except content-length-range). Real AWS S3 rejects with `403 AccessDenied` when any condition is not met.

**Corrected behavior:** Now matches AWS S3 — mismatched `Content-Type`, `key`, `bucket`, or failed `starts-with` prefix checks return 403 with the standard error message format: `Invalid according to Policy: Policy Condition failed: ["eq", "$Content-Type", "image/png"]`.

Verified against AWS SDK-generated presigned POST policies used in production (discovered via [ProjectOpenSea/seadn#1921](https://github.com/ProjectOpenSea/seadn/pull/1921)).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
