### PR TITLE
fix: RDS DescribeDBInstances returns empty results due to wrong XML names and missing Filters support

### DIFF
--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -113,6 +113,18 @@ resource "aws_secretsmanager_secret_version" "db_creds" {
   })
 }
 
+# -- RDS DB Instance -----------------------------------------------------------
+resource "aws_db_instance" "app" {
+  identifier        = "floci-compat-db"
+  engine            = "postgres"
+  engine_version    = "15"
+  instance_class    = "db.t3.micro"
+  allocated_storage = 20
+  username          = "admin"
+  password          = "Password1!"
+  skip_final_snapshot = true
+}
+
 # -- Outputs -------------------------------------------------------------------
 output "bucket_id" {
   value = aws_s3_bucket.app.id

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -35,5 +35,6 @@ provider "aws" {
     ssm            = var.endpoint
     secretsmanager = var.endpoint
     cognitoidp     = var.endpoint
+    rds            = var.endpoint
   }
 }

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -95,3 +95,10 @@ setup() {
     assert_success
     assert_output --partial "floci-compat"
 }
+
+@test "Terraform: RDS DB instance created and available" {
+    run aws_cmd rds describe-db-instances --db-instance-identifier floci-compat-db
+    assert_success
+    assert_output --partial "floci-compat-db"
+    assert_output --partial "available"
+}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -107,11 +107,14 @@ public class RdsQueryHandler {
 
     private Response handleDescribeDbInstances(MultivaluedMap<String, String> params) {
         String filterId = params.getFirst("DBInstanceIdentifier");
+        if (filterId == null || filterId.isBlank()) {
+            filterId = extractRdsFilterValue(params, "db-instance-id");
+        }
         try {
             Collection<DbInstance> result = service.listDbInstances(filterId);
             XmlBuilder xml = new XmlBuilder().start("DBInstances");
             for (DbInstance i : result) {
-                xml.start("member").raw(dbInstanceInnerXml(i)).end("member");
+                xml.start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance");
             }
             xml.end("DBInstances").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBInstances", AwsNamespaces.RDS, xml.build())).build();
@@ -198,11 +201,14 @@ public class RdsQueryHandler {
 
     private Response handleDescribeDbClusters(MultivaluedMap<String, String> params) {
         String filterId = params.getFirst("DBClusterIdentifier");
+        if (filterId == null || filterId.isBlank()) {
+            filterId = extractRdsFilterValue(params, "db-cluster-id");
+        }
         try {
             Collection<DbCluster> result = service.listDbClusters(filterId);
             XmlBuilder xml = new XmlBuilder().start("DBClusters");
             for (DbCluster c : result) {
-                xml.start("member").raw(dbClusterInnerXml(c)).end("member");
+                xml.start("DBCluster").raw(dbClusterInnerXml(c)).end("DBCluster");
             }
             xml.end("DBClusters").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBClusters", AwsNamespaces.RDS, xml.build())).build();
@@ -267,7 +273,7 @@ public class RdsQueryHandler {
             Collection<DbParameterGroup> result = service.listDbParameterGroups(filterName);
             XmlBuilder xml = new XmlBuilder().start("DBParameterGroups");
             for (DbParameterGroup g : result) {
-                xml.start("member").raw(paramGroupInnerXml(g)).end("member");
+                xml.start("DBParameterGroup").raw(paramGroupInnerXml(g)).end("DBParameterGroup");
             }
             xml.end("DBParameterGroups").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBParameterGroups", AwsNamespaces.RDS, xml.build())).build();
@@ -487,6 +493,24 @@ public class RdsQueryHandler {
             case REBOOTING -> "rebooting";
             case MODIFYING -> "modifying";
         };
+    }
+
+    /**
+     * Extracts the first value for a named filter from RDS Query API encoded params:
+     * {@code Filters.Filter.N.Name=filterName} / {@code Filters.Filter.N.Values.Value.1=value}.
+     * Returns null if no matching filter is present.
+     */
+    private static String extractRdsFilterValue(MultivaluedMap<String, String> params, String filterName) {
+        for (int i = 1; ; i++) {
+            String name = params.getFirst("Filters.Filter." + i + ".Name");
+            if (name == null) {
+                break;
+            }
+            if (filterName.equals(name)) {
+                return params.getFirst("Filters.Filter." + i + ".Values.Value.1");
+            }
+        }
+        return null;
     }
 
     private static int parseIntSafe(String value, int defaultValue) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.rds.model.DbCluster;
+import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
+import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies the XML format and Filters parsing in RdsQueryHandler.
+ */
+class RdsQueryHandlerTest {
+
+    private RdsService service;
+    private RdsQueryHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(RdsService.class);
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.RdsServiceConfig rdsConfig = mock(EmulatorConfig.RdsServiceConfig.class);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.rds()).thenReturn(rdsConfig);
+        when(config.defaultAvailabilityZone()).thenReturn("us-east-1a");
+        handler = new RdsQueryHandler(service, config);
+    }
+
+    // ──────────────────────────── DBInstances XML tag ────────────────────────────
+
+    @Test
+    void describeDbInstances_usesDBInstanceTag() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBInstance>"), "Expected <DBInstance> element in response");
+        assertFalse(body.contains("<member><DBInstanceIdentifier>"), "Did not expect <member> wrapping DBInstance");
+    }
+
+    @Test
+    void describeDbInstances_filterByDirectIdentifier() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.listDbInstances("mydb")).thenReturn(List.of(instance));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        handler.handle("DescribeDBInstances", p);
+
+        verify(service).listDbInstances("mydb");
+    }
+
+    @Test
+    void describeDbInstances_filterByFiltersParam() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.listDbInstances("mydb")).thenReturn(List.of(instance));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "db-instance-id");
+        p.add("Filters.Filter.1.Values.Value.1", "mydb");
+        handler.handle("DescribeDBInstances", p);
+
+        verify(service).listDbInstances("mydb");
+    }
+
+    @Test
+    void describeDbInstances_directIdentifierTakesPriorityOverFilters() {
+        when(service.listDbInstances(any())).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "direct-id");
+        p.add("Filters.Filter.1.Name", "db-instance-id");
+        p.add("Filters.Filter.1.Values.Value.1", "filter-id");
+        handler.handle("DescribeDBInstances", p);
+
+        verify(service).listDbInstances("direct-id");
+    }
+
+    // ──────────────────────────── DBClusters XML tag ────────────────────────────
+
+    @Test
+    void describeDbClusters_usesDBClusterTag() {
+        DbCluster cluster = makeCluster("mycluster");
+        when(service.listDbClusters(null)).thenReturn(List.of(cluster));
+
+        Response response = handler.handle("DescribeDBClusters", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBCluster>"), "Expected <DBCluster> element in response");
+        assertFalse(body.contains("<member><DBClusterIdentifier>"), "Did not expect <member> wrapping DBCluster");
+    }
+
+    @Test
+    void describeDbClusters_filterByFiltersParam() {
+        when(service.listDbClusters("mycluster")).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "db-cluster-id");
+        p.add("Filters.Filter.1.Values.Value.1", "mycluster");
+        handler.handle("DescribeDBClusters", p);
+
+        verify(service).listDbClusters("mycluster");
+    }
+
+    // ──────────────────────────── DBParameterGroups XML tag ──────────────────────
+
+    @Test
+    void describeDbParameterGroups_usesDBParameterGroupTag() {
+        DbParameterGroup group = new DbParameterGroup("pg1", "postgres15", "test group");
+        when(service.listDbParameterGroups(null)).thenReturn(List.of(group));
+
+        Response response = handler.handle("DescribeDBParameterGroups", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBParameterGroup>"), "Expected <DBParameterGroup> element in response");
+        assertFalse(body.contains("<member><DBParameterGroupName>"), "Did not expect <member> wrapping DBParameterGroup");
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private static MultivaluedMap<String, String> params() {
+        return new MultivaluedHashMap<>();
+    }
+
+    private static DbInstance makeInstance(String id) {
+        DbInstance i = new DbInstance();
+        i.setDbInstanceIdentifier(id);
+        i.setStatus(DbInstanceStatus.AVAILABLE);
+        i.setEngine(io.github.hectorvent.floci.services.rds.model.DatabaseEngine.POSTGRES);
+        i.setEngineVersion("15");
+        i.setMasterUsername("admin");
+        i.setDbInstanceClass("db.t3.micro");
+        i.setAllocatedStorage(20);
+        return i;
+    }
+
+    private static DbCluster makeCluster(String id) {
+        DbCluster c = new DbCluster();
+        c.setDbClusterIdentifier(id);
+        c.setStatus(DbInstanceStatus.AVAILABLE);
+        c.setEngine(io.github.hectorvent.floci.services.rds.model.DatabaseEngine.POSTGRES);
+        c.setEngineVersion("15");
+        c.setMasterUsername("admin");
+        return c;
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Two bugs caused Terraform's aws_db_instance waiter to always report "couldn't find resource":

1. DescribeDBInstances, DescribeDBClusters, and DescribeDBParameterGroups wrapped list items in <member> tags. The AWS SDK Go v2 deserializer expects <DBInstance>, <DBCluster>, and <DBParameterGroup> respectively and silently skips anything else, producing an empty list every time.

2. The Terraform AWS provider v6 polls DescribeDBInstances using Filters.Filter.N.Name=db-instance-id instead of DBInstanceIdentifier. Floci ignored Filters entirely, so the waiter always received all instances regardless of the filter value, causing AssertSingleValueResult to fail when more than one instance existed.

Adds a compatibility test covering aws_db_instance create via Terraform.

Closes #307

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
