### PR TITLE
fix: include ProvisionedThroughput in DynamoDB GSI responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -95,7 +95,13 @@ public class DynamoDbJsonHandler {
                                 ks.path("AttributeName").asText(),
                                 ks.path("KeyType").asText())));
                 String projectionType = gsiNode.path("Projection").path("ProjectionType").asText("ALL");
-                gsis.add(new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType));
+                GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType);
+                JsonNode gsiPt = gsiNode.path("ProvisionedThroughput");
+                if (!gsiPt.isMissingNode()) {
+                    gsi.getProvisionedThroughput().setReadCapacityUnits(gsiPt.path("ReadCapacityUnits").asLong(0));
+                    gsi.getProvisionedThroughput().setWriteCapacityUnits(gsiPt.path("WriteCapacityUnits").asLong(0));
+                }
+                gsis.add(gsi);
             }
         }
 
@@ -410,7 +416,13 @@ public class DynamoDbJsonHandler {
                                     ks.path("AttributeName").asText(),
                                     ks.path("KeyType").asText())));
                     String projectionType = createNode.path("Projection").path("ProjectionType").asText("ALL");
-                    gsiCreates.add(new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType));
+                    GlobalSecondaryIndex newGsi = new GlobalSecondaryIndex(indexName, gsiKeySchema, null, projectionType);
+                    JsonNode newGsiPt = createNode.path("ProvisionedThroughput");
+                    if (!newGsiPt.isMissingNode()) {
+                        newGsi.getProvisionedThroughput().setReadCapacityUnits(newGsiPt.path("ReadCapacityUnits").asLong(0));
+                        newGsi.getProvisionedThroughput().setWriteCapacityUnits(newGsiPt.path("WriteCapacityUnits").asLong(0));
+                    }
+                    gsiCreates.add(newGsi);
                 }
                 JsonNode deleteNode = update.path("Delete");
                 if (!deleteNode.isMissingNode()) {
@@ -654,6 +666,14 @@ public class DynamoDbJsonHandler {
                 projection.put("ProjectionType",
                         gsi.getProjectionType() != null ? gsi.getProjectionType() : "ALL");
                 gsiNode.set("Projection", projection);
+
+                ObjectNode gsiPt = objectMapper.createObjectNode();
+                gsiPt.put("ReadCapacityUnits", gsi.getProvisionedThroughput().getReadCapacityUnits());
+                gsiPt.put("WriteCapacityUnits", gsi.getProvisionedThroughput().getWriteCapacityUnits());
+                gsiPt.put("NumberOfDecreasesToday", gsi.getProvisionedThroughput().getNumberOfDecreasesToday());
+                gsiNode.set("ProvisionedThroughput", gsiPt);
+                gsiNode.put("IndexSizeBytes", gsi.getIndexSizeBytes());
+                gsiNode.put("ItemCount", gsi.getItemCount());
 
                 gsiArray.add(gsiNode);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
@@ -13,8 +13,13 @@ public class GlobalSecondaryIndex {
     private List<KeySchemaElement> keySchema;
     private String indexArn;
     private String projectionType;
+    private ProvisionedThroughput provisionedThroughput;
+    private long itemCount;
+    private long indexSizeBytes;
 
-    public GlobalSecondaryIndex() {}
+    public GlobalSecondaryIndex() {
+        this.provisionedThroughput = new ProvisionedThroughput(0, 0);
+    }
 
     public GlobalSecondaryIndex(String indexName, List<KeySchemaElement> keySchema,
                                  String indexArn, String projectionType) {
@@ -22,6 +27,7 @@ public class GlobalSecondaryIndex {
         this.keySchema = keySchema;
         this.indexArn = indexArn;
         this.projectionType = projectionType != null ? projectionType : "ALL";
+        this.provisionedThroughput = new ProvisionedThroughput(0, 0);
     }
 
     public String getIndexName() { return indexName; }
@@ -35,6 +41,15 @@ public class GlobalSecondaryIndex {
 
     public String getProjectionType() { return projectionType; }
     public void setProjectionType(String projectionType) { this.projectionType = projectionType; }
+
+    public ProvisionedThroughput getProvisionedThroughput() { return provisionedThroughput; }
+    public void setProvisionedThroughput(ProvisionedThroughput provisionedThroughput) { this.provisionedThroughput = provisionedThroughput; }
+
+    public long getItemCount() { return itemCount; }
+    public void setItemCount(long itemCount) { this.itemCount = itemCount; }
+
+    public long getIndexSizeBytes() { return indexSizeBytes; }
+    public void setIndexSizeBytes(long indexSizeBytes) { this.indexSizeBytes = indexSizeBytes; }
 
     public String getPartitionKeyName() {
         return keySchema.stream()

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -603,6 +603,12 @@ class DynamoDbIntegrationTest {
             .body("Table.GlobalSecondaryIndexes[0].IndexName", equalTo("TestGsi"))
             .body("Table.GlobalSecondaryIndexes[0].IndexStatus", equalTo("ACTIVE"))
             .body("Table.GlobalSecondaryIndexes[0].IndexArn", containsString("/index/TestGsi"))
+            .body("Table.GlobalSecondaryIndexes[0].ProvisionedThroughput", notNullValue())
+            .body("Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.ReadCapacityUnits", equalTo(0))
+            .body("Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.WriteCapacityUnits", equalTo(0))
+            .body("Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.NumberOfDecreasesToday", equalTo(0))
+            .body("Table.GlobalSecondaryIndexes[0].IndexSizeBytes", equalTo(0))
+            .body("Table.GlobalSecondaryIndexes[0].ItemCount", equalTo(0))
             .body("Table.AttributeDefinitions.size()", equalTo(3));
     }
 


### PR DESCRIPTION
## Summary

Fixes #272

The DescribeTable response was dropping ProvisionedThroughput attributes from Global Secondary Indexes. The JSON handler was creating the GSI objects but not parsing the throughput values from the response. Now it checks for ProvisionedThroughput and sets the read/write capacity units on the index. Applied the same fix to the Create operation path as well.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The actual DynamoDB DescribeTable API includes ProvisionedThroughput for all GSIs (except on-demand billing). The fix makes the handler match that behavior by extracting ReadCapacityUnits and WriteCapacityUnits from the response.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)