### PR TITLE
fix: default shell executable to /bin/sh for Alpine compatibility

### DIFF
--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -42,7 +42,7 @@ floci:
     presign-secret: local-emulator-secret  # HMAC secret for S3 pre-signed URL verification
 
   init-hooks:
-    shell-executable: /bin/bash
+    shell-executable: /bin/sh
     timeout-seconds: 30
     shutdown-grace-period-seconds: 2
 

--- a/docs/configuration/initialization-hooks.md
+++ b/docs/configuration/initialization-hooks.md
@@ -117,7 +117,7 @@ You can customize hook behavior via configuration:
 
 | Key                                              | Default     | Description                                                                                                      |
 |--------------------------------------------------|-------------|------------------------------------------------------------------------------------------------------------------|
-| `floci.init-hooks.shell-executable`              | `/bin/bash` | Shell executable used to run scripts                                                                             |
+| `floci.init-hooks.shell-executable`              | `/bin/sh`   | Shell executable used to run scripts                                                                             |
 | `floci.init-hooks.timeout-seconds`               | `30`        | Maximum execution time per script before it is terminated and considered failed                                  |
 | `floci.init-hooks.shutdown-grace-period-seconds` | `2`         | Time to wait after calling `destroy()` before forcefully stopping the process (allows cleanup hooks to complete) |
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -430,7 +430,7 @@ public interface EmulatorConfig {
     }
 
     interface InitHooksConfig {
-        @WithDefault("/bin/bash")
+        @WithDefault("/bin/sh")
         String shellExecutable();
 
         @WithDefault("2")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,7 +37,7 @@ floci:
     presign-secret: test-secret
 
   init-hooks:
-    shell-executable: /bin/bash
+    shell-executable: /bin/sh
     timeout-seconds: 5
     shutdown-grace-period-seconds: 2
 


### PR DESCRIPTION
## Summary
- The init hook executor defaulted to `/bin/bash`, which is not available on Alpine-based Docker images (`eclipse-temurin:25-jre-alpine`), causing startup hooks to crash with `Cannot run program "/bin/bash": No such file or directory`
- Changed the default `shell-executable` from `/bin/bash` to `/bin/sh`, which is universally available and POSIX-compatible
- Updated config, tests, and docs to reflect the new default

## Test plan
- [x] Existing `HookScriptExecutorTest` and `InitializationHooksRunnerTest` pass
- [ ] Verify startup hooks execute successfully in Alpine-based Docker image

Fixes #239 
