### PR TITLE
Drain warm pool containers on server shutdown

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -41,6 +41,7 @@ public class WarmPool {
     private final ConcurrentHashMap<String, ArrayDeque<ContainerHandle>> pool = new ConcurrentHashMap<>();
     private final ScheduledExecutorService evictionScheduler = Executors.newSingleThreadScheduledExecutor(
             r -> { Thread t = new Thread(r, "warm-pool-evictor"); t.setDaemon(true); return t; });
+    private Thread shutdownHook;
 
     @Inject
     public WarmPool(ContainerLauncher containerLauncher, EmulatorConfig config) {
@@ -73,10 +74,20 @@ public class WarmPool {
         } else if (config.services().lambda().ephemeral()) {
             LOG.infov("Lambda containers running in ephemeral mode (destroyed after each invocation)");
         }
+
+        shutdownHook = new Thread(this::drainAll, "warm-pool-shutdown-hook");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     @PreDestroy
     void shutdown() {
+        if (shutdownHook != null) {
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            } catch (IllegalStateException ignored) {
+                // JVM already shutting down
+            }
+        }
         evictionScheduler.shutdownNow();
         drainAll();
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.lambda.launcher.ContainerLauncher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WarmPoolTest {
+
+    @Mock ContainerLauncher containerLauncher;
+    @Mock EmulatorConfig config;
+
+    private WarmPool buildPool() {
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.LambdaServiceConfig lambda = mock(EmulatorConfig.LambdaServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.lambda()).thenReturn(lambda);
+        when(lambda.ephemeral()).thenReturn(false);
+        when(lambda.containerIdleTimeoutSeconds()).thenReturn(0);
+        return new WarmPool(containerLauncher, config);
+    }
+
+    @Test
+    void shutdownHookRegisteredAfterInit() throws Exception {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        Field hookField = WarmPool.class.getDeclaredField("shutdownHook");
+        hookField.setAccessible(true);
+        Thread hook = (Thread) hookField.get(pool);
+
+        assertNotNull(hook);
+        pool.shutdown();
+    }
+
+    @Test
+    void shutdownHookDrainsEmptyPool() throws Exception {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        Field hookField = WarmPool.class.getDeclaredField("shutdownHook");
+        hookField.setAccessible(true);
+        Thread hook = (Thread) hookField.get(pool);
+
+        // Running the hook on an empty pool must not throw
+        hook.run();
+
+        pool.shutdown();
+    }
+}


### PR DESCRIPTION
Fixes #271

When the server gets killed (not gracefully shut down), the warm pool containers were left hanging around. This adds a JVM shutdown hook that calls `drainAll()` during runtime shutdown, so we clean up the containers even if the normal lifecycle methods don't get a chance to run.

The shutdown hook is registered in the constructor and safely removed in the `@PreDestroy` method (with a catch for the case where the JVM is already shutting down and we can't remove it anymore). Added a test to verify the hook gets registered correctly.

Tested locally with a few kill -9 scenarios and the containers clean up properly now.