### PR TITLE
fix(s3): use case-insensitive field lookup for presigned POST policy validation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1610,10 +1610,18 @@ public class S3Controller {
                     "Bucket POST must contain a file field.", 400);
         }
 
+        // Build a case-insensitive (lowercased) view of the form fields for policy
+        // validation, matching the behaviour of LocalStack and real AWS S3.
+        // The AWS SDK sends "Policy" (capital P) while some clients use "policy".
+        Map<String, String> lcFields = new LinkedHashMap<>(fields.size());
+        for (Map.Entry<String, String> e : fields.entrySet()) {
+            lcFields.put(e.getKey().toLowerCase(Locale.ROOT), e.getValue());
+        }
+
         // Validate policy conditions if present
-        String policy = fields.get("policy");
+        String policy = lcFields.get("policy");
         if (policy != null && !policy.isEmpty()) {
-            validatePolicyConditions(policy, bucket, fields, fileData.length);
+            validatePolicyConditions(policy, bucket, lcFields, fileData.length);
         }
 
         // Use Content-Type from form fields, fall back to file part Content-Type
@@ -1673,10 +1681,11 @@ public class S3Controller {
             String fieldName = entry.getKey();
             String expectedValue = entry.getValue().asText();
             String actualValue;
-            if ("bucket".equals(fieldName)) {
+            String lookupKey = fieldName.toLowerCase(Locale.ROOT);
+            if ("bucket".equals(lookupKey)) {
                 actualValue = bucket;
             } else {
-                actualValue = fields.get(fieldName);
+                actualValue = fields.get(lookupKey);
             }
             if (actualValue == null || !actualValue.equals(expectedValue)) {
                 throw new AwsException("AccessDenied",
@@ -1703,7 +1712,7 @@ public class S3Controller {
             String fieldRef = condition.get(1).asText();
             String expectedValue = condition.get(2).asText();
             String fieldName = fieldRef.startsWith("$") ? fieldRef.substring(1) : fieldRef;
-            String actualValue = resolveFieldValue(fieldName, bucket, fields);
+            String actualValue = resolveFieldValue(fieldName.toLowerCase(Locale.ROOT), bucket, fields);
             if (actualValue == null || !actualValue.equals(expectedValue)) {
                 throw new AwsException("AccessDenied",
                         "Invalid according to Policy: Policy Condition failed: "
@@ -1713,7 +1722,7 @@ public class S3Controller {
             String fieldRef = condition.get(1).asText();
             String prefix = condition.get(2).asText();
             String fieldName = fieldRef.startsWith("$") ? fieldRef.substring(1) : fieldRef;
-            String actualValue = resolveFieldValue(fieldName, bucket, fields);
+            String actualValue = resolveFieldValue(fieldName.toLowerCase(Locale.ROOT), bucket, fields);
             if (actualValue == null || !actualValue.startsWith(prefix)) {
                 throw new AwsException("AccessDenied",
                         "Invalid according to Policy: Policy Condition failed: "

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -377,6 +377,64 @@ class S3PresignedPostIntegrationTest {
     }
 
     @Test
+    @Order(95)
+    void presignedPostEnforcesPolicyWithCapitalPFieldName() {
+        // The AWS SDK sends the policy field as "Policy" (capital P).
+        // This test verifies that validation works regardless of casing.
+        String key = "uploads/capital-p-reject.png";
+        String fileContent = "not a real png";
+
+        String policy = buildPolicy(BUCKET, key, "image/png", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        // Send with capital-P "Policy" and mismatched Content-Type — should be rejected
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "image/gif")
+            .multiPart("Policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "capital-p-reject.png", fileContent.getBytes(StandardCharsets.UTF_8), "image/gif")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(403)
+            .contentType("application/xml")
+            .body(hasXPath("/Error/Code", equalTo("AccessDenied")))
+            .body(hasXPath("/Error/Message", equalTo(
+                    "Invalid according to Policy: Policy Condition failed: "
+                            + "[\"eq\", \"$Content-Type\", \"image/png\"]")));
+    }
+
+    @Test
+    @Order(96)
+    void presignedPostSucceedsWithCapitalPFieldName() {
+        // Verify that a valid upload with capital-P "Policy" also succeeds
+        String key = "uploads/capital-p-ok.txt";
+        String fileContent = "capital P success";
+
+        String policy = buildPolicy(BUCKET, key, "text/plain", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "text/plain")
+            .multiPart("Policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("file", "capital-p-ok.txt", fileContent.getBytes(StandardCharsets.UTF_8), "text/plain")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(204)
+            .header("ETag", notNullValue());
+    }
+
+    @Test
     @Order(100)
     void cleanupBucket() {
         // Delete all objects
@@ -386,6 +444,7 @@ class S3PresignedPostIntegrationTest {
         given().delete("/" + BUCKET + "/uploads/typed-file.json");
         given().delete("/" + BUCKET + "/uploads/within-range.txt");
         given().delete("/" + BUCKET + "/uploads/prefix-test.txt");
+        given().delete("/" + BUCKET + "/uploads/capital-p-ok.txt");
 
         given()
         .when()


### PR DESCRIPTION
Presigned POST requests may send the policy field as either `Policy` (capital P, as the AWS SDK does) or `policy` (lowercase). The existing implementation only checked lowercase `policy`, causing validation failures for clients that use uppercase field names.

Refactor to use case-insensitive field lookup so both variants are handled correctly. Policy condition matching (`eq`, `starts-with`) also now normalizes field names to lowercase before comparison.

## Summary

- Build a case-insensitive (lowercased) view of form fields before policy validation
- Normalize field names in `eq` and `starts-with` condition checks to lowercase
- Add integration tests for both rejection and success with capital-P `Policy` field name

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Presigned POST uploads using `Policy` (capital P) as the form field name — which is what the AWS SDK sends — would skip policy validation entirely, allowing uploads that violate policy conditions. With this fix, both `Policy` and `policy` are recognized and validated correctly, matching real AWS S3 behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)