### PR TITLE
feat(kms): add GetKeyRotationStatus, EnableKeyRotation, and DisableKeyRotation (#290)

### DIFF
--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -25,6 +25,11 @@
 | `TagResource` | Tag a key |
 | `UntagResource` | Remove tags |
 | `ListResourceTags` | List tags |
+| `GetKeyPolicy` | Get a key's resource policy |
+| `PutKeyPolicy` | Update a key's resource policy |
+| `GetKeyRotationStatus` | Check if automatic key rotation is enabled |
+| `EnableKeyRotation` | Enable automatic key rotation (symmetric keys only) |
+| `DisableKeyRotation` | Disable automatic key rotation |
 
 ## Examples
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -50,6 +50,9 @@ public class KmsJsonHandler {
             case "ListResourceTags" -> handleListResourceTags(request, region);
             case "GetKeyPolicy" -> handleGetKeyPolicy(request, region);
             case "PutKeyPolicy" -> handlePutKeyPolicy(request, region);
+            case "GetKeyRotationStatus" -> handleGetKeyRotationStatus(request, region);
+            case "EnableKeyRotation" -> handleEnableKeyRotation(request, region);
+            case "DisableKeyRotation" -> handleDisableKeyRotation(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -269,6 +272,24 @@ public class KmsJsonHandler {
                 request.path("KeyId").asText(),
                 request.path("Policy").asText(),
                 region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleGetKeyRotationStatus(JsonNode request, String region) {
+        String keyId = request.path("KeyId").asText();
+        boolean enabled = service.getKeyRotationStatus(keyId, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("KeyRotationEnabled", enabled);
+        return Response.ok(response).build();
+    }
+
+    private Response handleEnableKeyRotation(JsonNode request, String region) {
+        service.enableKeyRotation(request.path("KeyId").asText(), region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleDisableKeyRotation(JsonNode request, String region) {
+        service.disableKeyRotation(request.path("KeyId").asText(), region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -107,6 +107,40 @@ public class KmsService {
         LOG.infov("Updated key policy for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    // ──────────────────────────── Key Rotation ────────────────────────────
+
+    public boolean getKeyRotationStatus(String keyId, String region) {
+        KmsKey key = resolveKey(keyId, region);
+        validateRotationSupported(key);
+        return key.isKeyRotationEnabled();
+    }
+
+    public void enableKeyRotation(String keyId, String region) {
+        KmsKey key = resolveKey(keyId, region);
+        validateRotationSupported(key);
+        key.setKeyRotationEnabled(true);
+        keyStore.put(region + "::" + key.getKeyId(), key);
+        LOG.infov("Enabled key rotation for KMS key: {0} in {1}", key.getKeyId(), region);
+    }
+
+    public void disableKeyRotation(String keyId, String region) {
+        KmsKey key = resolveKey(keyId, region);
+        validateRotationSupported(key);
+        key.setKeyRotationEnabled(false);
+        keyStore.put(region + "::" + key.getKeyId(), key);
+        LOG.infov("Disabled key rotation for KMS key: {0} in {1}", key.getKeyId(), region);
+    }
+
+    private void validateRotationSupported(KmsKey key) {
+        if (!"ENCRYPT_DECRYPT".equals(key.getKeyUsage())
+                || !"SYMMETRIC_DEFAULT".equals(key.getCustomerMasterKeySpec())) {
+            throw new AwsException(
+                    "UnsupportedOperationException",
+                    "You cannot perform this operation on a non-symmetric key or a key with non-ENCRYPT_DECRYPT key usage.",
+                    400);
+        }
+    }
+
     // ──────────────────────────── Aliases ────────────────────────────
 
     public void createAlias(String aliasName, String targetKeyId, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
@@ -20,6 +20,7 @@ public class KmsKey {
     private long creationDate;
     private long deletionDate;
     private String policy;
+    private boolean keyRotationEnabled = false;
     private Map<String, String> tags = new HashMap<>();
 
     public KmsKey() {
@@ -55,6 +56,9 @@ public class KmsKey {
 
     public String getPolicy() { return policy; }
     public void setPolicy(String policy) { this.policy = policy; }
+
+    public boolean isKeyRotationEnabled() { return keyRotationEnabled; }
+    public void setKeyRotationEnabled(boolean keyRotationEnabled) { this.keyRotationEnabled = keyRotationEnabled; }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -287,4 +287,43 @@ class KmsServiceTest {
         assertThrows(AwsException.class, () ->
                 kmsService.putKeyPolicy("non-existent", "{}", REGION));
     }
+
+    // ── Issue #290 — Key Rotation ───────────────────────────────────────────
+
+    @Test
+    void getKeyRotationStatusDefaultFalse() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        assertFalse(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
+    }
+
+    @Test
+    void enableAndGetKeyRotationStatus() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        kmsService.enableKeyRotation(key.getKeyId(), REGION);
+        assertTrue(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
+    }
+
+    @Test
+    void disableKeyRotationAfterEnable() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        kmsService.enableKeyRotation(key.getKeyId(), REGION);
+        kmsService.disableKeyRotation(key.getKeyId(), REGION);
+        assertFalse(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
+    }
+
+    @Test
+    void keyRotationOnNonExistentKeyThrows() {
+        assertThrows(AwsException.class, () ->
+                kmsService.getKeyRotationStatus("non-existent", REGION));
+    }
+
+    @Test
+    void keyRotationOnAsymmetricKeyThrows() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        key.setCustomerMasterKeySpec("RSA_2048");
+        key.setKeyUsage("SIGN_VERIFY");
+        // Persist the modified key
+        assertThrows(AwsException.class, () ->
+                kmsService.enableKeyRotation(key.getKeyId(), REGION));
+    }
 }


### PR DESCRIPTION
## Summary
- Add `GetKeyRotationStatus`, `EnableKeyRotation`, and `DisableKeyRotation` KMS actions
- Persist rotation state on `KmsKey` model (`keyRotationEnabled` boolean, default `false`)
- Validate rotation is only supported for symmetric `ENCRYPT_DECRYPT` keys, rejecting asymmetric keys with `UnsupportedOperationException`
- Update KMS service docs (also backfills missing `GetKeyPolicy`/`PutKeyPolicy` entries)

Closes #290

## Review
Pre-commit review by Codex (o3) and Gemini (2.5 Pro), both LGTM. Codex noted a pre-existing gap where `CreateKey` doesn't persist `KeyUsage`/`KeySpec` from the request (not introduced by this PR).

## Changes
```
 docs/services/kms.md                          |  5 +++
 .../services/kms/KmsJsonHandler.java          | 21 ++++++++++++
 .../services/kms/KmsService.java              | 34 +++++++++++++++++++
 .../services/kms/model/KmsKey.java            |  4 +++
 .../services/kms/KmsServiceTest.java          | 39 +++++++++++++++++++++
 5 files changed, 103 insertions(+)
```

## Test plan
- [x] 5 new unit tests: default false, enable, disable, non-existent key, asymmetric key rejection
- [x] All 32 KMS tests passing (`./mvnw test -Dtest=KmsServiceTest`)