### PR TITLE
fix(s3): versioning IsTruncated, PublicAccessBlock, ListObjectsV2 pag…

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3FeaturesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3FeaturesTest.java
@@ -1,0 +1,362 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.paginators.ListObjectVersionsIterable;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for S3 features fixed in issues #119, #236, #237.
+ */
+@DisplayName("S3 Features — pagination, versioning, public access block")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3FeaturesTest {
+
+    private static S3Client s3;
+
+    // Dedicated buckets per feature group — avoids ordering conflicts with S3Test
+    private static final String BUCKET_VERSIONS  = "compat-versions-bucket";
+    private static final String BUCKET_PAB       = "compat-pab-bucket";
+    private static final String BUCKET_PAGINATE  = "compat-paginate-bucket";
+
+    @BeforeAll
+    static void setup() {
+        s3 = TestFixtures.s3Client();
+        createBucket(BUCKET_VERSIONS);
+        createBucket(BUCKET_PAB);
+        createBucket(BUCKET_PAGINATE);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (s3 == null) return;
+        deleteBucketContents(BUCKET_VERSIONS);
+        deleteBucketContents(BUCKET_PAB);
+        deleteBucketContents(BUCKET_PAGINATE);
+        quietDeleteBucket(BUCKET_VERSIONS);
+        quietDeleteBucket(BUCKET_PAB);
+        quietDeleteBucket(BUCKET_PAGINATE);
+        s3.close();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #237 — listObjectVersionsPaginator must not NPE (IsTruncated=null)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Iterating listObjectVersionsPaginator on a versioning-disabled bucket used to throw
+     * NullPointerException because IsTruncated was missing from the XML response.
+     */
+    @Test
+    @Order(10)
+    @DisplayName("#237 listObjectVersionsPaginator: non-versioned bucket does not NPE")
+    void listObjectVersionsPaginatorNonVersionedBucketDoesNotNpe() {
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("plain.txt").build(),
+                RequestBody.fromString("content"));
+
+        // Must not throw NullPointerException
+        ListObjectVersionsIterable pages = s3.listObjectVersionsPaginator(
+                ListObjectVersionsRequest.builder().bucket(BUCKET_VERSIONS).build());
+
+        assertThatNoException().isThrownBy(() -> {
+            for (ListObjectVersionsResponse page : pages) {
+                assertThat(page.isTruncated()).isNotNull();
+            }
+        });
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("#237 listObjectVersionsPaginator: versioned bucket returns isTruncated=false")
+    void listObjectVersionsPaginatorVersionedBucketReturnsTruncatedFlag() {
+        // Enable versioning and put two versions of the same key
+        s3.putBucketVersioning(PutBucketVersioningRequest.builder()
+                .bucket(BUCKET_VERSIONS)
+                .versioningConfiguration(VersioningConfiguration.builder()
+                        .status(BucketVersioningStatus.ENABLED)
+                        .build())
+                .build());
+
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("versioned.txt").build(),
+                RequestBody.fromString("v1"));
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("versioned.txt").build(),
+                RequestBody.fromString("v2"));
+
+        List<ObjectVersion> collected = new ArrayList<>();
+        for (ListObjectVersionsResponse page :
+                s3.listObjectVersionsPaginator(ListObjectVersionsRequest.builder()
+                        .bucket(BUCKET_VERSIONS).build())) {
+            assertThat(page.isTruncated()).isNotNull();
+            collected.addAll(page.versions());
+        }
+
+        assertThat(collected).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(collected).anyMatch(v -> "versioned.txt".equals(v.key()));
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("#237 listObjectVersionsPaginator: paginates correctly with maxKeys")
+    void listObjectVersionsPaginatorPaginates() {
+        // Put additional versioned objects to exceed a single page
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("a.txt").build(),
+                RequestBody.fromString("a1"));
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("a.txt").build(),
+                RequestBody.fromString("a2"));
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_VERSIONS).key("b.txt").build(),
+                RequestBody.fromString("b1"));
+
+        List<ObjectVersion> allVersions = new ArrayList<>();
+        ListObjectVersionsIterable pages = s3.listObjectVersionsPaginator(
+                ListObjectVersionsRequest.builder()
+                        .bucket(BUCKET_VERSIONS)
+                        .maxKeys(2)
+                        .build());
+
+        for (ListObjectVersionsResponse page : pages) {
+            assertThat(page.isTruncated()).isNotNull();
+            allVersions.addAll(page.versions());
+        }
+
+        // We put at least 5 versions total — should all be collected across pages
+        assertThat(allVersions.size()).isGreaterThanOrEqualTo(5);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #236 — PutPublicAccessBlock must not return BucketAlreadyOwnedByYou
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(20)
+    @DisplayName("#236 putPublicAccessBlock succeeds on existing bucket")
+    void putPublicAccessBlockSucceeds() {
+        assertThatNoException().isThrownBy(() ->
+                s3.putPublicAccessBlock(PutPublicAccessBlockRequest.builder()
+                        .bucket(BUCKET_PAB)
+                        .publicAccessBlockConfiguration(PublicAccessBlockConfiguration.builder()
+                                .blockPublicAcls(true)
+                                .ignorePublicAcls(true)
+                                .blockPublicPolicy(true)
+                                .restrictPublicBuckets(true)
+                                .build())
+                        .build()));
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("#236 getPublicAccessBlock returns stored configuration")
+    void getPublicAccessBlockReturnsConfig() {
+        GetPublicAccessBlockResponse response = s3.getPublicAccessBlock(
+                GetPublicAccessBlockRequest.builder().bucket(BUCKET_PAB).build());
+
+        PublicAccessBlockConfiguration config = response.publicAccessBlockConfiguration();
+        assertThat(config.blockPublicAcls()).isTrue();
+        assertThat(config.ignorePublicAcls()).isTrue();
+        assertThat(config.blockPublicPolicy()).isTrue();
+        assertThat(config.restrictPublicBuckets()).isTrue();
+    }
+
+    @Test
+    @Order(22)
+    @DisplayName("#236 putPublicAccessBlock can be updated")
+    void putPublicAccessBlockCanBeUpdated() {
+        s3.putPublicAccessBlock(PutPublicAccessBlockRequest.builder()
+                .bucket(BUCKET_PAB)
+                .publicAccessBlockConfiguration(PublicAccessBlockConfiguration.builder()
+                        .blockPublicAcls(false)
+                        .ignorePublicAcls(false)
+                        .blockPublicPolicy(false)
+                        .restrictPublicBuckets(false)
+                        .build())
+                .build());
+
+        GetPublicAccessBlockResponse response = s3.getPublicAccessBlock(
+                GetPublicAccessBlockRequest.builder().bucket(BUCKET_PAB).build());
+
+        assertThat(response.publicAccessBlockConfiguration().blockPublicAcls()).isFalse();
+    }
+
+    @Test
+    @Order(23)
+    @DisplayName("#236 deletePublicAccessBlock removes the configuration")
+    void deletePublicAccessBlockRemovesConfig() {
+        s3.deletePublicAccessBlock(DeletePublicAccessBlockRequest.builder()
+                .bucket(BUCKET_PAB).build());
+
+        assertThatThrownBy(() -> s3.getPublicAccessBlock(
+                GetPublicAccessBlockRequest.builder().bucket(BUCKET_PAB).build()))
+                .isInstanceOf(S3Exception.class)
+                .satisfies(e -> assertThat(((S3Exception) e).statusCode()).isEqualTo(404));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #119 — ListObjectsV2 pagination fields
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @BeforeEach
+    void setupPaginateBucket() {
+        // Ensure objects are present before pagination tests run.
+        // Idempotent — SDK suppresses errors if already exists.
+    }
+
+    @Test
+    @Order(30)
+    @DisplayName("#119 listObjectsV2Paginator collects all objects across pages")
+    void listObjectsV2PaginatorCollectsAllObjects() {
+        // Put 5 objects
+        for (int i = 1; i <= 5; i++) {
+            s3.putObject(PutObjectRequest.builder()
+                            .bucket(BUCKET_PAGINATE).key("file-" + i + ".txt").build(),
+                    RequestBody.fromString("content " + i));
+        }
+
+        List<S3Object> collected = new ArrayList<>();
+        ListObjectsV2Iterable pages = s3.listObjectsV2Paginator(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .maxKeys(2)
+                        .build());
+
+        for (ListObjectsV2Response page : pages) {
+            collected.addAll(page.contents());
+        }
+
+        assertThat(collected).hasSize(5);
+        assertThat(collected.stream().map(S3Object::key).toList())
+                .containsExactlyInAnyOrder(
+                        "file-1.txt", "file-2.txt", "file-3.txt", "file-4.txt", "file-5.txt");
+    }
+
+    @Test
+    @Order(31)
+    @DisplayName("#119 listObjectsV2 with startAfter skips keys up to and including the marker")
+    void listObjectsV2StartAfterSkipsKeys() {
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .startAfter("file-3.txt")
+                        .build());
+
+        List<String> keys = response.contents().stream().map(S3Object::key).toList();
+        assertThat(keys).doesNotContain("file-1.txt", "file-2.txt", "file-3.txt");
+        assertThat(keys).contains("file-4.txt", "file-5.txt");
+    }
+
+    @Test
+    @Order(32)
+    @DisplayName("#119 listObjectsV2 response echoes startAfter when provided")
+    void listObjectsV2ResponseEchoesStartAfter() {
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .startAfter("file-2.txt")
+                        .build());
+
+        assertThat(response.startAfter()).isEqualTo("file-2.txt");
+    }
+
+    @Test
+    @Order(33)
+    @DisplayName("#119 listObjectsV2 first truncated page contains NextContinuationToken")
+    void listObjectsV2TruncatedPageHasNextToken() {
+        ListObjectsV2Response firstPage = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .maxKeys(2)
+                        .build());
+
+        assertThat(firstPage.isTruncated()).isTrue();
+        assertThat(firstPage.nextContinuationToken()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @Order(34)
+    @DisplayName("#119 listObjectsV2 continuation token resumes from correct position")
+    void listObjectsV2ContinuationTokenResumesCorrectly() {
+        // Page 1
+        ListObjectsV2Response page1 = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .maxKeys(3)
+                        .build());
+        assertThat(page1.isTruncated()).isTrue();
+        List<String> page1Keys = page1.contents().stream().map(S3Object::key).toList();
+
+        // Page 2 using token
+        ListObjectsV2Response page2 = s3.listObjectsV2(
+                ListObjectsV2Request.builder()
+                        .bucket(BUCKET_PAGINATE)
+                        .maxKeys(3)
+                        .continuationToken(page1.nextContinuationToken())
+                        .build());
+
+        assertThat(page2.isTruncated()).isFalse();
+        assertThat(page2.continuationToken()).isEqualTo(page1.nextContinuationToken());
+
+        // No key should appear on both pages
+        List<String> page2Keys = page2.contents().stream().map(S3Object::key).toList();
+        assertThat(page2Keys).doesNotContainAnyElementsOf(page1Keys);
+
+        // Together they must cover all 5 objects
+        List<String> allKeys = new ArrayList<>(page1Keys);
+        allKeys.addAll(page2Keys);
+        assertThat(allKeys).containsExactlyInAnyOrder(
+                "file-1.txt", "file-2.txt", "file-3.txt", "file-4.txt", "file-5.txt");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static void createBucket(String bucket) {
+        try {
+            s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        } catch (BucketAlreadyOwnedByYouException ignored) {}
+    }
+
+    private static void deleteBucketContents(String bucket) {
+        try {
+            // Delete all ordinary objects
+            String token = null;
+            do {
+                ListObjectsV2Response resp = s3.listObjectsV2(ListObjectsV2Request.builder()
+                        .bucket(bucket).continuationToken(token).build());
+                for (S3Object obj : resp.contents()) {
+                    s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(obj.key()).build());
+                }
+                token = resp.isTruncated() ? resp.nextContinuationToken() : null;
+            } while (token != null);
+
+            // Delete all versions and delete-markers
+            String keyMarker = null;
+            String versionMarker = null;
+            do {
+                ListObjectVersionsResponse resp = s3.listObjectVersions(
+                        ListObjectVersionsRequest.builder()
+                                .bucket(bucket).keyMarker(keyMarker).versionIdMarker(versionMarker).build());
+                for (ObjectVersion v : resp.versions()) {
+                    s3.deleteObject(DeleteObjectRequest.builder()
+                            .bucket(bucket).key(v.key()).versionId(v.versionId()).build());
+                }
+                for (DeleteMarkerEntry dm : resp.deleteMarkers()) {
+                    s3.deleteObject(DeleteObjectRequest.builder()
+                            .bucket(bucket).key(dm.key()).versionId(dm.versionId()).build());
+                }
+                keyMarker = resp.isTruncated() ? resp.nextKeyMarker() : null;
+                versionMarker = resp.isTruncated() ? resp.nextVersionIdMarker() : null;
+            } while (keyMarker != null);
+        } catch (Exception ignored) {}
+    }
+
+    private static void quietDeleteBucket(String bucket) {
+        try { s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build()); }
+        catch (Exception ignored) {}
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -159,6 +159,10 @@ public class S3Controller {
                 s3Service.putBucketEncryption(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
             }
+            if (hasQueryParam(uriInfo, "publicAccessBlock")) {
+                s3Service.putPublicAccessBlock(bucket, new String(body, StandardCharsets.UTF_8));
+                return Response.ok().build();
+            }
 
             String locationConstraint = null;
             if (body != null && body.length > 0) {
@@ -214,6 +218,10 @@ public class S3Controller {
                 s3Service.deleteBucketEncryption(bucket);
                 return Response.noContent().build();
             }
+            if (hasQueryParam(uriInfo, "publicAccessBlock")) {
+                s3Service.deletePublicAccessBlock(bucket);
+                return Response.noContent().build();
+            }
             s3Service.deleteBucket(bucket);
             return Response.noContent().build();
         } catch (AwsException e) {
@@ -231,6 +239,8 @@ public class S3Controller {
                                 @QueryParam("list-type") String listType,
                                 @QueryParam("continuation-token") String continuationToken,
                                 @QueryParam("start-after") String startAfter,
+                                @QueryParam("encoding-type") String encodingType,
+                                @QueryParam("key-marker") String keyMarker,
                                 @Context UriInfo uriInfo) {
         try {
             if (hasQueryParam(uriInfo, "uploads")) {
@@ -243,7 +253,7 @@ public class S3Controller {
                 return handleGetBucketVersioning(bucket);
             }
             if (hasQueryParam(uriInfo, "versions")) {
-                return handleListObjectVersions(bucket, prefix, maxKeys);
+                return handleListObjectVersions(bucket, prefix, maxKeys, keyMarker);
             }
             if (hasQueryParam(uriInfo, "location")) {
                 return handleGetBucketLocation(bucket);
@@ -269,9 +279,13 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "encryption")) {
                 return Response.ok(s3Service.getBucketEncryption(bucket)).build();
             }
+            if (hasQueryParam(uriInfo, "publicAccessBlock")) {
+                return Response.ok(s3Service.getPublicAccessBlock(bucket)).build();
+            }
 
             int max = (maxKeys != null && maxKeys > 0) ? maxKeys : 1000;
-            S3Service.ListObjectsResult result = s3Service.listObjectsWithPrefixes(bucket, prefix, delimiter, max);
+            S3Service.ListObjectsResult result = s3Service.listObjectsWithPrefixes(
+                    bucket, prefix, delimiter, max, continuationToken, startAfter);
             List<S3Object> objects = result.objects();
             List<String> commonPrefixes = result.commonPrefixes();
             boolean v2 = "2".equals(listType);
@@ -300,6 +314,20 @@ public class S3Controller {
                 xml.start("CommonPrefixes")
                    .elem("Prefix", cp)
                    .end("CommonPrefixes");
+            }
+            if (encodingType != null) {
+                xml.elem("EncodingType", encodingType);
+            }
+            if (v2) {
+                if (continuationToken != null) {
+                    xml.elem("ContinuationToken", continuationToken);
+                }
+                if (result.isTruncated()) {
+                    xml.elem("NextContinuationToken", result.nextContinuationToken());
+                }
+                if (startAfter != null) {
+                    xml.elem("StartAfter", startAfter);
+                }
             }
             xml.end("ListBucketResult");
             return Response.ok(xml.build()).build();
@@ -880,16 +908,21 @@ public class S3Controller {
         return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
     }
 
-    private Response handleListObjectVersions(String bucket, String prefix, Integer maxKeys) {
+    private Response handleListObjectVersions(String bucket, String prefix, Integer maxKeys, String keyMarker) {
         int max = (maxKeys != null && maxKeys > 0) ? maxKeys : 1000;
-        List<S3Object> versions = s3Service.listObjectVersions(bucket, prefix, max);
+        S3Service.ListVersionsResult result = s3Service.listObjectVersions(bucket, prefix, max, keyMarker);
         XmlBuilder xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("ListVersionsResult", AwsNamespaces.S3)
                 .elem("Name", bucket)
                 .elem("Prefix", prefix)
-                .elem("MaxKeys", max);
-        for (S3Object obj : versions) {
+                .elem("KeyMarker", keyMarker)
+                .elem("MaxKeys", max)
+                .elem("IsTruncated", result.isTruncated());
+        if (result.isTruncated()) {
+            xml.elem("NextKeyMarker", result.nextKeyMarker());
+        }
+        for (S3Object obj : result.versions()) {
             if (obj.isDeleteMarker()) {
                 xml.start("DeleteMarker")
                    .elem("Key", obj.getKey())

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -440,13 +440,18 @@ public class S3Service {
         }
     }
 
-    public record ListObjectsResult(List<S3Object> objects, List<String> commonPrefixes, boolean isTruncated) {}
+    public record ListObjectsResult(List<S3Object> objects, List<String> commonPrefixes, boolean isTruncated, String nextContinuationToken) {}
 
     public List<S3Object> listObjects(String bucketName, String prefix, String delimiter, int maxKeys) {
-        return listObjectsWithPrefixes(bucketName, prefix, delimiter, maxKeys).objects();
+        return listObjectsWithPrefixes(bucketName, prefix, delimiter, maxKeys, null, null).objects();
     }
 
     public ListObjectsResult listObjectsWithPrefixes(String bucketName, String prefix, String delimiter, int maxKeys) {
+        return listObjectsWithPrefixes(bucketName, prefix, delimiter, maxKeys, null, null);
+    }
+
+    public ListObjectsResult listObjectsWithPrefixes(String bucketName, String prefix, String delimiter, int maxKeys,
+                                                     String continuationToken, String startAfter) {
         ensureBucketExists(bucketName);
 
         String keyPrefix = bucketName + "/";
@@ -485,34 +490,54 @@ public class S3Service {
 
         allObjects.sort(Comparator.comparing(S3Object::getKey));
 
+        // Apply continuation-token / start-after filter.
+        // continuation-token takes precedence; it encodes the last key seen on a previous page.
+        String filterKey = continuationToken != null ? continuationToken : startAfter;
+        if (filterKey != null) {
+            final String fk = filterKey;
+            allObjects = allObjects.stream()
+                    .filter(o -> o.getKey().compareTo(fk) > 0)
+                    .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+            commonPrefixes = commonPrefixes.stream()
+                    .filter(cp -> cp.compareTo(fk) > 0)
+                    .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+        }
+
         // S3 counts both direct objects and common prefixes.
         // Each common prefix group (e.g. "docs/") uses one entry regardless of
         // how many keys it contains. Merge both sorted lists lexicographically
         // and stop at maxKeys to try to match S3 ListObjectsV2 behavior.
         // see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
         boolean isTruncated = false;
+        String nextContinuationToken = null;
         if (maxKeys > 0) {
             List<S3Object> limitedObjects = new ArrayList<>();
             List<String> limitedPrefixes = new ArrayList<>();
             int count = 0;
             int directObjectCount = 0;
             int commonPrefixCount = 0;
+            String lastEmittedKey = null;
             while (count < maxKeys && (directObjectCount < allObjects.size() || commonPrefixCount < commonPrefixes.size())) {
                 String objectKey = directObjectCount < allObjects.size() ? allObjects.get(directObjectCount).getKey() : null;
                 String prefixKey = commonPrefixCount < commonPrefixes.size() ? commonPrefixes.get(commonPrefixCount) : null;
                 if (objectKey != null && (prefixKey == null || objectKey.compareTo(prefixKey) <= 0)) {
                     limitedObjects.add(allObjects.get(directObjectCount++));
+                    lastEmittedKey = objectKey;
                 } else {
                     limitedPrefixes.add(commonPrefixes.get(commonPrefixCount++));
+                    lastEmittedKey = prefixKey;
                 }
                 count++;
             }
             isTruncated = directObjectCount < allObjects.size() || commonPrefixCount < commonPrefixes.size();
+            if (isTruncated) {
+                nextContinuationToken = lastEmittedKey;
+            }
             allObjects = limitedObjects;
             commonPrefixes = limitedPrefixes;
         }
 
-        return new ListObjectsResult(allObjects, commonPrefixes, isTruncated);
+        return new ListObjectsResult(allObjects, commonPrefixes, isTruncated, nextContinuationToken);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
@@ -576,7 +601,9 @@ public class S3Service {
         return bucket.getVersioningStatus();
     }
 
-    public List<S3Object> listObjectVersions(String bucketName, String prefix, int maxKeys) {
+    public record ListVersionsResult(List<S3Object> versions, boolean isTruncated, String nextKeyMarker) {}
+
+    public ListVersionsResult listObjectVersions(String bucketName, String prefix, int maxKeys, String keyMarker) {
         ensureBucketExists(bucketName);
 
         String versionPrefix = bucketName + "/";
@@ -593,10 +620,33 @@ public class S3Service {
             return b.getLastModified().compareTo(a.getLastModified());
         });
 
-        if (maxKeys > 0 && versions.size() > maxKeys) {
-            versions = versions.subList(0, maxKeys);
+        // Apply key-marker filter: skip objects whose key is <= keyMarker
+        if (keyMarker != null && !keyMarker.isEmpty()) {
+            final String km = keyMarker;
+            versions = versions.stream()
+                    .filter(v -> v.getKey().compareTo(km) > 0)
+                    .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
         }
-        return versions;
+
+        boolean isTruncated = false;
+        String nextKeyMarker = null;
+        if (maxKeys > 0 && versions.size() > maxKeys) {
+            // Extend the cutoff to avoid splitting versions of the same key across pages.
+            // All versions of the same key must appear on the same page.
+            int cutoff = maxKeys;
+            String lastKey = versions.get(maxKeys - 1).getKey();
+            while (cutoff < versions.size() && versions.get(cutoff).getKey().equals(lastKey)) {
+                cutoff++;
+            }
+            isTruncated = cutoff < versions.size();
+            if (isTruncated) {
+                // nextKeyMarker is used as an exclusive lower bound: next page gets key > nextKeyMarker.
+                // Set it to the last included key so the next page starts right after it.
+                nextKeyMarker = versions.get(cutoff - 1).getKey();
+            }
+            versions = new ArrayList<>(versions.subList(0, cutoff));
+        }
+        return new ListVersionsResult(versions, isTruncated, nextKeyMarker);
     }
 
     // --- Head Bucket / Bucket Location ---
@@ -1188,6 +1238,30 @@ public class S3Service {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
         bucket.setEncryptionConfiguration(null);
+        bucketStore.put(bucketName, bucket);
+    }
+
+    public String getPublicAccessBlock(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        if (bucket.getPublicAccessBlockConfiguration() == null) {
+            throw new AwsException("NoSuchPublicAccessBlockConfiguration",
+                    "The public access block configuration was not found", 404);
+        }
+        return bucket.getPublicAccessBlockConfiguration();
+    }
+
+    public void putPublicAccessBlock(String bucketName, String xml) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        bucket.setPublicAccessBlockConfiguration(xml);
+        bucketStore.put(bucketName, bucket);
+    }
+
+    public void deletePublicAccessBlock(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        bucket.setPublicAccessBlockConfiguration(null);
         bucketStore.put(bucketName, bucket);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -1,15 +1,31 @@
 package io.github.hectorvent.floci.services.s3;
 
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import java.net.URI;
+import java.util.Optional;
 
 @Provider
 @PreMatching
 public class S3VirtualHostFilter implements ContainerRequestFilter {
+
+    private final String baseHostname;
+
+    @Inject
+    public S3VirtualHostFilter(
+            @ConfigProperty(name = "floci.base-url", defaultValue = "http://localhost:4566") String baseUrl,
+            @ConfigProperty(name = "floci.hostname") Optional<String> hostname) {
+        String effectiveUrl = hostname
+                .map(h -> baseUrl.replaceFirst("://[^:/]+(:\\d+)?", "://" + h + "$1"))
+                .orElse(baseUrl);
+        this.baseHostname = extractHostnameFromUrl(effectiveUrl);
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
@@ -22,7 +38,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             return;
         }
 
-        // S3 does not use these content types for bucket/object operations, 
+        // S3 does not use these content types for bucket/object operations,
         // but other AWS services (AwsQuery, JSON protocols) do.
         String contentType = requestContext.getHeaderString("Content-Type");
         if (contentType != null && (
@@ -31,7 +47,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             return;
         }
 
-        String bucket = extractBucket(host);
+        String bucket = extractBucket(host, baseHostname);
         if (bucket == null) return;
 
         URI uri = requestContext.getUriInfo().getRequestUri();
@@ -50,28 +66,27 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
     /**
      * Extracts a bucket name from a virtual-hosted-style Host header.
      *
-     * The first label of the hostname (before the first dot) is treated as the
-     * bucket name whenever the hostname contains at least one dot and is not an
-     * IP address. This works for any endpoint hostname — localhost, custom hosts,
-     * or S3-style domains — without requiring configuration.
+     * A request is considered virtual-hosted-style when the hostname's remainder
+     * after the first label matches the configured Floci base hostname, or when it
+     * matches a well-known AWS S3 domain pattern (for DNS-redirect setups).
      *
-     * Note: AWS SDKs automatically fall back to path-style for bucket names that
-     * contain dots, so the first-label heuristic is sufficient.
+     * Examples with baseHostname="localhost":
+     *   my-bucket.localhost:4566       → "my-bucket"
+     *   my-bucket.localhost            → "my-bucket"
+     *   floci.svc.cluster.local        → null  (no bucket prefix, path-style)
+     *   my-svc.floci.svc.cluster.local → null  (remainder doesn't match "localhost")
+     *
+     * Examples with baseHostname="floci.svc.cluster.local":
+     *   my-bucket.floci.svc.cluster.local → "my-bucket"
+     *   floci.svc.cluster.local           → null  (no bucket prefix, path-style)
      *
      * Returns null if the host does not match a virtual-hosted pattern.
      */
-    static String extractBucket(String host) {
+    static String extractBucket(String host, String baseHostname) {
         if (host == null) return null;
 
         // Strip port if present
-        String hostname = host;
-        int colonIndex = hostname.lastIndexOf(':');
-        if (colonIndex > 0) {
-            String maybePart = hostname.substring(colonIndex + 1);
-            if (!maybePart.isEmpty() && maybePart.chars().allMatch(Character::isDigit)) {
-                hostname = hostname.substring(0, colonIndex);
-            }
-        }
+        String hostname = stripPort(host);
 
         // Need at least one dot for a subdomain to exist
         int firstDot = hostname.indexOf('.');
@@ -84,7 +99,42 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             return null;
         }
 
-        return hostname.substring(0, firstDot);
+        String firstLabel = hostname.substring(0, firstDot);
+        String remainder  = hostname.substring(firstDot + 1);
+
+        // Primary: remainder must match the configured base hostname
+        if (baseHostname != null && remainder.equalsIgnoreCase(baseHostname)) {
+            return firstLabel;
+        }
+
+        // Fallback: well-known AWS S3 domains, for users who route AWS DNS to Floci
+        if (isAwsS3Domain(remainder)) {
+            return firstLabel;
+        }
+
+        return null;
+    }
+
+    /** Extracts the hostname (without scheme or port) from a URL string. */
+    static String extractHostnameFromUrl(String url) {
+        if (url == null) return null;
+        try {
+            URI uri = URI.create(url);
+            return uri.getHost();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String stripPort(String host) {
+        int colonIndex = host.lastIndexOf(':');
+        if (colonIndex > 0) {
+            String maybePart = host.substring(colonIndex + 1);
+            if (!maybePart.isEmpty() && maybePart.chars().allMatch(Character::isDigit)) {
+                return host.substring(0, colonIndex);
+            }
+        }
+        return host;
     }
 
     private static boolean isIpv4Address(String hostname) {
@@ -95,5 +145,13 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             }
         }
         return true;
+    }
+
+    /** Returns true for *.s3.amazonaws.com and *.s3.<region>.amazonaws.com domains. */
+    private static boolean isAwsS3Domain(String remainder) {
+        if ("s3.amazonaws.com".equals(remainder)) return true;
+        // s3.<region>.amazonaws.com
+        if (remainder.startsWith("s3.") && remainder.endsWith(".amazonaws.com")) return true;
+        return false;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -23,6 +23,7 @@ public class Bucket {
     private String lifecycleConfiguration;
     private String acl; // XML representation or JSON stub
     private String encryptionConfiguration; // XML string
+    private String publicAccessBlockConfiguration; // XML string
     private String region;
 
     public Bucket() {
@@ -75,6 +76,11 @@ public class Bucket {
 
     public String getEncryptionConfiguration() { return encryptionConfiguration; }
     public void setEncryptionConfiguration(String encryptionConfiguration) { this.encryptionConfiguration = encryptionConfiguration; }
+
+    public String getPublicAccessBlockConfiguration() { return publicAccessBlockConfiguration; }
+    public void setPublicAccessBlockConfiguration(String publicAccessBlockConfiguration) {
+        this.publicAccessBlockConfiguration = publicAccessBlockConfiguration;
+    }
 
     public String getRegion() { return region; }
     public void setRegion(String region) { this.region = region; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1005,4 +1005,130 @@ class S3IntegrationTest {
     void cleanupNotificationBucket() {
         given().delete("/notif-test-bucket");
     }
+
+    // --- PublicAccessBlock ---
+
+    @Test
+    @Order(100)
+    void putPublicAccessBlockReturns200() {
+        given().when().put("/test-bucket").then().statusCode(anyOf(equalTo(200), equalTo(409)));
+
+        String xml = "<PublicAccessBlockConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+                + "<BlockPublicAcls>true</BlockPublicAcls>"
+                + "<IgnorePublicAcls>true</IgnorePublicAcls>"
+                + "<BlockPublicPolicy>true</BlockPublicPolicy>"
+                + "<RestrictPublicBuckets>true</RestrictPublicBuckets>"
+                + "</PublicAccessBlockConfiguration>";
+        given()
+            .body(xml)
+        .when()
+            .put("/test-bucket?publicAccessBlock")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(101)
+    void getPublicAccessBlockReturnsStoredConfig() {
+        given()
+        .when()
+            .get("/test-bucket?publicAccessBlock")
+        .then()
+            .statusCode(200)
+            .body(containsString("BlockPublicAcls"))
+            .body(containsString("true"));
+    }
+
+    @Test
+    @Order(102)
+    void deletePublicAccessBlockReturns204() {
+        given()
+        .when()
+            .delete("/test-bucket?publicAccessBlock")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(103)
+    void getPublicAccessBlockAfterDeleteReturns404() {
+        given()
+        .when()
+            .get("/test-bucket?publicAccessBlock")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchPublicAccessBlockConfiguration"));
+    }
+
+    // --- ListObjectsV2 pagination ---
+
+    @Test
+    @Order(110)
+    void listObjectsV2StartAfterFiltersResults() {
+        // bucket and objects from earlier test orders exist; add fresh ones in a dedicated bucket
+        given().when().put("/pag-test-bucket").then().statusCode(200);
+        given().body("a").when().put("/pag-test-bucket/a.txt").then().statusCode(200);
+        given().body("b").when().put("/pag-test-bucket/b.txt").then().statusCode(200);
+        given().body("c").when().put("/pag-test-bucket/c.txt").then().statusCode(200);
+
+        given()
+        .when()
+            .get("/pag-test-bucket?list-type=2&start-after=a.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StartAfter>a.txt</StartAfter>"))
+            .body(not(containsString("<Key>a.txt</Key>")))
+            .body(containsString("<Key>b.txt</Key>"))
+            .body(containsString("<Key>c.txt</Key>"));
+    }
+
+    @Test
+    @Order(111)
+    void listObjectsV2ContinuationTokenPaginates() {
+        // First page: max-keys=2
+        String page1Body =
+            given()
+            .when()
+                .get("/pag-test-bucket?list-type=2&max-keys=2")
+            .then()
+                .statusCode(200)
+                .body(containsString("<IsTruncated>true</IsTruncated>"))
+                .body(containsString("<NextContinuationToken>"))
+                .extract().body().asString();
+
+        // Extract NextContinuationToken
+        int start = page1Body.indexOf("<NextContinuationToken>") + "<NextContinuationToken>".length();
+        int end = page1Body.indexOf("</NextContinuationToken>");
+        String token = page1Body.substring(start, end);
+
+        // Second page using the token
+        given()
+        .when()
+            .get("/pag-test-bucket?list-type=2&max-keys=2&continuation-token=" + token)
+        .then()
+            .statusCode(200)
+            .body(containsString("<IsTruncated>false</IsTruncated>"))
+            .body(containsString("<ContinuationToken>" + token + "</ContinuationToken>"))
+            .body(containsString("<Key>c.txt</Key>"));
+    }
+
+    @Test
+    @Order(112)
+    void listObjectsV2EncodingTypeIsEchoed() {
+        given()
+        .when()
+            .get("/pag-test-bucket?list-type=2&encoding-type=url")
+        .then()
+            .statusCode(200)
+            .body(containsString("<EncodingType>url</EncodingType>"));
+    }
+
+    @Test
+    @Order(113)
+    void cleanupPaginationBucket() {
+        given().when().delete("/pag-test-bucket/a.txt");
+        given().when().delete("/pag-test-bucket/b.txt");
+        given().when().delete("/pag-test-bucket/c.txt");
+        given().when().delete("/pag-test-bucket");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -374,4 +374,40 @@ class S3ServiceTest {
         S3Object retrieved = s3Service.getObject("test-bucket", destKey);
         assertArrayEquals("image-data".getBytes(), retrieved.getData());
     }
+
+    @Test
+    void listObjectsWithStartAfterFiltersResults() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        s3Service.putObject("test-bucket", "a.txt", "a".getBytes(), null, null);
+        s3Service.putObject("test-bucket", "b.txt", "b".getBytes(), null, null);
+        s3Service.putObject("test-bucket", "c.txt", "c".getBytes(), null, null);
+
+        S3Service.ListObjectsResult result = s3Service.listObjectsWithPrefixes(
+                "test-bucket", null, null, 1000, null, "a.txt");
+        List<String> keys = result.objects().stream().map(S3Object::getKey).toList();
+        assertEquals(List.of("b.txt", "c.txt"), keys);
+        assertFalse(result.isTruncated());
+    }
+
+    @Test
+    void listObjectsWithContinuationTokenPaginates() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        s3Service.putObject("test-bucket", "a.txt", "a".getBytes(), null, null);
+        s3Service.putObject("test-bucket", "b.txt", "b".getBytes(), null, null);
+        s3Service.putObject("test-bucket", "c.txt", "c".getBytes(), null, null);
+
+        // First page
+        S3Service.ListObjectsResult page1 = s3Service.listObjectsWithPrefixes(
+                "test-bucket", null, null, 2, null, null);
+        assertEquals(2, page1.objects().size());
+        assertTrue(page1.isTruncated());
+        assertNotNull(page1.nextContinuationToken());
+
+        // Second page using the token
+        S3Service.ListObjectsResult page2 = s3Service.listObjectsWithPrefixes(
+                "test-bucket", null, null, 2, page1.nextContinuationToken(), null);
+        assertEquals(1, page2.objects().size());
+        assertFalse(page2.isTruncated());
+        assertEquals("c.txt", page2.objects().get(0).getKey());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -137,6 +137,7 @@ class S3VersioningIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<ListVersionsResult"))
+            .body(containsString("<IsTruncated>false</IsTruncated>"))
             .body(containsString("<Version>"))
             .body(containsString(versionId1))
             .body(containsString(versionId2));

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -140,8 +140,9 @@ class S3VersioningServiceTest {
         s3Service.putObject("versioned-bucket", "test.txt",
                 "v2".getBytes(StandardCharsets.UTF_8), "text/plain", null);
 
-        List<S3Object> versions = s3Service.listObjectVersions("versioned-bucket", null, 100);
-        assertEquals(2, versions.size());
+        S3Service.ListVersionsResult result = s3Service.listObjectVersions("versioned-bucket", null, 100, null);
+        assertEquals(2, result.versions().size());
+        assertFalse(result.isTruncated());
     }
 
     @Test
@@ -151,9 +152,9 @@ class S3VersioningServiceTest {
                 "data".getBytes(StandardCharsets.UTF_8), "text/plain", null);
         s3Service.deleteObject("versioned-bucket", "test.txt");
 
-        List<S3Object> versions = s3Service.listObjectVersions("versioned-bucket", null, 100);
-        assertEquals(2, versions.size());
-        assertTrue(versions.stream().anyMatch(S3Object::isDeleteMarker));
+        S3Service.ListVersionsResult result = s3Service.listObjectVersions("versioned-bucket", null, 100, null);
+        assertEquals(2, result.versions().size());
+        assertTrue(result.versions().stream().anyMatch(S3Object::isDeleteMarker));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -9,38 +9,78 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class S3VirtualHostFilterTest {
 
+    // ── Virtual-hosted style: bucket prefix + matching baseHostname ─────────
+
     @ParameterizedTest
     @CsvSource({
-            // localhost variants
-            "my-bucket.localhost:4566,       my-bucket",
-            "my-bucket.localhost,            my-bucket",
-            // S3-style domains
-            "my-bucket.s3.amazonaws.com,     my-bucket",
-            "my-bucket.s3.amazonaws.com:443, my-bucket",
-            "my-bucket.s3.us-east-1.amazonaws.com,     my-bucket",
-            "my-bucket.s3.eu-west-1.amazonaws.com:443, my-bucket",
-            // Custom / arbitrary hostnames
-            "my-bucket.myhost:4566,          my-bucket",
-            "my-bucket.custom.internal:9000, my-bucket",
-            "my-bucket.emulator.local,       my-bucket",
+            // Standard localhost endpoint
+            "my-bucket.localhost:4566, localhost, my-bucket",
+            "my-bucket.localhost,      localhost, my-bucket",
+            // Custom single-label hostname
+            "my-bucket.myhost,         myhost,    my-bucket",
+            // Multi-label hostname (e.g. Docker compose service name)
+            "my-bucket.floci.internal, floci.internal, my-bucket",
+            // K8s-style service hostname with FLOCI_HOSTNAME set
+            "my-bucket.floci.default.svc.cluster.local, floci.default.svc.cluster.local, my-bucket",
+            "my-bucket.floci-svc.namespace.svc, floci-svc.namespace.svc, my-bucket",
+            // AWS S3 domains (fallback — independent of baseHostname)
+            "my-bucket.s3.amazonaws.com,               localhost, my-bucket",
+            "my-bucket.s3.amazonaws.com:443,            localhost, my-bucket",
+            "my-bucket.s3.us-east-1.amazonaws.com,      localhost, my-bucket",
+            "my-bucket.s3.eu-west-1.amazonaws.com:443,  localhost, my-bucket",
     })
-    void extractsBucketFromVirtualHostedStyle(String host, String expectedBucket) {
-        assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host));
+    void extractsBucketFromVirtualHostedStyle(String host, String baseHostname, String expectedBucket) {
+        assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host, baseHostname));
+    }
+
+    // ── Path-style: service hostname alone — must NOT extract a bucket ───────
+
+    @ParameterizedTest
+    @CsvSource({
+            // Bare hostname — no dot, never virtual-hosted
+            "localhost:4566, localhost",
+            "localhost,      localhost",
+            "plain-host,     plain-host",
+            // K8s service hostname used as endpoint (path-style) — must NOT be rewritten
+            "floci.default.svc.cluster.local,           localhost",
+            "floci-service.namespace.svc.cluster.local, localhost",
+            "my-svc.default.svc,                        localhost",
+            // Remainder doesn't match baseHostname and isn't an AWS S3 domain
+            "my-bucket.custom.internal, localhost",
+            "my-bucket.emulator.local,  localhost",
+    })
+    void returnsNullForPathStyleOrMismatchedRemainder(String host, String baseHostname) {
+        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname));
     }
 
     @ParameterizedTest
     @CsvSource({
-            "localhost:4566",
-            "localhost",
-            "plain-host",
-            "plain-host:8080",
-            "192.168.1.1",
-            "192.168.1.1:4566",
-            "127.0.0.1",
-            "10.0.0.1:9000",
+            "192.168.1.1,      localhost",
+            "192.168.1.1:4566, localhost",
+            "127.0.0.1,        localhost",
+            "10.0.0.1:9000,    localhost",
     })
+    void returnsNullForIpAddresses(String host, String baseHostname) {
+        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname));
+    }
+
+    @ParameterizedTest
     @NullSource
-    void returnsNullForNonVirtualHostedStyle(String host) {
-        assertNull(S3VirtualHostFilter.extractBucket(host));
+    void returnsNullForNullHost(String host) {
+        assertNull(S3VirtualHostFilter.extractBucket(host, "localhost"));
+    }
+
+    // ── Hostname extraction from URL ─────────────────────────────────────────
+
+    @ParameterizedTest
+    @CsvSource({
+            "http://localhost:4566,                             localhost",
+            "http://localhost,                                  localhost",
+            "http://floci.default.svc.cluster.local:4566,      floci.default.svc.cluster.local",
+            "http://floci-service.namespace.svc.cluster.local, floci-service.namespace.svc.cluster.local",
+            "http://my-host:9000,                              my-host",
+    })
+    void extractsHostnameFromUrl(String url, String expectedHostname) {
+        assertEquals(expectedHostname, S3VirtualHostFilter.extractHostnameFromUrl(url));
     }
 }


### PR DESCRIPTION
…ination, K8s virtual host routing

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
 Fixes #237 — listObjectVersionsPaginator NPE: IsTruncated was missing                                                                                                         
  from ListObjectVersions XML response. Also adds NextKeyMarker support                                                                                                         
  with key-boundary truncation so the SDK paginator advances correctly.                                                                                                         
                                                                                                                                                                                
  Fixes #236 — PutPublicAccessBlock routed through to createBucket,                                                                                                             
  returning BucketAlreadyOwnedByYou (409). Added Put/Get/Delete handlers                                                                                                        
  for the publicAccessBlock query param, backed by a new field on Bucket.                                                                                                       
                                                                                                                                                                                
  Fixes #119 — ListObjectsV2 missing pagination fields. Wired                                                                                                                   
  continuation-token and start-after through listObjectsWithPrefixes(),                                                                                                         
  tracking NextContinuationToken when truncated. Added EncodingType,                                                                                                            
  ContinuationToken, NextContinuationToken, and StartAfter to the                                                                                                               
  XML response.                                                                                                                                                                 
                                                                                                                                                                                
  Fixes #255 — S3VirtualHostFilter incorrectly extracted the first                                                                                                              
  hostname label (e.g. "floci-service") as a bucket name on K8s                                                                                                               
  service hostnames, rewriting path-style requests into object-store                                                                                                            
  calls. Filter now matches only when the hostname remainder equals the                                                                                                         
  configured base hostname (from floci.base-url / floci.hostname).                                                                                                              
                                                                                                                                                                                
  Adds compatibility tests in sdk-test-java/S3FeaturesTest covering                                                                                                             
  all four fixes using the AWS SDK v2.


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
