### PR TITLE
feat: add GlobalSecondaryIndexUpdates support in DynamoDB UpdateTable

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -396,7 +396,41 @@ public class DynamoDbJsonHandler {
             writeCapacity = pt.has("WriteCapacityUnits") ? pt.get("WriteCapacityUnits").asLong() : null;
         }
 
-        TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity, region);
+        List<GlobalSecondaryIndex> gsiCreates = new ArrayList<>();
+        List<String> gsiDeletes = new ArrayList<>();
+        JsonNode gsiUpdates = request.path("GlobalSecondaryIndexUpdates");
+        if (!gsiUpdates.isMissingNode() && gsiUpdates.isArray()) {
+            for (JsonNode update : gsiUpdates) {
+                JsonNode createNode = update.path("Create");
+                if (!createNode.isMissingNode()) {
+                    String indexName = createNode.path("IndexName").asText();
+                    List<KeySchemaElement> gsiKeySchema = new ArrayList<>();
+                    createNode.path("KeySchema").forEach(ks ->
+                            gsiKeySchema.add(new KeySchemaElement(
+                                    ks.path("AttributeName").asText(),
+                                    ks.path("KeyType").asText())));
+                    String projectionType = createNode.path("Projection").path("ProjectionType").asText("ALL");
+                    gsiCreates.add(new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType));
+                }
+                JsonNode deleteNode = update.path("Delete");
+                if (!deleteNode.isMissingNode()) {
+                    gsiDeletes.add(deleteNode.path("IndexName").asText());
+                }
+            }
+        }
+
+        List<AttributeDefinition> newAttrDefs = new ArrayList<>();
+        JsonNode attrDefsNode = request.path("AttributeDefinitions");
+        if (!attrDefsNode.isMissingNode() && attrDefsNode.isArray()) {
+            for (JsonNode ad : attrDefsNode) {
+                newAttrDefs.add(new AttributeDefinition(
+                        ad.path("AttributeName").asText(),
+                        ad.path("AttributeType").asText()));
+            }
+        }
+
+        TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity,
+                gsiCreates, gsiDeletes, newAttrDefs, region);
 
         String billingMode = request.has("BillingMode")
                 ? request.get("BillingMode").asText() : null;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -726,6 +726,12 @@ public class DynamoDbService {
     // --- UpdateTable ---
 
     public TableDefinition updateTable(String tableName, Long readCapacity, Long writeCapacity, String region) {
+        return updateTable(tableName, readCapacity, writeCapacity, List.of(), List.of(), List.of(), region);
+    }
+
+    public TableDefinition updateTable(String tableName, Long readCapacity, Long writeCapacity,
+                                        List<GlobalSecondaryIndex> gsiCreates, List<String> gsiDeletes,
+                                        List<AttributeDefinition> newAttrDefs, String region) {
         String storageKey = regionKey(region, tableName);
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(tableName));
@@ -736,6 +742,27 @@ public class DynamoDbService {
         if (writeCapacity != null) {
             table.getProvisionedThroughput().setWriteCapacityUnits(writeCapacity);
         }
+
+        for (String indexName : gsiDeletes) {
+            table.getGlobalSecondaryIndexes().removeIf(g -> indexName.equals(g.getIndexName()));
+        }
+
+        for (GlobalSecondaryIndex gsi : gsiCreates) {
+            gsi.setIndexArn(table.getTableArn() + "/index/" + gsi.getIndexName());
+            table.getGlobalSecondaryIndexes().add(gsi);
+        }
+
+        if (newAttrDefs != null && !newAttrDefs.isEmpty()) {
+            List<AttributeDefinition> existing = table.getAttributeDefinitions();
+            for (AttributeDefinition newDef : newAttrDefs) {
+                boolean found = existing.stream()
+                        .anyMatch(e -> e.getAttributeName().equals(newDef.getAttributeName()));
+                if (!found) {
+                    existing.add(newDef);
+                }
+            }
+        }
+
         tableStore.put(storageKey, table);
         LOG.infov("Updated table: {0} in region {1}", tableName, region);
         return table;

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -523,8 +523,202 @@ class DynamoDbIntegrationTest {
             .body("Item", nullValue());
     }
 
+    // --- UpdateTable GSI tests (separate table to avoid key schema conflicts) ---
+
     @Test
     @Order(19)
+    void createTableForGsiTests() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "GsiTestTable",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"}
+                    ],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableName", equalTo("GsiTestTable"))
+            .body("TableDescription.GlobalSecondaryIndexes", nullValue());
+    }
+
+    @Test
+    @Order(20)
+    void updateTableAddGsi() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "GsiTestTable",
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "gsiPk", "AttributeType": "S"},
+                        {"AttributeName": "gsiSk", "AttributeType": "S"}
+                    ],
+                    "GlobalSecondaryIndexUpdates": [
+                        {
+                            "Create": {
+                                "IndexName": "TestGsi",
+                                "KeySchema": [
+                                    {"AttributeName": "gsiPk", "KeyType": "HASH"},
+                                    {"AttributeName": "gsiSk", "KeyType": "RANGE"}
+                                ],
+                                "Projection": {"ProjectionType": "ALL"}
+                            }
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes.size()", equalTo(1))
+            .body("TableDescription.GlobalSecondaryIndexes[0].IndexName", equalTo("TestGsi"))
+            .body("TableDescription.GlobalSecondaryIndexes[0].IndexStatus", equalTo("ACTIVE"))
+            .body("TableDescription.GlobalSecondaryIndexes[0].KeySchema.size()", equalTo(2))
+            .body("TableDescription.GlobalSecondaryIndexes[0].Projection.ProjectionType", equalTo("ALL"));
+    }
+
+    @Test
+    @Order(21)
+    void describeTableReturnsGsi() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "GsiTestTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.GlobalSecondaryIndexes.size()", equalTo(1))
+            .body("Table.GlobalSecondaryIndexes[0].IndexName", equalTo("TestGsi"))
+            .body("Table.GlobalSecondaryIndexes[0].IndexStatus", equalTo("ACTIVE"))
+            .body("Table.GlobalSecondaryIndexes[0].IndexArn", containsString("/index/TestGsi"))
+            .body("Table.AttributeDefinitions.size()", equalTo(3));
+    }
+
+    @Test
+    @Order(22)
+    void updateTableAddGsiWithKeysOnlyProjection() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "GsiTestTable",
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "gsiPk", "AttributeType": "S"},
+                        {"AttributeName": "gsiSk", "AttributeType": "S"},
+                        {"AttributeName": "owner", "AttributeType": "S"}
+                    ],
+                    "GlobalSecondaryIndexUpdates": [
+                        {
+                            "Create": {
+                                "IndexName": "OwnerIndex",
+                                "KeySchema": [
+                                    {"AttributeName": "owner", "KeyType": "HASH"},
+                                    {"AttributeName": "pk", "KeyType": "RANGE"}
+                                ],
+                                "Projection": {"ProjectionType": "KEYS_ONLY"}
+                            }
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes.size()", equalTo(2))
+            .body("TableDescription.GlobalSecondaryIndexes.find { it.IndexName == 'OwnerIndex' }.IndexStatus", equalTo("ACTIVE"))
+            .body("TableDescription.GlobalSecondaryIndexes.find { it.IndexName == 'OwnerIndex' }.Projection.ProjectionType", equalTo("KEYS_ONLY"));
+    }
+
+    @Test
+    @Order(23)
+    void updateTableDeleteGsi() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "GsiTestTable",
+                    "GlobalSecondaryIndexUpdates": [
+                        {
+                            "Delete": {
+                                "IndexName": "TestGsi"
+                            }
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes.size()", equalTo(1))
+            .body("TableDescription.GlobalSecondaryIndexes[0].IndexName", equalTo("OwnerIndex"));
+    }
+
+    @Test
+    @Order(24)
+    void updateTableDeleteAllGsis() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "GsiTestTable",
+                    "GlobalSecondaryIndexUpdates": [
+                        {
+                            "Delete": {
+                                "IndexName": "OwnerIndex"
+                            }
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes", nullValue());
+    }
+
+    @Test
+    @Order(25)
+    void describeTableAfterAllGsisDeletion() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "GsiTestTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.GlobalSecondaryIndexes", nullValue());
+    }
+
+    // --- Cleanup ---
+
+    @Test
+    @Order(26)
     void deleteTable() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")


### PR DESCRIPTION
## Summary

Add support for the `GlobalSecondaryIndexUpdates` parameter in the DynamoDB `UpdateTable` operation, enabling Create and Delete actions for Global Secondary Indexes.

Closes #221

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- **API Reference**: [UpdateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html)
- **Supported parameters**:
  - `GlobalSecondaryIndexUpdates[].Create` — IndexName, KeySchema, Projection
  - `GlobalSecondaryIndexUpdates[].Update` — accepted and ignored (throughput settings are not enforced by the emulator)
  - `GlobalSecondaryIndexUpdates[].Delete` — IndexName
  - `AttributeDefinitions` — new key attributes are merged into the table definition
- **Verified with**: AWS SDK for Java v2 (via floci-compatibility-tests)

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

> Note: Compatibility tests have been added in floci-io/floci-compatibility-tests (PR to follow).