### PR TITLE
fix(s3): use EmulatorConfig for FLOCI_HOSTNAME to fix native image crash

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -1,12 +1,11 @@
 package io.github.hectorvent.floci.services.s3;
 
-import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.net.URI;
 import java.util.Optional;
@@ -17,10 +16,13 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     private final String baseHostname;
 
-    @Inject
-    public S3VirtualHostFilter(
-            @ConfigProperty(name = "floci.base-url", defaultValue = "http://localhost:4566") String baseUrl,
-            @ConfigProperty(name = "floci.hostname") Optional<String> hostname) {
+    public S3VirtualHostFilter() {
+        var config = ConfigProvider.getConfig();
+        String baseUrl = config
+                .getOptionalValue("floci.base-url", String.class)
+                .orElse("http://localhost:4566");
+        Optional<String> hostname = config
+                .getOptionalValue("floci.hostname", String.class);
         String effectiveUrl = hostname
                 .map(h -> baseUrl.replaceFirst("://[^:/]+(:\\d+)?", "://" + h + "$1"))
                 .orElse(baseUrl);
@@ -71,19 +73,21 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
      * matches a well-known AWS S3 domain pattern (for DNS-redirect setups).
      *
      * Examples with baseHostname="localhost":
-     *   my-bucket.localhost:4566       → "my-bucket"
-     *   my-bucket.localhost            → "my-bucket"
-     *   floci.svc.cluster.local        → null  (no bucket prefix, path-style)
-     *   my-svc.floci.svc.cluster.local → null  (remainder doesn't match "localhost")
+     *   my-bucket.localhost:4566       -> "my-bucket"
+     *   my-bucket.localhost            -> "my-bucket"
+     *   floci.svc.cluster.local        -> null  (no bucket prefix, path-style)
+     *   my-svc.floci.svc.cluster.local -> null  (remainder doesn't match "localhost")
      *
      * Examples with baseHostname="floci.svc.cluster.local":
-     *   my-bucket.floci.svc.cluster.local → "my-bucket"
-     *   floci.svc.cluster.local           → null  (no bucket prefix, path-style)
+     *   my-bucket.floci.svc.cluster.local -> "my-bucket"
+     *   floci.svc.cluster.local           -> null  (no bucket prefix, path-style)
      *
      * Returns null if the host does not match a virtual-hosted pattern.
      */
     static String extractBucket(String host, String baseHostname) {
-        if (host == null) return null;
+        if (host == null) {
+            return null;
+        }
 
         // Strip port if present
         String hostname = stripPort(host);
@@ -117,7 +121,9 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     /** Extracts the hostname (without scheme or port) from a URL string. */
     static String extractHostnameFromUrl(String url) {
-        if (url == null) return null;
+        if (url == null) {
+            return null;
+        }
         try {
             URI uri = URI.create(url);
             return uri.getHost();
@@ -147,11 +153,15 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         return true;
     }
 
-    /** Returns true for *.s3.amazonaws.com and *.s3.<region>.amazonaws.com domains. */
+    /** Returns true for *.s3.amazonaws.com and *.s3.region.amazonaws.com domains. */
     private static boolean isAwsS3Domain(String remainder) {
-        if ("s3.amazonaws.com".equals(remainder)) return true;
+        if ("s3.amazonaws.com".equals(remainder)) {
+            return true;
+        }
         // s3.<region>.amazonaws.com
-        if (remainder.startsWith("s3.") && remainder.endsWith(".amazonaws.com")) return true;
+        if (remainder.startsWith("s3.") && remainder.endsWith(".amazonaws.com")) {
+            return true;
+        }
         return false;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.s3;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
@@ -9,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class S3VirtualHostFilterTest {
 
-    // ── Virtual-hosted style: bucket prefix + matching baseHostname ─────────
+    // --- extractBucket with baseHostname ---
 
     @ParameterizedTest
     @CsvSource({
@@ -33,7 +34,7 @@ class S3VirtualHostFilterTest {
         assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host, baseHostname));
     }
 
-    // ── Path-style: service hostname alone — must NOT extract a bucket ───────
+    // --- Path-style: service hostname alone — must NOT extract a bucket ---
 
     @ParameterizedTest
     @CsvSource({
@@ -70,7 +71,14 @@ class S3VirtualHostFilterTest {
         assertNull(S3VirtualHostFilter.extractBucket(host, "localhost"));
     }
 
-    // ── Hostname extraction from URL ─────────────────────────────────────────
+    @Test
+    void returnsNullForNullBaseHostname() {
+        // Without a baseHostname, only AWS S3 domains should match
+        assertNull(S3VirtualHostFilter.extractBucket("my-bucket.localhost:4566", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.amazonaws.com", null));
+    }
+
+    // --- Hostname extraction from URL ---
 
     @ParameterizedTest
     @CsvSource({
@@ -82,5 +90,10 @@ class S3VirtualHostFilterTest {
     })
     void extractsHostnameFromUrl(String url, String expectedHostname) {
         assertEquals(expectedHostname, S3VirtualHostFilter.extractHostnameFromUrl(url));
+    }
+
+    @Test
+    void extractHostnameFromUrlReturnsNullForNull() {
+        assertNull(S3VirtualHostFilter.extractHostnameFromUrl(null));
     }
 }


### PR DESCRIPTION
S3VirtualHostFilter used @ConfigProperty constructor injection, which gets baked into the GraalVM native binary at build time. Setting FLOCI_HOSTNAME at runtime via Docker env var caused an IllegalStateException because the runtime value differed from the build-time value (null).

Replace @ConfigProperty with programmatic `ConfigProvider.getConfig()` lookup. `@PreMatching` JAX-RS filters run before CDI beans are fully initialized, so neither `@ConfigProperty` nor `@ConfigMapping` beans like `EmulatorConfig` are available during filter construction.

Also make bucket extraction hostname-aware: only treat the first label as a bucket name when the remainder matches the configured base hostname (or a well-known AWS S3 domain). This prevents false positives when Floci sits behind a multi-label hostname like floci.svc.cluster.local.

## Summary

Fixes native image crash when `FLOCI_HOSTNAME` is set at runtime, and prevents false-positive virtual-host bucket extraction in multi-label hostname environments (e.g. Kubernetes).

**Reproduction:**

```
$ docker run -e FLOCI_HOSTNAME=floci hectorvent/floci:1.4.0

2026-04-08 12:25:15,330 ERROR [io.quarkus.runtime.Application] (main) Failed to start application: java.lang.RuntimeException: Failed to start quarkus
    at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
    at io.quarkus.runtime.Application.start(Application.java:112)
    at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:127)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:79)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:50)
    at io.quarkus.runtime.Quarkus.run(Quarkus.java:143)
    at io.quarkus.runner.GeneratedMain.main(Unknown Source)
Caused by: java.lang.IllegalStateException: A runtime config property value differs from the value that was injected during the static intialization phase:
 - the runtime value of 'floci.hostname' is [floci] but the value [null] was injected into io.github.hectorvent.floci.services.s3.S3VirtualHostFilter()

If that's intentional then annotate the injected field/parameter with @io.quarkus.runtime.annotations.StaticInitSafe to eliminate the false positive.
    at io.quarkus.arc.runtime.ConfigStaticInitValues.onStart(ConfigStaticInitValues.java:61)
    at io.quarkus.arc.runtime.ConfigStaticInitValues_Observer_onStart_fdhd3Q2CPu5KfpwUMYn5Ol6axJU.notify(Unknown Source)
    at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:366)
    at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:348)
    at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:81)
    at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:165)
    at io.quarkus.arc.runtime.ArcRecorder.handleLifecycleEvents(ArcRecorder.java:115)
    at io.quarkus.runner.recorded.LifecycleEventsBuildStep$startupEvent1144526294.deploy_0(Unknown Source)
    at io.quarkus.runner.recorded.LifecycleEventsBuildStep$startupEvent1144526294.deploy(Unknown Source)
    ... 7 more
```

## Type of change

- [x] Bug fix (\`fix:\`)
- [ ] New feature (\`feat:\`)
- [ ] Breaking change (\`feat!:\` or \`fix!:\`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** \`FLOCI_HOSTNAME\` env var crashes the native image on startup. Without it, virtual-host bucket extraction has no hostname awareness, causing false positives in Docker Compose / Kubernetes setups.

## Checklist

- [x] \`./mvnw test\` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)