### PR TITLE
feat(sfn): nested state machine execution and activity support (#254,…

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsActivityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsActivityTest.java
@@ -1,0 +1,232 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for SFN Activity APIs and waitForTaskToken mechanics.
+ *
+ * Part A — Activity CRUD:
+ *   CreateActivity, DescribeActivity, ListActivities, DeleteActivity
+ *
+ * Part B — Activity task roundtrip:
+ *   GetActivityTask (long-poll) unblocks once the SM enters the activity task state,
+ *   SendTaskSuccess resumes the execution.
+ *
+ * Part C — waitForTaskToken:
+ *   $$.Task.Token is resolved in Parameters before the activity is invoked,
+ *   SendTaskSuccess with that token unblocks the execution.
+ *
+ * Covers Issue #91.
+ */
+@DisplayName("SFN Activities and waitForTaskToken")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StepFunctionsActivityTest {
+
+    private static final String ROLE_ARN = System.getenv("SFN_ROLE_ARN") != null
+            ? System.getenv("SFN_ROLE_ARN")
+            : "arn:aws:iam::000000000000:role/service-role/test-role";
+
+    private static SfnClient sfn;
+    private static String activityArn;
+    private static String activityName;
+
+    @BeforeAll
+    static void setup() {
+        sfn = TestFixtures.sfnClient();
+        activityName = TestFixtures.uniqueName("activity");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sfn != null) {
+            if (activityArn != null) {
+                try { sfn.deleteActivity(b -> b.activityArn(activityArn)); } catch (Exception ignored) {}
+            }
+            sfn.close();
+        }
+    }
+
+    // ──────────────────────────── Part A: Activity CRUD ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createActivity_returnsArnAndCreationDate() {
+        CreateActivityResponse resp = sfn.createActivity(b -> b.name(activityName));
+        activityArn = resp.activityArn();
+
+        assertThat(activityArn).isNotNull().contains(activityName);
+        assertThat(resp.creationDate()).isNotNull();
+    }
+
+    @Test
+    @Order(2)
+    void describeActivity_returnsCorrectFields() {
+        DescribeActivityResponse resp = sfn.describeActivity(b -> b.activityArn(activityArn));
+
+        assertThat(resp.activityArn()).isEqualTo(activityArn);
+        assertThat(resp.name()).isEqualTo(activityName);
+        assertThat(resp.creationDate()).isNotNull();
+    }
+
+    @Test
+    @Order(3)
+    void listActivities_containsCreatedActivity() {
+        ListActivitiesResponse resp = sfn.listActivities();
+
+        assertThat(resp.activities())
+                .anyMatch(a -> activityArn.equals(a.activityArn()) && activityName.equals(a.name()));
+    }
+
+    @Test
+    @Order(4)
+    void deleteActivity_removesItFromList() {
+        sfn.deleteActivity(b -> b.activityArn(activityArn));
+        activityArn = null; // prevent @AfterAll from double-deleting
+
+        ListActivitiesResponse resp = sfn.listActivities();
+        assertThat(resp.activities())
+                .noneMatch(a -> activityName.equals(a.name()));
+    }
+
+    // ──────────────────────────── Part B: Activity task roundtrip ────────────────────────────
+
+    /**
+     * Full roundtrip:
+     * 1. Create a fresh activity and a SM with that activity as its task resource.
+     * 2. Start execution (async).
+     * 3. A background worker calls GetActivityTask (long-poll), then SendTaskSuccess.
+     * 4. Verify execution completes SUCCEEDED with the expected output.
+     */
+    @Test
+    @Order(5)
+    void activityTaskRoundtrip_executionSucceedsWithWorkerOutput() throws Exception {
+        String name = TestFixtures.uniqueName("roundtrip");
+        String arn = sfn.createActivity(b -> b.name(name)).activityArn();
+
+        String smDef = """
+                {
+                  "StartAt": "DoWork",
+                  "States": {
+                    "DoWork": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(arn);
+
+        String smArn = sfn.createStateMachine(b -> b
+                .name(TestFixtures.uniqueName("roundtrip-sm"))
+                .definition(smDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            String execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(smArn)
+                    .input("{\"job\":\"process\"}")).executionArn();
+
+            // Background worker: poll for task, then report success
+            CompletableFuture<Void> worker = CompletableFuture.runAsync(() -> {
+                GetActivityTaskResponse task = sfn.getActivityTask(b -> b.activityArn(arn));
+                assertThat(task.taskToken()).isNotEmpty();
+                sfn.sendTaskSuccess(b -> b
+                        .taskToken(task.taskToken())
+                        .output("{\"result\":\"done\"}"));
+            });
+
+            worker.get(90, TimeUnit.SECONDS);
+
+            DescribeExecutionResponse result = pollUntilDone(execArn);
+            assertThat(result.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+            assertThat(result.output()).contains("\"result\":\"done\"");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(smArn)); } catch (Exception ignored) {}
+            try { sfn.deleteActivity(b -> b.activityArn(arn)); } catch (Exception ignored) {}
+        }
+    }
+
+    // ──────────────────────────── Part C: waitForTaskToken ────────────────────────────
+
+    /**
+     * waitForTaskToken with an activity resource:
+     * - $$.Task.Token is injected into Parameters before the activity task is enqueued.
+     * - The worker receives the token via GetActivityTask input, then calls SendTaskSuccess.
+     * - Execution output equals the SendTaskSuccess output.
+     */
+    @Test
+    @Order(6)
+    void waitForTaskToken_contextTokenInjectedAndExecutionResumes() throws Exception {
+        String name = TestFixtures.uniqueName("wftt");
+        String arn = sfn.createActivity(b -> b.name(name)).activityArn();
+
+        String smDef = """
+                {
+                  "StartAt": "PauseAndWait",
+                  "States": {
+                    "PauseAndWait": {
+                      "Type": "Task",
+                      "Resource": "%s.waitForTaskToken",
+                      "Parameters": {
+                        "token.$": "$$.Task.Token",
+                        "payload.$": "$.data"
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(arn);
+
+        String smArn = sfn.createStateMachine(b -> b
+                .name(TestFixtures.uniqueName("wftt-sm"))
+                .definition(smDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            String execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(smArn)
+                    .input("{\"data\":\"hello\"}")).executionArn();
+
+            CompletableFuture<Void> worker = CompletableFuture.runAsync(() -> {
+                // GetActivityTask receives { "token": "<uuid>", "payload": "hello" }
+                GetActivityTaskResponse task = sfn.getActivityTask(b -> b.activityArn(arn));
+                assertThat(task.taskToken()).isNotEmpty();
+                // The activity input must contain the injected token and payload fields
+                assertThat(task.input()).contains("\"token\"").contains("\"payload\"");
+
+                sfn.sendTaskSuccess(b -> b
+                        .taskToken(task.taskToken())
+                        .output("{\"processed\":true}"));
+            });
+
+            worker.get(90, TimeUnit.SECONDS);
+
+            DescribeExecutionResponse result = pollUntilDone(execArn);
+            assertThat(result.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+            assertThat(result.output()).contains("\"processed\":true");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(smArn)); } catch (Exception ignored) {}
+            try { sfn.deleteActivity(b -> b.activityArn(arn)); } catch (Exception ignored) {}
+        }
+    }
+
+    // ──────────────────────────── helper ────────────────────────────
+
+    private DescribeExecutionResponse pollUntilDone(String execArn) throws InterruptedException {
+        for (int i = 0; i < 120; i++) {
+            DescribeExecutionResponse resp = sfn.describeExecution(b -> b.executionArn(execArn));
+            if (resp.status() != ExecutionStatus.RUNNING) {
+                return resp;
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError("Execution did not complete within 60s: " + execArn);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsNestedSmTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsNestedSmTest.java
@@ -1,0 +1,208 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for nested state machine execution via optimised integrations:
+ *   arn:aws:states:::states:startExecution          (fire-and-forget)
+ *   arn:aws:states:::states:startExecution.sync     (wait, return full execution envelope)
+ *   arn:aws:states:::states:startExecution.sync:2   (wait, return only child output)
+ *
+ * Covers Issue #254.
+ */
+@DisplayName("SFN Nested State Machine Execution")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StepFunctionsNestedSmTest {
+
+    private static final String ROLE_ARN = System.getenv("SFN_ROLE_ARN") != null
+            ? System.getenv("SFN_ROLE_ARN")
+            : "arn:aws:iam::000000000000:role/service-role/test-role";
+
+    private static SfnClient sfn;
+    private static String childSmArn;
+    private static String suffix;
+
+    @BeforeAll
+    static void setup() {
+        sfn = TestFixtures.sfnClient();
+        suffix = TestFixtures.uniqueName("nested");
+
+        // Child SM: Pass state returning a fixed result
+        String childDef = """
+                {
+                  "StartAt": "AddResult",
+                  "States": {
+                    "AddResult": {
+                      "Type": "Pass",
+                      "Result": {"computed": true, "value": 42},
+                      "End": true
+                    }
+                  }
+                }
+                """;
+        childSmArn = sfn.createStateMachine(b -> b
+                .name("child-sm-" + suffix)
+                .definition(childDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sfn != null) {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(childSmArn)); } catch (Exception ignored) {}
+            sfn.close();
+        }
+    }
+
+    // ──────────────────────────── .sync:2 ────────────────────────────
+
+    @Test
+    @Order(1)
+    void sync2_parentReceivesChildOutputDirectly() throws InterruptedException {
+        String parentDef = """
+                {
+                  "StartAt": "InvokeChild",
+                  "States": {
+                    "InvokeChild": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+                      "Parameters": {
+                        "StateMachineArn": "%s",
+                        "Input": {"trigger": "sync2"}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(childSmArn);
+
+        String parentSmArn = sfn.createStateMachine(b -> b
+                .name("parent-sync2-" + suffix)
+                .definition(parentDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            String execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(parentSmArn)
+                    .input("{}")).executionArn();
+
+            DescribeExecutionResponse result = pollUntilDone(execArn);
+
+            assertThat(result.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+            // Output must be the child's parsed output object, not an envelope
+            assertThat(result.output())
+                    .contains("\"computed\":true")
+                    .contains("\"value\":42")
+                    .doesNotContain("executionArn");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(parentSmArn)); } catch (Exception ignored) {}
+        }
+    }
+
+    // ──────────────────────────── .sync ────────────────────────────
+
+    @Test
+    @Order(2)
+    void sync_parentReceivesFullExecutionEnvelope() throws InterruptedException {
+        String parentDef = """
+                {
+                  "StartAt": "InvokeChild",
+                  "States": {
+                    "InvokeChild": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::states:startExecution.sync",
+                      "Parameters": {
+                        "StateMachineArn": "%s",
+                        "Input": {"trigger": "sync"}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(childSmArn);
+
+        String parentSmArn = sfn.createStateMachine(b -> b
+                .name("parent-sync-" + suffix)
+                .definition(parentDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            String execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(parentSmArn)
+                    .input("{}")).executionArn();
+
+            DescribeExecutionResponse result = pollUntilDone(execArn);
+
+            assertThat(result.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+            // Output must be the full envelope: executionArn, status, output (as a string), etc.
+            assertThat(result.output())
+                    .contains("executionArn")
+                    .contains("\"SUCCEEDED\"")
+                    .contains("\"output\"");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(parentSmArn)); } catch (Exception ignored) {}
+        }
+    }
+
+    // ──────────────────────────── fire-and-forget ────────────────────────────
+
+    @Test
+    @Order(3)
+    void fireAndForget_parentReceivesExecutionArnAndStartDate() throws InterruptedException {
+        String parentDef = """
+                {
+                  "StartAt": "InvokeChild",
+                  "States": {
+                    "InvokeChild": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::states:startExecution",
+                      "Parameters": {
+                        "StateMachineArn": "%s",
+                        "Input": {"trigger": "fnf"}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(childSmArn);
+
+        String parentSmArn = sfn.createStateMachine(b -> b
+                .name("parent-fnf-" + suffix)
+                .definition(parentDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            String execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(parentSmArn)
+                    .input("{}")).executionArn();
+
+            DescribeExecutionResponse result = pollUntilDone(execArn);
+
+            assertThat(result.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+            // Output must be { executionArn, startDate } — no child output
+            assertThat(result.output())
+                    .contains("executionArn")
+                    .contains("startDate")
+                    .doesNotContain("\"SUCCEEDED\"");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(parentSmArn)); } catch (Exception ignored) {}
+        }
+    }
+
+    // ──────────────────────────── helper ────────────────────────────
+
+    private DescribeExecutionResponse pollUntilDone(String execArn) throws InterruptedException {
+        for (int i = 0; i < 60; i++) {
+            DescribeExecutionResponse resp = sfn.describeExecution(b -> b.executionArn(execArn));
+            if (resp.status() != ExecutionStatus.RUNNING) {
+                return resp;
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError("Execution did not complete within 30s: " + execArn);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
@@ -25,6 +26,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -46,6 +50,7 @@ public class AslExecutor {
     private final DynamoDbJsonHandler dynamoDbJsonHandler;
     private final ObjectMapper objectMapper;
     private final JsonataEvaluator jsonataEvaluator;
+    private final Instance<StepFunctionsService> sfnService;
     private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "sfn-executor");
         t.setDaemon(true);
@@ -55,13 +60,15 @@ public class AslExecutor {
     @Inject
     public AslExecutor(LambdaExecutorService lambdaExecutor, LambdaFunctionStore functionStore,
                        DynamoDbService dynamoDbService, DynamoDbJsonHandler dynamoDbJsonHandler,
-                       ObjectMapper objectMapper, JsonataEvaluator jsonataEvaluator) {
+                       ObjectMapper objectMapper, JsonataEvaluator jsonataEvaluator,
+                       Instance<StepFunctionsService> sfnService) {
         this.lambdaExecutor = lambdaExecutor;
         this.functionStore = functionStore;
         this.dynamoDbService = dynamoDbService;
         this.dynamoDbJsonHandler = dynamoDbJsonHandler;
         this.objectMapper = objectMapper;
         this.jsonataEvaluator = jsonataEvaluator;
+        this.sfnService = sfnService;
     }
 
     /**
@@ -207,36 +214,74 @@ public class AslExecutor {
     private StateResult executeTaskState(String stateName, JsonNode stateDef, JsonNode input,
                                          List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
                                          boolean jsonata, JsonNode context) throws Exception {
+        String resource = stateDef.path("Resource").asText();
+        boolean isWaitForToken = resource.endsWith(".waitForTaskToken");
+        String effectiveResource = isWaitForToken
+                ? resource.substring(0, resource.length() - ".waitForTaskToken".length())
+                : resource;
+        boolean isActivity = isActivityArn(effectiveResource);
+        boolean needsToken = isWaitForToken || isActivity;
+
+        String taskToken = null;
+        CompletableFuture<JsonNode> tokenFuture = null;
+        if (needsToken) {
+            taskToken = UUID.randomUUID().toString();
+            ((ObjectNode) context.get("Task")).put("Token", taskToken);
+            tokenFuture = sfnService.get().registerPendingToken(taskToken);
+        }
+
+        JsonNode taskResult;
         if (jsonata) {
             JsonNode effectiveInput = input;
             if (stateDef.has("Arguments")) {
                 JsonNode statesVar = buildStatesVar(input, null, context);
                 effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar);
             }
+            taskResult = invokeResource(effectiveResource, effectiveInput, sm, taskToken);
+        } else {
+            JsonNode effectiveInput = applyInputPath(stateDef, input);
+            if (stateDef.has("Parameters")) {
+                effectiveInput = resolveParameters(stateDef.get("Parameters"), effectiveInput, context);
+            }
+            taskResult = invokeResource(effectiveResource, effectiveInput, sm, taskToken);
+        }
 
-            String resource = stateDef.path("Resource").asText();
-            JsonNode taskResult = invokeResource(resource, effectiveInput, stateDef, sm);
+        if (tokenFuture != null) {
+            taskResult = awaitToken(tokenFuture, stateDef);
+        }
+
+        if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context);
-
+            return new StateResult(output, stateDef.path("Next").asText(null));
+        } else {
+            JsonNode output = mergeResult(stateDef, input, taskResult);
+            output = applyOutputPath(stateDef, input, output);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
-
-        JsonNode effectiveInput = applyInputPath(stateDef, input);
-        if (stateDef.has("Parameters")) {
-            effectiveInput = resolveParameters(stateDef.get("Parameters"), effectiveInput);
-        }
-
-        String resource = stateDef.path("Resource").asText();
-        JsonNode taskResult = invokeResource(resource, effectiveInput, stateDef, sm);
-
-        JsonNode output = mergeResult(stateDef, input, taskResult);
-        output = applyOutputPath(stateDef, input, output);
-
-        String next = stateDef.path("Next").asText(null);
-        return new StateResult(output, next);
     }
 
-    private JsonNode invokeResource(String resource, JsonNode input, JsonNode stateDef, StateMachine sm) throws Exception {
+    private JsonNode awaitToken(CompletableFuture<JsonNode> future, JsonNode stateDef) throws Exception {
+        int timeout = stateDef.path("HeartbeatSeconds").asInt(0);
+        if (timeout <= 0) {
+            timeout = 300;
+        }
+        try {
+            return future.get(timeout, TimeUnit.SECONDS);
+        } catch (java.util.concurrent.TimeoutException e) {
+            future.cancel(true);
+            throw new FailStateException("States.HeartbeatTimeout",
+                    "Task timed out after " + timeout + " seconds");
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof FailStateException fse) {
+                throw fse;
+            }
+            throw new FailStateException("States.TaskFailed",
+                    cause != null ? cause.getMessage() : "Task failed");
+        }
+    }
+
+    private JsonNode invokeResource(String resource, JsonNode input, StateMachine sm, String taskToken) throws Exception {
         // Support Lambda resources: direct ARN or optimized integration
         String functionName = null;
         JsonNode lambdaPayload = input;
@@ -244,22 +289,15 @@ public class AslExecutor {
         if (resource.contains(":lambda:") && resource.contains(":function:")) {
             // Direct Lambda ARN: arn:aws:lambda:region:account:function:name
             functionName = resource.substring(resource.lastIndexOf(':') + 1);
-        } else if (resource.equals("arn:aws:states:::lambda:invoke") ||
-                   resource.equals("arn:aws:states:::lambda:invoke.waitForTaskToken")) {
-            // Optimized Lambda integration — function name comes from Parameters
-            if (stateDef.has("Parameters")) {
-                JsonNode params = stateDef.get("Parameters");
-                String fnRef = params.path("FunctionName").asText(null);
-                if (fnRef == null) fnRef = params.path("FunctionName.$").asText(null);
-                if (fnRef != null) {
-                    functionName = fnRef.contains(":") ? fnRef.substring(fnRef.lastIndexOf(':') + 1) : fnRef;
-                }
-                // Payload comes from Payload or Payload.$
-                if (params.has("Payload.$")) {
-                    lambdaPayload = resolvePath(params.path("Payload.$").asText(), input);
-                } else if (params.has("Payload")) {
-                    lambdaPayload = params.get("Payload");
-                }
+        } else if (resource.equals("arn:aws:states:::lambda:invoke")) {
+            // Optimized Lambda integration — function name and payload come from resolved input
+            String fnRef = input.path("FunctionName").asText(null);
+            if (fnRef != null) {
+                functionName = fnRef.contains(":") ? fnRef.substring(fnRef.lastIndexOf(':') + 1) : fnRef;
+            }
+            JsonNode payload = input.path("Payload");
+            if (!payload.isMissingNode()) {
+                lambdaPayload = payload;
             }
         }
 
@@ -303,8 +341,100 @@ public class AslExecutor {
             return invokeAwsSdkDynamoDb(camelCaseAction, input, region);
         }
 
+        // Nested state machine integration
+        if (resource.startsWith("arn:aws:states:::states:startExecution")) {
+            String mode = resource.substring("arn:aws:states:::states:startExecution".length());
+            String region = extractRegionFromArn(sm.getStateMachineArn());
+            return invokeNestedStateMachine(mode, input, region);
+        }
+
+        // Activity resource: arn:aws:states:{region}:{account}:activity:{name}
+        if (isActivityArn(resource)) {
+            if (taskToken == null) {
+                throw new FailStateException("States.TaskFailed",
+                        "Activity resource requires waitForTaskToken: " + resource);
+            }
+            String inputStr = objectMapper.writeValueAsString(input);
+            sfnService.get().enqueueActivityTask(resource, taskToken, inputStr);
+            return NullNode.getInstance(); // caller blocks via token future
+        }
+
         throw new FailStateException("States.TaskFailed",
                 "Unsupported resource: " + resource);
+    }
+
+    private JsonNode invokeNestedStateMachine(String mode, JsonNode input, String region) throws Exception {
+        String smArn = input.path("StateMachineArn").asText(null);
+        if (smArn == null || smArn.isBlank()) {
+            throw new FailStateException("States.TaskFailed",
+                    "StateMachineArn is required for nested state machine execution");
+        }
+        JsonNode inputNode = input.path("Input");
+        String childInput = inputNode.isMissingNode() ? "{}" : objectMapper.writeValueAsString(inputNode);
+
+        io.github.hectorvent.floci.services.stepfunctions.model.Execution exec =
+                sfnService.get().startExecution(smArn, null, childInput, region);
+        String execArn = exec.getExecutionArn();
+
+        if ("".equals(mode)) {
+            // Fire-and-forget: return { executionArn, startDate }
+            ObjectNode result = objectMapper.createObjectNode();
+            result.put("executionArn", execArn);
+            result.put("startDate", exec.getStartDate());
+            return result;
+        }
+
+        // .sync or .sync:2 — poll until terminal
+        for (int i = 0; i < 600; i++) {
+            Thread.sleep(100);
+            io.github.hectorvent.floci.services.stepfunctions.model.Execution current =
+                    sfnService.get().describeExecution(execArn);
+            String status = current.getStatus();
+            if ("RUNNING".equals(status)) {
+                continue;
+            }
+            if ("SUCCEEDED".equals(status)) {
+                if (".sync:2".equals(mode)) {
+                    String out = current.getOutput();
+                    return objectMapper.readTree(out != null ? out : "null");
+                }
+                // .sync — full execution envelope; output field is a JSON string
+                ObjectNode envelope = objectMapper.createObjectNode();
+                envelope.put("executionArn", current.getExecutionArn());
+                envelope.put("stateMachineArn", current.getStateMachineArn());
+                envelope.put("name", current.getName());
+                envelope.put("status", current.getStatus());
+                envelope.put("startDate", current.getStartDate());
+                if (current.getStopDate() != null) {
+                    envelope.put("stopDate", current.getStopDate());
+                }
+                if (current.getInput() != null) {
+                    envelope.put("input", current.getInput());
+                }
+                if (current.getOutput() != null) {
+                    envelope.put("output", current.getOutput());
+                }
+                return envelope;
+            }
+            throw new FailStateException(
+                    current.getError() != null ? current.getError() : "States.TaskFailed",
+                    current.getCause() != null ? current.getCause()
+                            : "Nested execution ended with status: " + status);
+        }
+        throw new FailStateException("States.TaskFailed",
+                "Nested execution timed out: " + execArn);
+    }
+
+    private boolean isActivityArn(String resource) {
+        // arn:aws:states:{region}:{account}:activity:{name}
+        // Distinguish from integration ARNs like arn:aws:states:::lambda:invoke (empty region/account)
+        String[] parts = resource.split(":");
+        return parts.length >= 7
+                && "arn".equals(parts[0])
+                && "states".equals(parts[2])
+                && "activity".equals(parts[5])
+                && !parts[3].isEmpty()
+                && !parts[4].isEmpty();
     }
 
     private JsonNode invokeDynamoDb(String operation, JsonNode input, String region) {
@@ -729,6 +859,10 @@ public class AslExecutor {
         stateMachine.put("Id", sm.getStateMachineArn());
         stateMachine.put("Name", sm.getName());
         context.set("StateMachine", stateMachine);
+        // Task node — Token is populated by executeTaskState when waitForTaskToken is active
+        ObjectNode task = objectMapper.createObjectNode();
+        task.putNull("Token");
+        context.set("Task", task);
         return context;
     }
 
@@ -797,7 +931,7 @@ public class AslExecutor {
         return resolvePath(path, output);
     }
 
-    private JsonNode resolveParameters(JsonNode parameters, JsonNode input) throws Exception {
+    private JsonNode resolveParameters(JsonNode parameters, JsonNode input, JsonNode context) throws Exception {
         if (parameters.isObject()) {
             ObjectNode resolved = objectMapper.createObjectNode();
             Iterator<Map.Entry<String, JsonNode>> fields = parameters.fields();
@@ -807,7 +941,17 @@ public class AslExecutor {
                 JsonNode val = entry.getValue();
                 if (key.endsWith(".$")) {
                     String realKey = key.substring(0, key.length() - 2);
-                    resolved.set(realKey, resolvePath(val.asText(), input));
+                    String path = val.asText();
+                    if (path.startsWith("$$.")) {
+                        // Context reference: $$. → resolve against context as $.
+                        resolved.set(realKey, resolvePath("$." + path.substring(3), context));
+                    } else if ("$$".equals(path)) {
+                        resolved.set(realKey, context);
+                    } else {
+                        resolved.set(realKey, resolvePath(path, input));
+                    }
+                } else if (val.isObject()) {
+                    resolved.set(key, resolveParameters(val, input, context));
                 } else {
                     resolved.set(key, val);
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.stepfunctions.model.Activity;
+import io.github.hectorvent.floci.services.stepfunctions.model.ActivityTask;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
 import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
@@ -41,6 +43,11 @@ public class StepFunctionsJsonHandler {
             case "SendTaskSuccess" -> handleSendTaskSuccess(request);
             case "SendTaskFailure" -> handleSendTaskFailure(request);
             case "SendTaskHeartbeat" -> handleSendTaskHeartbeat(request);
+            case "CreateActivity" -> handleCreateActivity(request, region);
+            case "DeleteActivity" -> handleDeleteActivity(request);
+            case "DescribeActivity" -> handleDescribeActivity(request);
+            case "ListActivities" -> handleListActivities(request, region);
+            case "GetActivityTask" -> handleGetActivityTask(request);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -204,6 +211,53 @@ public class StepFunctionsJsonHandler {
     private Response handleSendTaskHeartbeat(JsonNode request) {
         service.sendTaskHeartbeat(request.path("taskToken").asText());
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleCreateActivity(JsonNode request, String region) {
+        Activity activity = service.createActivity(request.path("name").asText(), region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("activityArn", activity.getActivityArn());
+        response.put("creationDate", activity.getCreationDate());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteActivity(JsonNode request) {
+        service.deleteActivity(request.path("activityArn").asText());
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleDescribeActivity(JsonNode request) {
+        Activity activity = service.describeActivity(request.path("activityArn").asText());
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("activityArn", activity.getActivityArn());
+        response.put("name", activity.getName());
+        response.put("creationDate", activity.getCreationDate());
+        return Response.ok(response).build();
+    }
+
+    private Response handleListActivities(JsonNode request, String region) {
+        List<Activity> list = service.listActivities(region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode array = response.putArray("activities");
+        for (Activity a : list) {
+            ObjectNode item = array.addObject();
+            item.put("activityArn", a.getActivityArn());
+            item.put("name", a.getName());
+            item.put("creationDate", a.getCreationDate());
+        }
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetActivityTask(JsonNode request) {
+        String activityArn = request.path("activityArn").asText();
+        String workerName = request.path("workerName").asText(null);
+        ActivityTask task = service.getActivityTask(activityArn, workerName);
+        ObjectNode response = objectMapper.createObjectNode();
+        if (task != null) {
+            response.put("taskToken", task.getTaskToken());
+            response.put("input", task.getInput());
+        }
+        return Response.ok(response).build();
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -7,6 +7,8 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.stepfunctions.model.Activity;
+import io.github.hectorvent.floci.services.stepfunctions.model.ActivityTask;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
 import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
@@ -18,7 +20,11 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class StepFunctionsService {
@@ -27,7 +33,10 @@ public class StepFunctionsService {
 
     private final StorageBackend<String, StateMachine> stateMachineStore;
     private final StorageBackend<String, Execution> executionStore;
+    private final StorageBackend<String, Activity> activityStore;
     private final Map<String, List<HistoryEvent>> historyCache = new ConcurrentHashMap<>();
+    private final Map<String, BlockingQueue<ActivityTask>> activityQueues = new ConcurrentHashMap<>();
+    private final Map<String, CompletableFuture<JsonNode>> pendingTaskTokens = new ConcurrentHashMap<>();
     private final RegionResolver regionResolver;
     private final AslExecutor aslExecutor;
     private final ObjectMapper objectMapper;
@@ -44,6 +53,8 @@ public class StepFunctionsService {
                 new TypeReference<Map<String, StateMachine>>() {});
         this.executionStore = storageFactory.create("stepfunctions", "sfn-executions.json",
                 new TypeReference<Map<String, Execution>>() {});
+        this.activityStore = storageFactory.create("stepfunctions", "sfn-activities.json",
+                new TypeReference<Map<String, Activity>>() {});
         this.regionResolver = regionResolver;
         this.aslExecutor = aslExecutor;
         this.objectMapper = objectMapper;
@@ -200,14 +211,86 @@ public class StepFunctionsService {
         return historyCache.getOrDefault(arn, Collections.emptyList());
     }
 
+    // ──────────────────────────── Activities ────────────────────────────
+
+    public Activity createActivity(String name, String region) {
+        String arn = regionResolver.buildArn("states", region, "activity:" + name);
+        if (activityStore.get(arn).isPresent()) {
+            throw new AwsException("ActivityAlreadyExists", "Activity already exists: " + arn, 400);
+        }
+        Activity activity = new Activity();
+        activity.setActivityArn(arn);
+        activity.setName(name);
+        activityStore.put(arn, activity);
+        LOG.infov("Created activity: {0}", arn);
+        return activity;
+    }
+
+    public Activity describeActivity(String arn) {
+        return activityStore.get(arn)
+                .orElseThrow(() -> new AwsException("ActivityDoesNotExist", "Activity does not exist: " + arn, 400));
+    }
+
+    public List<Activity> listActivities(String region) {
+        String prefix = "arn:aws:states:" + region + ":";
+        return activityStore.scan(k -> k.startsWith(prefix) && k.contains(":activity:"));
+    }
+
+    public void deleteActivity(String arn) {
+        activityStore.delete(arn);
+        activityQueues.remove(arn);
+    }
+
+    /**
+     * Long-poll: blocks up to 60 seconds waiting for a task to be enqueued for this activity.
+     * Returns null if no task arrives within the timeout.
+     */
+    public ActivityTask getActivityTask(String activityArn, String workerName) {
+        describeActivity(activityArn); // validate exists
+        BlockingQueue<ActivityTask> queue = activityQueues.computeIfAbsent(activityArn,
+                k -> new LinkedBlockingQueue<>());
+        try {
+            return queue.poll(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+    }
+
+    public void enqueueActivityTask(String activityArn, String taskToken, String input) {
+        BlockingQueue<ActivityTask> queue = activityQueues.computeIfAbsent(activityArn,
+                k -> new LinkedBlockingQueue<>());
+        queue.add(new ActivityTask(taskToken, input));
+    }
+
+    public CompletableFuture<JsonNode> registerPendingToken(String token) {
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pendingTaskTokens.put(token, future);
+        return future;
+    }
+
     // ──────────────────────────── Tasks ────────────────────────────
 
     public void sendTaskSuccess(String taskToken, String output) {
-        LOG.infov("Task success received for token {0}", taskToken);
+        CompletableFuture<JsonNode> future = pendingTaskTokens.remove(taskToken);
+        if (future != null) {
+            try {
+                future.complete(objectMapper.readTree(output));
+            } catch (Exception e) {
+                future.completeExceptionally(new RuntimeException("Invalid JSON output: " + e.getMessage()));
+            }
+        } else {
+            LOG.warnv("SendTaskSuccess: no pending task for token {0}", taskToken);
+        }
     }
 
     public void sendTaskFailure(String taskToken, String cause, String error) {
-        LOG.infov("Task failure received for token {0}: {1}", taskToken, error);
+        CompletableFuture<JsonNode> future = pendingTaskTokens.remove(taskToken);
+        if (future != null) {
+            future.completeExceptionally(new AslExecutor.FailStateException(error, cause));
+        } else {
+            LOG.warnv("SendTaskFailure: no pending task for token {0}", taskToken);
+        }
     }
 
     public void sendTaskHeartbeat(String taskToken) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/Activity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/Activity.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.stepfunctions.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Activity {
+    private String activityArn;
+    private String name;
+    private double creationDate;
+
+    public Activity() {
+        this.creationDate = System.currentTimeMillis() / 1000.0;
+    }
+
+    public String getActivityArn() { return activityArn; }
+    public void setActivityArn(String activityArn) { this.activityArn = activityArn; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public double getCreationDate() { return creationDate; }
+    public void setCreationDate(double creationDate) { this.creationDate = creationDate; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/ActivityTask.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/ActivityTask.java
@@ -1,0 +1,17 @@
+package io.github.hectorvent.floci.services.stepfunctions.model;
+
+/**
+ * In-memory only — not persisted. Represents a task queued for an activity worker.
+ */
+public class ActivityTask {
+    private final String taskToken;
+    private final String input;
+
+    public ActivityTask(String taskToken, String input) {
+        this.taskToken = taskToken;
+        this.input = input;
+    }
+
+    public String getTaskToken() { return taskToken; }
+    public String getInput() { return input; }
+}


### PR DESCRIPTION
… #91)

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

  - Implements arn:aws:states:::states:startExecution (fire-and-forget), .sync (full envelope), and .sync:2 (parsed output) nested SM integrations in AslExecutor               
  - Adds full Activity API: CreateActivity, DescribeActivity, ListActivities, DeleteActivity, GetActivityTask (60s long-poll)
  - SendTaskSuccess / SendTaskFailure now unblock paused executions via CompletableFuture                                                                                       
  - waitForTaskToken suffix and bare activity ARNs both trigger token generation, context injection ($$.Task.Token), and blocking wait                                          
  - resolveParameters() handles $$. context references and recurses into nested objects                                                                                         
  - Instance<StepFunctionsService> lazy injection resolves the CDI circular dependency  

Closes #254 #91 

## Type of change

- [x] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
