### PR TITLE
fix(ses): add missing Result element to query protocol responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryResponse.java
@@ -78,6 +78,14 @@ public final class AwsQueryResponse {
     }
 
     /**
+     * Same as {@link #envelope} but with an empty Result element.
+     * Some services (e.g. SES) require the Result element even if it is empty.
+     */
+    public static String envelopeEmptyResult(String action, String xmlns) {
+        return envelope(action, xmlns, "");
+    }
+
+    /**
      * Builds a Query-protocol XML error response and returns a JAX-RS {@link Response}.
      *
      * <pre>{@code

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -62,7 +62,7 @@ public class SesQueryHandler {
     private Response handleVerifyEmailIdentity(MultivaluedMap<String, String> params, String region) {
         String emailAddress = getParam(params, "EmailAddress");
         sesService.verifyEmailIdentity(emailAddress, region);
-        return Response.ok(AwsQueryResponse.envelopeNoResult("VerifyEmailIdentity", AwsNamespaces.SES)).build();
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("VerifyEmailIdentity", AwsNamespaces.SES)).build();
     }
 
     private Response handleVerifyEmailAddress(MultivaluedMap<String, String> params, String region) {
@@ -81,7 +81,7 @@ public class SesQueryHandler {
     private Response handleDeleteIdentity(MultivaluedMap<String, String> params, String region) {
         String identityValue = getParam(params, "Identity");
         sesService.deleteIdentity(identityValue, region);
-        return Response.ok(AwsQueryResponse.envelopeNoResult("DeleteIdentity", AwsNamespaces.SES)).build();
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("DeleteIdentity", AwsNamespaces.SES)).build();
     }
 
     private Response handleListIdentities(MultivaluedMap<String, String> params, String region) {
@@ -197,7 +197,7 @@ public class SesQueryHandler {
         String notificationType = getParam(params, "NotificationType");
         String snsTopic = getParam(params, "SnsTopic");
         sesService.setIdentityNotificationTopic(identityValue, notificationType, snsTopic, region);
-        return Response.ok(AwsQueryResponse.envelopeNoResult("SetIdentityNotificationTopic", AwsNamespaces.SES)).build();
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("SetIdentityNotificationTopic", AwsNamespaces.SES)).build();
     }
 
     private Response handleGetIdentityNotificationAttributes(MultivaluedMap<String, String> params, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -28,7 +28,8 @@ class SesIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(containsString("VerifyEmailIdentityResponse"));
+            .body(containsString("VerifyEmailIdentityResponse"))
+            .body(containsString("VerifyEmailIdentityResult"));
     }
 
     @Test
@@ -265,7 +266,8 @@ class SesIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(200);
+            .statusCode(200)
+            .body(containsString("SetIdentityNotificationTopicResult"));
     }
 
     @Test
@@ -320,7 +322,8 @@ class SesIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(200);
+            .statusCode(200)
+            .body(containsString("DeleteIdentityResult"));
 
         // Verify it's gone
         given()


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
  This PR fixes a compatibility issue in the SES service where certain actions were returning XML responses missing the <ActionResult/> wrapper element. While these elements are empty for these specific actions, the AWS Query protocol (and consequently the AWS CLI and various SDKs) expects them to be present.

  Changes
   - Core: Added envelopeEmptyResult to AwsQueryResponse to support actions that require an empty result wrapper.
   - SES: Updated VerifyEmailIdentity, DeleteIdentity, and SetIdentityNotificationTopic to use the new envelope.
   - Tests: 
       - Updated SesIntegrationTest.java to explicitly assert the presence of these result elements.
       - Cleaned up the sdk-test-awscli compatibility suite by removing the "parser bug" workarounds, as the underlying response format is now correct.

  Fixes #147.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
