### PR TITLE
fix: Implement S3 Lambda notifications

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
@@ -96,6 +96,22 @@ public final class LambdaUtils {
     }
 
     /**
+     * ZIP containing a Node.js handler that logs the first S3 event record.
+     */
+    public static byte[] s3NotificationLoggerZip() {
+        String code = """
+                exports.handler = async (event) => {
+                    const record = (event && event.Records && event.Records[0]) ? event.Records[0] : null;
+                    const bucket = record?.s3?.bucket?.name || 'unknown-bucket';
+                    const key = record?.s3?.object?.key || 'unknown-key';
+                    console.log(`[s3-notification] received ${bucket}/${key}`);
+                    return { statusCode: 200, body: JSON.stringify({ bucket, key }) };
+                };
+                """;
+        return createZip("index.js", code);
+    }
+
+    /**
      * ZIP containing a Node.js handler that checks whether a file at a deeply nested
      * long path (> 100 chars) exists inside the container.
      *

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3NotificationsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3NotificationsTest.java
@@ -1,0 +1,268 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilterLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.CreateFunctionRequest;
+import software.amazon.awssdk.services.lambda.model.DeleteFunctionRequest;
+import software.amazon.awssdk.services.lambda.model.FunctionCode;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.Event;
+import software.amazon.awssdk.services.s3.model.FilterRule;
+import software.amazon.awssdk.services.s3.model.FilterRuleName;
+import software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketNotificationConfigurationResponse;
+import software.amazon.awssdk.services.s3.model.LambdaFunctionConfiguration;
+import software.amazon.awssdk.services.s3.model.NotificationConfiguration;
+import software.amazon.awssdk.services.s3.model.NotificationConfigurationFilter;
+import software.amazon.awssdk.services.s3.model.PutBucketNotificationConfigurationRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.QueueConfiguration;
+import software.amazon.awssdk.services.s3.model.S3KeyFilter;
+import software.amazon.awssdk.services.s3.model.TopicConfiguration;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sns.model.DeleteTopicRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("S3 Notifications")
+class S3NotificationsTest {
+
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static S3Client s3;
+    private static SqsClient sqs;
+    private static SnsClient sns;
+    private static LambdaClient lambda;
+    private static CloudWatchLogsClient logs;
+
+    private static String bucketName;
+    private static String queueUrl;
+    private static String queueArn;
+    private static String topicArn;
+    private static String functionName;
+    private static String functionArn;
+
+    @BeforeAll
+    static void setup() {
+        s3 = TestFixtures.s3Client();
+        sqs = TestFixtures.sqsClient();
+        sns = TestFixtures.snsClient();
+        lambda = TestFixtures.lambdaClient();
+        logs = TestFixtures.cloudWatchLogsClient();
+
+        bucketName = TestFixtures.uniqueName("java-s3-notif-bucket");
+        String queueName = TestFixtures.uniqueName("java-s3-notif-queue");
+        String topicName = TestFixtures.uniqueName("java-s3-notif-topic");
+        functionName = TestFixtures.uniqueName("java-s3-notif-fn");
+
+        queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                        .queueName(queueName)
+                        .build())
+                .queueUrl();
+
+        queueArn = sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
+                        .queueUrl(queueUrl)
+                        .attributeNames(QueueAttributeName.QUEUE_ARN)
+                        .build())
+                .attributes()
+                .get(QueueAttributeName.QUEUE_ARN);
+
+        topicArn = sns.createTopic(CreateTopicRequest.builder()
+                        .name(topicName)
+                        .build())
+                .topicArn();
+
+        s3.createBucket(CreateBucketRequest.builder()
+                .bucket(bucketName)
+                .build());
+
+        functionArn = lambda.createFunction(CreateFunctionRequest.builder()
+                        .functionName(functionName)
+                        .runtime(Runtime.NODEJS20_X)
+                        .role(ROLE)
+                        .handler("index.handler")
+                        .code(FunctionCode.builder()
+                                .zipFile(SdkBytes.fromByteArray(LambdaUtils.s3NotificationLoggerZip()))
+                                .build())
+                        .build())
+                .functionArn();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (s3 != null) {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key("incoming/report.csv").build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build());
+            } catch (Exception ignored) {}
+            s3.close();
+        }
+        if (sqs != null) {
+            try {
+                sqs.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build());
+            } catch (Exception ignored) {}
+            sqs.close();
+        }
+        if (sns != null) {
+            try {
+                sns.deleteTopic(DeleteTopicRequest.builder().topicArn(topicArn).build());
+            } catch (Exception ignored) {}
+            sns.close();
+        }
+        if (lambda != null) {
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder().functionName(functionName).build());
+            } catch (Exception ignored) {}
+            lambda.close();
+        }
+        if (logs != null) {
+            logs.close();
+        }
+    }
+
+    @Test
+    void bucketNotificationConfigurationRoundTripIncludesLambdaAndFilters() {
+        s3.putBucketNotificationConfiguration(PutBucketNotificationConfigurationRequest.builder()
+                .bucket(bucketName)
+                .notificationConfiguration(NotificationConfiguration.builder()
+                        .queueConfigurations(QueueConfiguration.builder()
+                                .id("sqs-filtered")
+                                .queueArn(queueArn)
+                                .events(Event.S3_OBJECT_CREATED)
+                                .filter(filter("incoming/", ".csv"))
+                                .build())
+                        .topicConfigurations(TopicConfiguration.builder()
+                                .id("sns-filtered")
+                                .topicArn(topicArn)
+                                .events(Event.S3_OBJECT_REMOVED)
+                                .filter(filter("", ".txt"))
+                                .build())
+                        .lambdaFunctionConfigurations(LambdaFunctionConfiguration.builder()
+                                .id("lambda-filtered")
+                                .lambdaFunctionArn(functionArn)
+                                .events(Event.S3_OBJECT_CREATED_PUT)
+                                .filter(filter("incoming/", ".csv"))
+                                .build())
+                        .build())
+                .build());
+
+        GetBucketNotificationConfigurationResponse response = s3.getBucketNotificationConfiguration(
+                GetBucketNotificationConfigurationRequest.builder()
+                        .bucket(bucketName)
+                        .build());
+
+        assertThat(response.queueConfigurations())
+                .anySatisfy(config -> {
+                    assertThat(config.id()).isEqualTo("sqs-filtered");
+                    assertThat(config.queueArn()).isEqualTo(queueArn);
+                    assertThat(config.events()).contains(Event.S3_OBJECT_CREATED);
+                    assertThat(config.filter().key().filterRules())
+                            .anyMatch(rule -> rule.name() == FilterRuleName.PREFIX && "incoming/".equals(rule.value()))
+                            .anyMatch(rule -> rule.name() == FilterRuleName.SUFFIX && ".csv".equals(rule.value()));
+                });
+
+        assertThat(response.topicConfigurations())
+                .anySatisfy(config -> {
+                    assertThat(config.id()).isEqualTo("sns-filtered");
+                    assertThat(config.topicArn()).isEqualTo(topicArn);
+                    assertThat(config.events()).contains(Event.S3_OBJECT_REMOVED);
+                    assertThat(config.filter().key().filterRules())
+                            .anyMatch(rule -> rule.name() == FilterRuleName.PREFIX && "".equals(rule.value()))
+                            .anyMatch(rule -> rule.name() == FilterRuleName.SUFFIX && ".txt".equals(rule.value()));
+                });
+
+        assertThat(response.lambdaFunctionConfigurations())
+                .anySatisfy(config -> {
+                    assertThat(config.id()).isEqualTo("lambda-filtered");
+                    assertThat(config.lambdaFunctionArn()).isEqualTo(functionArn);
+                    assertThat(config.events()).contains(Event.S3_OBJECT_CREATED_PUT);
+                    assertThat(config.filter().key().filterRules())
+                            .anyMatch(rule -> rule.name() == FilterRuleName.PREFIX && "incoming/".equals(rule.value()))
+                            .anyMatch(rule -> rule.name() == FilterRuleName.SUFFIX && ".csv".equals(rule.value()));
+                });
+    }
+
+    @Test
+    void lambdaNotificationInvokesFunctionForMatchingObject() throws InterruptedException {
+        String key = "incoming/report.csv";
+        String expectedMessage = "[s3-notification] received " + bucketName + "/" + key;
+
+        s3.putBucketNotificationConfiguration(PutBucketNotificationConfigurationRequest.builder()
+                .bucket(bucketName)
+                .notificationConfiguration(NotificationConfiguration.builder()
+                        .lambdaFunctionConfigurations(LambdaFunctionConfiguration.builder()
+                                .id("lambda-filtered")
+                                .lambdaFunctionArn(functionArn)
+                                .events(Event.S3_OBJECT_CREATED_PUT)
+                                .filter(filter("incoming/", ".csv"))
+                                .build())
+                        .build())
+                .build());
+
+        s3.putObject(PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .contentType("text/plain")
+                        .build(),
+                RequestBody.fromString("compatibility test payload"));
+
+        assertThat(waitForLogMessage("/aws/lambda/" + functionName, expectedMessage))
+                .as("expected Lambda logs to contain the S3 notification record")
+                .isTrue();
+    }
+
+    private static NotificationConfigurationFilter filter(String prefix, String suffix) {
+        return NotificationConfigurationFilter.builder()
+                .key(S3KeyFilter.builder()
+                        .filterRules(
+                                FilterRule.builder().name(FilterRuleName.PREFIX).value(prefix).build(),
+                                FilterRule.builder().name(FilterRuleName.SUFFIX).value(suffix).build()
+                        )
+                        .build())
+                .build();
+    }
+
+    private static boolean waitForLogMessage(String logGroupName, String expectedMessage) throws InterruptedException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(45).toNanos();
+        while (System.nanoTime() < deadline) {
+            boolean found;
+            try {
+                found = logs.filterLogEvents(FilterLogEventsRequest.builder()
+                                .logGroupName(logGroupName)
+                                .build())
+                        .events()
+                        .stream()
+                        .anyMatch(event -> event.message() != null && event.message().contains(expectedMessage));
+            } catch (ResourceNotFoundException ignored) {
+                found = false;
+            }
+            if (found) {
+                return true;
+            }
+            Thread.sleep(500);
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesParts;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
+import io.github.hectorvent.floci.services.s3.model.LambdaNotification;
 import io.github.hectorvent.floci.services.s3.model.MultipartUpload;
 import io.github.hectorvent.floci.services.s3.model.FilterRule;
 import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
@@ -941,6 +942,16 @@ public class S3Controller {
                 appendFilterRules(xml, tn.filterRules());
                 xml.end("TopicConfiguration");
             }
+            for (LambdaNotification ln : config.getLambdaFunctionConfigurations()) {
+                xml.start("CloudFunctionConfiguration")
+                   .elem("Id", ln.id())
+                   .elem("CloudFunction", ln.functionArn());
+                for (String event : ln.events()) {
+                    xml.elem("Event", event);
+                }
+                appendFilterRules(xml, ln.filterRules());
+                xml.end("CloudFunctionConfiguration");
+            }
             xml.end("NotificationConfiguration");
             return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
         } catch (AwsException e) {
@@ -960,6 +971,14 @@ public class S3Controller {
             for (var parsed : parseNotificationGroups(xml, "TopicConfiguration", "Topic")) {
                 config.getTopicConfigurations().add(
                         new TopicNotification(parsed.id, parsed.arn, parsed.events, parsed.filterRules));
+            }
+            for (var parsed : parseNotificationGroups(xml, "LambdaFunctionConfiguration", "LambdaFunctionArn")) {
+                config.getLambdaFunctionConfigurations().add(
+                        new LambdaNotification(parsed.id, parsed.arn, parsed.events, parsed.filterRules));
+            }
+            for (var parsed : parseNotificationGroups(xml, "CloudFunctionConfiguration", "CloudFunction")) {
+                config.getLambdaFunctionConfigurations().add(
+                        new LambdaNotification(parsed.id, parsed.arn, parsed.events, parsed.filterRules));
             }
 
             s3Service.putBucketNotificationConfiguration(bucket, config);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -8,6 +8,8 @@ import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.s3.model.*;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
@@ -15,12 +17,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -32,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class S3Service {
+
+    @FunctionalInterface
+    interface LambdaInvoker {
+        void invoke(String region, String functionName, byte[] payload, InvocationType type);
+    }
 
     private static final Logger LOG = Logger.getLogger(S3Service.class);
 
@@ -45,13 +54,17 @@ public class S3Service {
 
     private final SqsService sqsService;
     private final SnsService snsService;
+    private final LambdaService lambdaService;
+    private final Instance<LambdaService> lambdaServiceProvider;
+    private final LambdaInvoker lambdaInvoker;
     private final RegionResolver regionResolver;
     private final String baseUrl;
     private final ObjectMapper objectMapper;
 
     @Inject
     public S3Service(StorageFactory storageFactory, EmulatorConfig config,
-                     SqsService sqsService, SnsService snsService, RegionResolver regionResolver,
+                     SqsService sqsService, SnsService snsService, Instance<LambdaService> lambdaServiceProvider,
+                     RegionResolver regionResolver,
                      ObjectMapper objectMapper) {
         this(
                 storageFactory.create("s3", "s3-buckets.json",
@@ -62,7 +75,8 @@ public class S3Service {
                         }),
                 Path.of(config.storage().persistentPath()).resolve("s3"),
                 "memory".equals(config.storage().services().s3().mode().orElse(config.storage().mode())),
-                sqsService, snsService, regionResolver, config.effectiveBaseUrl(), objectMapper
+                sqsService, snsService, null, lambdaServiceProvider, null, regionResolver,
+                config.effectiveBaseUrl(), objectMapper
         );
     }
 
@@ -72,13 +86,34 @@ public class S3Service {
     S3Service(StorageBackend<String, Bucket> bucketStore,
               StorageBackend<String, S3Object> objectStore,
               Path dataRoot, boolean inMemory) {
-        this(bucketStore, objectStore, dataRoot, inMemory, null, null, null, "http://localhost:4566",
-                new ObjectMapper());
+        this(bucketStore, objectStore, dataRoot, inMemory, null, null, null, null, null, null,
+                "http://localhost:4566", new ObjectMapper());
+    }
+
+    S3Service(StorageBackend<String, Bucket> bucketStore,
+              StorageBackend<String, S3Object> objectStore,
+              Path dataRoot, boolean inMemory,
+              LambdaService lambdaService,
+              RegionResolver regionResolver) {
+        this(bucketStore, objectStore, dataRoot, inMemory, null, null, lambdaService, null, null, regionResolver,
+                "http://localhost:4566", new ObjectMapper());
+    }
+
+    S3Service(StorageBackend<String, Bucket> bucketStore,
+              StorageBackend<String, S3Object> objectStore,
+              Path dataRoot, boolean inMemory,
+              LambdaInvoker lambdaInvoker,
+              RegionResolver regionResolver) {
+        this(bucketStore, objectStore, dataRoot, inMemory, null, null, null, null, lambdaInvoker, regionResolver,
+                "http://localhost:4566", new ObjectMapper());
     }
 
     private S3Service(StorageBackend<String, Bucket> bucketStore,
                       StorageBackend<String, S3Object> objectStore,
                       Path dataRoot, boolean inMemory, SqsService sqsService, SnsService snsService,
+                      LambdaService lambdaService,
+                      Instance<LambdaService> lambdaServiceProvider,
+                      LambdaInvoker lambdaInvoker,
                       RegionResolver regionResolver, String baseUrl, ObjectMapper objectMapper) {
         this.bucketStore = bucketStore;
         this.objectStore = objectStore;
@@ -86,6 +121,9 @@ public class S3Service {
         this.inMemory = inMemory;
         this.sqsService = sqsService;
         this.snsService = snsService;
+        this.lambdaService = lambdaService;
+        this.lambdaServiceProvider = lambdaServiceProvider;
+        this.lambdaInvoker = lambdaInvoker;
         this.regionResolver = regionResolver;
         this.baseUrl = baseUrl;
         this.objectMapper = objectMapper;
@@ -1218,7 +1256,8 @@ public class S3Service {
     }
 
     private void fireNotifications(String bucketName, String key, String eventName, S3Object obj) {
-        if (sqsService == null && snsService == null) {
+        if (sqsService == null && snsService == null && lambdaService == null
+                && lambdaServiceProvider == null && lambdaInvoker == null) {
             return;
         }
         Bucket bucket = bucketStore.get(bucketName).orElse(null);
@@ -1254,6 +1293,27 @@ public class S3Service {
                 }
             }
         }
+
+        if (lambdaInvoker == null && resolveLambdaService() == null) {
+            return;
+        }
+
+        for (LambdaNotification ln : config.getLambdaFunctionConfigurations()) {
+            if (ln.events().stream().anyMatch(p -> matchesEvent(p, eventName)) && ln.matchesKey(key)) {
+                try {
+                    String lambdaRegion = extractRegionFromArn(ln.functionArn());
+                    String functionName = extractLambdaFunctionName(ln.functionArn());
+                    if (lambdaRegion == null || functionName == null) {
+                        throw new AwsException("InvalidParameterValueException",
+                                "Invalid Lambda function ARN: " + ln.functionArn(), 400);
+                    }
+                    invokeLambda(lambdaRegion, functionName, eventJson.getBytes(StandardCharsets.UTF_8));
+                    LOG.debugv("Fired S3 event {0} to Lambda {1}", eventName, ln.functionArn());
+                } catch (Exception e) {
+                    LOG.warnv("Failed to deliver S3 event to Lambda {0}: {1}", ln.functionArn(), e.getMessage());
+                }
+            }
+        }
     }
 
     private boolean matchesEvent(String pattern, String eventName) {
@@ -1267,6 +1327,48 @@ public class S3Service {
     private String sqsUrlFromArn(String arn) {
         if (arn.split(":").length < 6) return arn;
         return AwsArnUtils.arnToQueueUrl(arn, baseUrl);
+    }
+
+    private static String extractRegionFromArn(String arn) {
+        if (arn == null || !arn.startsWith("arn:aws:")) {
+            return null;
+        }
+        String[] parts = arn.split(":");
+        return parts.length >= 4 ? parts[3] : null;
+    }
+
+    private static String extractLambdaFunctionName(String functionArn) {
+        if (functionArn == null) {
+            return null;
+        }
+        int functionMarker = functionArn.indexOf(":function:");
+        if (functionMarker < 0) {
+            return null;
+        }
+        String suffix = functionArn.substring(functionMarker + ":function:".length());
+        int qualifierSeparator = suffix.indexOf(':');
+        return qualifierSeparator >= 0 ? suffix.substring(0, qualifierSeparator) : suffix;
+    }
+
+    private LambdaService resolveLambdaService() {
+        if (lambdaService != null) {
+            return lambdaService;
+        }
+        if (lambdaServiceProvider != null && lambdaServiceProvider.isResolvable()) {
+            return lambdaServiceProvider.get();
+        }
+        return null;
+    }
+
+    private void invokeLambda(String region, String functionName, byte[] payload) {
+        if (lambdaInvoker != null) {
+            lambdaInvoker.invoke(region, functionName, payload, InvocationType.Event);
+            return;
+        }
+        LambdaService service = resolveLambdaService();
+        if (service != null) {
+            service.invoke(region, functionName, payload, InvocationType.Event);
+        }
     }
 
     private String buildS3EventJson(String bucketName, String key, String eventName,

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/LambdaNotification.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/LambdaNotification.java
@@ -1,0 +1,17 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+public record LambdaNotification(String id, String functionArn, List<String> events, List<FilterRule> filterRules) {
+
+    public LambdaNotification(String id, String functionArn, List<String> events) {
+        this(id, functionArn, events, List.of());
+    }
+
+    public boolean matchesKey(String key) {
+        return filterRules == null || filterRules.isEmpty() || filterRules.stream().allMatch(r -> r.matches(key));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/NotificationConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/NotificationConfiguration.java
@@ -12,20 +12,39 @@ public class NotificationConfiguration {
 
     private List<QueueNotification> queueConfigurations = new ArrayList<>();
     private List<TopicNotification> topicConfigurations = new ArrayList<>();
+    private List<LambdaNotification> lambdaFunctionConfigurations = new ArrayList<>();
 
-    public NotificationConfiguration() {}
+    public NotificationConfiguration() {
+    }
 
-    public List<QueueNotification> getQueueConfigurations() { return queueConfigurations; }
+    public List<QueueNotification> getQueueConfigurations() {
+        return queueConfigurations;
+    }
+
     public void setQueueConfigurations(List<QueueNotification> queueConfigurations) {
         this.queueConfigurations = queueConfigurations != null ? queueConfigurations : new ArrayList<>();
     }
 
-    public List<TopicNotification> getTopicConfigurations() { return topicConfigurations; }
+    public List<TopicNotification> getTopicConfigurations() {
+        return topicConfigurations;
+    }
+
     public void setTopicConfigurations(List<TopicNotification> topicConfigurations) {
         this.topicConfigurations = topicConfigurations != null ? topicConfigurations : new ArrayList<>();
     }
 
+    public List<LambdaNotification> getLambdaFunctionConfigurations() {
+        return lambdaFunctionConfigurations;
+    }
+
+    public void setLambdaFunctionConfigurations(List<LambdaNotification> lambdaFunctionConfigurations) {
+        this.lambdaFunctionConfigurations = lambdaFunctionConfigurations != null
+                ? lambdaFunctionConfigurations : new ArrayList<>();
+    }
+
     public boolean isEmpty() {
-        return queueConfigurations.isEmpty() && topicConfigurations.isEmpty();
+        return queueConfigurations.isEmpty()
+               && topicConfigurations.isEmpty()
+               && lambdaFunctionConfigurations.isEmpty();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1002,6 +1002,55 @@ class S3IntegrationTest {
 
     @Test
     @Order(93)
+    void putLambdaNotificationConfigWithFilterIsPersisted() {
+        String xml = """
+                <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <CloudFunctionConfiguration>
+                    <Id>lambda-notif</Id>
+                    <CloudFunction>arn:aws:lambda:us-east-1:000000000000:function:s3-notif-test</CloudFunction>
+                    <Event>s3:ObjectCreated:Put</Event>
+                    <Filter>
+                      <S3Key>
+                        <FilterRule>
+                          <Name>prefix</Name>
+                          <Value>uploads/</Value>
+                        </FilterRule>
+                        <FilterRule>
+                          <Name>suffix</Name>
+                          <Value>.json</Value>
+                        </FilterRule>
+                      </S3Key>
+                    </Filter>
+                  </CloudFunctionConfiguration>
+                </NotificationConfiguration>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .queryParam("notification", "")
+            .body(xml)
+        .when()
+            .put("/notif-test-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("notification", "")
+        .when()
+            .get("/notif-test-bucket")
+        .then()
+            .statusCode(200)
+            .body(containsString("CloudFunctionConfiguration"))
+            .body(containsString("arn:aws:lambda:us-east-1:000000000000:function:s3-notif-test"))
+            .body(containsString("s3:ObjectCreated:Put"))
+            .body(containsString("<Name>prefix</Name>"))
+            .body(containsString("<Value>uploads/</Value>"))
+            .body(containsString("<Name>suffix</Name>"))
+            .body(containsString("<Value>.json</Value>"));
+    }
+
+    @Test
+    @Order(94)
     void cleanupNotificationBucket() {
         given().delete("/notif-test-bucket");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3NotificationModelTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3NotificationModelTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.services.s3.model.FilterRule;
+import io.github.hectorvent.floci.services.s3.model.LambdaNotification;
 import io.github.hectorvent.floci.services.s3.model.QueueNotification;
 import io.github.hectorvent.floci.services.s3.model.TopicNotification;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,10 @@ class S3NotificationModelTest {
         var tn = new TopicNotification("id", "arn:aws:sns:us-east-1:000000000000:t",
                 List.of("s3:ObjectCreated:*"), null);
         assertTrue(tn.matchesKey("anything"));
+
+        var ln = new LambdaNotification("id", "arn:aws:lambda:us-east-1:000000000000:function:test",
+                List.of("s3:ObjectCreated:*"), null);
+        assertTrue(ln.matchesKey("anything"));
     }
 
     @Test
@@ -37,6 +42,12 @@ class S3NotificationModelTest {
         assertTrue(qn.matchesKey("images/photo.jpg"));
         assertFalse(qn.matchesKey("images/photo.png"));
         assertFalse(qn.matchesKey("docs/photo.jpg"));
+
+        var ln = new LambdaNotification("id", "arn", List.of("s3:ObjectCreated:*"),
+                List.of(new FilterRule("prefix", "images/"), new FilterRule("suffix", ".jpg")));
+        assertTrue(ln.matchesKey("images/photo.jpg"));
+        assertFalse(ln.matchesKey("images/photo.png"));
+        assertFalse(ln.matchesKey("docs/photo.jpg"));
     }
 
     // --- FilterRule.matches ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -1,8 +1,13 @@
 package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.s3.model.FilterRule;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
+import io.github.hectorvent.floci.services.s3.model.LambdaNotification;
+import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
 import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
@@ -373,5 +378,68 @@ class S3ServiceTest {
 
         S3Object retrieved = s3Service.getObject("test-bucket", destKey);
         assertArrayEquals("image-data".getBytes(), retrieved.getData());
+    }
+
+    @Test
+    void putObjectTriggersLambdaNotificationWhenKeyMatches() {
+        RecordingLambdaInvoker lambdaInvoker = new RecordingLambdaInvoker();
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+
+        S3Service service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir.resolve("notif-s3"),
+                false, lambdaInvoker, regionResolver);
+        service.createBucket("test-bucket", "ap-northeast-1");
+        service.putBucketNotificationConfiguration("test-bucket", lambdaNotificationConfig("uploads/", ".json"));
+
+        service.putObject("test-bucket", "uploads/test.json", "{\"ok\":true}".getBytes(StandardCharsets.UTF_8),
+                "application/json", null);
+
+        assertEquals("ap-northeast-1", lambdaInvoker.region);
+        assertEquals("s3-notif-test", lambdaInvoker.functionName);
+        assertEquals(InvocationType.Event, lambdaInvoker.type);
+        assertNotNull(lambdaInvoker.payload);
+    }
+
+    @Test
+    void putObjectDoesNotTriggerLambdaNotificationWhenKeyDoesNotMatch() {
+        RecordingLambdaInvoker lambdaInvoker = new RecordingLambdaInvoker();
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+
+        S3Service service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir.resolve("notif-s3-no-match"),
+                false, lambdaInvoker, regionResolver);
+        service.createBucket("test-bucket", "ap-northeast-1");
+        service.putBucketNotificationConfiguration("test-bucket", lambdaNotificationConfig("uploads/", ".json"));
+
+        service.putObject("test-bucket", "incoming/test.txt", "ignored".getBytes(StandardCharsets.UTF_8),
+                "text/plain", null);
+
+        assertNull(lambdaInvoker.functionName);
+    }
+
+    private static NotificationConfiguration lambdaNotificationConfig(String prefix, String suffix) {
+        NotificationConfiguration config = new NotificationConfiguration();
+        config.getLambdaFunctionConfigurations().add(new LambdaNotification(
+                "lambda-notif",
+                "arn:aws:lambda:ap-northeast-1:000000000000:function:s3-notif-test",
+                List.of("s3:ObjectCreated:Put"),
+                List.of(
+                        new FilterRule("prefix", prefix),
+                        new FilterRule("suffix", suffix)
+                )));
+        return config;
+    }
+
+    private static final class RecordingLambdaInvoker implements S3Service.LambdaInvoker {
+        private String region;
+        private String functionName;
+        private byte[] payload;
+        private InvocationType type;
+
+        @Override
+        public void invoke(String region, String functionName, byte[] payload, InvocationType type) {
+            this.region = region;
+            this.functionName = functionName;
+            this.payload = payload;
+            this.type = type;
+        }
     }
 }


### PR DESCRIPTION
## Summary

feat: Implement S3 Lambda notifications

- Add support for S3 event notifications to AWS Lambda functions.
- Introduce `LambdaNotification` model to represent Lambda configurations.
- Update S3 controller to parse and serialize `CloudFunctionConfiguration` in notification XML.
- Implement logic in `S3Service` to extract Lambda ARN details and invoke functions upon matching S3 events.
- Add unit and integration tests for Lambda notification configuration persistence and event triggering.


test(s3-notifications): Add S3 bucket notification compatibility tests
- Introduces `S3NotificationsTest` to verify S3 event notifications for SQS, SNS, and Lambda targets.
- Includes tests for notification configuration round-trip and Lambda invocation with object filters.
- Adds `s3NotificationLoggerZip` to `LambdaUtils` for creating a test Lambda function.

close #201 

## Validation

Validated with automated tests and a local end-to-end runtime check.

Automated coverage:
- `./mvnw -Dtest=S3NotificationModelTest,S3ServiceTest test`
- `./mvnw -Dtest=S3IntegrationTest test`

Manual end-to-end check:
1. Build and start Floci locally
2. Create an S3 bucket
3. Create a Lambda function
4. Configure `PutBucketNotificationConfiguration` with `LambdaFunctionConfigurations`
5. Upload a matching object
6. Verify:
   - `GetBucketNotificationConfiguration` returns the configured Lambda notification
   - the Lambda function is invoked
   - CloudWatch Logs contain the expected S3 event log
   
```bash
./mvnw -DskipTests package
docker build --no-cache -f Dockerfile.jvm-package -t floci-local:s3-lambda-notif .

docker rm -f floci-s3-lambda-test >/dev/null 2>&1 || true
docker run -d --name floci-s3-lambda-test \
  -p 4566:4566 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e FLOCI_DEFAULT_REGION=ap-northeast-1 \
  -e FLOCI_HOSTNAME=floci \
  -e FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK=bridge \
  floci-local:s3-lambda-notif
```
## Validation

1. Start Floci locally on `http://localhost:4566` with Lambda support enabled.
2. From `compatibility-tests/sdk-test-java`, run:

```bash
mvn -q -DskipTests compile
FLOCI_ENDPOINT=http://localhost:4566 mvn -q -Dtest=S3NotificationsTest test
```
This validates:

- S3 bucket notification configuration round-trip for SQS, SNS, and Lambda
- prefix/suffix filter persistence
- end-to-end Lambda invocation after PutObject
- CloudWatch Logs visibility for the Lambda notification flow

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
