### PR TITLE
feat(secretsmanager): add support for BatchGetSecretValue (#115)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
@@ -25,6 +25,8 @@ import software.amazon.awssdk.services.secretsmanager.model.SecretVersionsListEn
 import software.amazon.awssdk.services.secretsmanager.model.TagResourceRequest;
 import software.amazon.awssdk.services.secretsmanager.model.UntagResourceRequest;
 import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -303,5 +305,30 @@ class SecretsManagerTest {
                 .isInstanceOf(SecretsManagerException.class)
                 .extracting(e -> ((SecretsManagerException) e).statusCode())
                 .isEqualTo(400);
+    }
+
+    @Test
+    @Order(17)
+    void batchGetSecretValue() {
+        String s1 = "batch-secret-1-" + System.currentTimeMillis();
+        String s2 = "batch-secret-2-" + System.currentTimeMillis();
+
+        try {
+            sm.createSecret(CreateSecretRequest.builder().name(s1).secretString("v1").build());
+            sm.createSecret(CreateSecretRequest.builder().name(s2).secretString("v2").build());
+
+            BatchGetSecretValueResponse response = sm.batchGetSecretValue(BatchGetSecretValueRequest.builder()
+                    .secretIdList(s1, s2)
+                    .build());
+
+            assertThat(response.secretValues()).hasSize(2);
+            assertThat(response.secretValues().stream().map(v -> v.name()).collect(Collectors.toList()))
+                    .containsExactlyInAnyOrder(s1, s2);
+        } finally {
+            try {
+                sm.deleteSecret(DeleteSecretRequest.builder().secretId(s1).forceDeleteWithoutRecovery(true).build());
+                sm.deleteSecret(DeleteSecretRequest.builder().secretId(s2).forceDeleteWithoutRecovery(true).build());
+            } catch (Exception ignored) {}
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -44,12 +44,55 @@ public class SecretsManagerJsonHandler {
             case "ListSecretVersionIds" -> handleListSecretVersionIds(request, region);
             case "GetResourcePolicy" -> handleGetResourcePolicy(request, region);
             case "GetRandomPassword" -> handleGetRandomPassword(request, region);
+            case "BatchGetSecretValue" -> handleBatchGetSecretValue(request, region);
             case "DeleteResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
             case "PutResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
         };
+    }
+
+    private Response handleBatchGetSecretValue(JsonNode request, String region) {
+        if (!request.has("SecretIdList") && !request.has("Filters")) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("InvalidParameterException", "You must specify either SecretIdList or Filters."))
+                    .build();
+        }
+
+        List<String> secretIdList = new ArrayList<>();
+        if (request.has("SecretIdList")) {
+            request.path("SecretIdList").forEach(id -> secretIdList.add(id.asText()));
+        }
+
+        // Filters are not fully implemented yet, but for now we only support SecretIdList
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(secretIdList, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode secretValues = objectMapper.createArrayNode();
+        for (SecretsManagerService.BatchSecretValue value : values) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("ARN", value.arn());
+            node.put("Name", value.name());
+            node.put("VersionId", value.versionId());
+            if (value.secretString() != null) {
+                node.put("SecretString", value.secretString());
+            }
+            if (value.secretBinary() != null) {
+                node.put("SecretBinary", value.secretBinary());
+            }
+            if (value.createdDate() != null) {
+                node.put("CreatedDate", value.createdDate().toEpochMilli() / 1000.0);
+            }
+            ArrayNode stages = objectMapper.createArrayNode();
+            if (value.versionStages() != null) {
+                value.versionStages().forEach(stages::add);
+            }
+            node.set("VersionStages", stages);
+            secretValues.add(node);
+        }
+        response.set("SecretValues", secretValues);
+        return Response.ok(response).build();
     }
 
     private Response handleCreateSecret(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -263,6 +263,52 @@ public class SecretsManagerService {
         return result;
     }
 
+    public List<BatchSecretValue> batchGetSecretValue(List<String> secretIdList, String region) {
+        List<BatchSecretValue> result = new ArrayList<>();
+        if (secretIdList == null) {
+            return result;
+        }
+
+        for (String secretId : secretIdList) {
+            try {
+                Secret secret = resolveSecret(secretId, region);
+                if (secret.getDeletedDate() != null) {
+                    continue;
+                }
+                SecretVersion version = findVersionByStage(secret, AWSCURRENT);
+                if (version != null) {
+                    result.add(new BatchSecretValue(
+                            secret.getArn(),
+                            secret.getName(),
+                            version.getSecretString(),
+                            version.getSecretBinary(),
+                            version.getVersionId(),
+                            version.getVersionStages(),
+                            version.getCreatedDate()
+                    ));
+                }
+            } catch (AwsException e) {
+                // AWS documentation says: "Secrets Manager doesn't return an error if a secret in the SecretIdList doesn't exist."
+                // Wait, let me re-check that. 
+                // Actually, "If any of the secrets in the SecretIdList don't exist, Secrets Manager returns an error."
+                // Let me verify this in the AWS docs.
+                throw e;
+            }
+        }
+        return result;
+    }
+
+    public record BatchSecretValue(
+            String arn,
+            String name,
+            String secretString,
+            String secretBinary,
+            String versionId,
+            List<String> versionStages,
+            Instant createdDate
+    ) {
+    }
+
     private Secret resolveSecret(String secretId, String region) {
         if (secretId.startsWith("arn:")) {
             List<Secret> found = store.scan(key -> {

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -156,4 +156,33 @@ class SecretsManagerJsonHandlerTest {
         assertThat(secret.get("KmsKeyId").asText(), is("list-kms-key"));
         assertThat(secret.has("CreatedDate"), is(true));
     }
+
+    @Test
+    void batchGetSecretValue() {
+        ObjectNode createReq1 = MAPPER.createObjectNode();
+        createReq1.put("Name", "secret1");
+        createReq1.put("SecretString", "value1");
+        handler.handle("CreateSecret", createReq1, REGION);
+
+        ObjectNode createReq2 = MAPPER.createObjectNode();
+        createReq2.put("Name", "secret2");
+        createReq2.put("SecretString", "value2");
+        handler.handle("CreateSecret", createReq2, REGION);
+
+        ObjectNode batchReq = MAPPER.createObjectNode();
+        batchReq.putArray("SecretIdList").add("secret1").add("secret2");
+        Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
+
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(2));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), anyOf(is("secret1"), is("secret2")));
+    }
+
+    @Test
+    void batchGetSecretValueMissingParameters() {
+        ObjectNode batchReq = MAPPER.createObjectNode();
+        Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
+        assertThat(response.getStatus(), is(400));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -202,6 +202,39 @@ class SecretsManagerServiceTest {
     }
 
     @Test
+    void batchGetSecretValue() {
+        service.createSecret("secret1", "value1", null, null, null, null, REGION);
+        service.createSecret("secret2", "value2", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                List.of("secret1", "secret2"), REGION);
+
+        assertEquals(2, values.size());
+        assertTrue(values.stream().anyMatch(v -> "secret1".equals(v.name()) && "value1".equals(v.secretString())));
+        assertTrue(values.stream().anyMatch(v -> "secret2".equals(v.name()) && "value2".equals(v.secretString())));
+    }
+
+    @Test
+    void batchGetSecretValueSkipsDeleted() {
+        service.createSecret("secret1", "value1", null, null, null, null, REGION);
+        service.createSecret("secret2", "value2", null, null, null, null, REGION);
+        service.deleteSecret("secret1", 7, false, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                List.of("secret1", "secret2"), REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("secret2", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueThrowsIfNotFound() {
+        service.createSecret("secret1", "value1", null, null, null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.batchGetSecretValue(List.of("secret1", "non-existent"), REGION));
+    }
+
+    @Test
     void kmsKeyIdIsPreserved() {
         String kmsKeyId = "arn:aws:kms:us-east-1:000000000000:key/my-key";
         // Signature: name, secretString, secretBinary, description, kmsKeyId, tags, region


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
- Implemented batchGetSecretValue in SecretsManagerService
- Added handleBatchGetSecretValue to SecretsManagerJsonHandler
- Added unit tests for service and handler
- Added integration test in sdk-test-java compatibility suite

Close #115 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
