### PR TITLE
fix: support LocalStack-compatible _user_request_ URL for API Gateway execution

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.*;
@@ -37,6 +38,7 @@ import java.util.regex.Pattern;
  * <p>This mirrors the real AWS execute-api URL format:
  * {@code https://{apiId}.execute-api.{region}.amazonaws.com/{stageName}/{path}}
  */
+@ApplicationScoped
 @Path("/execute-api/{apiId}/{stageName}")
 @Produces(MediaType.WILDCARD)
 public class ApiGatewayExecuteController {
@@ -115,7 +117,7 @@ public class ApiGatewayExecuteController {
 
     // ──────────────────────────── Core dispatch ────────────────────────────
 
-    private Response dispatch(String httpMethod, String apiId, String stageName,
+    Response dispatch(String httpMethod, String apiId, String stageName,
                               String proxy, HttpHeaders headers, UriInfo uriInfo, byte[] body) {
         String region = regionResolver.resolveRegion(headers);
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestController.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+
+/**
+ * LocalStack-compatible execute endpoint for deployed REST APIs.
+ *
+ * <p>Supports the alternative URL format used by LocalStack and compatible tooling:
+ * {@code /restapis/{apiId}/{stageName}/_user_request_/{proxy+}}
+ *
+ * <p>This is equivalent to the standard execute-api path:
+ * {@code /execute-api/{apiId}/{stageName}/{proxy+}}
+ */
+@Path("/restapis/{apiId}/{stageName}/_user_request_")
+@Produces(MediaType.WILDCARD)
+public class ApiGatewayUserRequestController {
+
+    private final ApiGatewayExecuteController executeController;
+
+    @Inject
+    public ApiGatewayUserRequestController(ApiGatewayExecuteController executeController) {
+        this.executeController = executeController;
+    }
+
+    @GET
+    @Path("/{proxy: .*}")
+    public Response handleGet(@Context HttpHeaders headers, @Context UriInfo uriInfo,
+                              @PathParam("apiId") String apiId,
+                              @PathParam("stageName") String stageName,
+                              @PathParam("proxy") String proxy) {
+        return executeController.dispatch("GET", apiId, stageName, proxy, headers, uriInfo, null);
+    }
+
+    @POST
+    @Path("/{proxy: .*}")
+    public Response handlePost(@Context HttpHeaders headers, @Context UriInfo uriInfo,
+                               @PathParam("apiId") String apiId,
+                               @PathParam("stageName") String stageName,
+                               @PathParam("proxy") String proxy,
+                               byte[] body) {
+        return executeController.dispatch("POST", apiId, stageName, proxy, headers, uriInfo, body);
+    }
+
+    @PUT
+    @Path("/{proxy: .*}")
+    public Response handlePut(@Context HttpHeaders headers, @Context UriInfo uriInfo,
+                              @PathParam("apiId") String apiId,
+                              @PathParam("stageName") String stageName,
+                              @PathParam("proxy") String proxy,
+                              byte[] body) {
+        return executeController.dispatch("PUT", apiId, stageName, proxy, headers, uriInfo, body);
+    }
+
+    @DELETE
+    @Path("/{proxy: .*}")
+    public Response handleDelete(@Context HttpHeaders headers, @Context UriInfo uriInfo,
+                                 @PathParam("apiId") String apiId,
+                                 @PathParam("stageName") String stageName,
+                                 @PathParam("proxy") String proxy) {
+        return executeController.dispatch("DELETE", apiId, stageName, proxy, headers, uriInfo, null);
+    }
+
+    @PATCH
+    @Path("/{proxy: .*}")
+    public Response handlePatch(@Context HttpHeaders headers, @Context UriInfo uriInfo,
+                                @PathParam("apiId") String apiId,
+                                @PathParam("stageName") String stageName,
+                                @PathParam("proxy") String proxy,
+                                byte[] body) {
+        return executeController.dispatch("PATCH", apiId, stageName, proxy, headers, uriInfo, body);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestIntegrationTest.java
@@ -1,0 +1,126 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Verifies that the LocalStack-compatible {@code _user_request_} URL format
+ * correctly routes to the same execution logic as the standard execute-api path.
+ *
+ * <p>LocalStack URL: {@code /restapis/{apiId}/{stageName}/_user_request_/{proxy+}}
+ * <p>Standard URL:   {@code /execute-api/{apiId}/{stageName}/{proxy+}}
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayUserRequestIntegrationTest {
+
+    private static String apiId;
+    private static String rootId;
+    private static String resourceId;
+    private static String deploymentId;
+
+    @Test @Order(1)
+    void createRestApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"user-request-test-api\"}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", notNullValue())
+                .extract().path("id");
+    }
+
+    @Test @Order(2)
+    void setupMockIntegration() {
+        rootId = given()
+                .when().get("/restapis/" + apiId + "/resources")
+                .then()
+                .statusCode(200)
+                .extract().path("item[0].id");
+
+        resourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"hello\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"responseParameters\":{}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/responses/200")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"message\\\":\\\"ok\\\"}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/integration/responses/200")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test @Order(3)
+    void createDeploymentAndStage() {
+        deploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"description\":\"v1\"}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"stageName\":\"prod\",\"deploymentId\":\"" + deploymentId + "\"}")
+                .when().post("/restapis/" + apiId + "/stages")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test @Order(4)
+    void executeViaUserRequestPath() {
+        given()
+                .when().get("/restapis/" + apiId + "/prod/_user_request_/hello")
+                .then()
+                .statusCode(200)
+                .body("message", equalTo("ok"));
+    }
+
+    @Test @Order(5)
+    void executeViaStandardExecuteApiPath() {
+        given()
+                .when().get("/execute-api/" + apiId + "/prod/hello")
+                .then()
+                .statusCode(200)
+                .body("message", equalTo("ok"));
+    }
+
+    @Test @Order(6)
+    void cleanup() {
+        given().when().delete("/restapis/" + apiId).then().statusCode(202);
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

 Closes #295

  ## Problem                                                                                                                                                                    
   
  Requests to the LocalStack-compatible execute URL format:                                                                                                                     
                                                            
      GET /restapis/{apiId}/{stageName}/_user_request_/{proxy+}                                                                                                                 
   
  had no handler in Floci. The request fell through to S3's wildcard                                                                                                            
  handler and returned a misleading `NoSuchBucket` XML error.

Verified manually with a Python Lambda + AWS CLI against a running. Floci container. Both formats return identical responses:
                                                                                                                                                                                
      curl http://localhost:4566/execute-api/{apiId}/prod/hello                                                                                                                 
      curl http://localhost:4566/restapis/{apiId}/prod/_user_request_/hello
                                                       

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
