### PR TITLE
fix: implement missing RDS resource identifiers and fix filtering (#231)

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# RDS integration tests
+
+setup() {
+    load 'test_helper/common-setup'
+}
+
+teardown() {
+    # Delete test instance if it exists
+    aws_cmd rds delete-db-instance --db-instance-identifier "test-cli-db" --skip-final-snapshot >/dev/null 2>&1 || true
+    aws_cmd rds delete-db-instance --db-instance-identifier "test-cli-db-2" --skip-final-snapshot >/dev/null 2>&1 || true
+}
+
+@test "RDS: create db instance returns resource identifiers" {
+    run aws_cmd rds create-db-instance \
+        --db-instance-identifier "test-cli-db" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10
+    
+    assert_success
+    
+    dbi_resource_id=$(json_get "$output" '.DBInstance.DbiResourceId')
+    db_instance_arn=$(json_get "$output" '.DBInstance.DBInstanceArn')
+    
+    [ -n "$dbi_resource_id" ]
+    [[ "$dbi_resource_id" =~ ^db- ]]
+    
+    [ -n "$db_instance_arn" ]
+    [[ "$db_instance_arn" =~ ^arn:aws:rds:.*:db:test-cli-db$ ]]
+}
+
+@test "RDS: describe db instances filters by identifier" {
+    aws_cmd rds create-db-instance \
+        --db-instance-identifier "test-cli-db" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10
+
+    run aws_cmd rds describe-db-instances --db-instance-identifier "test-cli-db"
+    assert_success
+    
+    count=$(echo "$output" | jq '.DBInstances | length')
+    [ "$count" -eq 1 ]
+    
+    id=$(json_get "$output" '.DBInstances[0].DBInstanceIdentifier')
+    [ "$id" = "test-cli-db" ]
+}
+
+@test "RDS: describe db instances is case-insensitive" {
+    aws_cmd rds create-db-instance \
+        --db-instance-identifier "test-cli-db" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10
+
+    run aws_cmd rds describe-db-instances --db-instance-identifier "TEST-CLI-DB"
+    assert_success
+    
+    count=$(echo "$output" | jq '.DBInstances | length')
+    [ "$count" -eq 1 ]
+    
+    id=$(json_get "$output" '.DBInstances[0].DBInstanceIdentifier')
+    [ "$id" = "test-cli-db" ]
+}
+
+@test "RDS: describe db instances returns all when no filter" {
+    aws_cmd rds create-db-instance \
+        --db-instance-identifier "test-cli-db" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10
+    
+    aws_cmd rds create-db-instance \
+        --db-instance-identifier "test-cli-db-2" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10
+
+    run aws_cmd rds describe-db-instances
+    assert_success
+    
+    # Might have more from other tests, but at least 2
+    count=$(echo "$output" | jq '.DBInstances | length')
+    [ "$count" -ge 2 ]
+}

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -35,6 +35,9 @@ public interface EmulatorConfig {
     @WithDefault("us-east-1")
     String defaultRegion();
 
+    @WithDefault("us-east-1a")
+    String defaultAvailabilityZone();
+
     @WithDefault("000000000000")
     String defaultAccountId();
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.rds;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
@@ -28,14 +29,16 @@ public class RdsQueryHandler {
     private static final Logger LOG = Logger.getLogger(RdsQueryHandler.class);
 
     private final RdsService service;
+    private final EmulatorConfig config;
 
     @Inject
-    public RdsQueryHandler(RdsService service) {
+    public RdsQueryHandler(RdsService service, EmulatorConfig config) {
         this.service = service;
+        this.config = config;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params) {
-        LOG.debugv("RDS action: {0}", action);
+        LOG.infov("RDS action: {0}", action);
         try {
             return switch (action) {
                 case "CreateDBInstance" -> handleCreateDbInstance(params);
@@ -366,7 +369,32 @@ public class RdsQueryHandler {
         xml.elem("IAMDatabaseAuthenticationEnabled", i.isIamDatabaseAuthenticationEnabled())
            .elem("MultiAZ", false)
            .elem("StorageType", "gp2")
-           .elem("PubliclyAccessible", false);
+           .elem("PubliclyAccessible", false)
+           .elem("AvailabilityZone", config.defaultAvailabilityZone())
+           .elem("PreferredMaintenanceWindow", "mon:00:00-mon:03:00")
+           .elem("PreferredBackupWindow", "04:00-06:00")
+           .start("VpcSecurityGroups")
+             .start("VpcSecurityGroupMembership")
+               .elem("VpcSecurityGroupId", "sg-00000000")
+               .elem("Status", "active")
+             .end("VpcSecurityGroupMembership")
+           .end("VpcSecurityGroups")
+           .start("DBSubnetGroup")
+             .elem("DBSubnetGroupName", "default")
+             .elem("VpcId", "vpc-00000000")
+             .elem("SubnetGroupStatus", "Complete")
+             .start("Subnets")
+               .start("member")
+                 .elem("SubnetIdentifier", "subnet-00000000")
+                 .start("SubnetAvailabilityZone")
+                   .elem("Name", config.defaultAvailabilityZone())
+                 .end("SubnetAvailabilityZone")
+                 .elem("SubnetStatus", "Active")
+               .end("member")
+             .end("Subnets")
+           .end("DBSubnetGroup")
+           .elem("DbiResourceId", i.getDbiResourceId())
+           .elem("DBInstanceArn", i.getDbInstanceArn());
         if (i.getDbClusterIdentifier() != null && !i.getDbClusterIdentifier().isBlank()) {
             xml.elem("DBClusterIdentifier", i.getDbClusterIdentifier());
         }
@@ -401,6 +429,31 @@ public class RdsQueryHandler {
         }
         xml.elem("IAMDatabaseAuthenticationEnabled", c.isIamDatabaseAuthenticationEnabled())
            .elem("MultiAZ", false)
+           .elem("AvailabilityZone", config.defaultAvailabilityZone())
+           .elem("PreferredMaintenanceWindow", "mon:00:00-mon:03:00")
+           .elem("PreferredBackupWindow", "04:00-06:00")
+           .start("VpcSecurityGroups")
+             .start("VpcSecurityGroupMembership")
+               .elem("VpcSecurityGroupId", "sg-00000000")
+               .elem("Status", "active")
+             .end("VpcSecurityGroupMembership")
+           .end("VpcSecurityGroups")
+           .start("DBSubnetGroup")
+             .elem("DBSubnetGroupName", "default")
+             .elem("VpcId", "vpc-00000000")
+             .elem("SubnetGroupStatus", "Complete")
+             .start("Subnets")
+               .start("member")
+                 .elem("SubnetIdentifier", "subnet-00000000")
+                 .start("SubnetAvailabilityZone")
+                   .elem("Name", config.defaultAvailabilityZone())
+                 .end("SubnetAvailabilityZone")
+                 .elem("SubnetStatus", "Active")
+               .end("member")
+             .end("Subnets")
+           .end("DBSubnetGroup")
+           .elem("DbClusterResourceId", c.getDbClusterResourceId())
+           .elem("DBClusterArn", c.getDbClusterArn())
            .start("DBClusterMembers");
         if (c.getDbClusterMembers() != null) {
             for (String memberId : c.getDbClusterMembers()) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.rds;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerHandle;
@@ -38,15 +39,18 @@ public class RdsService {
     private final StorageBackend<String, DbParameterGroup> parameterGroups;
     private final RdsContainerManager containerManager;
     private final RdsProxyManager proxyManager;
+    private final RegionResolver regionResolver;
     private final EmulatorConfig config;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
 
     @Inject
     public RdsService(RdsContainerManager containerManager,
                       RdsProxyManager proxyManager,
+                      RegionResolver regionResolver,
                       EmulatorConfig config) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
+        this.regionResolver = regionResolver;
         this.config = config;
         this.instances = new InMemoryStorage<>();
         this.clusters = new InMemoryStorage<>();
@@ -103,6 +107,10 @@ public class RdsService {
         instance.setContainerHost(containerHost);
         instance.setContainerPort(containerPort);
 
+        String region = regionResolver.getDefaultRegion();
+        instance.setDbiResourceId("db-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
+        instance.setDbInstanceArn(regionResolver.buildArn("rds", region, "db:" + id));
+
         String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
         proxyManager.startProxy(id, engine, iamEnabled, proxyPort, backendHost, backendPort,
                 effectiveMasterUser, masterPassword, dbName,
@@ -129,7 +137,7 @@ public class RdsService {
 
     public Collection<DbInstance> listDbInstances(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
-            return instances.get(filterId).map(List::of).orElse(List.of());
+            return instances.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return instances.scan(k -> true);
     }
@@ -246,6 +254,10 @@ public class RdsService {
         cluster.setContainerHost(handle.getHost());
         cluster.setContainerPort(handle.getPort());
 
+        String region = regionResolver.getDefaultRegion();
+        cluster.setDbClusterResourceId("cluster-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
+        cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
+
         String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
         proxyManager.startProxy(id, engine, iamEnabled, proxyPort, handle.getHost(), handle.getPort(),
                 effectiveMasterUser, masterPassword, databaseName,
@@ -264,7 +276,7 @@ public class RdsService {
 
     public Collection<DbCluster> listDbClusters(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
-            return clusters.get(filterId).map(List::of).orElse(List.of());
+            return clusters.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return clusters.scan(k -> true);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
@@ -21,6 +21,8 @@ public class DbCluster {
     private boolean iamDatabaseAuthenticationEnabled;
     private List<String> dbClusterMembers = new ArrayList<>();
     private String parameterGroupName;
+    private String dbClusterResourceId;
+    private String dbClusterArn;
     private Instant createdAt;
     private int proxyPort;
 
@@ -89,6 +91,12 @@ public class DbCluster {
 
     public String getParameterGroupName() { return parameterGroupName; }
     public void setParameterGroupName(String parameterGroupName) { this.parameterGroupName = parameterGroupName; }
+
+    public String getDbClusterResourceId() { return dbClusterResourceId; }
+    public void setDbClusterResourceId(String dbClusterResourceId) { this.dbClusterResourceId = dbClusterResourceId; }
+
+    public String getDbClusterArn() { return dbClusterArn; }
+    public void setDbClusterArn(String dbClusterArn) { this.dbClusterArn = dbClusterArn; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -20,6 +20,8 @@ public class DbInstance {
     private boolean iamDatabaseAuthenticationEnabled;
     private String parameterGroupName;
     private String dbClusterIdentifier;
+    private String dbiResourceId;
+    private String dbInstanceArn;
     private Instant createdAt;
     private int proxyPort;
 
@@ -93,6 +95,12 @@ public class DbInstance {
 
     public String getDbClusterIdentifier() { return dbClusterIdentifier; }
     public void setDbClusterIdentifier(String dbClusterIdentifier) { this.dbClusterIdentifier = dbClusterIdentifier; }
+
+    public String getDbiResourceId() { return dbiResourceId; }
+    public void setDbiResourceId(String dbiResourceId) { this.dbiResourceId = dbiResourceId; }
+
+    public String getDbInstanceArn() { return dbInstanceArn; }
+    public void setDbInstanceArn(String dbInstanceArn) { this.dbInstanceArn = dbInstanceArn; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
@@ -282,6 +282,8 @@ class EventBridgeSchedulerIntegrationTest {
             @Override
             public String defaultRegion() { return REGION; }
             @Override
+            public String defaultAvailabilityZone() { return REGION + "a"; }
+            @Override
             public String defaultAccountId() { return ACCOUNT; }
             @Override
             public int maxRequestSize() { return 512; }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -1,0 +1,79 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.rds.container.RdsContainerHandle;
+import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
+import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RdsServiceTest {
+
+    private RdsService rdsService;
+    private RdsContainerManager containerManager;
+    private RdsProxyManager proxyManager;
+    private RegionResolver regionResolver;
+    private EmulatorConfig config;
+
+    @BeforeEach
+    void setUp() {
+        containerManager = mock(RdsContainerManager.class);
+        proxyManager = mock(RdsProxyManager.class);
+        regionResolver = new RegionResolver("us-east-1", "123456789012");
+        config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.RdsServiceConfig rdsConfig = mock(EmulatorConfig.RdsServiceConfig.class);
+
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.rds()).thenReturn(rdsConfig);
+        when(rdsConfig.proxyBasePort()).thenReturn(7000);
+        when(rdsConfig.proxyMaxPort()).thenReturn(7099);
+
+        rdsService = new RdsService(containerManager, proxyManager, regionResolver, config);
+
+        when(containerManager.start(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new RdsContainerHandle("cont-id", "id", "localhost", 5432));
+    }
+
+    @Test
+    void createDbInstanceGeneratesMissingFields() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null);
+
+        assertEquals("mydb", instance.getDbInstanceIdentifier());
+        assertNotNull(instance.getDbiResourceId());
+        assertTrue(instance.getDbiResourceId().startsWith("db-"));
+        assertEquals("arn:aws:rds:us-east-1:123456789012:db:mydb", instance.getDbInstanceArn());
+    }
+
+    @Test
+    void listDbInstancesIsCaseInsensitive() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null);
+
+        Collection<DbInstance> result = rdsService.listDbInstances("MYDB");
+        assertEquals(1, result.size());
+        assertEquals("mydb", result.iterator().next().getDbInstanceIdentifier());
+
+        result = rdsService.listDbInstances("mydb");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void listDbInstancesReturnsEmptyWhenNotFound() {
+        Collection<DbInstance> result = rdsService.listDbInstances("nonexistent");
+        assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

- Make DescribeDBInstances and DescribeDBClusters filtering case-insensitive to match AWS behavior.
- Generate and return DbiResourceId, DBInstanceArn, and DbClusterResourceId.
- Add critical XML fields (AvailabilityZone, VpcSecurityGroups, DBSubnetGroup) for Terraform compatibility.
- Implement automated AWS CLI compatibility tests for RDS.
- Fix anonymous EmulatorConfig in tests to support new defaultAvailabilityZone method.

Closes #231

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
