### PR TITLE
feat(cloudformation): add AWS::Events::Rule provisioning support

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2,6 +2,9 @@ package io.github.hectorvent.floci.services.cloudformation;
 
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
+import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
+import io.github.hectorvent.floci.services.eventbridge.model.Target;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
@@ -45,13 +48,15 @@ public class CloudFormationResourceProvisioner {
     private final SsmService ssmService;
     private final KmsService kmsService;
     private final SecretsManagerService secretsManagerService;
+    private final EventBridgeService eventBridgeService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
                                              SnsService snsService, DynamoDbService dynamoDbService,
                                              LambdaService lambdaService, IamService iamService,
                                              SsmService ssmService, KmsService kmsService,
-                                             SecretsManagerService secretsManagerService) {
+                                             SecretsManagerService secretsManagerService,
+                                             EventBridgeService eventBridgeService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -61,6 +66,7 @@ public class CloudFormationResourceProvisioner {
         this.ssmService = ssmService;
         this.kmsService = kmsService;
         this.secretsManagerService = secretsManagerService;
+        this.eventBridgeService = eventBridgeService;
     }
 
     /**
@@ -99,6 +105,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::ECR::Repository" -> provisionEcrRepository(resource, properties, engine, stackName);
                 case "AWS::Route53::HostedZone" -> provisionRoute53HostedZone(resource, properties, engine);
                 case "AWS::Route53::RecordSet" -> provisionRoute53RecordSet(resource, properties, engine);
+                case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
                 default -> {
                     LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
                     resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
@@ -131,6 +138,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::KMS::Alias" -> kmsService.deleteAlias(physicalId, region);
                 case "AWS::SecretsManager::Secret" ->
                         secretsManagerService.deleteSecret(physicalId, null, true, region);
+                case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, region);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -556,6 +564,67 @@ public class CloudFormationResourceProvisioner {
         r.setPhysicalId(nestedId);
         r.getAttributes().put("Arn", nestedId);
         r.getAttributes().put("Outputs.BootstrapVersion", "21");
+    }
+
+    // ── EventBridge ─────────────────────────────────────────────────────────
+
+    private void provisionEventBridgeRule(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                          String region, String stackName) {
+        String ruleName = resolveOptional(props, "Name", engine);
+        if (ruleName == null || ruleName.isBlank()) {
+            ruleName = generatePhysicalName(stackName, r.getLogicalId(), 64, false);
+        }
+
+        String busName = resolveOptional(props, "EventBusName", engine);
+        String description = resolveOptional(props, "Description", engine);
+        String roleArn = resolveOptional(props, "RoleArn", engine);
+        String scheduleExpression = resolveOptional(props, "ScheduleExpression", engine);
+
+        String eventPattern = null;
+        if (props != null && props.has("EventPattern") && !props.get("EventPattern").isNull()) {
+            JsonNode patternNode = engine.resolveNode(props.get("EventPattern"));
+            eventPattern = patternNode.toString();
+        }
+
+        String stateStr = resolveOptional(props, "State", engine);
+        RuleState state = "DISABLED".equals(stateStr) ? RuleState.DISABLED : RuleState.ENABLED;
+
+        var rule = eventBridgeService.putRule(ruleName, busName, eventPattern, scheduleExpression,
+                state, description, roleArn, Map.of(), region);
+        r.setPhysicalId(ruleName);
+        r.getAttributes().put("Arn", rule.getArn());
+
+        // Provision inline targets
+        if (props != null && props.has("Targets")) {
+            List<Target> targets = new ArrayList<>();
+            for (JsonNode targetNode : props.get("Targets")) {
+                JsonNode resolved = engine.resolveNode(targetNode);
+                String targetId = resolved.path("Id").asText(null);
+                String targetArn = resolved.path("Arn").asText(null);
+                String input = resolved.path("Input").asText(null);
+                String inputPath = resolved.path("InputPath").asText(null);
+                if (targetId != null && targetArn != null) {
+                    targets.add(new Target(targetId, targetArn, input, inputPath));
+                }
+            }
+            if (!targets.isEmpty()) {
+                eventBridgeService.putTargets(ruleName, busName, targets, region);
+            }
+        }
+    }
+
+    private void deleteEventBridgeRuleSafe(String ruleName, String region) {
+        try {
+            // Remove all targets before deleting the rule
+            var targets = eventBridgeService.listTargetsByRule(ruleName, null, region);
+            if (!targets.isEmpty()) {
+                List<String> targetIds = targets.stream().map(Target::getId).toList();
+                eventBridgeService.removeTargets(ruleName, null, targetIds, region);
+            }
+            eventBridgeService.deleteRule(ruleName, null, region);
+        } catch (Exception e) {
+            LOG.debugv("Could not delete EventBridge rule {0}: {1}", ruleName, e.getMessage());
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1439,4 +1439,201 @@ class CloudFormationIntegrationTest {
             .statusCode(200)
             .body(containsString("arn:aws:secretsmanager:"));
     }
+
+    @Test
+    void createStack_withEventBridgeRule() {
+        // First, create an SQS queue to use as a target
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "cfn-eventbridge-target-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "MyRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-test-rule",
+                    "Description": "Test rule created via CloudFormation",
+                    "EventPattern": {
+                      "source": ["my.application"],
+                      "detail-type": ["MyEvent"]
+                    },
+                    "Targets": [
+                      {
+                        "Id": "Target0",
+                        "Arn": "arn:aws:sqs:us-east-1:000000000000:cfn-eventbridge-target-queue"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        // 1. Create Stack
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eventbridge-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // 2. Verify stack is CREATE_COMPLETE
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eventbridge-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // 3. Verify the EventBridge rule was actually created
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("cfn-test-rule"))
+            .body("Description", equalTo("Test rule created via CloudFormation"))
+            .body("State", equalTo("ENABLED"))
+            .body("Arn", notNullValue());
+
+        // 4. Verify targets were attached to the rule
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets[0].Id", equalTo("Target0"))
+            .body("Targets[0].Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:cfn-eventbridge-target-queue"));
+    }
+
+    @Test
+    void createStack_withEventBridgeRuleAutoName() {
+        String template = """
+            {
+              "Resources": {
+                "AutoNamedRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "EventPattern": {
+                      "source": ["auto.test"]
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-autoname-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eb-autoname-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // Verify the rule was created via ListRules — should find one matching the auto-generated name
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListRules")
+            .body("{\"NamePrefix\":\"cfn-eb-autoname-stack\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Rules.size()", equalTo(1));
+    }
+
+    @Test
+    void deleteStack_withEventBridgeRule() {
+        String template = """
+            {
+              "Resources": {
+                "DeleteTestRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-delete-test-rule",
+                    "EventPattern": {
+                      "source": ["delete.test"]
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        // Create
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-delete-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify rule exists
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-delete-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("cfn-delete-test-rule"));
+
+        // Delete stack
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", "cfn-eb-delete-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify rule is gone
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-delete-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
 }


### PR DESCRIPTION
## Summary

CloudFormation stacks containing `AWS::Events::Rule` resources were marked as `CREATE_COMPLETE` but no actual EventBridge rules or targets were created. The resource type was falling through to the default stub handler in `CloudFormationResourceProvisioner`, which generates a fake physical ID without calling the EventBridge service.

This PR adds proper provisioning support:

- **Create**: Calls `EventBridgeService.putRule()` with all CloudFormation properties (EventPattern, ScheduleExpression, State, Description, RoleArn) and wires inline `Targets` via `putTargets()`
- **Delete**: Removes all targets before deleting the rule (required by EventBridge API)
- **Auto-naming**: Generates a physical name when the `Name` property is omitted (matching the pattern used by S3, SQS, SNS, etc.)

### Files changed

- `CloudFormationResourceProvisioner.java` — inject `EventBridgeService`, add `provisionEventBridgeRule()` and `deleteEventBridgeRuleSafe()` 
- `CloudFormationIntegrationTest.java` — 3 new integration tests:
  - `createStack_withEventBridgeRule` — verifies rule + targets are created and queryable via EventBridge API
  - `createStack_withEventBridgeRuleAutoName` — verifies auto-generated names work
  - `deleteStack_withEventBridgeRule` — verifies rule cleanup on stack deletion

## Context

When using Floci with AWS CDK, `cdklocal deploy` creates stacks that include EventBridge rules routing events to SQS queues. Without this fix, the rules exist only as CloudFormation metadata — events published to EventBridge are silently dropped because no rules exist to match and forward them.

## Test plan

- [x] All 29 CloudFormation integration tests pass (26 existing + 3 new)
- [x] Verified manually with a CDK stack deploying EventBridge rules with SQS targets
