### PR TITLE
feat(s3): preserve Cache-Control header on PutObject, GetObject, HeadObject, and CopyObject

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -391,10 +391,12 @@ public class S3Controller {
             byte[] data = decodeAwsChunked(body, contentEncoding, contentSha256);
             validateChecksumHeaders(httpHeaders, data);
             String persistedEncoding = toPersistedContentEncoding(contentEncoding);
+            String cacheControl = httpHeaders.getHeaderString("Cache-Control");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     httpHeaders.getHeaderString("x-amz-storage-class"),
                     persistedEncoding,
-                    lockMode, retainUntil, legalHold);
+                    lockMode, retainUntil, legalHold,
+                    cacheControl);
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
@@ -1266,6 +1268,9 @@ public class S3Controller {
         if (obj.getContentEncoding() != null) {
             resp.header("Content-Encoding", obj.getContentEncoding());
         }
+        if (obj.getCacheControl() != null) {
+            resp.header("Cache-Control", obj.getCacheControl());
+        }
         if (obj.getMetadata() != null) {
             for (Map.Entry<String, String> entry : obj.getMetadata().entrySet()) {
                 resp.header("x-amz-meta-" + entry.getKey(), entry.getValue());
@@ -1310,12 +1315,14 @@ public class S3Controller {
         String sourceKey = decodedSource.substring(slashIndex + 1);
 
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
+        String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
         S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
                 httpHeaders.getHeaderString("x-amz-metadata-directive"),
                 extractUserMetadata(httpHeaders),
                 httpHeaders.getHeaderString("x-amz-storage-class"),
                 contentType,
-                copyContentEncoding);
+                copyContentEncoding,
+                copyCacheControl);
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyObjectResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -138,29 +138,30 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
-        return putObject(bucketName, key, data, contentType, metadata, null,
-                objectLockMode, retainUntilDate, legalHoldStatus);
+        return putObject(bucketName, key, data, contentType, metadata, null, null,
+                objectLockMode, retainUntilDate, legalHoldStatus, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, storageClass, null,
-                objectLockMode, retainUntilDate, legalHoldStatus);
+                objectLockMode, retainUntilDate, legalHoldStatus, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String contentEncoding,
-                              String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
+                              String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
+                              String cacheControl) {
         S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding);
+                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, cacheControl);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
     }
@@ -171,7 +172,7 @@ public class S3Service {
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
         return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
-                null, null, null, null);
+                null, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
@@ -179,14 +180,14 @@ public class S3Service {
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return storeObject(bucketName, key, data, contentType, metadata, storageClass, checksum, parts,
-                objectLockMode, retainUntilDate, legalHoldStatus, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata, String storageClass,
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                                 String contentEncoding) {
+                                 String contentEncoding, String cacheControl) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
@@ -199,6 +200,7 @@ public class S3Service {
         object.setChecksum(checksum != null ? copyChecksum(checksum) : buildChecksum(data, parts, false));
         object.setParts(copyParts(parts));
         object.setContentEncoding(contentEncoding);
+        object.setCacheControl(cacheControl);
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();
@@ -551,13 +553,14 @@ public class S3Service {
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType) {
         return copyObject(sourceBucket, sourceKey, destBucket, destKey, metadataDirective,
-                replacementMetadata, storageClass, contentType, null);
+                replacementMetadata, storageClass, contentType, null, null);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey,
                                String metadataDirective, Map<String, String> replacementMetadata,
-                               String storageClass, String contentType, String contentEncoding) {
+                               String storageClass, String contentType, String contentEncoding,
+                               String cacheControl) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
 
@@ -570,9 +573,10 @@ public class S3Service {
         String effectiveContentType = replaceMetadata && contentType != null ? contentType : source.getContentType();
         String effectiveStorageClass = storageClass != null ? storageClass : source.getStorageClass();
         String effectiveContentEncoding = replaceMetadata && contentEncoding != null ? contentEncoding : source.getContentEncoding();
+        String effectiveCacheControl = replaceMetadata && cacheControl != null ? cacheControl : source.getCacheControl();
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
                 effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null,
-                effectiveContentEncoding);
+                effectiveContentEncoding, effectiveCacheControl);
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
@@ -1415,6 +1419,7 @@ public class S3Service {
         copy.setMetadata(new HashMap<>(source.getMetadata()));
         copy.setContentType(source.getContentType());
         copy.setContentEncoding(source.getContentEncoding());
+        copy.setCacheControl(source.getCacheControl());
         copy.setSize(source.getSize());
         copy.setLastModified(source.getLastModified());
         copy.setETag(source.getETag());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -22,6 +22,7 @@ public class S3Object {
     private Map<String, String> metadata;
     private String contentType;
     private String contentEncoding;
+    private String cacheControl;
     private long size;
     private Instant lastModified;
     private String eTag;
@@ -80,6 +81,9 @@ public class S3Object {
 
     public String getContentEncoding() { return contentEncoding; }
     public void setContentEncoding(String contentEncoding) { this.contentEncoding = contentEncoding; }
+
+    public String getCacheControl() { return cacheControl; }
+    public void setCacheControl(String cacheControl) { this.cacheControl = cacheControl; }
 
     public long getSize() { return size; }
     public void setSize(long size) { this.size = size; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -898,6 +898,98 @@ class S3IntegrationTest {
         given().delete("/encoding-test-bucket");
     }
 
+    // --- Cache-Control header preservation ---
+
+    @Test
+    @Order(89)
+    void createCacheControlBucketAndPutObject() {
+        given()
+            .put("/cache-control-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("text/plain")
+            .header("Cache-Control", "public, max-age=31536000")
+            .body("cached-content")
+        .when()
+            .put("/cache-control-bucket/cached.txt")
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue());
+    }
+
+    @Test
+    @Order(90)
+    void getObjectReturnsCacheControl() {
+        given()
+        .when()
+            .get("/cache-control-bucket/cached.txt")
+        .then()
+            .statusCode(200)
+            .header("Cache-Control", equalTo("public, max-age=31536000"));
+    }
+
+    @Test
+    @Order(90)
+    void headObjectReturnsCacheControl() {
+        given()
+        .when()
+            .head("/cache-control-bucket/cached.txt")
+        .then()
+            .statusCode(200)
+            .header("Cache-Control", equalTo("public, max-age=31536000"));
+    }
+
+    @Test
+    @Order(91)
+    void copyObjectPreservesCacheControl() {
+        given()
+            .header("x-amz-copy-source", "/cache-control-bucket/cached.txt")
+        .when()
+            .put("/cache-control-bucket/cached-copy.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .head("/cache-control-bucket/cached-copy.txt")
+        .then()
+            .statusCode(200)
+            .header("Cache-Control", equalTo("public, max-age=31536000"));
+    }
+
+    @Test
+    @Order(91)
+    void copyObjectReplaceCacheControl() {
+        given()
+            .header("x-amz-copy-source", "/cache-control-bucket/cached.txt")
+            .header("x-amz-metadata-directive", "REPLACE")
+            .header("Cache-Control", "no-cache")
+        .when()
+            .put("/cache-control-bucket/cached-nocache.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .head("/cache-control-bucket/cached-nocache.txt")
+        .then()
+            .statusCode(200)
+            .header("Cache-Control", equalTo("no-cache"));
+    }
+
+    @Test
+    @Order(92)
+    void cleanupCacheControlBucket() {
+        given().delete("/cache-control-bucket/cached.txt");
+        given().delete("/cache-control-bucket/cached-copy.txt");
+        given().delete("/cache-control-bucket/cached-nocache.txt");
+        given().delete("/cache-control-bucket");
+    }
+
     // --- S3 Notification Configuration with Filter ---
 
     @Test


### PR DESCRIPTION
Add `cacheControl` as a dedicated field on `S3Object` (following the `contentEncoding` pattern) and thread it through `putObject`, `storeObject`, and `copyObject` in `S3Service`. Extract `Cache-Control` from request headers in `S3Controller.putObject`, return it in `appendObjectHeaders` for GetObject/HeadObject responses, and handle it in `handleCopyObject` with REPLACE directive support.

## Summary

S3 was silently dropping the `Cache-Control` header on upload. This PR preserves it across PutObject, GetObject, HeadObject, and CopyObject, matching real AWS S3 behavior.

- Add `cacheControl` field to `S3Object` model
- Extract and persist `Cache-Control` header in `putObject`
- Return `Cache-Control` in `appendObjectHeaders` for GET/HEAD responses
- Handle `Cache-Control` in `copyObject` with REPLACE directive support
- Add 6 integration tests: put, get, head, copy-preserve, copy-replace, cleanup

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `Cache-Control` header sent with PutObject was silently discarded. GetObject and HeadObject responses never included `Cache-Control`, and CopyObject did not preserve or replace it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)