### PR TITLE
fix(lambda): support Code.S3Bucket + Code.S3Key in CreateFunction and…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -12,6 +12,8 @@ import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.lambda.model.LambdaUrlConfig;
 import io.github.hectorvent.floci.services.lambda.zip.CodeStore;
 import io.github.hectorvent.floci.services.lambda.zip.ZipExtractor;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -48,6 +50,7 @@ public class LambdaService {
     private final RegionResolver regionResolver;
     private final EsmStore esmStore;
     private final LambdaAliasStore aliasStore;
+    private final S3Service s3Service;
     private final SqsService sqsService;
     private final SqsEventSourcePoller poller;
     private final KinesisEventSourcePoller kinesisPoller;
@@ -69,6 +72,7 @@ public class LambdaService {
         this.regionResolver = regionResolver;
         this.esmStore = null;
         this.aliasStore = null;
+        this.s3Service = null;
         this.sqsService = null;
         this.poller = null;
         this.kinesisPoller = null;
@@ -85,6 +89,7 @@ public class LambdaService {
                           RegionResolver regionResolver,
                           EsmStore esmStore,
                           LambdaAliasStore aliasStore,
+                          S3Service s3Service,
                           SqsService sqsService,
                           SqsEventSourcePoller poller,
                           KinesisEventSourcePoller kinesisPoller,
@@ -98,6 +103,7 @@ public class LambdaService {
         this.regionResolver = regionResolver;
         this.esmStore = esmStore;
         this.aliasStore = aliasStore;
+        this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.poller = poller;
         this.kinesisPoller = kinesisPoller;
@@ -172,6 +178,11 @@ public class LambdaService {
             if (zipFileBase64 != null) {
                 extractZipCode(fn, zipFileBase64);
             }
+            String s3Bucket = (String) code.get("S3Bucket");
+            String s3Key = (String) code.get("S3Key");
+            if (s3Bucket != null && s3Key != null) {
+                extractZipCodeFromS3(fn, s3Bucket, s3Key);
+            }
         }
 
         functionStore.save(region, fn);
@@ -194,12 +205,17 @@ public class LambdaService {
 
         String zipFileBase64 = (String) request.get("ZipFile");
         String imageUri = (String) request.get("ImageUri");
+        String s3Bucket = (String) request.get("S3Bucket");
+        String s3Key = (String) request.get("S3Key");
 
         if (zipFileBase64 != null) {
             extractZipCode(fn, zipFileBase64);
         }
         if (imageUri != null) {
             fn.setImageUri(imageUri);
+        }
+        if (s3Bucket != null && s3Key != null) {
+            extractZipCodeFromS3(fn, s3Bucket, s3Key);
         }
 
         fn.setLastModified(System.currentTimeMillis());
@@ -617,6 +633,20 @@ public class LambdaService {
             throw new AwsException("InvalidParameterValueException",
                     "Failed to extract deployment package: " + e.getMessage(), 400);
         }
+    }
+
+    private void extractZipCodeFromS3(LambdaFunction fn, String s3Bucket, String s3Key) {
+        if (s3Service == null) {
+            throw new AwsException("ServiceUnavailableException", "S3 service not available", 503);
+        }
+        S3Object obj;
+        try {
+            obj = s3Service.getObject(s3Bucket, s3Key);
+        } catch (Exception e) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Unable to fetch code from s3://" + s3Bucket + "/" + s3Key + ": " + e.getMessage(), 400);
+        }
+        extractZipCode(fn, Base64.getEncoder().encodeToString(obj.getData()));
     }
 
     private int toInt(Object value, int defaultValue) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
@@ -286,6 +286,14 @@ class EventBridgeSchedulerIntegrationTest {
             public AuthConfig auth() { return null; }
             @Override
             public ServicesConfig services() { return null; }
+            @Override
+            public String ecrBaseUri() { return ""; }
+            @Override
+            public int maxRequestSize() { return 512; }
+            @Override
+            public java.util.Optional<String> hostname() { return java.util.Optional.empty(); }
+            @Override
+            public EmulatorConfig.InitHooksConfig initHooks() { return null; }
         };
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaS3CodeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaS3CodeIntegrationTest.java
@@ -1,0 +1,177 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Verifies that Lambda CreateFunction and UpdateFunctionCode accept
+ * Code.S3Bucket + Code.S3Key as an alternative to an inline ZipFile.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaS3CodeIntegrationTest {
+
+    private static final String BUCKET = "lambda-code-bucket";
+    private static final String KEY    = "functions/hello-s3.zip";
+    private static final String KEY_V2 = "functions/hello-s3-v2.zip";
+    private static final String FN     = "hello-s3";
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static byte[] makeZip(String handlerJs) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write(handlerJs.getBytes());
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    // ── setup ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void createS3Bucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void uploadCodeZipToS3() throws Exception {
+        byte[] zip = makeZip("exports.handler = async (e) => ({ statusCode: 200, body: 's3-v1' });");
+        given()
+            .contentType("application/octet-stream")
+            .body(zip)
+        .when()
+            .put("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200);
+    }
+
+    // ── CreateFunction with S3 code ───────────────────────────────────────────
+
+    @Test
+    @Order(3)
+    void createFunctionFromS3Code() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Code": {
+                        "S3Bucket": "%s",
+                        "S3Key": "%s"
+                    }
+                }
+                """.formatted(FN, BUCKET, KEY))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("FunctionName", equalTo(FN))
+            .body("State", equalTo("Active"))
+            .body("CodeSize", greaterThan(0));
+    }
+
+    @Test
+    @Order(4)
+    void getFunctionShowsCodeSize() {
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(200)
+            .body("Configuration.FunctionName", equalTo(FN))
+            .body("Configuration.CodeSize", greaterThan(0));
+    }
+
+    // ── UpdateFunctionCode with S3 code ───────────────────────────────────────
+
+    @Test
+    @Order(5)
+    void uploadUpdatedCodeZipToS3() throws Exception {
+        byte[] zip = makeZip("exports.handler = async (e) => ({ statusCode: 200, body: 's3-v2' });");
+        given()
+            .contentType("application/octet-stream")
+            .body(zip)
+        .when()
+            .put("/" + BUCKET + "/" + KEY_V2)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void updateFunctionCodeFromS3() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "S3Bucket": "%s",
+                    "S3Key": "%s"
+                }
+                """.formatted(BUCKET, KEY_V2))
+        .when()
+            .put("/2015-03-31/functions/" + FN + "/code")
+        .then()
+            .statusCode(200)
+            .body("FunctionName", equalTo(FN))
+            .body("CodeSize", greaterThan(0));
+    }
+
+    // ── Error: S3 object not found ─────────────────────────────────────────────
+
+    @Test
+    @Order(7)
+    void createFunctionFromMissingS3Object_returns400() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "fn-missing-s3",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Code": {
+                        "S3Bucket": "%s",
+                        "S3Key": "does-not-exist.zip"
+                    }
+                }
+                """.formatted(BUCKET))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(400);
+    }
+
+    // ── cleanup ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(10)
+    void deleteFunction() {
+        given()
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(204);
+    }
+}


### PR DESCRIPTION
… UpdateFunctionCode

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

  - `LambdaService.createFunction()` and `updateFunctionCode()` previously ignored                                                                                              
    `Code.S3Bucket` / `Code.S3Key`, leaving functions with no executable code when
    deployed via CDK, SAM, or any zip exceeding the 50 MB inline limit.                                                                                                         
  - Injects `S3Service` into `LambdaService` and fetches + extracts the zip from S3                                                                                             
    when `S3Bucket` + `S3Key` are present, mirroring the existing logic in                                                                                                      
    `CloudFormationResourceProvisioner.resolveLambdaCode()`.                                                                                                                    
  - Returns HTTP 400 `InvalidParameterValueException` when the referenced S3 object                                                                                             
    does not exist, matching AWS behaviour.                 

This is part of the fix for issue #28

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
