### PR TITLE
fix(lambda): copy code to TASK_DIR for provided runtimes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -150,36 +150,20 @@ public class ContainerLauncher {
         // Copy code into container via Docker API tar stream (works inside Docker too)
         if (fn.getCodeLocalPath() != null) {
             Path codePath = Path.of(fn.getCodeLocalPath());
-            try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
-                 java.io.PipedInputStream pis = new java.io.PipedInputStream(pos)) {
-                
-                // Use a separate thread to feed the pipe to avoid deadlock
-                new Thread(() -> {
-                    try (pos) {
-                        createTar(codePath, pos);
-                    } catch (IOException e) {
-                        LOG.errorv("Failed to stream tar for function {0}: {1}", fn.getFunctionName(), e.getMessage());
-                    }
-                }, "tar-streamer-" + fn.getFunctionName()).start();
+            
+            // 1. Always copy all code to /var/task (TASK_DIR)
+            copyDirToContainer(containerId, codePath, TASK_DIR, fn.getFunctionName());
 
-                String codeDir = isProvidedRuntime(fn.getRuntime()) ? RUNTIME_DIR : TASK_DIR;
-                dockerClient.copyArchiveToContainerCmd(containerId)
-                        .withRemotePath(codeDir)
-                        .withTarInputStream(pis)
-                        .exec();
-                LOG.debugv("Copied code into container {0} at {1}", containerId, codeDir);
-            } catch (java.nio.file.NoSuchFileException e) {
-                // Race condition: code directory deleted between the pre-launch check and the copy
-                // (e.g. function deleted while the image was being pulled).
-                // Abort cleanly — remove the container and stop the Runtime API server.
-                LOG.debugv("Code directory removed during image pull for function {0}, aborting launch",
-                        fn.getFunctionName());
-                try { dockerClient.removeContainerCmd(containerId).withForce(true).exec(); } catch (Exception ignored) {}
-                runtimeApiServer.stop();
-                throw new RuntimeException("Function code was deleted during container launch: "
-                        + fn.getFunctionName());
-            } catch (Exception e) {
-                LOG.warnv("Failed to copy code into container {0}: {1}", containerId, e.getMessage());
+            // 2. For provided runtimes, also copy the 'bootstrap' file to /var/runtime (RUNTIME_DIR)
+            // matching real AWS Lambda behavior where /var/runtime/bootstrap is the entry point.
+            if (isProvidedRuntime(fn.getRuntime())) {
+                Path bootstrapPath = codePath.resolve("bootstrap");
+                if (Files.exists(bootstrapPath)) {
+                    copyFileToContainer(containerId, bootstrapPath, RUNTIME_DIR, "bootstrap", fn.getFunctionName());
+                } else {
+                    LOG.warnv("Provided runtime function {0} is missing 'bootstrap' file in {1}", 
+                            fn.getFunctionName(), fn.getCodeLocalPath());
+                }
             }
         }
 
@@ -272,6 +256,57 @@ public class ContainerLauncher {
         }
     }
 
+    private void copyDirToContainer(String containerId, Path sourceDir, String remotePath, String functionName) {
+        try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
+             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos)) {
+
+            new Thread(() -> {
+                try (pos) {
+                    createTarFromDir(sourceDir, pos);
+                } catch (IOException e) {
+                    LOG.errorv("Failed to stream tar for function {0}: {1}", functionName, e.getMessage());
+                }
+            }, "tar-streamer-dir-" + functionName).start();
+
+            dockerClient.copyArchiveToContainerCmd(containerId)
+                    .withRemotePath(remotePath)
+                    .withTarInputStream(pis)
+                    .exec();
+            LOG.debugv("Copied directory {0} into container {1} at {2}", sourceDir, containerId, remotePath);
+        } catch (Exception e) {
+            LOG.warnv("Failed to copy directory {0} into container {1}: {2}", sourceDir, containerId, e.getMessage());
+        }
+    }
+
+    private void copyFileToContainer(String containerId, Path sourceFile, String remotePath, String entryName, String functionName) {
+        try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
+             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos)) {
+
+            new Thread(() -> {
+                try (pos) {
+                    long size = Files.size(sourceFile);
+                    writeTarHeader(pos, entryName, size);
+                    try (java.io.InputStream fis = Files.newInputStream(sourceFile)) {
+                        fis.transferTo(pos);
+                    }
+                    int pad = (int) ((512 - (size % 512)) % 512);
+                    if (pad > 0) pos.write(new byte[pad]);
+                    pos.write(new byte[1024]); // End-of-archive
+                } catch (IOException e) {
+                    LOG.errorv("Failed to stream file tar for function {0}: {1}", functionName, e.getMessage());
+                }
+            }, "tar-streamer-file-" + functionName).start();
+
+            dockerClient.copyArchiveToContainerCmd(containerId)
+                    .withRemotePath(remotePath)
+                    .withTarInputStream(pis)
+                    .exec();
+            LOG.debugv("Copied file {0} as {1} into container {2} at {3}", sourceFile, entryName, containerId, remotePath);
+        } catch (Exception e) {
+            LOG.warnv("Failed to copy file {0} into container {1}: {2}", sourceFile, containerId, e.getMessage());
+        }
+    }
+
     private static boolean isProvidedRuntime(String runtime) {
         return runtime != null && runtime.startsWith("provided");
     }
@@ -288,7 +323,7 @@ public class ContainerLauncher {
      * Creates a minimal POSIX TAR archive from all files in {@code sourceDir}.
      * Streams content to the OutputStream to avoid loading entire files into memory.
      */
-    private static void createTar(Path sourceDir, java.io.OutputStream out) throws IOException {
+    private static void createTarFromDir(Path sourceDir, java.io.OutputStream out) throws IOException {
         try (var stream = Files.walk(sourceDir)) {
             for (Path path : (Iterable<Path>) stream::iterator) {
                 if (Files.isDirectory(path)) continue;


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Ensure all function code is extracted to /var/task (LAMBDA_TASK_ROOT) for provided runtimes, while additionally copying the bootstrap binary to /var/runtime/bootstrap. This ensures that companion files like configuration or schemas are accessible to the application, matching real AWS Lambda behavior.

Fixes #204



## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
