### PR TITLE
fix: register Xerces XML resource bundles for native image (#293)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
@@ -91,7 +91,7 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {}
+        } catch (Exception ignored) {}
         return result;
     }
 
@@ -160,7 +160,7 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {}
+        } catch (Exception ignored) {}
         return result;
     }
 
@@ -206,7 +206,7 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {}
+        } catch (Exception ignored) {}
         return result;
     }
 
@@ -256,7 +256,7 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {}
+        } catch (Exception ignored) {}
         return result;
     }
 
@@ -312,7 +312,7 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (XMLStreamException ignored) {}
+        } catch (Exception ignored) {}
         return result;
     }
 }

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "bundles": [
+    {"name": "com.sun.org.apache.xerces.internal.impl.msg.XMLMessages"},
+    {"name": "com.sun.org.apache.xerces.internal.impl.msg.XMLSerializerMessages"},
+    {"name": "com.sun.org.apache.xerces.internal.impl.xpath.regex.message"}
+  ]
+}


### PR DESCRIPTION

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Fixes #293 — CDK asset publishing fails in native image because XmlParser receives non-XML bodies (CDK PutObject requests) and Xerces throws MissingResourceException trying to format the error, which escaped the catch (XMLStreamException) blocks.                                                                                                    
   
  - Widen all 5 catch blocks in XmlParser from XMLStreamException → Exception                                                                                                 
  - Add resource-config.json registering the Xerces XML message resource bundles so they're available in the native image at runtime
                                                                                                                                        


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
