### PR TITLE
Add support for DynamoDB list_append function

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -961,6 +961,28 @@ public class DynamoDbService {
                         item.set(attrName, resolved);
                     }
                 }
+            } else if (valuePart.startsWith("list_append(")) {
+                String[] args = extractFunctionArgs(valuePart);
+                if (args.length == 2) {
+                    String arg1 = args[0].trim();
+                    String arg2 = args[1].trim();
+                    JsonNode list1 = arg1.startsWith(":") && exprAttrValues != null
+                        ? exprAttrValues.get(arg1)
+                        : item.get(resolveAttributeName(arg1, exprAttrNames));
+                    JsonNode list2 = arg2.startsWith(":") && exprAttrValues != null
+                        ? exprAttrValues.get(arg2)
+                        : item.get(resolveAttributeName(arg2, exprAttrNames));
+                    if (list1 != null && list2 != null && list1.has("L") && list2.has("L")) {
+                        com.fasterxml.jackson.databind.node.ArrayNode merged =
+                            com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+                        list1.get("L").forEach(merged::add);
+                        list2.get("L").forEach(merged::add);
+                        com.fasterxml.jackson.databind.node.ObjectNode result =
+                            com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                        result.set("L", merged);
+                        item.set(attrName, result);
+                    }
+                }
             } else if (valuePart.startsWith(":") && exprAttrValues != null) {
                 JsonNode value = exprAttrValues.get(valuePart);
                 if (value != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -743,6 +743,89 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    @Order(27)
+    void updateItemListAppend() {
+        // Create a table for this test
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ListAppendTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Put item with initial list
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ListAppendTable",
+                    "Item": {"pk": {"S": "k1"}, "items": {"L": [{"S": "a"}]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Append to list
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ListAppendTable",
+                    "Key": {"pk": {"S": "k1"}},
+                    "UpdateExpression": "SET items = list_append(items, :val)",
+                    "ExpressionAttributeValues": {":val": {"L": [{"S": "b"}]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify both elements present
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ListAppendTable",
+                    "Key": {"pk": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.items.L.size()", equalTo(2))
+            .body("Item.items.L[0].S", equalTo("a"))
+            .body("Item.items.L[1].S", equalTo("b"));
+
+        // Cleanup
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ListAppendTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedOperation() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateGlobalTable")


### PR DESCRIPTION
## Description
DynamoDbService wasn't handling list_append operations in update expressions. Added the function handling to properly merge two lists together. The code extracts both arguments, resolves them from expression attribute values or item attributes as needed, and then merges the lists into the DynamoDB format.

## Related Issue
Fixes #242

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have run `./mvnw test` and all tests pass
- [x] I have added tests for new behavior or regression tests for bug fixes
- [x] I have verified AWS compatibility
- [x] My commits follow the Conventional Commits format