### PR TITLE
fix(apigateway): implement v2 management api and cfn provisioning

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -8,8 +8,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Api;
+import io.github.hectorvent.floci.services.apigatewayv2.model.Authorizer;
+import io.github.hectorvent.floci.services.apigatewayv2.model.Deployment;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Integration;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Route;
+import io.github.hectorvent.floci.services.apigatewayv2.model.Stage;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
@@ -121,7 +124,7 @@ public class ApiGatewayController {
     @Path("/restapis/{apiId}/authorizers")
     public Response getAuthorizers(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
         String region = regionResolver.resolveRegion(headers);
-        List<Authorizer> auths = service.getAuthorizers(region, apiId);
+        List<io.github.hectorvent.floci.services.apigateway.model.Authorizer> auths = service.getAuthorizers(region, apiId);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("item");
         auths.forEach(a -> items.add(toAuthorizerNode(a)));
@@ -141,7 +144,7 @@ public class ApiGatewayController {
     @Path("/restapis/{apiId}/stages")
     public Response getStages(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
         String region = regionResolver.resolveRegion(headers);
-        List<Stage> stages = service.getStages(region, apiId);
+        List<io.github.hectorvent.floci.services.apigateway.model.Stage> stages = service.getStages(region, apiId);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("item");
         stages.forEach(s -> items.add(toStageNode(s)));
@@ -420,7 +423,7 @@ public class ApiGatewayController {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            Deployment deployment = service.createDeployment(region, apiId, request);
+            io.github.hectorvent.floci.services.apigateway.model.Deployment deployment = service.createDeployment(region, apiId, request);
             return Response.status(201).entity(toDeploymentNode(deployment).toString()).type(MediaType.APPLICATION_JSON).build();
         } catch (IOException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
@@ -432,7 +435,7 @@ public class ApiGatewayController {
     public Response getDeployments(@Context HttpHeaders headers,
                                    @PathParam("apiId") String apiId) {
         String region = regionResolver.resolveRegion(headers);
-        List<Deployment> deployments = service.getDeployments(region, apiId);
+        List<io.github.hectorvent.floci.services.apigateway.model.Deployment> deployments = service.getDeployments(region, apiId);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("item");
         deployments.forEach(d -> items.add(toDeploymentNode(d)));
@@ -448,7 +451,7 @@ public class ApiGatewayController {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            Stage stage = service.createStage(region, apiId, request);
+            io.github.hectorvent.floci.services.apigateway.model.Stage stage = service.createStage(region, apiId, request);
             return Response.status(201).entity(toStageNode(stage).toString()).type(MediaType.APPLICATION_JSON).build();
         } catch (IOException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
@@ -466,7 +469,7 @@ public class ApiGatewayController {
             com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(body).path("patchOperations");
             @SuppressWarnings("unchecked")
             List<Map<String, String>> patchOperations = objectMapper.convertValue(node, List.class);
-            Stage stage = service.updateStage(region, apiId, stageName, patchOperations);
+            io.github.hectorvent.floci.services.apigateway.model.Stage stage = service.updateStage(region, apiId, stageName, patchOperations);
             return Response.ok(toStageNode(stage).toString()).type(MediaType.APPLICATION_JSON).build();
         } catch (IOException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
@@ -494,7 +497,7 @@ public class ApiGatewayController {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            Authorizer auth = service.createAuthorizer(region, apiId, request);
+            io.github.hectorvent.floci.services.apigateway.model.Authorizer auth = service.createAuthorizer(region, apiId, request);
             return Response.status(201).entity(toAuthorizerNode(auth).toString()).type(MediaType.APPLICATION_JSON).build();
         } catch (IOException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
@@ -842,6 +845,21 @@ public class ApiGatewayController {
         return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
     }
 
+    @GET
+    @Path("/v2/apis/{apiId}/routes/{routeId}")
+    public Response getRoute(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("routeId") String routeId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2RouteNode(v2Service.getRoute(region, apiId, routeId)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/routes/{routeId}")
+    public Response deleteRoute(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("routeId") String routeId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteRoute(region, apiId, routeId);
+        return Response.noContent().build();
+    }
+
     @POST
     @Path("/v2/apis/{apiId}/integrations")
     public Response createIntegration(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
@@ -865,6 +883,141 @@ public class ApiGatewayController {
         ArrayNode items = root.putArray("items");
         integrations.forEach(i -> items.add(toV2IntegrationNode(i)));
         return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}")
+    public Response getIntegration(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("integrationId") String integrationId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2IntegrationNode(v2Service.getIntegration(region, apiId, integrationId)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}")
+    public Response deleteIntegration(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("integrationId") String integrationId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteIntegration(region, apiId, integrationId);
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/v2/apis/{apiId}/authorizers")
+    public Response createV2Authorizer(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Authorizer authorizer = v2Service.createAuthorizer(region, apiId, request);
+            return Response.status(201).entity(toV2AuthorizerNode(authorizer).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/authorizers")
+    public Response getV2Authorizers(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<Authorizer> authorizers = v2Service.getAuthorizers(region, apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        authorizers.forEach(a -> items.add(toV2AuthorizerNode(a)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/authorizers/{authorizerId}")
+    public Response getV2Authorizer(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("authorizerId") String authorizerId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2AuthorizerNode(v2Service.getAuthorizer(region, apiId, authorizerId)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/authorizers/{authorizerId}")
+    public Response deleteV2Authorizer(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("authorizerId") String authorizerId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteAuthorizer(region, apiId, authorizerId);
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/v2/apis/{apiId}/stages")
+    public Response createV2Stage(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Stage stage = v2Service.createStage(region, apiId, request);
+            return Response.status(201).entity(toV2StageNode(stage).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/stages")
+    public Response getV2Stages(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<Stage> stages = v2Service.getStages(region, apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        stages.forEach(s -> items.add(toV2StageNode(s)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/stages/{stageName}")
+    public Response getV2Stage(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("stageName") String stageName) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2StageNode(v2Service.getStage(region, apiId, stageName)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/stages/{stageName}")
+    public Response deleteV2Stage(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("stageName") String stageName) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteStage(region, apiId, stageName);
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/v2/apis/{apiId}/deployments")
+    public Response createV2Deployment(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Deployment deployment = v2Service.createDeployment(region, apiId, request);
+            return Response.status(201).entity(toV2DeploymentNode(deployment).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/deployments")
+    public Response getV2Deployments(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<Deployment> deployments = v2Service.getDeployments(region, apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        deployments.forEach(d -> items.add(toV2DeploymentNode(d)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/deployments/{deploymentId}")
+    public Response getV2Deployment(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("deploymentId") String deploymentId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2DeploymentNode(v2Service.getDeployment(region, apiId, deploymentId)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/deployments/{deploymentId}")
+    public Response deleteV2Deployment(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("deploymentId") String deploymentId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteDeployment(region, apiId, deploymentId);
+        return Response.noContent().build();
     }
 
     // ──────────────────────────── Tags ────────────────────────────
@@ -940,7 +1093,7 @@ public class ApiGatewayController {
         return node;
     }
 
-    private ObjectNode toDeploymentNode(Deployment d) {
+    private ObjectNode toDeploymentNode(io.github.hectorvent.floci.services.apigateway.model.Deployment d) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("id", d.id());
         if (d.description() != null) node.put("description", d.description());
@@ -948,7 +1101,7 @@ public class ApiGatewayController {
         return node;
     }
 
-    private ObjectNode toStageNode(Stage s) {
+    private ObjectNode toStageNode(io.github.hectorvent.floci.services.apigateway.model.Stage s) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("stageName", s.getStageName());
         node.put("deploymentId", s.getDeploymentId());
@@ -962,7 +1115,7 @@ public class ApiGatewayController {
         return node;
     }
 
-    private ObjectNode toAuthorizerNode(Authorizer a) {
+    private ObjectNode toAuthorizerNode(io.github.hectorvent.floci.services.apigateway.model.Authorizer a) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("id", a.getId());
         node.put("name", a.getName());
@@ -1062,6 +1215,47 @@ public class ApiGatewayController {
         node.put("integrationType", i.getIntegrationType());
         node.put("payloadFormatVersion", i.getPayloadFormatVersion());
         if (i.getIntegrationUri() != null) node.put("integrationUri", i.getIntegrationUri());
+        return node;
+    }
+
+    private ObjectNode toV2StageNode(Stage s) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("stageName", s.getStageName());
+        if (s.getDeploymentId() != null) node.put("deploymentId", s.getDeploymentId());
+        node.put("autoDeploy", s.isAutoDeploy());
+        node.put("createdDate", java.time.Instant.ofEpochMilli(s.getCreatedDate()).toString());
+        node.put("lastUpdatedDate", java.time.Instant.ofEpochMilli(s.getLastUpdatedDate()).toString());
+        return node;
+    }
+
+    private ObjectNode toV2DeploymentNode(Deployment d) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("deploymentId", d.getDeploymentId());
+        node.put("deploymentStatus", d.getDeploymentStatus());
+        if (d.getDescription() != null) node.put("description", d.getDescription());
+        node.put("createdDate", java.time.Instant.ofEpochMilli(d.getCreatedDate()).toString());
+        return node;
+    }
+
+    private ObjectNode toV2AuthorizerNode(Authorizer a) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("authorizerId", a.getAuthorizerId());
+        node.put("authorizerType", a.getAuthorizerType());
+        node.put("name", a.getName());
+        if (a.getIdentitySource() != null) {
+            ArrayNode idSources = node.putArray("identitySource");
+            a.getIdentitySource().forEach(idSources::add);
+        }
+        if (a.getJwtConfiguration() != null) {
+            ObjectNode jwt = node.putObject("jwtConfiguration");
+            if (a.getJwtConfiguration().audience() != null) {
+                ArrayNode aud = jwt.putArray("audience");
+                a.getJwtConfiguration().audience().forEach(aud::add);
+            }
+            if (a.getJwtConfiguration().issuer() != null) {
+                jwt.put("issuer", a.getJwtConfiguration().issuer());
+            }
+        }
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -217,6 +217,11 @@ public class ApiGatewayV2Service {
         return integrationStore.scan(k -> k.startsWith(prefix));
     }
 
+    public void deleteIntegration(String region, String apiId, String integrationId) {
+        getIntegration(region, apiId, integrationId);
+        integrationStore.delete(integrationKey(region, apiId, integrationId));
+    }
+
     // ──────────────────────────── Stage CRUD ────────────────────────────
 
     public Stage createStage(String region, String apiId, Map<String, Object> request) {
@@ -261,9 +266,19 @@ public class ApiGatewayV2Service {
         return deployment;
     }
 
+    public Deployment getDeployment(String region, String apiId, String deploymentId) {
+        return deploymentStore.get(deploymentKey(region, apiId, deploymentId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Deployment not found", 404));
+    }
+
     public List<Deployment> getDeployments(String region, String apiId) {
         String prefix = region + "::" + apiId + "::";
         return deploymentStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public void deleteDeployment(String region, String apiId, String deploymentId) {
+        getDeployment(region, apiId, deploymentId);
+        deploymentStore.delete(deploymentKey(region, apiId, deploymentId));
     }
 
     // ──────────────────────────── Key helpers ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -17,6 +17,9 @@ import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import io.github.hectorvent.floci.services.ssm.SsmService;
+import io.github.hectorvent.floci.services.apigateway.ApiGatewayService;
+import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2Service;
+import io.github.hectorvent.floci.services.apigatewayv2.model.*;
 import io.github.hectorvent.floci.core.common.AwsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -49,6 +52,8 @@ public class CloudFormationResourceProvisioner {
     private final KmsService kmsService;
     private final SecretsManagerService secretsManagerService;
     private final EventBridgeService eventBridgeService;
+    private final ApiGatewayService apiGatewayService;
+    private final ApiGatewayV2Service apiGatewayV2Service;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -56,7 +61,9 @@ public class CloudFormationResourceProvisioner {
                                              LambdaService lambdaService, IamService iamService,
                                              SsmService ssmService, KmsService kmsService,
                                              SecretsManagerService secretsManagerService,
-                                             EventBridgeService eventBridgeService) {
+                                             EventBridgeService eventBridgeService,
+                                             ApiGatewayService apiGatewayService,
+                                             ApiGatewayV2Service apiGatewayV2Service) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -67,6 +74,8 @@ public class CloudFormationResourceProvisioner {
         this.kmsService = kmsService;
         this.secretsManagerService = secretsManagerService;
         this.eventBridgeService = eventBridgeService;
+        this.apiGatewayService = apiGatewayService;
+        this.apiGatewayV2Service = apiGatewayV2Service;
     }
 
     /**
@@ -106,6 +115,16 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Route53::HostedZone" -> provisionRoute53HostedZone(resource, properties, engine);
                 case "AWS::Route53::RecordSet" -> provisionRoute53RecordSet(resource, properties, engine);
                 case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
+                case "AWS::ApiGateway::RestApi" -> provisionApiGatewayRestApi(resource, properties, engine, region, accountId, stackName);
+                case "AWS::ApiGateway::Resource" -> provisionApiGatewayResource(resource, properties, engine, region);
+                case "AWS::ApiGateway::Method" -> provisionApiGatewayMethod(resource, properties, engine, region);
+                case "AWS::ApiGateway::Deployment" -> provisionApiGatewayDeployment(resource, properties, engine, region);
+                case "AWS::ApiGateway::Stage" -> provisionApiGatewayStage(resource, properties, engine, region);
+                case "AWS::ApiGatewayV2::Api" -> provisionApiGatewayV2Api(resource, properties, engine, region, accountId, stackName);
+                case "AWS::ApiGatewayV2::Route" -> provisionApiGatewayV2Route(resource, properties, engine, region);
+                case "AWS::ApiGatewayV2::Integration" -> provisionApiGatewayV2Integration(resource, properties, engine, region);
+                case "AWS::ApiGatewayV2::Stage" -> provisionApiGatewayV2Stage(resource, properties, engine, region);
+                case "AWS::ApiGatewayV2::Deployment" -> provisionApiGatewayV2Deployment(resource, properties, engine, region);
                 default -> {
                     LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
                     resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
@@ -139,6 +158,8 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::SecretsManager::Secret" ->
                         secretsManagerService.deleteSecret(physicalId, null, true, region);
                 case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, region);
+                case "AWS::ApiGateway::RestApi" -> apiGatewayService.deleteRestApi(region, physicalId);
+                case "AWS::ApiGatewayV2::Api" -> apiGatewayV2Service.deleteApi(region, physicalId);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -686,6 +707,149 @@ public class CloudFormationResourceProvisioner {
     private void provisionRoute53RecordSet(StackResource r, JsonNode props, CloudFormationTemplateEngine engine) {
         String name = resolveOptional(props, "Name", engine);
         r.setPhysicalId(name != null ? name : "record-" + UUID.randomUUID().toString().substring(0, 8));
+    }
+
+    // ── ApiGateway (V1) ──────────────────────────────────────────────────────
+
+    private void provisionApiGatewayRestApi(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                            String region, String accountId, String stackName) {
+        String name = resolveOptional(props, "Name", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        Map<String, Object> req = new HashMap<>();
+        req.put("name", name);
+        req.put("description", resolveOptional(props, "Description", engine));
+
+        var api = apiGatewayService.createRestApi(region, req);
+        r.setPhysicalId(api.getId());
+        r.getAttributes().put("RootResourceId", apiGatewayService.getResources(region, api.getId()).get(0).getId());
+    }
+
+    private void provisionApiGatewayResource(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                             String region) {
+        String apiId = resolveOptional(props, "RestApiId", engine);
+        String parentId = resolveOptional(props, "ParentId", engine);
+        String pathPart = resolveOptional(props, "PathPart", engine);
+
+        Map<String, Object> req = new HashMap<>();
+        req.put("pathPart", pathPart);
+
+        var res = apiGatewayService.createResource(region, apiId, parentId, req);
+        r.setPhysicalId(res.getId());
+    }
+
+    private void provisionApiGatewayMethod(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                           String region) {
+        String apiId = resolveOptional(props, "RestApiId", engine);
+        String resourceId = resolveOptional(props, "ResourceId", engine);
+        String httpMethod = resolveOptional(props, "HttpMethod", engine);
+
+        Map<String, Object> req = new HashMap<>();
+        req.put("authorizationType", resolveOrDefault(props, "AuthorizationType", engine, "NONE"));
+
+        apiGatewayService.putMethod(region, apiId, resourceId, httpMethod, req);
+        r.setPhysicalId(apiId + "-" + resourceId + "-" + httpMethod);
+
+        // Provision integration if present
+        if (props != null && props.has("Integration")) {
+            JsonNode integNode = engine.resolveNode(props.get("Integration"));
+            Map<String, Object> integReq = new HashMap<>();
+            integReq.put("type", resolveOptional(integNode, "Type", engine));
+            integReq.put("httpMethod", resolveOptional(integNode, "IntegrationHttpMethod", engine));
+            integReq.put("uri", resolveOptional(integNode, "Uri", engine));
+
+            apiGatewayService.putIntegration(region, apiId, resourceId, httpMethod, integReq);
+        }
+    }
+
+    private void provisionApiGatewayDeployment(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                               String region) {
+        String apiId = resolveOptional(props, "RestApiId", engine);
+        Map<String, Object> req = new HashMap<>();
+        req.put("description", resolveOptional(props, "Description", engine));
+
+        var deployment = apiGatewayService.createDeployment(region, apiId, req);
+        r.setPhysicalId(deployment.id());
+    }
+
+    private void provisionApiGatewayStage(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                          String region) {
+        String apiId = resolveOptional(props, "RestApiId", engine);
+        String stageName = resolveOptional(props, "StageName", engine);
+        String deploymentId = resolveOptional(props, "DeploymentId", engine);
+
+        Map<String, Object> req = new HashMap<>();
+        req.put("stageName", stageName);
+        req.put("deploymentId", deploymentId);
+        req.put("description", resolveOptional(props, "Description", engine));
+
+        var stage = apiGatewayService.createStage(region, apiId, req);
+        r.setPhysicalId(stageName);
+    }
+
+    // ── ApiGatewayV2 (HTTP/WebSocket) ────────────────────────────────────────
+
+    private void provisionApiGatewayV2Api(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                          String region, String accountId, String stackName) {
+        String name = resolveOptional(props, "Name", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        Map<String, Object> req = new HashMap<>();
+        req.put("name", name);
+        req.put("protocolType", resolveOrDefault(props, "ProtocolType", engine, "HTTP"));
+
+        Api api = apiGatewayV2Service.createApi(region, req);
+        r.setPhysicalId(api.getApiId());
+        r.getAttributes().put("ApiEndpoint", api.getApiEndpoint());
+    }
+
+    private void provisionApiGatewayV2Route(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                            String region) {
+        String apiId = resolveOptional(props, "ApiId", engine);
+        Map<String, Object> req = new HashMap<>();
+        req.put("routeKey", resolveOptional(props, "RouteKey", engine));
+        req.put("authorizationType", resolveOrDefault(props, "AuthorizationType", engine, "NONE"));
+        req.put("target", resolveOptional(props, "Target", engine));
+
+        Route route = apiGatewayV2Service.createRoute(region, apiId, req);
+        r.setPhysicalId(route.getRouteId());
+    }
+
+    private void provisionApiGatewayV2Integration(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                                  String region) {
+        String apiId = resolveOptional(props, "ApiId", engine);
+        Map<String, Object> req = new HashMap<>();
+        req.put("integrationType", resolveOptional(props, "IntegrationType", engine));
+        req.put("integrationUri", resolveOptional(props, "IntegrationUri", engine));
+        req.put("payloadFormatVersion", resolveOrDefault(props, "PayloadFormatVersion", engine, "2.0"));
+
+        Integration integration = apiGatewayV2Service.createIntegration(region, apiId, req);
+        r.setPhysicalId(integration.getIntegrationId());
+    }
+
+    private void provisionApiGatewayV2Stage(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                            String region) {
+        String apiId = resolveOptional(props, "ApiId", engine);
+        String stageName = resolveOptional(props, "StageName", engine);
+
+        Map<String, Object> req = new HashMap<>();
+        req.put("stageName", stageName);
+        req.put("autoDeploy", resolveOrDefault(props, "AutoDeploy", engine, "false"));
+
+        Stage stage = apiGatewayV2Service.createStage(region, apiId, req);
+        r.setPhysicalId(stageName);
+    }
+
+    private void provisionApiGatewayV2Deployment(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                                 String region) {
+        String apiId = resolveOptional(props, "ApiId", engine);
+        Map<String, Object> req = new HashMap<>();
+        req.put("description", resolveOptional(props, "Description", engine));
+
+        Deployment deployment = apiGatewayV2Service.createDeployment(region, apiId, req);
+        r.setPhysicalId(deployment.getDeploymentId());
     }
 
     private String resolveOptional(JsonNode props, String name, CloudFormationTemplateEngine engine) {


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

- Implement missing CRUD operations for ApiGateway V2 (Integrations, Stages, Deployments, Authorizers)
- Add CloudFormation provisioning support for AWS::ApiGateway::* and AWS::ApiGatewayV2::* resources
- Refactor controllers to use specific model imports and resolve V1/V2 name conflicts

Closes #253


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
