### PR TITLE
feat(kinesis): add IncreaseStreamRetentionPeriod and DecreaseStreamRetentionPeriod

### DIFF
--- a/docs/services/kinesis.md
+++ b/docs/services/kinesis.md
@@ -26,6 +26,8 @@
 | `AddTagsToStream` | Tag a stream |
 | `RemoveTagsFromStream` | Remove tags |
 | `ListTagsForStream` | List tags |
+| `IncreaseStreamRetentionPeriod` | Increase retention up to 8760 hours (365 days) |
+| `DecreaseStreamRetentionPeriod` | Decrease retention down to 24 hours |
 | `StartStreamEncryption` | Enable KMS encryption |
 | `StopStreamEncryption` | Disable encryption |
 

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -55,6 +55,8 @@ public class KinesisJsonHandler {
             case "GetShardIterator" -> handleGetShardIterator(request, region);
             case "GetRecords" -> handleGetRecords(request, region);
             case "ListShards" -> handleListShards(request, region);
+            case "IncreaseStreamRetentionPeriod" -> handleIncreaseStreamRetentionPeriod(request, region);
+            case "DecreaseStreamRetentionPeriod" -> handleDecreaseStreamRetentionPeriod(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -328,21 +330,38 @@ public class KinesisJsonHandler {
         return Response.ok(response).build();
     }
 
-    private Response handleListShards(JsonNode request, String region) {
+    private Response handleIncreaseStreamRetentionPeriod(JsonNode request, String region) {
+        String streamName = resolveStreamName(request);
+        int retentionPeriodHours = request.path("RetentionPeriodHours").asInt();
+        service.increaseStreamRetentionPeriod(streamName, retentionPeriodHours, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleDecreaseStreamRetentionPeriod(JsonNode request, String region) {
+        String streamName = resolveStreamName(request);
+        int retentionPeriodHours = request.path("RetentionPeriodHours").asInt();
+        service.decreaseStreamRetentionPeriod(streamName, retentionPeriodHours, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private String resolveStreamName(JsonNode request) {
         String streamName = request.has("StreamName") ? request.path("StreamName").asText(null) : null;
         String streamArn = request.has("StreamARN") ? request.path("StreamARN").asText(null) : null;
-
-        String resolvedStreamName = streamName;
-        if (resolvedStreamName == null && streamArn != null) {
+        if (streamName == null && streamArn != null) {
             int idx = streamArn.lastIndexOf("/");
             if (idx >= 0) {
-                resolvedStreamName = streamArn.substring(idx + 1);
+                streamName = streamArn.substring(idx + 1);
             }
         }
-        if (resolvedStreamName == null) {
+        if (streamName == null) {
             throw new AwsException("InvalidArgumentException",
                     "StreamName or StreamARN must be provided", 400);
         }
+        return streamName;
+    }
+
+    private Response handleListShards(JsonNode request, String region) {
+        String resolvedStreamName = resolveStreamName(request);
 
         KinesisStream stream = service.describeStream(resolvedStreamName, region);
 

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -141,6 +141,40 @@ public class KinesisService {
         store.put(regionKey(region, streamName), stream);
     }
 
+    public void increaseStreamRetentionPeriod(String streamName, int retentionPeriodHours, String region) {
+        KinesisStream stream = resolveStream(streamName, region);
+        if (retentionPeriodHours > 8760) {
+            throw new AwsException("InvalidArgumentException",
+                    "Retention period must not exceed 8760 hours (365 days)", 400);
+        }
+        if (retentionPeriodHours <= stream.getRetentionPeriodHours()) {
+            throw new AwsException("InvalidArgumentException",
+                    "Requested retention period (" + retentionPeriodHours +
+                    " hours) must be greater than current retention period (" +
+                    stream.getRetentionPeriodHours() + " hours)", 400);
+        }
+        stream.setRetentionPeriodHours(retentionPeriodHours);
+        store.put(regionKey(region, streamName), stream);
+        LOG.infov("Increased retention period for stream {0} to {1} hours", streamName, retentionPeriodHours);
+    }
+
+    public void decreaseStreamRetentionPeriod(String streamName, int retentionPeriodHours, String region) {
+        KinesisStream stream = resolveStream(streamName, region);
+        if (retentionPeriodHours < 24) {
+            throw new AwsException("InvalidArgumentException",
+                    "Retention period must not be less than 24 hours", 400);
+        }
+        if (retentionPeriodHours >= stream.getRetentionPeriodHours()) {
+            throw new AwsException("InvalidArgumentException",
+                    "Requested retention period (" + retentionPeriodHours +
+                    " hours) must be less than current retention period (" +
+                    stream.getRetentionPeriodHours() + " hours)", 400);
+        }
+        stream.setRetentionPeriodHours(retentionPeriodHours);
+        store.put(regionKey(region, streamName), stream);
+        LOG.infov("Decreased retention period for stream {0} to {1} hours", streamName, retentionPeriodHours);
+    }
+
     public void stopStreamEncryption(String streamName, String region) {
         KinesisStream stream = resolveStream(streamName, region);
         stream.setEncryptionType("NONE");

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -147,6 +147,137 @@ class KinesisIntegrationTest {
 
     @Test
     @Order(7)
+    void increaseStreamRetentionPeriod() {
+        // Create a dedicated stream for retention tests
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "ShardCount": 1}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Increase from default 24 to 48
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.IncreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 48}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify via DescribeStream
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.RetentionPeriodHours", equalTo(48));
+    }
+
+    @Test
+    @Order(8)
+    void decreaseStreamRetentionPeriod() {
+        // Decrease from 48 back to 24
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DecreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 24}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.RetentionPeriodHours", equalTo(24));
+    }
+
+    @Test
+    @Order(9)
+    void increaseRetentionPeriodRejectsTooHigh() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.IncreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 9999}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidArgumentException"));
+    }
+
+    @Test
+    @Order(10)
+    void decreaseRetentionPeriodRejectsTooLow() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DecreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 12}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidArgumentException"));
+    }
+
+    @Test
+    @Order(11)
+    void increaseRetentionPeriodRejectsLowerValue() {
+        // First increase to 48
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.IncreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 48}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Try to "increase" to 24 (lower) - should fail
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.IncreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 24}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidArgumentException"));
+    }
+
+    @Test
+    @Order(12)
     void listShardsForNonExistentStream() {
         given()
             .header("X-Amz-Target", "Kinesis_20131202.ListShards")


### PR DESCRIPTION
## Summary
- Add `IncreaseStreamRetentionPeriod` and `DecreaseStreamRetentionPeriod` actions to the Kinesis service
- Validation matches AWS behavior: increase rejects values ≤ current or > 8760; decrease rejects values ≥ current or < 24
- Both actions accept `StreamName` or `StreamARN` (via shared `resolveStreamName` helper, which also DRYs up `ListShards`)

## Changes
- `KinesisJsonHandler.java`: two new handler methods + shared `resolveStreamName()` extracted from `handleListShards`
- `KinesisService.java`: two new service methods with bounds validation
- `KinesisIntegrationTest.java`: 5 new tests (happy path increase/decrease, too-high, too-low, wrong-direction, all assert `__type`)
- `docs/services/kinesis.md`: both actions added to supported actions table

## Review
- Codex + Gemini external review, two-pass internal review
- Fixed: missing StreamARN support (P1.1), validation order (P2.4)

## Test plan
- [x] 12 integration tests pass (5 new + 7 existing)
- [x] All validation error cases assert `InvalidArgumentException` error type

Closes #291