### PR TITLE
fix: implement list_append with if_not_exists support

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -961,6 +961,29 @@ public class DynamoDbService {
                         item.set(attrName, resolved);
                     }
                 }
+            } else if (valuePart.toLowerCase().startsWith("list_append(")) {
+                int open = valuePart.indexOf('(');
+                int close = valuePart.lastIndexOf(')');
+                if (open >= 0 && close > open) {
+                    String inner = valuePart.substring(open + 1, close);
+                    int commaPos = findNextComma(inner);
+                    if (commaPos >= 0) {
+                        String arg1 = inner.substring(0, commaPos).trim();
+                        String arg2 = inner.substring(commaPos + 1).trim();
+                        JsonNode list1 = evaluateSetExpr(item, arg1, exprAttrNames, exprAttrValues);
+                        JsonNode list2 = evaluateSetExpr(item, arg2, exprAttrNames, exprAttrValues);
+                        if (list1 != null && list2 != null && list1.has("L") && list2.has("L")) {
+                            com.fasterxml.jackson.databind.node.ArrayNode merged =
+                                    com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+                            list1.get("L").forEach(merged::add);
+                            list2.get("L").forEach(merged::add);
+                            com.fasterxml.jackson.databind.node.ObjectNode result =
+                                    com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                            result.set("L", merged);
+                            item.set(attrName, result);
+                        }
+                    }
+                }
             } else if (valuePart.startsWith(":") && exprAttrValues != null) {
                 JsonNode value = exprAttrValues.get(valuePart);
                 if (value != null) {
@@ -978,6 +1001,29 @@ public class DynamoDbService {
             clause = rest;
         }
         return clause;
+    }
+
+    private JsonNode evaluateSetExpr(ObjectNode item, String expr,
+                                     JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        if (expr.toLowerCase().startsWith("if_not_exists(")) {
+            String[] args = extractFunctionArgs(expr);
+            if (args.length == 2) {
+                String checkAttr = resolveAttributeName(args[0].trim(), exprAttrNames);
+                String fallbackExpr = args[1].trim();
+                if (item.has(checkAttr)) {
+                    return item.get(checkAttr);
+                } else if (fallbackExpr.startsWith(":") && exprAttrValues != null) {
+                    return exprAttrValues.get(fallbackExpr);
+                } else {
+                    return item.get(resolveAttributeName(fallbackExpr, exprAttrNames));
+                }
+            }
+            return null;
+        } else if (expr.startsWith(":") && exprAttrValues != null) {
+            return exprAttrValues.get(expr);
+        } else {
+            return item.get(resolveAttributeName(expr, exprAttrNames));
+        }
     }
 
     private String applyRemoveClause(ObjectNode item, String clause, JsonNode exprAttrNames) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -738,6 +738,51 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void listAppendIfNotExistsCreatesListWhenAttributeMissing() {
+        createUsersTable();
+
+        ObjectNode key = item("userId", "u-list-new");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":e", listAttributeValue());
+        exprValues.set(":val", listAttributeValue("a"));
+
+        service.updateItem("Users", key, null,
+                "SET items = list_append(if_not_exists(items, :e), :val)",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertTrue(stored.has("items"), "items attribute must be created");
+        assertEquals(1, stored.get("items").get("L").size());
+        assertEquals("a", stored.get("items").get("L").get(0).get("S").asText());
+    }
+
+    @Test
+    void listAppendIfNotExistsAppendsWhenAttributePresent() {
+        createUsersTable();
+
+        ObjectNode existing = item("userId", "u-list-existing");
+        existing.set("items", listAttributeValue("a"));
+        service.putItem("Users", existing);
+
+        ObjectNode key = item("userId", "u-list-existing");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":e", listAttributeValue());
+        exprValues.set(":val", listAttributeValue("b"));
+
+        service.updateItem("Users", key, null,
+                "SET items = list_append(if_not_exists(items, :e), :val)",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals(2, stored.get("items").get("L").size());
+        assertEquals("a", stored.get("items").get("L").get(0).get("S").asText());
+        assertEquals("b", stored.get("items").get("L").get(1).get("S").asText());
+    }
+
+    @Test
     void scanContainsOnListWithNumericElements() {
         createUsersTable();
         ObjectNode u1 = item("userId", "u1");


### PR DESCRIPTION
## Summary

Fixes #311

The list_append() operation wasn't actually doing anything when used with if_not_exists. Added the implementation to handle list concatenation and fallback behavior properly.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Standard DynamoDB behavior for list_append with if_not_exists fallback. Tested locally against the expected wire protocol behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)