### PR TITLE
docs: comprehensive audit sweep + CHANGELOG backfill (1.1.0-1.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,200 @@
+## [1.5.2](https://github.com/floci-io/floci/compare/1.5.1...1.5.2) (2026-04-10)
+
+
+### Bug Fixes
+
+* **apigateway:** implement v2 management api and cfn provisioning ([#323](https://github.com/floci-io/floci/issues/323)) ([30f9cd3](https://github.com/floci-io/floci/commit/30f9cd3d04b24f2e83597e5edaef9b223f115b10))
+* **cloudwatch:** implement tagging support for metrics and alarms ([#320](https://github.com/floci-io/floci/issues/320)) ([c426e80](https://github.com/floci-io/floci/commit/c426e805c2f1ed9f96eeb44dc9e70cde0e70a88d))
+* **dynamodb:** handle null for Java AWS SDK v2 DynamoDB EnhancedClient correctly ([#309](https://github.com/floci-io/floci/issues/309)) ([8bac818](https://github.com/floci-io/floci/commit/8bac818))
+* **dynamodb:** implement list_append with if_not_exists support ([#317](https://github.com/floci-io/floci/issues/317)) ([0eb908a](https://github.com/floci-io/floci/commit/0eb908a))
+* **dynamodb:** remove duplicate list_append handler that breaks nested expressions ([#321](https://github.com/floci-io/floci/issues/321)) ([92ba56b](https://github.com/floci-io/floci/commit/92ba56b))
+* **rds:** DescribeDBInstances returns empty results due to wrong XML element names and missing Filters support ([#319](https://github.com/floci-io/floci/issues/319)) ([473fece](https://github.com/floci-io/floci/commit/473fece))
+* **s3:** preserve leading slashes in object keys to prevent key collisions ([#286](https://github.com/floci-io/floci/issues/286)) ([c7d5c55](https://github.com/floci-io/floci/commit/c7d5c55))
+* support LocalStack-compatible `_user_request_` URL for API Gateway execution ([#314](https://github.com/floci-io/floci/issues/314)) ([55325ec](https://github.com/floci-io/floci/commit/55325ec))
+
+
+### Features
+
+* **kinesis:** add IncreaseStreamRetentionPeriod and DecreaseStreamRetentionPeriod ([#305](https://github.com/floci-io/floci/issues/305)) ([a770b61](https://github.com/floci-io/floci/commit/a770b61))
+* **kinesis:** resolve stream name from StreamARN parameter ([#304](https://github.com/floci-io/floci/issues/304)) ([202d6eb](https://github.com/floci-io/floci/commit/202d6eb))
+* **kms:** add GetKeyRotationStatus, EnableKeyRotation, and DisableKeyRotation ([#290](https://github.com/floci-io/floci/issues/290)) ([1fa7ae7](https://github.com/floci-io/floci/commit/1fa7ae7))
+* **s3:** preserve Cache-Control header on PutObject, GetObject, HeadObject, and CopyObject ([#313](https://github.com/floci-io/floci/issues/313)) ([89a0744](https://github.com/floci-io/floci/commit/89a0744))
+
+## [1.5.1](https://github.com/floci-io/floci/compare/1.5.0...1.5.1) (2026-04-09)
+
+
+### Bug Fixes
+
+* merge branch 'main' into release/1.x ([b2075be](https://github.com/floci-io/floci/commit/b2075be55cc3955db03f6b6df5ee7f7f633eb5ef))
+* native image build failure due to SecureRandom in CognitoSrpHelper ([e83f6d6](https://github.com/floci-io/floci/commit/e83f6d6cbd0fe8e348e228b18ef2163ab8a80271))
+
+# [1.5.0](https://github.com/floci-io/floci/compare/1.4.0...1.5.0) (2026-04-09)
+
+
+### Bug Fixes
+
+* append march x86-64-v2 ([#303](https://github.com/floci-io/floci/issues/303)) ([ddccbe0](https://github.com/floci-io/floci/commit/ddccbe067a22d415b0b52d65bee5d1293087d4e6))
+* DynamoDB DescribeTable returns Projection.NonKeyAttributes ([#300](https://github.com/floci-io/floci/issues/300)) ([552e71e](https://github.com/floci-io/floci/commit/552e71e76f19bc31b7ee40fd084441a10d6294ca))
+* implement missing RDS resource identifiers and fix filtering ([#231](https://github.com/floci-io/floci/issues/231)) ([#302](https://github.com/floci-io/floci/issues/302)) ([7af3600](https://github.com/floci-io/floci/commit/7af3600bcaa4652ad57ceebe211ad3ba0e336adb))
+* Implement S3 Lambda notifications ([#278](https://github.com/floci-io/floci/issues/278)) ([04cbeb5](https://github.com/floci-io/floci/commit/04cbeb542f377b46cd3b84806628c14ab68cada2))
+* implement SRP-6a authentication for Cognito ([#284](https://github.com/floci-io/floci/issues/284)) ([#298](https://github.com/floci-io/floci/issues/298)) ([7c6e6a6](https://github.com/floci-io/floci/commit/7c6e6a6dfaa5fc73ebfa41a17ab40f506baba3c6))
+* merge branch 'main' into release/1.x ([f32f4a9](https://github.com/floci-io/floci/commit/f32f4a97a7e2cdcf5186b8e525efbd7a2df9c3e7))
+* register Xerces XML resource bundles for native image ([#293](https://github.com/floci-io/floci/issues/293)) ([#296](https://github.com/floci-io/floci/issues/296)) ([0bad933](https://github.com/floci-io/floci/commit/0bad9338f9269fc9ddf4e2f01bc71dda6ca418b9))
+* **s3:** use case-insensitive field lookup for presigned POST policy validation ([#289](https://github.com/floci-io/floci/issues/289)) ([3d2cc1c](https://github.com/floci-io/floci/commit/3d2cc1c95e5a39b8006a5a92366bc5dc22842bb0))
+* **s3:** use ConfigProvider for runtime config lookup in S3VirtualHostFilter ([#288](https://github.com/floci-io/floci/issues/288)) ([944fddf](https://github.com/floci-io/floci/commit/944fddf5acb8f9fa394550f5a4f088f0ef6ad3ee))
+
+
+### Features
+
+* **cloudformation:** add AWS::Events::Rule provisioning support ([#261](https://github.com/floci-io/floci/issues/261)) ([c475e52](https://github.com/floci-io/floci/commit/c475e529845d413c23ec70165789864d013463e7))
+* **eventbridge:** add InputTransformer support and S3 event notifications ([#294](https://github.com/floci-io/floci/issues/294)) ([9ca82e5](https://github.com/floci-io/floci/commit/9ca82e5748cb700760aca3efd3c34a06a5766ec2)), closes [#140](https://github.com/floci-io/floci/issues/140)
+* load persisted dynamodb streams on start up ([#299](https://github.com/floci-io/floci/issues/299)) ([ae49bfb](https://github.com/floci-io/floci/commit/ae49bfb378b00c251b5d952ba16d81e892f364bd))
+
+# [1.4.0](https://github.com/floci-io/floci/compare/1.3.0...1.4.0) (2026-04-08)
+
+
+### Bug Fixes
+
+* add list_append support to DynamoDB update expressions ([#277](https://github.com/floci-io/floci/issues/277)) ([b723a9c](https://github.com/floci-io/floci/commit/b723a9c519b15372a4dc8f01a434b43e504bbc8d))
+* default shell executable to /bin/sh for Alpine compatibility ([#241](https://github.com/floci-io/floci/issues/241)) ([d02a1d9](https://github.com/floci-io/floci/commit/d02a1d9a13bddd46db5fbe0522a0d96fca0facda))
+* drain warm pool containers on server shutdown ([#274](https://github.com/floci-io/floci/issues/274)) ([caabf46](https://github.com/floci-io/floci/commit/caabf46b1c61f5ce49b109dbbb2b9d8b20d744d6))
+* dynamodb support add function multiple values ([#263](https://github.com/floci-io/floci/issues/263)) ([1ddc8a3](https://github.com/floci-io/floci/commit/1ddc8a32f7523d2c35b861e1987e39b2ff264e26))
+* handle base64-encoded ACM cert imports ([#248](https://github.com/floci-io/floci/issues/248)) ([1391691](https://github.com/floci-io/floci/commit/13916913e8f18f228217620f14609dca3798b3cb))
+* include ProvisionedThroughput in DynamoDB GSI responses ([#273](https://github.com/floci-io/floci/issues/273)) ([399a96d](https://github.com/floci-io/floci/commit/399a96d70c0510a62a69bcfd42cf5566f8718e60))
+* issues 226 227 ([#257](https://github.com/floci-io/floci/issues/257)) ([81f1a01](https://github.com/floci-io/floci/commit/81f1a01c39c090c1a82b71c0c79b0fe50b3831b7))
+* make EmulatorLifecycle use more idiomatic Quarkus code ([#190](https://github.com/floci-io/floci/issues/190)) ([7ea586e](https://github.com/floci-io/floci/commit/7ea586e446ccc89bd38f8ee6d11ba83c9e6f84a3))
+* merge branch 'main' into release/1.x ([1feec3a](https://github.com/floci-io/floci/commit/1feec3a29222adce872ba2926e9935bd7d0f3cdb))
+* removing log file ([17841d2](https://github.com/floci-io/floci/commit/17841d2d5afd7ebea7149f0745a55b3774d86ef0))
+* resolve Cognito auth, token, and user lookup issues ([#218](https://github.com/floci-io/floci/issues/218) [#220](https://github.com/floci-io/floci/issues/220) [#228](https://github.com/floci-io/floci/issues/228) [#229](https://github.com/floci-io/floci/issues/229) [#233](https://github.com/floci-io/floci/issues/233) [#234](https://github.com/floci-io/floci/issues/234) [#235](https://github.com/floci-io/floci/issues/235)) ([#279](https://github.com/floci-io/floci/issues/279)) ([5e8b39c](https://github.com/floci-io/floci/commit/5e8b39c1aaecd738bb9e7ba36580d5c3da89f276))
+* return 400 when encoded s3 copy source is malformed ([#244](https://github.com/floci-io/floci/issues/244)) ([f4f1752](https://github.com/floci-io/floci/commit/f4f1752b0daa61e16cd9aded6443ec355a314b0e))
+* **s3:** enforce presigned POST policy conditions (eq, starts-with, content-type) ([#203](https://github.com/floci-io/floci/issues/203)) ([cd1759a](https://github.com/floci-io/floci/commit/cd1759aebed320939c7b13fce4a98909ed6d2235))
+* **s3:** versioning IsTruncated, PublicAccessBlock, ListObjectsV2 pagination, K8s virtual host routing ([#276](https://github.com/floci-io/floci/issues/276)) ([6d5839b](https://github.com/floci-io/floci/commit/6d5839bec88a38a9690f5111fc8eda1c2def254c))
+
+
+### Features
+
+* add KMS GetKeyPolicy, PutKeyPolicy and fix CreateKey Tags ([#258](https://github.com/floci-io/floci/issues/258) [#259](https://github.com/floci-io/floci/issues/259) [#269](https://github.com/floci-io/floci/issues/269)) ([#280](https://github.com/floci-io/floci/issues/280)) ([4724db9](https://github.com/floci-io/floci/commit/4724db97be2bc719f4d76e0edfc12202cd1d6e21))
+* add SES V2 REST JSON protocol support ([#265](https://github.com/floci-io/floci/issues/265)) ([e7ab687](https://github.com/floci-io/floci/commit/e7ab687a6a066bd38548d3c425243ad5e024840a))
+* **lambda:** add missing runtimes, fix handler validation, long path… ([#256](https://github.com/floci-io/floci/issues/256)) ([0ef6f87](https://github.com/floci-io/floci/commit/0ef6f87cba2880c321c91c3d90d769603511aa56))
+* **scheduler:** add EventBridge Scheduler service ([#260](https://github.com/floci-io/floci/issues/260)) ([48b6ca3](https://github.com/floci-io/floci/commit/48b6ca347583eb6ace95a69797a2688a3d3e953d))
+* **secretsmanager:** add support for BatchGetSecretValue ([#115](https://github.com/floci-io/floci/issues/115)) ([#264](https://github.com/floci-io/floci/issues/264)) ([37026b7](https://github.com/floci-io/floci/commit/37026b75f1bad702aa649e61e188a25cc2fa8924))
+* **sfn:** nested state machine execution and activity support ([#254](https://github.com/floci-io/floci/issues/254), [#91](https://github.com/floci-io/floci/issues/91)) ([#266](https://github.com/floci-io/floci/issues/266)) ([18bee5b](https://github.com/floci-io/floci/commit/18bee5b278aaaed7e018111c6c146051d862511a))
+* use AWS-specific content type within the response of all JSON-based controllers ([#240](https://github.com/floci-io/floci/issues/240)) ([b4afdbb](https://github.com/floci-io/floci/commit/b4afdbb8421f9101eb3c24159443647160b331d5))
+
+# [1.3.0](https://github.com/floci-io/floci/compare/1.2.0...1.3.0) (2026-04-06)
+
+
+### Bug Fixes
+
+* compilation issue ([10edd2b](https://github.com/floci-io/floci/commit/10edd2bc38523d4f55226b653696f843129a38c7))
+* fall back to Docker bridge IP when host.docker.internal is unresolvable ([#216](https://github.com/floci-io/floci/issues/216)) ([b973b70](https://github.com/floci-io/floci/commit/b973b7060d4cadbf54b6c4bac4f28c69bbf5cdab))
+* **lambda:** copy code to TASK_DIR for provided runtimes ([#206](https://github.com/floci-io/floci/issues/206)) ([0de7931](https://github.com/floci-io/floci/commit/0de793148063f37973f876bbcbe9f76a1fcdead0))
+* **lambda:** honour ReportBatchItemFailures in SQS ESM ([#208](https://github.com/floci-io/floci/issues/208)) ([55b2f29](https://github.com/floci-io/floci/commit/55b2f292cc879be814a2e3e3675255ecf382f618))
+* **lambda:** support Code.S3Bucket + Code.S3Key in CreateFunction and UpdateFunctionCode ([#219](https://github.com/floci-io/floci/issues/219)) ([d4ebc8e](https://github.com/floci-io/floci/commit/d4ebc8e82087a57dfd86a7bcff27ef8739f12b70))
+* merge branch 'main' into release/1.x ([82d3184](https://github.com/floci-io/floci/commit/82d3184498796a4f177a6af0bf0fffb066f245ab))
+* **ses:** add missing Result element to query protocol responses ([#207](https://github.com/floci-io/floci/issues/207)) ([80e2054](https://github.com/floci-io/floci/commit/80e205452b7966c5bb5dcda66d1a5f4159f5161a))
+* **sns:** make Subscribe idempotent for same topic+protocol+endpoint ([#185](https://github.com/floci-io/floci/issues/185)) ([858775c](https://github.com/floci-io/floci/commit/858775c38edb23f8e79b1b121640549a10c16ebb))
+
+
+### Features
+
+* add GlobalSecondaryIndexUpdates support in DynamoDB UpdateTable ([#222](https://github.com/floci-io/floci/issues/222)) ([4e6e953](https://github.com/floci-io/floci/commit/4e6e9533b5983530a9b9bc000abf9349e620dcb6)), closes [#221](https://github.com/floci-io/floci/issues/221)
+* add scheduled rules support for EventBridge Rules ([#217](https://github.com/floci-io/floci/issues/217)) ([e8c6440](https://github.com/floci-io/floci/commit/e8c64404899f011493d9ce477ce5db306d76b76f))
+* **dynamodb:** add ScanFilter support for Scan operation ([#175](https://github.com/floci-io/floci/issues/175)) ([fe4ffd1](https://github.com/floci-io/floci/commit/fe4ffd1ee4f76bff685fd16162327b69f11da3d7))
+* **ec2:** add EC2 service with 61 operations, integration tests, and docs ([#213](https://github.com/floci-io/floci/issues/213)) ([2859d25](https://github.com/floci-io/floci/commit/2859d257b50824548292467903c9ab3210325974))
+* **ecs:** adding ecs service ([#209](https://github.com/floci-io/floci/issues/209)) ([07a7a97](https://github.com/floci-io/floci/commit/07a7a97b4747977641ec16a1e1f06e7124016683))
+* **eventbridge:** forward resources array and support resources pattern matching ([#210](https://github.com/floci-io/floci/issues/210)) ([6d49f09](https://github.com/floci-io/floci/commit/6d49f0983f0d89c896115fdcc98095b9f50ed76a))
+* **lambda:** add AddPermission, GetPolicy, ListTags, ListLayerVersions, etc endpoints ([#223](https://github.com/floci-io/floci/issues/223)) ([c79f02f](https://github.com/floci-io/floci/commit/c79f02f26f6610e67be5b7ac53b8dc26af4fb747))
+* **sfn:** JSONata improvements, States.* intrinsics, DynamoDB ConditionExpression, StartSyncExecution ([#205](https://github.com/floci-io/floci/issues/205)) ([53dd7a6](https://github.com/floci-io/floci/commit/53dd7a68dd79f148265d24eea016d57f043cda08))
+
+# [1.2.0](https://github.com/hectorvent/floci/compare/1.1.0...1.2.0) (2026-04-04)
+
+
+### Bug Fixes
+
+* adding aws-cli in its own floci image hectorvent/floci:x.y.z-aws ([#151](https://github.com/hectorvent/floci/issues/151)) ([aba9593](https://github.com/hectorvent/floci/commit/aba95933cfa774d6397dca9e47f5d6411249c393))
+* **cognito:** auto-generate sub, fix JWT sub claim, add AdminUserGlobalSignOut ([#68](https://github.com/hectorvent/floci/issues/68)) ([#183](https://github.com/hectorvent/floci/issues/183)) ([9d6181c](https://github.com/hectorvent/floci/commit/9d6181c5479a856064892da3ce39339a6bd8f4ca))
+* **cognito:** enrich User Pool responses and implement MfaConfig stub ([#198](https://github.com/hectorvent/floci/issues/198)) ([441d9f1](https://github.com/hectorvent/floci/commit/441d9f179ec1430d7b7d187ac66b7cdc8741c37e))
+* **Cognito:** OAuth/OIDC parity for RS256/JWKS, /oauth2/token, and OAuth app-client settings ([#97](https://github.com/hectorvent/floci/issues/97)) ([a4af506](https://github.com/hectorvent/floci/commit/a4af506c1509d8673dc2b2d9bfd9b8d5e1784aa7))
+* **core:** globally inject aws request-id headers for sdk compatibility ([#146](https://github.com/hectorvent/floci/issues/146)) ([35e129d](https://github.com/hectorvent/floci/commit/35e129d02482bfd2a7b18ca30e8939b16c2a10cc)), closes [#145](https://github.com/hectorvent/floci/issues/145)
+* defer startup hooks until HTTP server is ready ([#157](https://github.com/hectorvent/floci/issues/157)) ([#159](https://github.com/hectorvent/floci/issues/159)) ([59c24c5](https://github.com/hectorvent/floci/commit/59c24c5e4e44f48b225c1d2fc99aaa0fe3f45957))
+* **dynamodb:** fix FilterExpression for BOOL types, List/Set contains, and nested attribute paths ([#137](https://github.com/hectorvent/floci/issues/137)) ([453555a](https://github.com/hectorvent/floci/commit/453555a12474a9429dbaaf7b91026570c47c4fac)), closes [#126](https://github.com/hectorvent/floci/issues/126)
+* **lambda:** copy function code to /var/runtime for provided runtimes ([#114](https://github.com/hectorvent/floci/issues/114)) ([a5ad6cf](https://github.com/hectorvent/floci/commit/a5ad6cf7bc90339ba384d791bfd1ac22c7b1e6b3))
+* merge branch 'main' into release/1.x ([0105e36](https://github.com/hectorvent/floci/commit/0105e36d873cc751f064bf08ca34444f4d19095e))
+* polish HealthController ([#188](https://github.com/hectorvent/floci/issues/188)) ([084237d](https://github.com/hectorvent/floci/commit/084237ddf4ba2ea6b0f9de13241a85055c5fb007))
+* remove private modifier on injected field ([#186](https://github.com/hectorvent/floci/issues/186)) ([ebc0661](https://github.com/hectorvent/floci/commit/ebc06616e717f095007b0888cee7357151343e0b))
+* resolve CloudFormation Lambda Code.S3Key base64 decode error ([#62](https://github.com/hectorvent/floci/issues/62)) ([78be523](https://github.com/hectorvent/floci/commit/78be5232e212ffb05bba651c2c39573c762586b7))
+* resolve numeric ExpressionAttributeNames in DynamoDB expressions ([#192](https://github.com/hectorvent/floci/issues/192)) ([d93296a](https://github.com/hectorvent/floci/commit/d93296a7663414cdcb4cf20d0018e7ecabc987bf))
+* return stable cursor tokens in GetLogEvents to fix SDK pagination loop ([#90](https://github.com/hectorvent/floci/issues/90)) ([#184](https://github.com/hectorvent/floci/issues/184)) ([7354663](https://github.com/hectorvent/floci/commit/73546637ec0e7385ff19d28992beb47025e5db42))
+* **s3:** Evaluate S3 CORS against incoming HTTP Requests ([#131](https://github.com/hectorvent/floci/issues/131)) ([e78c833](https://github.com/hectorvent/floci/commit/e78c8337948c1c680a9596ab4b55d63d84b4c5c8))
+* **s3:** list part for multipart upload ([#164](https://github.com/hectorvent/floci/issues/164)) ([7253559](https://github.com/hectorvent/floci/commit/7253559207ed0d86f5a7b293e42fff7be5d080a2))
+* **s3:** persist Content-Encoding header on S3 objects ([#57](https://github.com/hectorvent/floci/issues/57)) ([ff2f68d](https://github.com/hectorvent/floci/commit/ff2f68d8ab20559494661fb14981c68812edbcd9))
+* **s3:** prevent S3VirtualHostFilter from hijacking non-S3 requests ([#199](https://github.com/hectorvent/floci/issues/199)) ([59cdc3f](https://github.com/hectorvent/floci/commit/59cdc3fea69bb42a44f53c094582961ca44f2e8c))
+* **s3:** resolve file/folder name collision on persistent filesystem ([#134](https://github.com/hectorvent/floci/issues/134)) ([020a546](https://github.com/hectorvent/floci/commit/020a54642d8863c3c94c7385d94aaaa37aa05b7a))
+* **s3:** return CommonPrefixes in ListObjects when delimiter is specified ([#133](https://github.com/hectorvent/floci/issues/133)) ([845ac85](https://github.com/hectorvent/floci/commit/845ac853632130b1835f6c35edfc0efc39cf32a1))
+* **secretsmanager:** return KmsKeyId in DescribeSecret and improve ListSecrets ([#195](https://github.com/hectorvent/floci/issues/195)) ([1e44f39](https://github.com/hectorvent/floci/commit/1e44f39c7c3f0d0ea89c1124dae318b8cc46d363))
+* **sns:** enforce FilterPolicy on message delivery ([#53](https://github.com/hectorvent/floci/issues/53)) ([2f875d4](https://github.com/hectorvent/floci/commit/2f875d41694ace585f00865e3b82987b40ae92a8)), closes [#49](https://github.com/hectorvent/floci/issues/49)
+* **sns:** honor RawMessageDelivery attribute for SQS subscriptions ([#54](https://github.com/hectorvent/floci/issues/54)) ([b762bec](https://github.com/hectorvent/floci/commit/b762becaea3795d2a6320e10dd290a84088e9b2b))
+* **sns:** pass messageDeduplicationId from FIFO topics to SQS FIFO queues ([#171](https://github.com/hectorvent/floci/issues/171)) ([4529823](https://github.com/hectorvent/floci/commit/452982355716f5ada53c1f8bdc67293bc2282963))
+* **sqs:** route queue URL path requests to SQS handler ([#153](https://github.com/hectorvent/floci/issues/153)) ([6bbc9d9](https://github.com/hectorvent/floci/commit/6bbc9d93755e5bbeb17ec6ee39319711f74f3ebb)), closes [#99](https://github.com/hectorvent/floci/issues/99) [#17](https://github.com/hectorvent/floci/issues/17)
+* **sqs:** support binary message attributes and fix MD5OfMessageAttributes ([#168](https://github.com/hectorvent/floci/issues/168)) ([5440ae8](https://github.com/hectorvent/floci/commit/5440ae8a558c18157bcf0699caf3855c36494912))
+* **sqs:** translate Query-protocol error codes to JSON __type equivalents ([#59](https://github.com/hectorvent/floci/issues/59)) ([7d6cf61](https://github.com/hectorvent/floci/commit/7d6cf6179deb642b1d3add2b806eeb5814e18280))
+* support DynamoDB Query BETWEEN and ScanIndexForward=false ([#160](https://github.com/hectorvent/floci/issues/160)) ([cf2c705](https://github.com/hectorvent/floci/commit/cf2c705b7d2e2f92956c8d7e5ffa96fbeb0dc302))
+* wrong method call in test ([665af53](https://github.com/hectorvent/floci/commit/665af531498c65bef5d5117ccc3ba57e92c5af3d))
+
+
+### Features
+
+* add support of Cloudformation mapping and Fn::FindInMap function ([#101](https://github.com/hectorvent/floci/issues/101)) ([eef6698](https://github.com/hectorvent/floci/commit/eef66983d90e1f3cee6aabdb3bc4e1205b68f83e))
+* **cloudwatch-logs:** add ListTagsForResource, TagResource, and UntagResource support ([#172](https://github.com/hectorvent/floci/issues/172)) ([835f8c6](https://github.com/hectorvent/floci/commit/835f8c6ff420691e3efe703d3c24380cbb245e37)), closes [#77](https://github.com/hectorvent/floci/issues/77)
+* **cognito:** add group management support ([#149](https://github.com/hectorvent/floci/issues/149)) ([75bf3c3](https://github.com/hectorvent/floci/commit/75bf3c3bdbe24a46d4a31c8b2fef687e80d64df8))
+* health endpoint ([#139](https://github.com/hectorvent/floci/issues/139)) ([fb42087](https://github.com/hectorvent/floci/commit/fb42087631dcd7980b6fa3706671f8044cb32c84))
+* implement UploadPartCopy for S3 multipart uploads ([#98](https://github.com/hectorvent/floci/issues/98)) ([d1b9a9c](https://github.com/hectorvent/floci/commit/d1b9a9ca6d8dd8df7235481ce00720ea0277ea59))
+* **lambda:** implement ListVersionsByFunction API ([#182](https://github.com/hectorvent/floci/issues/182)) ([#193](https://github.com/hectorvent/floci/issues/193)) ([ecf25d4](https://github.com/hectorvent/floci/commit/ecf25d47367524c7ef26d4b7691b472b10e9d345))
+* officially support Docker named volumes for Native images ([#155](https://github.com/hectorvent/floci/issues/155)) ([4fc9398](https://github.com/hectorvent/floci/commit/4fc9398df4a68b58f218102e0e032e4d9e5d48b1))
+* **s3:** support Filter rules in PutBucketNotificationConfiguration ([#178](https://github.com/hectorvent/floci/issues/178)) ([ef06fc3](https://github.com/hectorvent/floci/commit/ef06fc34933b6b043501ae706e842f127c19543b))
+* support GenerateSecretString and Description for AWS::SecretsManager::Secret in CloudFormation ([#176](https://github.com/hectorvent/floci/issues/176)) ([f994b95](https://github.com/hectorvent/floci/commit/f994b9545b02f6df7289d0f9e9da5dc2dfe23dc8))
+* support GSI and LSI in CloudFormation DynamoDB table provisioning ([#125](https://github.com/hectorvent/floci/issues/125)) ([48bee44](https://github.com/hectorvent/floci/commit/48bee44634dc9c665c15d8aaefac7378dd6c4970))
+
+# [1.1.0](https://github.com/hectorvent/floci/compare/1.0.11...1.1.0) (2026-03-31)
+
+
+### Bug Fixes
+
+* added versionId to S3 notifications for versioning enabled buckets. ([#135](https://github.com/hectorvent/floci/issues/135)) ([3d67bc4](https://github.com/hectorvent/floci/commit/3d67bc4ba38da69fe116a865e442cfc30a33c1b3))
+* align S3 CreateBucket and HeadBucket region behavior with AWS ([#75](https://github.com/hectorvent/floci/issues/75)) ([8380166](https://github.com/hectorvent/floci/commit/838016660cb58daa0e06892c3d7aa554eb191f62))
+* DynamoDB table creation compatibility with Terraform AWS provider v6 ([#89](https://github.com/hectorvent/floci/issues/89)) ([7b87bf2](https://github.com/hectorvent/floci/commit/7b87bf2c1fa8f9cff7aef4be488d7b2cbf3fe26d))
+* **dynamodb:** apply filter expressions in Query ([#123](https://github.com/hectorvent/floci/issues/123)) ([8b6f4fa](https://github.com/hectorvent/floci/commit/8b6f4fa4f51b73240f5b685bd835172fb996d780))
+* **dynamodb:** respect `if_not_exists` for `update_item` ([#102](https://github.com/hectorvent/floci/issues/102)) ([8882a8e](https://github.com/hectorvent/floci/commit/8882a8ebe2213e383ff719793c137b50a937c6c0))
+* for no-such-key with non-ascii key ([#112](https://github.com/hectorvent/floci/issues/112)) ([ab072cf](https://github.com/hectorvent/floci/commit/ab072cf660f784ab5a65077573e3adf36990a2ae))
+* **KMS:** Allow arn and alias to encrypt ([#69](https://github.com/hectorvent/floci/issues/69)) ([fa4e107](https://github.com/hectorvent/floci/commit/fa4e107572792b5cc4dc6e3f4b323695a4a9add7))
+* resolve compatibility test failures across multiple services ([#109](https://github.com/hectorvent/floci/issues/109)) ([1377868](https://github.com/hectorvent/floci/commit/1377868094389616308e3d379c9979a883051f9a))
+* **s3:** allow upload up to 512MB by default. close [#19](https://github.com/hectorvent/floci/issues/19) ([#110](https://github.com/hectorvent/floci/issues/110)) ([3891232](https://github.com/hectorvent/floci/commit/38912326c96741022fc05cc3c0ddc8c1612b906a))
+* **s3:** expose inMemory flag in test constructor to fix S3 disk-persistence tests ([#136](https://github.com/hectorvent/floci/issues/136)) ([522b369](https://github.com/hectorvent/floci/commit/522b3696a6ae3aa8bfb3b02f4284a507c91ffa94))
+* **sns:** add PublishBatch support to JSON protocol handler ([543df05](https://github.com/hectorvent/floci/commit/543df0539b2e68ad2795ce9deb0557624aeea70a))
+* Storage load after backend is created ([#71](https://github.com/hectorvent/floci/issues/71)) ([c95dd10](https://github.com/hectorvent/floci/commit/c95dd1068e7910e3c19bd888be421469b64a1ad9))
+* **storage:** fix storage global config issue and memory s3 directory creation ([b84a128](https://github.com/hectorvent/floci/commit/b84a1281f86f01a3de656748f8d6b90dd20e798f))
+
+
+### Features
+
+* add ACM support ([#21](https://github.com/hectorvent/floci/issues/21)) ([8a8d55d](https://github.com/hectorvent/floci/commit/8a8d55d9727c41eb0f5aa8a434ce792e64cfeed2))
+* add HOSTNAME_EXTERNAL support for multi-container Docker setups ([#82](https://github.com/hectorvent/floci/issues/82)) ([20b40c1](https://github.com/hectorvent/floci/commit/20b40c1565b87e203dd6ce3d453e019ab0557e80)), closes [#81](https://github.com/hectorvent/floci/issues/81)
+* add JSONata query language support for Step Functions ([#84](https://github.com/hectorvent/floci/issues/84)) ([f82b370](https://github.com/hectorvent/floci/commit/f82b370ab2e38f40306c7e330d97da4f720fe828))
+* add Kinesis ListShards operation ([#61](https://github.com/hectorvent/floci/issues/61)) ([6ff8190](https://github.com/hectorvent/floci/commit/6ff819083d48de01317c1de7f12eaa7f23a638a4))
+* add opensearch service emulation ([#85](https://github.com/hectorvent/floci/issues/85)) ([#132](https://github.com/hectorvent/floci/issues/132)) ([68b8ed8](https://github.com/hectorvent/floci/commit/68b8ed883a45ac35690c474a7d82179db642b145))
+* add SES (Simple Email Service) emulation ([#14](https://github.com/hectorvent/floci/issues/14)) ([9bf23d5](https://github.com/hectorvent/floci/commit/9bf23d5513ddeeca83b9185baea34b5fb2dbeaa9))
+* Adding/Fixing support for virtual hosts ([#88](https://github.com/hectorvent/floci/issues/88)) ([26facf2](https://github.com/hectorvent/floci/commit/26facf26e5d6b1cfd6dda0825e43d02645cdb0fa))
+* **APIGW:** add AWS integration type for API Gateway REST v1 ([#108](https://github.com/hectorvent/floci/issues/108)) ([bb4f000](https://github.com/hectorvent/floci/commit/bb4f000914caea64f27c78ce8abab85c1ffac344))
+* **APIGW:** OpenAPI/Swagger import, models, and request validation ([#113](https://github.com/hectorvent/floci/issues/113)) ([d1d7ec3](https://github.com/hectorvent/floci/commit/d1d7ec3bd31281a95626042ad71c4d50df0610ab))
+* docker image with awscli Closes: [#66](https://github.com/hectorvent/floci/issues/66)) ([#95](https://github.com/hectorvent/floci/issues/95)) ([823770e](https://github.com/hectorvent/floci/commit/823770e46325f47252ba3f3054f34710e51f597d))
+* implement GetRandomPassword for Secrets Manager ([#76](https://github.com/hectorvent/floci/issues/76)) ([#80](https://github.com/hectorvent/floci/issues/80)) ([c57d9eb](https://github.com/hectorvent/floci/commit/c57d9ebcf88f1e9ed31567f9b5989a17588ebf98))
+* **lifecycle:** add support for startup and shutdown initialization hooks ([#128](https://github.com/hectorvent/floci/issues/128)) ([7b2576f](https://github.com/hectorvent/floci/commit/7b2576fb42e52e49bd897490b0ace29d113b786d))
+* **s3:** add conditional request headers (If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since) ([#48](https://github.com/hectorvent/floci/issues/48)) ([66af545](https://github.com/hectorvent/floci/commit/66af545053595db74a16afc701b849bf078cbb23)), closes [#46](https://github.com/hectorvent/floci/issues/46)
+* **s3:** add presigned POST upload support ([#120](https://github.com/hectorvent/floci/issues/120)) ([1e59f8d](https://github.com/hectorvent/floci/commit/1e59f8dc59161b830887a31b3b3441cad34c781b))
+* **s3:** add Range header support for GetObject ([#44](https://github.com/hectorvent/floci/issues/44)) ([b0f5ae2](https://github.com/hectorvent/floci/commit/b0f5ae22cd9bbf9999eef49abd39402781d8f5fc)), closes [#40](https://github.com/hectorvent/floci/issues/40)
+* **SFN:** add DynamoDB AWS SDK integration and complete optimized updateItem ([#103](https://github.com/hectorvent/floci/issues/103)) ([4766a7e](https://github.com/hectorvent/floci/commit/4766a7e6f5ace562f9c620b4aa18f1de71a701c5))
+
 ## [1.0.11](https://github.com/hectorvent/floci/compare/1.0.10...1.0.11) (2026-03-24)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ sdk install java 25-open
 This project includes a Maven wrapper, so you don't need to install Maven separately:
 
 ```bash
-git clone https://github.com/hectorvent/floci.git
+git clone https://github.com/floci-io/floci.git
 cd floci
 ./mvnw quarkus:dev     # hot reload on port 4566
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | EC2 (VPCs, instances, security groups) | ✅ | ⚠️ Partial |
 | Native binary | ✅ ~40 MB | ❌ |
 
-**31 services. 1,873 automated compatibility tests. Free forever.**
+**Broad AWS coverage. 1,850+ automated compatibility tests. Free forever.**
 
 ## Architecture Overview
 
@@ -90,41 +90,43 @@ flowchart LR
 
 ## Supported Services
 
-| Service | Ops | How it works | Notable features |
-|---|---|---|---|
-| **SSM Parameter Store** | 12 | In-process | Version history, labels, SecureString, tagging |
-| **SQS** | 17 | In-process | Standard & FIFO, DLQ, visibility timeout, batch, tagging |
-| **SNS** | 13 | In-process | Topics, subscriptions, SQS / Lambda / HTTP delivery, tagging |
-| **S3** | 30 | In-process | Versioning, multipart upload, pre-signed URLs, Object Lock, event notifications |
-| **DynamoDB** | 22 | In-process | GSI / LSI, Query, Scan, TTL, transactions, batch operations |
-| **DynamoDB Streams** | 5 | In-process | Shard iterators, records, Lambda ESM trigger |
-| **Lambda** | 25 | **Real Docker containers** | Warm pool, aliases, Function URLs, SQS / Kinesis / DDB Streams ESM |
-| **API Gateway REST** | 24 | In-process | Resources, methods, stages, Lambda proxy, MOCK integrations, AWS integrations |
-| **API Gateway v2 (HTTP)** | 16 | In-process | Routes, integrations, JWT authorizers, stages |
-| **IAM** | 65+ | In-process | Users, roles, groups, policies, instance profiles, access keys |
-| **STS** | 7 | In-process | AssumeRole, WebIdentity, SAML, GetFederationToken, GetSessionToken |
-| **Cognito** | 20 | In-process | User pools, app clients, auth flows, JWKS / OpenID well-known endpoints |
-| **KMS** | 15 | In-process | Encrypt / decrypt, sign / verify, data keys, aliases |
-| **Kinesis** | 15 | In-process | Streams, shards, enhanced fan-out, split / merge |
-| **Secrets Manager** | 10 | In-process | Versioning, resource policies, tagging |
-| **Step Functions** | 11 | In-process | ASL execution, task tokens, execution history |
-| **CloudFormation** | 12 | In-process | Stacks, change sets, resource provisioning |
-| **EventBridge** | 14 | In-process | Custom buses, rules, targets (SQS / SNS / Lambda) |
-| **EventBridge Scheduler** | 9 | In-process | Schedule groups, schedules, flexible time windows, retry policies, dead-letter queues |
-| **CloudWatch Logs** | 14 | In-process | Log groups, streams, ingestion, filtering |
-| **CloudWatch Metrics** | 5 | In-process | Custom metrics, statistics, alarms |
-| **ElastiCache** | 9 | **Real Docker containers** | Redis / Valkey, IAM auth, SigV4 validation |
-| **RDS** | 14 | **Real Docker containers** | PostgreSQL & MySQL, IAM auth, JDBC-compatible |
-| **ECS** | 58 | **Real Docker containers** | Clusters, task definitions, tasks, services, capacity providers, task sets |
-| **EC2** | 61 | In-process | VPCs, subnets, security groups, instances, AMIs, key pairs, internet gateways, route tables, Elastic IPs, tags |
-| **ACM** | 8 | In-process | Certificate issuance, validation lifecycle |
-| **SES** | 14 | In-process | Send email / raw email, identity verification, DKIM attributes |
-| **SES v2 (HTTP)** | 9 | In-process | REST JSON API, identities, DKIM, feedback attributes, account sending |
-| **OpenSearch** | 24 | In-process | Domain CRUD, tags, versions, instance types, upgrade stubs |
-| **AppConfig** | 16 | In-process | Applications, environments, profiles, hosted configuration versions, deployments |
-| **AppConfigData** | 2 | In-process | Configuration sessions, dynamic configuration retrieval |
+| Service | How it works | Notable features |
+|---|---|---|
+| **SSM Parameter Store** | In-process | Version history, labels, SecureString, tagging |
+| **SQS** | In-process | Standard & FIFO, DLQ, visibility timeout, batch, tagging |
+| **SNS** | In-process | Topics, subscriptions, SQS / Lambda / HTTP delivery, tagging |
+| **S3** | In-process | Versioning, multipart upload, pre-signed URLs, Object Lock, event notifications |
+| **DynamoDB** | In-process | GSI / LSI, Query, Scan, TTL, transactions, batch operations |
+| **DynamoDB Streams** | In-process | Shard iterators, records, Lambda ESM trigger |
+| **Lambda** | **Real Docker containers** | Warm pool, aliases, Function URLs, SQS / Kinesis / DDB Streams ESM |
+| **API Gateway REST** | In-process | Resources, methods, stages, Lambda proxy, MOCK integrations, AWS integrations |
+| **API Gateway v2 (HTTP)** | In-process | Routes, integrations, JWT authorizers, stages |
+| **IAM** | In-process | Users, roles, groups, policies, instance profiles, access keys |
+| **STS** | In-process | AssumeRole, WebIdentity, SAML, GetFederationToken, GetSessionToken |
+| **Cognito** | In-process | User pools, app clients, auth flows, JWKS / OpenID well-known endpoints |
+| **KMS** | In-process | Encrypt / decrypt, sign / verify, data keys, aliases |
+| **Kinesis** | In-process | Streams, shards, enhanced fan-out, split / merge |
+| **Secrets Manager** | In-process | Versioning, resource policies, tagging |
+| **Step Functions** | In-process | ASL execution, task tokens, execution history |
+| **CloudFormation** | In-process | Stacks, change sets, resource provisioning |
+| **EventBridge** | In-process | Custom buses, rules, targets (SQS / SNS / Lambda) |
+| **EventBridge Scheduler** | In-process | Schedule groups, schedules, flexible time windows, retry policies, dead-letter queues |
+| **CloudWatch Logs** | In-process | Log groups, streams, ingestion, filtering |
+| **CloudWatch Metrics** | In-process | Custom metrics, statistics, alarms |
+| **ElastiCache** | **Real Docker containers** | Redis / Valkey, IAM auth, SigV4 validation |
+| **RDS** | **Real Docker containers** | PostgreSQL & MySQL, IAM auth, JDBC-compatible |
+| **ECS** | **Real Docker containers** | Clusters, task definitions, tasks, services, capacity providers, task sets |
+| **EC2** | In-process | VPCs, subnets, security groups, instances, AMIs, key pairs, internet gateways, route tables, Elastic IPs, tags |
+| **ACM** | In-process | Certificate issuance, validation lifecycle |
+| **SES** | In-process | Send email / raw email, identity verification, DKIM attributes |
+| **SES v2 (HTTP)** | In-process | REST JSON API, identities, DKIM, feedback attributes, account sending |
+| **OpenSearch** | In-process | Domain CRUD, tags, versions, instance types, upgrade stubs |
+| **AppConfig** | In-process | Applications, environments, profiles, hosted configuration versions, deployments |
+| **AppConfigData** | In-process | Configuration sessions, dynamic configuration retrieval |
 
-> **Lambda, ElastiCache, RDS, and ECS** spin up real Docker containers and support IAM authentication and SigV4 request signing — the same auth flow as production AWS.
+> **Lambda, ElastiCache, RDS, and ECS** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS.
+>
+> For per-service operation counts and endpoint protocols, see the [Services Overview](https://floci.io/floci/services/) in the documentation site.
 
 ## Quick Start
 

--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -29,22 +29,15 @@ See [Docker Compose — Multi-container networking](./docker-compose.md#multi-co
 
 ## Full Reference
 
+The block below mirrors `src/main/resources/application.yml`, it's the effective set of keys Floci ships with. Any key not listed here (for example `floci.init-hooks.*` or some `ecs.*` knobs) is available only as a code-level override via environment variables.
+
 ```yaml
 floci:
-  base-url: "http://localhost:4566"  # Used to build callback URLs (e.g. SNS subscription endpoints)
-  hostname: ""                       # Override host in base-url for multi-container Docker setups (e.g. "floci")
+  max-request-size: 512              # Max HTTP request body size in MB
+  base-url: "http://localhost:4566"  # Used to build response URLs (SQS QueueUrl, SNS endpoints, etc.)
+  # hostname: ""                     # When set, overrides the host in base-url for multi-container Docker
   default-region: us-east-1
   default-account-id: "000000000000"
-  max-request-size: 512              # Max HTTP request body size in MB (default 512 MB)
-
-  auth:
-    validate-signatures: false        # Set to true to enforce AWS request signing
-    presign-secret: local-emulator-secret  # HMAC secret for S3 pre-signed URL verification
-
-  init-hooks:
-    shell-executable: /bin/sh
-    timeout-seconds: 30
-    shutdown-grace-period-seconds: 2
 
   storage:
     mode: memory                      # memory | persistent | hybrid | wal
@@ -66,18 +59,24 @@ floci:
         flush-interval-ms: 5000
       secretsmanager:
         flush-interval-ms: 5000
+      acm:
+        flush-interval-ms: 5000
       opensearch:
-        flush-interval-ms: 5000   # inherits global storage mode
+        flush-interval-ms: 5000
+
+  auth:
+    validate-signatures: false               # Set to true to enforce AWS SigV4 validation
+    presign-secret: local-emulator-secret    # HMAC secret for S3 pre-signed URL verification
 
   services:
     ssm:
       enabled: true
-      max-parameter-history: 5        # Max versions kept per parameter
+      max-parameter-history: 5               # Max versions kept per parameter
 
     sqs:
       enabled: true
-      default-visibility-timeout: 30  # Seconds
-      max-message-size: 262144        # Bytes (256 KB)
+      default-visibility-timeout: 30         # Seconds
+      max-message-size: 262144               # Bytes (256 KB)
 
     s3:
       enabled: true
@@ -91,15 +90,15 @@ floci:
 
     lambda:
       enabled: true
-      ephemeral: false                # true = remove container after each invocation
+      ephemeral: false                        # true = remove container after each invocation
       default-memory-mb: 128
       default-timeout-seconds: 3
       docker-host: unix:///var/run/docker.sock
-      runtime-api-base-port: 9200    # Port range for Lambda Runtime API
+      runtime-api-base-port: 9200             # Port range for Lambda Runtime API
       runtime-api-max-port: 9299
-      code-path: ./data/lambda-code  # Where ZIP archives are stored
+      code-path: ./data/lambda-code           # Where ZIP archives are stored
       poll-interval-ms: 1000
-      container-idle-timeout-seconds: 300  # Remove idle containers after this
+      container-idle-timeout-seconds: 300     # Remove idle containers after this
 
     apigateway:
       enabled: true
@@ -122,6 +121,9 @@ floci:
       default-mariadb-image: "mariadb:11"
 
     eventbridge:
+      enabled: true
+
+    scheduler:
       enabled: true
 
     cloudwatchlogs:
@@ -152,43 +154,54 @@ floci:
 
     acm:
       enabled: true
-      validation-wait-seconds: 0  # Seconds before transitioning PENDING_VALIDATION → ISSUED
+      validation-wait-seconds: 0              # Seconds before transitioning PENDING_VALIDATION → ISSUED
 
     ses:
       enabled: true
 
     opensearch:
       enabled: true
-      mode: mock                                    # mock | real
+      mode: mock                              # mock | real
       default-image: "opensearchproject/opensearch:2"
       proxy-base-port: 9400
       proxy-max-port: 9499
 
+    ec2:
+      enabled: true
+
     ecs:
       enabled: true
-      mock: false               # true = tasks go to RUNNING without Docker (useful for CI)
-      docker-network: ""        # Docker network for task containers
-      default-memory-mb: 512
-      default-cpu-units: 256
+      mock: false                             # true = tasks go to RUNNING without Docker (useful for CI)
 ```
+
+### Initialization hooks
+
+`floci.init-hooks.*` is accepted as an override but is not declared in the shipped `application.yml`. See [Initialization Hooks](./initialization-hooks.md) for the full list of keys (`shell-executable`, `timeout-seconds`, `shutdown-grace-period-seconds`) and their defaults.
 
 ## Service Limits
 
-| Variable                                           | Default  | Description                                                   |
-|----------------------------------------------------|----------|---------------------------------------------------------------|
-| `FLOCI_SERVICES_SSM_MAX_PARAMETER_HISTORY`         | `5`      | Max parameter versions kept                                   |
-| `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT`    | `30`     | Visibility timeout (seconds)                                  |
-| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE`              | `262144` | Max message size (bytes)                                      |
-| `FLOCI_SERVICES_SQS_MAX_RECEIVE_COUNT`             | `10`     | Max receive count                                             |
-| `FLOCI_MAX_REQUEST_SIZE`                           | `512`    | Max HTTP request body size in MB                              |
-| `FLOCI_SERVICES_S3_MAX_MULTIPART_PARTS`            | `10000`  | Max parts per upload                                          |
-| `FLOCI_SERVICES_S3_DEFAULT_PRESIGN_EXPIRY_SECONDS` | `3600`   | Pre-signed URL expiry                                         |
-| `FLOCI_SERVICES_DYNAMODB_MAX_ITEM_SIZE`            | `400000` | Max item size (bytes)                                         |
-| `FLOCI_SERVICES_DOCKER_NETWORK`                    |          | Shared Docker network for Lambda, RDS, ElastiCache containers |
-| `FLOCI_SERVICES_ECS_MOCK`                          | `false`  | Skip Docker; tasks go straight to RUNNING (useful for CI)     |
-| `FLOCI_SERVICES_ECS_DOCKER_NETWORK`                |          | Docker network for ECS task containers                        |
-| `FLOCI_SERVICES_ECS_DEFAULT_MEMORY_MB`             | `512`    | Default memory (MB) when task definition omits it             |
-| `FLOCI_SERVICES_ECS_DEFAULT_CPU_UNITS`             | `256`    | Default CPU units when task definition omits it               |
+All keys in this table are declared on `EmulatorConfig` and accept environment variable overrides via the `FLOCI_` prefix.
+
+| Variable                                           | Default          | Description                                                   |
+|----------------------------------------------------|------------------|---------------------------------------------------------------|
+| `FLOCI_MAX_REQUEST_SIZE`                           | `512`            | Max HTTP request body size in MB                              |
+| `FLOCI_DEFAULT_REGION`                             | `us-east-1`      | Default AWS region used in ARNs and response URLs             |
+| `FLOCI_DEFAULT_AVAILABILITY_ZONE`                  | `us-east-1a`     | Default AZ reported by EC2, RDS, and other AZ-aware services  |
+| `FLOCI_DEFAULT_ACCOUNT_ID`                         | `000000000000`   | Default AWS account ID used in ARNs                           |
+| `FLOCI_ECR_BASE_URI`                               | `public.ecr.aws` | Base URI used when pulling container images (e.g. Lambda)     |
+| `FLOCI_SERVICES_SSM_MAX_PARAMETER_HISTORY`         | `5`              | Max parameter versions kept                                   |
+| `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT`    | `30`             | Default visibility timeout (seconds)                          |
+| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE`              | `262144`         | Max message size (bytes)                                      |
+| `FLOCI_SERVICES_S3_DEFAULT_PRESIGN_EXPIRY_SECONDS` | `3600`           | Pre-signed URL expiry                                         |
+| `FLOCI_SERVICES_DOCKER_NETWORK`                    | *(unset)*        | Shared Docker network for Lambda, RDS, ElastiCache containers |
+| `FLOCI_SERVICES_ECS_MOCK`                          | `false`          | Skip Docker; tasks go straight to RUNNING (useful for CI)     |
+| `FLOCI_SERVICES_ECS_DOCKER_NETWORK`                | *(unset)*        | Docker network for ECS task containers                        |
+| `FLOCI_SERVICES_ECS_DEFAULT_MEMORY_MB`             | `512`            | Default memory (MB) when task definition omits it             |
+| `FLOCI_SERVICES_ECS_DEFAULT_CPU_UNITS`             | `256`            | Default CPU units when task definition omits it               |
+
+Per-queue SQS redrive policy (`maxReceiveCount`) is configured at queue creation time via `SetQueueAttributes` / `CreateQueue`, not as a global default.
+
+`FLOCI_DEFAULT_AVAILABILITY_ZONE` and `FLOCI_ECR_BASE_URI` are declared in `EmulatorConfig` but not in the shipped `application.yml`, so they fall through to the `@WithDefault` values above when unset.
 
 ## Disabling Services
 

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -179,7 +179,7 @@ services:
 steps:
   - name: Run tests
     env:
-      AWS_ENDPOINT: http://localhost:4566
+      AWS_ENDPOINT_URL: http://localhost:4566
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test

--- a/docs/configuration/initialization-hooks.md
+++ b/docs/configuration/initialization-hooks.md
@@ -18,7 +18,7 @@ If the hook path exists but is not a directory, it is ignored.
 Hooks run:
 
 - Inside the Floci runtime environment (same context as Floci services)
-- Using the configured shell (default: `/bin/bash`)
+- Using the configured shell (default: `/bin/sh`)
 - With access to configured services and their endpoints
 - With the same environment variables as Floci
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -5,8 +5,10 @@
 | Port / Range | Protocol | Purpose |
 |---|---|---|
 | `4566` | HTTP | All AWS API calls (every service) |
-| `6379–6399` | TCP | ElastiCache Redis proxy — one port per replication group |
-| `7001–7099` | TCP | RDS proxy — one port per DB instance |
+| `6379–6399` | TCP | ElastiCache Redis proxy, one port per replication group |
+| `7001–7099` | TCP | RDS proxy, one port per DB instance |
+| `9200–9299` | HTTP | Lambda Runtime API (internal: consumed by spawned Lambda containers, not host-mapped) |
+| `9400–9499` | HTTP | OpenSearch proxy, reserved for `opensearch.mode: real` (not yet available) |
 
 ## Port 4566 — AWS API
 
@@ -60,6 +62,17 @@ psql -h localhost -p 7001 -U admin
 
 !!! note
     Configure the range with `FLOCI_SERVICES_RDS_PROXY_BASE_PORT` and `FLOCI_SERVICES_RDS_PROXY_MAX_PORT`.
+
+## Ports 9200–9299, Lambda Runtime API (internal)
+
+Floci binds a Lambda Runtime API port in the `9200–9299` range for each warm Lambda container to poll. These ports are consumed by containers Floci spawns itself on the shared Docker network, so they do not need to be mapped to the host. Configure the range with `FLOCI_SERVICES_LAMBDA_RUNTIME_API_BASE_PORT` and `FLOCI_SERVICES_LAMBDA_RUNTIME_API_MAX_PORT`.
+
+## Ports 9400–9499, OpenSearch (reserved)
+
+This range is reserved for OpenSearch `mode: real`, which will spin up an OpenSearch Docker container per domain and proxy data-plane traffic on the next available port in `9400–9499`. Real mode is not yet implemented: the default `mock` mode exposes only the management API on port `4566` and uses no proxy port. See [OpenSearch](../services/opensearch.md) for current status.
+
+!!! note
+ When real mode lands, configure the range with `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` and `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT`.
 
 ## Exposing Ports in Docker Compose
 

--- a/docs/configuration/storage.md
+++ b/docs/configuration/storage.md
@@ -16,11 +16,14 @@ Floci supports four storage backends. You can set a global default and override 
 ```yaml title="application.yml"
 floci:
   storage:
-    mode: hybrid              # default for all services
+    mode: memory              # shipped default (application.yml)
     persistent-path: ./data   # base directory for all persistent data
     wal:
       compaction-interval-ms: 30000
 ```
+
+!!! note "Code default vs shipped default"
+    `EmulatorConfig.StorageConfig.mode` has a Java-level `@WithDefault("hybrid")`, but the shipped `src/main/resources/application.yml` overrides it to `memory`. Running the stock Docker image gives you `memory`; if you supply your own `application.yml` and omit `storage.mode`, you fall back to the code default `hybrid`.
 
 ## Per-Service Override
 

--- a/docs/getting-started/aws-setup.md
+++ b/docs/getting-started/aws-setup.md
@@ -7,7 +7,7 @@ Floci accepts any non-empty credentials — no real AWS account is needed.
 The simplest approach for local development:
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
@@ -39,7 +39,7 @@ Or set it as the default for your shell session:
 
 ```bash
 export AWS_PROFILE=floci
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 ```
 
 ## SDK Configuration

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,7 +48,7 @@ services:
 
 | Image | Tag | Typical startup | Idle memory |
 |---|---|---|---|
-| Native | `latest` / `x.y.z` | < 100 ms | ~50 MB |
+| Native | `latest` / `x.y.z` | ~24 ms | ~13 MiB |
 | JVM | `latest-jvm` / `x.y.z-jvm` | ~2 s | ~250 MB |
 
 ## Build from Source

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -67,7 +67,7 @@ This guide gets Floci running and verifies that AWS CLI commands work against it
 Floci accepts any dummy credentials — no real AWS account needed.
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
@@ -81,16 +81,16 @@ Run a few quick smoke tests:
 
 ```bash
 # S3 — create a bucket and upload a file
-aws s3 mb s3://my-bucket --endpoint-url $AWS_ENDPOINT
-echo "hello floci" | aws s3 cp - s3://my-bucket/hello.txt --endpoint-url $AWS_ENDPOINT
-aws s3 ls s3://my-bucket --endpoint-url $AWS_ENDPOINT
+aws s3 mb s3://my-bucket --endpoint-url $AWS_ENDPOINT_URL
+echo "hello floci" | aws s3 cp - s3://my-bucket/hello.txt --endpoint-url $AWS_ENDPOINT_URL
+aws s3 ls s3://my-bucket --endpoint-url $AWS_ENDPOINT_URL
 
 # SQS — create a queue and send a message
-aws sqs create-queue --queue-name orders --endpoint-url $AWS_ENDPOINT
+aws sqs create-queue --queue-name orders --endpoint-url $AWS_ENDPOINT_URL
 aws sqs send-message \
-  --queue-url $AWS_ENDPOINT/000000000000/orders \
+  --queue-url $AWS_ENDPOINT_URL/000000000000/orders \
   --message-body '{"event":"order.placed"}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # DynamoDB — create a table
 aws dynamodb create-table \
@@ -98,7 +98,7 @@ aws dynamodb create-table \
   --attribute-definitions AttributeName=id,AttributeType=S \
   --key-schema AttributeName=id,KeyType=HASH \
   --billing-mode PAY_PER_REQUEST \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 You should see successful responses for all three commands.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,17 @@
 
 Floci is a fast, free, and open-source local AWS service emulator built for developers who need reliable AWS services in development and CI without cost, complexity, or vendor lock-in.
 
-## Supported Services 
+## Supported Services
+
+Floci emulates 31 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
 
 | Service | Protocol |
 |---|---|
 | SSM Parameter Store | JSON 1.1 |
 | SQS | Query / JSON |
 | SNS | Query / JSON |
-| SES | Query / REST JSON |
+| SES | Query |
+| SES v2 | REST JSON |
 | S3 | REST XML |
 | DynamoDB + Streams | JSON 1.1 |
 | Lambda | REST JSON |
@@ -30,11 +33,16 @@ Floci is a fast, free, and open-source local AWS service emulator built for deve
 | Step Functions | JSON 1.1 |
 | IAM | Query |
 | STS | Query |
-| ElastiCache (Redis) | Query + RESP proxy |
+| ElastiCache (Redis / Valkey) | Query + RESP proxy |
 | RDS (PostgreSQL / MySQL) | Query + wire proxy |
+| ECS | JSON 1.1 |
+| EC2 | EC2 Query |
+| ACM | JSON 1.1 |
+| OpenSearch | REST JSON |
 | EventBridge | JSON 1.1 |
 | EventBridge Scheduler | REST JSON |
 | CloudWatch Logs & Metrics | JSON 1.1 / Query |
+| AppConfig + AppConfigData | REST JSON |
 
 ## Why Floci?
 
@@ -70,7 +78,7 @@ docker compose up -d
 aws --endpoint-url http://localhost:4566 s3 mb s3://my-bucket
 ```
 
-All 19+ AWS services are immediately available at `http://localhost:4566`.
+All 31 AWS services are immediately available at `http://localhost:4566`.
 
 [Get started →](getting-started/quick-start.md){ .md-button .md-button--primary }
 [View services →](services/index.md){ .md-button }

--- a/docs/services/acm.md
+++ b/docs/services/acm.md
@@ -31,7 +31,7 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Request a certificate
 CERT_ARN=$(aws acm request-certificate \
@@ -39,56 +39,56 @@ CERT_ARN=$(aws acm request-certificate \
   --subject-alternative-names "www.example.com" "*.example.com" \
   --validation-method DNS \
   --query CertificateArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Describe the certificate
 aws acm describe-certificate \
   --certificate-arn $CERT_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get certificate in PEM format
 aws acm get-certificate \
   --certificate-arn $CERT_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List all certificates
 aws acm list-certificates \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List only issued certificates
 aws acm list-certificates \
   --certificate-statuses ISSUED \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Add tags
 aws acm add-tags-to-certificate \
   --certificate-arn $CERT_ARN \
   --tags Key=Environment,Value=Production Key=Project,Value=Demo \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List tags
 aws acm list-tags-for-certificate \
   --certificate-arn $CERT_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Request a private certificate (exportable)
 PRIVATE_ARN=$(aws acm request-certificate \
   --domain-name "internal.example.com" \
   --certificate-authority-arn "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012" \
   --query CertificateArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Export private certificate (passphrase must be base64-encoded, min 4 chars)
 PASSPHRASE=$(echo -n "mypassphrase123" | base64)
 aws acm export-certificate \
   --certificate-arn $PRIVATE_ARN \
   --passphrase $PASSPHRASE \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete a certificate
 aws acm delete-certificate \
   --certificate-arn $CERT_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## SDK Example (Java)

--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -11,34 +11,58 @@ Floci supports both API Gateway v1 (REST APIs) and API Gateway v2 (HTTP APIs).
 
 | Category | Operations |
 |---|---|
-| **APIs** | CreateRestApi, GetRestApi, GetRestApis, UpdateRestApi, DeleteRestApi |
+| **APIs** | CreateRestApi, ImportRestApi, PutRestApi, GetRestApi, GetRestApis, UpdateRestApi, DeleteRestApi |
 | **Resources** | CreateResource, GetResource, GetResources, UpdateResource, DeleteResource |
-| **Methods** | PutMethod, GetMethod, DeleteMethod |
-| **Method Responses** | PutMethodResponse, GetMethodResponse, DeleteMethodResponse |
-| **Integrations** | PutIntegration, GetIntegration, DeleteIntegration |
-| **Integration Responses** | PutIntegrationResponse, GetIntegrationResponse, DeleteIntegrationResponse |
-| **Deployments** | CreateDeployment, GetDeployment, GetDeployments |
+| **Methods** | PutMethod, GetMethod, UpdateMethod, DeleteMethod |
+| **Method Responses** | PutMethodResponse, GetMethodResponse |
+| **Integrations** | PutIntegration, GetIntegration, UpdateIntegration, DeleteIntegration |
+| **Integration Responses** | PutIntegrationResponse, GetIntegrationResponse |
+| **Deployments** | CreateDeployment, GetDeployments |
 | **Stages** | CreateStage, GetStage, GetStages, UpdateStage, DeleteStage |
-| **API Keys** | CreateApiKey, GetApiKey, GetApiKeys, UpdateApiKey, DeleteApiKey |
-| **Usage Plans** | CreateUsagePlan, GetUsagePlan, GetUsagePlans, UpdateUsagePlan, DeleteUsagePlan |
-| **Base Path Mappings** | CreateBasePathMapping, GetBasePathMapping, DeleteBasePathMapping |
+| **Authorizers** | CreateAuthorizer, GetAuthorizer, GetAuthorizers |
+| **API Keys** | CreateApiKey, GetApiKeys |
+| **Usage Plans** | CreateUsagePlan, GetUsagePlans, DeleteUsagePlan |
+| **Usage Plan Keys** | CreateUsagePlanKey, GetUsagePlanKey, GetUsagePlanKeys, DeleteUsagePlanKey |
+| **Request Validators** | CreateRequestValidator, GetRequestValidator, GetRequestValidators, DeleteRequestValidator |
+| **Models** | CreateModel, GetModel, GetModels, DeleteModel |
+| **Domain Names** | CreateDomainName, GetDomainName, GetDomainNames, DeleteDomainName |
+| **Base Path Mappings** | CreateBasePathMapping, GetBasePathMapping, GetBasePathMappings, DeleteBasePathMapping |
+| **Tags** | TagResource, UntagResource, GetTags (ListTagsForResource) |
+
+### Not Implemented
+
+These management-plane operations have no handler in v1. Calls will return `404` or an error:
+
+- Deployment detail and lifecycle: `GetDeployment`, `UpdateDeployment`, `DeleteDeployment`
+- Authorizer lifecycle: `UpdateAuthorizer`, `DeleteAuthorizer`, `TestInvokeAuthorizer`
+- API key detail: `GetApiKey`, `UpdateApiKey`, `DeleteApiKey`, `ImportApiKeys`
+- Usage plan detail: `GetUsagePlan`, `UpdateUsagePlan`
+- Model updates and templates: `UpdateModel`, `GetModelTemplate`
+- Gateway Responses (the entire family: `PutGatewayResponse`, `GetGatewayResponse`, etc.)
+- Documentation parts and versions (the entire family, 10 operations)
+- VPC Links (5 operations)
+- Client Certificates (5 operations)
+- Account: `GetAccount`, `UpdateAccount`
+- `GetExport` / `ImportDocumentationParts`
+
+The execute plane (actual proxied HTTP traffic via `/restapis/{id}/{stage}/_user_request_/…`) is implemented separately and is not counted as management-plane operations.
 
 ### Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a REST API
 API_ID=$(aws apigateway create-rest-api \
   --name "My API" \
   --query id --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Get the root resource
 ROOT_ID=$(aws apigateway get-resources \
   --rest-api-id $API_ID \
   --query 'items[?path==`/`].id' --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Create a resource
 RESOURCE_ID=$(aws apigateway create-resource \
@@ -46,7 +70,7 @@ RESOURCE_ID=$(aws apigateway create-resource \
   --parent-id $ROOT_ID \
   --path-part users \
   --query id --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Add a GET method
 aws apigateway put-method \
@@ -54,7 +78,7 @@ aws apigateway put-method \
   --resource-id $RESOURCE_ID \
   --http-method GET \
   --authorization-type NONE \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Add a Lambda integration
 aws apigateway put-integration \
@@ -64,13 +88,13 @@ aws apigateway put-integration \
   --type AWS_PROXY \
   --integration-http-method POST \
   --uri "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:my-function/invocations" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Deploy to a stage
 aws apigateway create-deployment \
   --rest-api-id $API_ID \
   --stage-name dev \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Call the deployed API
 curl http://localhost:4566/restapis/$API_ID/dev/_user_request_/users
@@ -97,14 +121,14 @@ curl http://localhost:4566/restapis/$API_ID/dev/_user_request_/users
 ### Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create an HTTP API
 API_ID=$(aws apigatewayv2 create-api \
   --name "My HTTP API" \
   --protocol-type HTTP \
   --query ApiId --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Create a Lambda integration
 INTEGRATION_ID=$(aws apigatewayv2 create-integration \
@@ -113,19 +137,19 @@ INTEGRATION_ID=$(aws apigatewayv2 create-integration \
   --integration-uri "arn:aws:lambda:us-east-1:000000000000:function:my-function" \
   --payload-format-version 2.0 \
   --query IntegrationId --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Create a route
 aws apigatewayv2 create-route \
   --api-id $API_ID \
   --route-key "GET /users" \
   --target "integrations/$INTEGRATION_ID" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Deploy
 aws apigatewayv2 create-stage \
   --api-id $API_ID \
   --stage-name dev \
   --auto-deploy \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -32,62 +32,62 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Validate a template
 aws cloudformation validate-template \
   --template-body file://template.yml \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Deploy a stack
 aws cloudformation create-stack \
   --stack-name my-stack \
   --template-body file://template.yml \
   --parameters ParameterKey=Env,ParameterValue=dev \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Check status
 aws cloudformation describe-stacks \
   --stack-name my-stack \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Watch events
 aws cloudformation describe-stack-events \
   --stack-name my-stack \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Update
 aws cloudformation update-stack \
   --stack-name my-stack \
   --template-body file://template.yml \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete
 aws cloudformation delete-stack \
   --stack-name my-stack \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a change set
 aws cloudformation create-change-set \
   --stack-name my-stack \
   --change-set-name my-change-set \
   --template-body file://template.yml \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List change sets
 aws cloudformation list-change-sets \
   --stack-name my-stack \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Describe a change set
 aws cloudformation describe-change-set \
   --stack-name my-stack \
   --change-set-name my-change-set \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete a change set
 aws cloudformation delete-change-set \
   --stack-name my-stack \
   --change-set-name my-change-set \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/cloudwatch.md
+++ b/docs/services/cloudwatch.md
@@ -41,14 +41,14 @@ floci:
 ### Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a log group and stream
-aws logs create-log-group --log-group-name /app/backend --endpoint-url $AWS_ENDPOINT
+aws logs create-log-group --log-group-name /app/backend --endpoint-url $AWS_ENDPOINT_URL
 aws logs create-log-stream \
   --log-group-name /app/backend \
   --log-stream-name 2025/01/app-1 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Write log events
 TIMESTAMP=$(date +%s%3N)   # milliseconds
@@ -56,25 +56,25 @@ aws logs put-log-events \
   --log-group-name /app/backend \
   --log-stream-name 2025/01/app-1 \
   --log-events "[{\"timestamp\":$TIMESTAMP,\"message\":\"Service started\"}]" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Read log events
 aws logs get-log-events \
   --log-group-name /app/backend \
   --log-stream-name 2025/01/app-1 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Search logs
 aws logs filter-log-events \
   --log-group-name /app/backend \
   --filter-pattern "ERROR" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Set retention
 aws logs put-retention-policy \
   --log-group-name /app/backend \
   --retention-in-days 30 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ---
@@ -100,7 +100,7 @@ aws logs put-retention-policy \
 ### Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Publish a custom metric
 aws cloudwatch put-metric-data \
@@ -111,12 +111,12 @@ aws cloudwatch put-metric-data \
     "Unit": "Count",
     "Dimensions": [{"Name":"Service","Value":"api"}]
   }]' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List metrics
 aws cloudwatch list-metrics \
   --namespace MyApp \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get statistics
 aws cloudwatch get-metric-statistics \
@@ -127,7 +127,7 @@ aws cloudwatch get-metric-statistics \
   --end-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
   --period 300 \
   --statistics Sum \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create an alarm
 aws cloudwatch put-metric-alarm \
@@ -139,5 +139,5 @@ aws cloudwatch put-metric-alarm \
   --threshold 10 \
   --comparison-operator GreaterThanThreshold \
   --evaluation-periods 1 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -40,13 +40,13 @@ Floci serves pool-specific discovery and JWKS endpoints, plus a relaxed OAuth to
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a user pool
 POOL_ID=$(aws cognito-idp create-user-pool \
   --pool-name MyApp \
   --query UserPool.Id --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Create an app client
 CLIENT_ID=$(aws cognito-idp create-user-pool-client \
@@ -57,14 +57,14 @@ CLIENT_ID=$(aws cognito-idp create-user-pool-client \
   --allowed-o-auth-flows client_credentials \
   --allowed-o-auth-scopes notes/read notes/write \
   --query UserPoolClient.ClientId --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Retrieve the generated client secret
 CLIENT_SECRET=$(aws cognito-idp describe-user-pool-client \
   --user-pool-id $POOL_ID \
   --client-id $CLIENT_ID \
   --query UserPoolClient.ClientSecret --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Register a resource server and scopes
 aws cognito-idp create-resource-server \
@@ -72,14 +72,14 @@ aws cognito-idp create-resource-server \
   --identifier notes \
   --name "Notes API" \
   --scopes ScopeName=read,ScopeDescription="Read notes" ScopeName=write,ScopeDescription="Write notes" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a user
 aws cognito-idp admin-create-user \
   --user-pool-id $POOL_ID \
   --username alice@example.com \
   --temporary-password Temp1234! \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Set a permanent password
 aws cognito-idp admin-set-user-password \
@@ -87,41 +87,41 @@ aws cognito-idp admin-set-user-password \
   --username alice@example.com \
   --password Perm1234! \
   --permanent \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Authenticate
 aws cognito-idp initiate-auth \
   --auth-flow USER_PASSWORD_AUTH \
   --client-id $CLIENT_ID \
   --auth-parameters USERNAME=alice@example.com,PASSWORD=Perm1234! \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a group
 aws cognito-idp create-group \
   --user-pool-id $POOL_ID \
   --group-name admin \
   --description "Admin group" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Add user to group
 aws cognito-idp admin-add-user-to-group \
   --user-pool-id $POOL_ID \
   --group-name admin \
   --username alice@example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List groups for user
 aws cognito-idp admin-list-groups-for-user \
   --user-pool-id $POOL_ID \
   --username alice@example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Fetch the pool discovery document
-curl -s "$AWS_ENDPOINT/$POOL_ID/.well-known/openid-configuration"
+curl -s "$AWS_ENDPOINT_URL/$POOL_ID/.well-known/openid-configuration"
 
 # Get a machine access token from the OAuth endpoint
 curl -s \
-  -X POST "$AWS_ENDPOINT/cognito-idp/oauth2/token" \
+  -X POST "$AWS_ENDPOINT_URL/cognito-idp/oauth2/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -u "$CLIENT_ID:$CLIENT_SECRET" \
   --data-urlencode "grant_type=client_credentials" \

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -42,7 +42,7 @@ DynamoDB Streams are supported via a separate target (`DynamoDBStreams_20120810`
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a table
 aws dynamodb create-table \
@@ -52,45 +52,45 @@ aws dynamodb create-table \
   --key-schema \
     AttributeName=userId,KeyType=HASH \
   --billing-mode PAY_PER_REQUEST \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Put an item
 aws dynamodb put-item \
   --table-name Users \
   --item '{"userId":{"S":"u1"},"name":{"S":"Alice"},"age":{"N":"30"}}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get an item
 aws dynamodb get-item \
   --table-name Users \
   --key '{"userId":{"S":"u1"}}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Query (partition key)
 aws dynamodb query \
   --table-name Users \
   --key-condition-expression "userId = :id" \
   --expression-attribute-values '{":id":{"S":"u1"}}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Scan with filter
 aws dynamodb scan \
   --table-name Users \
   --filter-expression "age > :min" \
   --expression-attribute-values '{":min":{"N":"25"}}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Enable TTL
 aws dynamodb update-time-to-live \
   --table-name Users \
   --time-to-live-specification Enabled=true,AttributeName=expiresAt \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Enable Streams
 aws dynamodb update-table \
   --table-name Users \
   --stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Global Secondary Indexes
@@ -108,5 +108,5 @@ aws dynamodb create-table \
     "Projection": {"ProjectionType":"ALL"}
   }]' \
   --billing-mode PAY_PER_REQUEST \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -57,13 +57,13 @@ Floci seeds the following resources on first use in each region so Terraform, th
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # List default subnets
-aws ec2 describe-subnets --endpoint-url $AWS_ENDPOINT
+aws ec2 describe-subnets --endpoint-url $AWS_ENDPOINT_URL
 
 # List default VPC
-aws ec2 describe-vpcs --endpoint-url $AWS_ENDPOINT
+aws ec2 describe-vpcs --endpoint-url $AWS_ENDPOINT_URL
 
 # Launch an instance
 aws ec2 run-instances \
@@ -71,37 +71,37 @@ aws ec2 run-instances \
   --instance-type t2.micro \
   --min-count 1 \
   --max-count 1 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Describe running instances
 aws ec2 describe-instances \
   --filters "Name=instance-state-name,Values=running" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a VPC and subnet
-aws ec2 create-vpc --cidr-block 10.0.0.0/16 --endpoint-url $AWS_ENDPOINT
-aws ec2 create-subnet --vpc-id vpc-XXXXX --cidr-block 10.0.1.0/24 --endpoint-url $AWS_ENDPOINT
+aws ec2 create-vpc --cidr-block 10.0.0.0/16 --endpoint-url $AWS_ENDPOINT_URL
+aws ec2 create-subnet --vpc-id vpc-XXXXX --cidr-block 10.0.1.0/24 --endpoint-url $AWS_ENDPOINT_URL
 
 # Create and configure a security group
 aws ec2 create-security-group \
   --group-name my-sg \
   --description "My security group" \
   --vpc-id vpc-XXXXX \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 aws ec2 authorize-security-group-ingress \
   --group-id sg-XXXXX \
   --protocol tcp \
   --port 22 \
   --cidr 0.0.0.0/0 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Allocate and associate an Elastic IP
-aws ec2 allocate-address --domain vpc --endpoint-url $AWS_ENDPOINT
+aws ec2 allocate-address --domain vpc --endpoint-url $AWS_ENDPOINT_URL
 aws ec2 associate-address \
   --allocation-id eipalloc-XXXXX \
   --instance-id i-XXXXX \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Notes

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -51,20 +51,20 @@ services:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a replication group (starts a Valkey container)
 aws elasticache create-replication-group \
   --replication-group-id my-cache \
   --replication-group-description "Dev cache" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get the connection port
 PORT=$(aws elasticache describe-replication-groups \
   --replication-group-id my-cache \
   --query 'ReplicationGroups[0].NodeGroups[0].PrimaryEndpoint.Port' \
   --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Connect with redis-cli
 redis-cli -h localhost -p $PORT ping
@@ -76,7 +76,7 @@ redis-cli -h localhost -p $PORT get mykey
 # Delete the cluster
 aws elasticache delete-replication-group \
   --replication-group-id my-cache \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## IAM Authentication
@@ -91,5 +91,5 @@ aws elasticache create-user \
   --engine redis \
   --access-string "on ~* +@all" \
   --no-no-password-required \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/eventbridge.md
+++ b/docs/services/eventbridge.md
@@ -25,12 +25,12 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a custom event bus
 aws events create-event-bus \
   --name my-bus \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a rule matching a pattern
 aws events put-rule \
@@ -38,7 +38,7 @@ aws events put-rule \
   --event-bus-name my-bus \
   --event-pattern '{"source":["com.myapp"],"detail-type":["OrderPlaced"]}' \
   --state ENABLED \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Add a Lambda target
 aws events put-targets \
@@ -48,7 +48,7 @@ aws events put-targets \
     "Id": "process-order",
     "Arn": "arn:aws:lambda:us-east-1:000000000000:function:process-order"
   }]' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Publish an event
 aws events put-events \
@@ -58,7 +58,7 @@ aws events put-events \
     "Detail": "{\"orderId\":\"123\",\"amount\":99.99}",
     "EventBusName": "my-bus"
   }]' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Default Event Bus
@@ -67,10 +67,10 @@ EventBridge includes a default event bus (`default`) that accepts events from AW
 
 ```bash
 # List rules on the default bus
-aws events list-rules --endpoint-url $AWS_ENDPOINT
+aws events list-rules --endpoint-url $AWS_ENDPOINT_URL
 
 # Send to default bus
 aws events put-events \
   --entries '[{"Source":"myapp","DetailType":"test","Detail":"{}"}]' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -38,7 +38,7 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a role
 aws iam create-role \
@@ -51,20 +51,20 @@ aws iam create-role \
       "Action": "sts:AssumeRole"
     }]
   }' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Attach a managed policy
 aws iam attach-role-policy \
   --role-name lambda-execution-role \
   --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a user
-aws iam create-user --user-name alice --endpoint-url $AWS_ENDPOINT
+aws iam create-user --user-name alice --endpoint-url $AWS_ENDPOINT_URL
 
 # Create an access key
-aws iam create-access-key --user-name alice --endpoint-url $AWS_ENDPOINT
+aws iam create-access-key --user-name alice --endpoint-url $AWS_ENDPOINT_URL
 
 # List roles
-aws iam list-roles --endpoint-url $AWS_ENDPOINT
+aws iam list-roles --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,50 +1,58 @@
 # Services Overview
 
-Floci emulates 27 AWS services on a single port (`4566`). All services use the real AWS wire protocol — your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 31 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+
+This page is the canonical reference for supported service counts and operation counts. Other docs (and the README) should link here rather than duplicating the table.
 
 ## Service Matrix
+
+Operation counts are exact. For dispatch-table services (Query and JSON 1.1) each count reflects one case per AWS action in the handler. For REST-based services (S3, Lambda, API Gateway v1) the count reflects distinct AWS SDK operations, collapsing routes where one JAX-RS handler fans out via query-string or header markers (e.g. `PUT /{bucket}/{key}` → `PutObject`, `PutObjectTagging`, `PutObjectAcl`, etc.).
 
 | Service | Endpoint | Protocol | Supported operations |
 |---|---|---|---|
 | [SSM](ssm.md) | `POST /` + `X-Amz-Target: AmazonSSM.*` | JSON 1.1 | 12 |
 | [SQS](sqs.md) | `POST /` with `Action=` param | Query / JSON | 20 |
 | [SNS](sns.md) | `POST /` with `Action=` param | Query / JSON | 17 |
-| [SES](ses.md) | `POST /` with `Action=` param | Query | 16 |
-| [S3](s3.md) | `/{bucket}/{key}` | REST XML | 50+ |
-| [DynamoDB](dynamodb.md) | `POST /` + `X-Amz-Target: DynamoDB_20120810.*` | JSON 1.1 | 19 |
+| [S3](s3.md) | `/{bucket}/{key}` | REST XML | 58 |
+| [DynamoDB](dynamodb.md) | `POST /` + `X-Amz-Target: DynamoDB_20120810.*` | JSON 1.1 | 20 |
 | [DynamoDB Streams](dynamodb.md#streams) | `POST /` + `X-Amz-Target: DynamoDBStreams_20120810.*` | JSON 1.1 | 4 |
-| [Lambda](lambda.md) | `/2015-03-31/functions/...` | REST JSON | 18 |
-| [API Gateway v1](api-gateway.md) | `/restapis/...` | REST JSON | 40+ |
-| [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 20 |
-| [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 24 |
-| [KMS](kms.md) | `POST /` + `X-Amz-Target: TrentService.*` | JSON 1.1 | 18 |
-| [Kinesis](kinesis.md) | `POST /` + `X-Amz-Target: Kinesis_20131202.*` | JSON 1.1 | 21 |
-| [Secrets Manager](secrets-manager.md) | `POST /` + `X-Amz-Target: secretsmanager.*` | JSON 1.1 | 14 |
-| [CloudFormation](cloudformation.md) | `POST /` with `Action=` param | Query | 20 |
-| [Step Functions](step-functions.md) | `POST /` + `X-Amz-Target: AmazonStatesService.*` | JSON 1.1 | 12 |
-| [IAM](iam.md) | `POST /` with `Action=` param | Query | 60+ |
+| [Lambda](lambda.md) | `/2015-03-31/functions/...` | REST JSON | 30 |
+| [API Gateway v1](api-gateway.md) | `/restapis/...` | REST JSON | 62 |
+| [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 21 |
+| [IAM](iam.md) | `POST /` with `Action=` param | Query | 68 |
 | [STS](sts.md) | `POST /` with `Action=` param | Query | 7 |
-| [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
-| [RDS](rds.md) | `POST /` with `Action=` param + TCP proxy | Query + wire | 13 |
-| [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 14 |
+| [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 40 |
+| [KMS](kms.md) | `POST /` + `X-Amz-Target: TrentService.*` | JSON 1.1 | 23 |
+| [Kinesis](kinesis.md) | `POST /` + `X-Amz-Target: Kinesis_20131202.*` | JSON 1.1 | 24 |
+| [Secrets Manager](secrets-manager.md) | `POST /` + `X-Amz-Target: secretsmanager.*` | JSON 1.1 | 16 |
+| [Step Functions](step-functions.md) | `POST /` + `X-Amz-Target: AmazonStatesService.*` | JSON 1.1 | 18 |
+| [CloudFormation](cloudformation.md) | `POST /` with `Action=` param | Query | 18 |
+| [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 16 |
 | [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*` | REST JSON | 9 |
-| [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 14 |
-| [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 8 |
-| [ACM](acm.md) | `POST /` + `X-Amz-Target: CertificateManager.*` | JSON 1.1 | 12 |
+| [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 17 |
+| [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
+| [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
+| [RDS](rds.md) | `POST /` with `Action=` param + TCP proxy | Query + wire | 14 |
 | [ECS](ecs.md) | `POST /` + `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*` | JSON 1.1 | 58 |
-| [SES](ses.md) | `POST /` with `Action=` param | Query | 14 |
-| [OpenSearch](opensearch.md) | `/2021-01-01/opensearch/...` | REST JSON | 24 |
 | [EC2](ec2.md) | `POST /` with `Action=` param | EC2 Query | 61 |
-| [AppConfig](appconfig.md) | `/applications/...` | REST JSON | 12 |
-| [AppConfigData](appconfig.md#data-plane) | `/environments/...` | REST JSON | 2 |
+| [ACM](acm.md) | `POST /` + `X-Amz-Target: CertificateManager.*` | JSON 1.1 | 12 |
+| [SES](ses.md) | `POST /` with `Action=` param | Query | 16 |
+| [SES v2](ses.md#v2) | `/v2/email/*` | REST JSON | 9 |
+| [OpenSearch](opensearch.md) | `/2021-01-01/opensearch/...` | REST JSON | 24 |
+| [AppConfig](appconfig.md) | `/applications/...`, `/deploymentstrategies/...` | REST JSON | 16 |
+| [AppConfigData](appconfig.md#data-plane) | `/configurationsessions`, `/configuration` | REST JSON | 2 |
+
+**Lambda, ElastiCache, RDS, and ECS** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS.
 
 ## Common Setup
 
 Before calling any service, configure your AWS client to point to Floci:
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 ```
+
+`AWS_ENDPOINT_URL` is the standard env var recognised by the AWS CLI v2 and AWS SDKs v2+, so no `--endpoint-url` flag is needed on each command.

--- a/docs/services/kinesis.md
+++ b/docs/services/kinesis.md
@@ -37,45 +37,45 @@ Most actions accept either `StreamName` or `StreamARN` to identify a stream. Whe
 
 ```bash
 # By name
-aws kinesis describe-stream --stream-name events --endpoint-url $AWS_ENDPOINT
+aws kinesis describe-stream --stream-name events --endpoint-url $AWS_ENDPOINT_URL
 
 # By ARN
-aws kinesis describe-stream --stream-arn arn:aws:kinesis:us-east-1:000000000000:stream/events --endpoint-url $AWS_ENDPOINT
+aws kinesis describe-stream --stream-arn arn:aws:kinesis:us-east-1:000000000000:stream/events --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a stream
 aws kinesis create-stream \
   --stream-name events \
   --shard-count 2 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Put a record
 aws kinesis put-record \
   --stream-name events \
   --partition-key "user-123" \
   --data '{"event":"page_view","page":"/home"}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get a shard iterator
 SHARD_ID=$(aws kinesis describe-stream \
   --stream-name events \
   --query 'StreamDescription.Shards[0].ShardId' --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 ITERATOR=$(aws kinesis get-shard-iterator \
   --stream-name events \
   --shard-id $SHARD_ID \
   --shard-iterator-type TRIM_HORIZON \
   --query ShardIterator --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Read records
 aws kinesis get-records \
   --shard-iterator $ITERATOR \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -34,36 +34,36 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a symmetric key
 KEY_ID=$(aws kms create-key \
   --description "My encryption key" \
   --query KeyMetadata.KeyId --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Create an alias
 aws kms create-alias \
   --alias-name alias/my-key \
   --target-key-id $KEY_ID \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Encrypt
 CIPHER=$(aws kms encrypt \
   --key-id alias/my-key \
   --plaintext "Hello, World!" \
   --query CiphertextBlob --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Decrypt
 aws kms decrypt \
   --ciphertext-blob $CIPHER \
   --query Plaintext --output text \
-  --endpoint-url $AWS_ENDPOINT | base64 --decode
+  --endpoint-url $AWS_ENDPOINT_URL | base64 --decode
 
 # Generate a data key (envelope encryption)
 aws kms generate-data-key \
   --key-id alias/my-key \
   --key-spec AES_256 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -22,11 +22,39 @@ Lambda runs your function code inside real Docker containers — the same way re
 | `UpdateEventSourceMapping` | Update a mapping |
 | `DeleteEventSourceMapping` | Remove a mapping |
 | `PublishVersion` | Publish an immutable version |
+| `ListVersionsByFunction` | List all published versions of a function |
 | `CreateAlias` | Create a named alias pointing to a version |
 | `GetAlias` | Get alias details |
 | `ListAliases` | List all aliases for a function |
 | `UpdateAlias` | Update an alias |
 | `DeleteAlias` | Delete an alias |
+| `AddPermission` | Add a resource-policy statement |
+| `GetPolicy` | Get the function resource policy |
+| `RemovePermission` | Remove a resource-policy statement |
+| `GetFunctionCodeSigningConfig` | Return code-signing config (always empty) |
+| `CreateFunctionUrlConfig` | Provision a function URL |
+| `GetFunctionUrlConfig` | Read function URL config |
+| `UpdateFunctionUrlConfig` | Update function URL config |
+| `DeleteFunctionUrlConfig` | Delete function URL config |
+| `ListTags` | List tags on a function |
+| `TagResource` | Tag a function |
+| `UntagResource` | Untag a function |
+
+Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL controller, which routes the request into the normal `Invoke` path.
+
+**Stubbed:** `ListLayers` and `ListLayerVersions` return empty arrays. No layer storage exists.
+
+## Not Implemented
+
+These AWS Lambda operations have no handler in Floci. Calls will return `404` or an error:
+
+- Layers (`PublishLayerVersion`, `DeleteLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
+- Concurrency controls (`PutFunctionConcurrency`, `GetFunctionConcurrency`, `DeleteFunctionConcurrency`, `PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
+- `UpdateFunctionConfiguration` (use `UpdateFunctionCode` for code-only updates; configuration-only updates are not separately supported)
+- Dead-letter, async invoke config, and event invoke config operations
+- `InvokeWithResponseStream`
+- Code signing management (only `GetFunctionCodeSigningConfig` is wired; there is no `PutFunctionCodeSigningConfig` or `CreateCodeSigningConfig`)
+- Account and regional settings (`GetAccountSettings`)
 
 ## Configuration
 
@@ -60,7 +88,7 @@ services:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Package a simple Node.js function
 cat > index.mjs << 'EOF'
@@ -78,7 +106,7 @@ aws lambda create-function \
   --role arn:aws:iam::000000000000:role/lambda-role \
   --handler index.handler \
   --zip-file fileb://function.zip \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Invoke synchronously
 aws lambda invoke \
@@ -86,7 +114,7 @@ aws lambda invoke \
   --payload '{"key":"value"}' \
   --cli-binary-format raw-in-base64-out \
   response.json \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 cat response.json
 
@@ -97,14 +125,14 @@ aws lambda invoke \
   --payload '{"key":"value"}' \
   --cli-binary-format raw-in-base64-out \
   /dev/null \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Update code
 zip function.zip index.mjs
 aws lambda update-function-code \
   --function-name my-function \
   --zip-file fileb://function.zip \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Event Source Mappings
@@ -114,16 +142,16 @@ Connect Lambda to SQS, Kinesis, or DynamoDB Streams:
 ```bash
 # SQS trigger
 QUEUE_ARN=$(aws sqs get-queue-attributes \
-  --queue-url $AWS_ENDPOINT/000000000000/orders \
+  --queue-url $AWS_ENDPOINT_URL/000000000000/orders \
   --attribute-names QueueArn \
   --query Attributes.QueueArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 aws lambda create-event-source-mapping \
   --function-name my-function \
   --event-source-arn $QUEUE_ARN \
   --batch-size 10 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Supported Runtimes

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -60,7 +60,7 @@ services:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a PostgreSQL instance
 aws rds create-db-instance \
@@ -70,13 +70,13 @@ aws rds create-db-instance \
   --master-username admin \
   --master-user-password secret123 \
   --allocated-storage 20 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get connection details
 aws rds describe-db-instances \
   --db-instance-identifier mypostgres \
   --query 'DBInstances[0].Endpoint' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Connect with psql (use the port returned above)
 psql -h localhost -p 7001 -U admin
@@ -89,7 +89,7 @@ aws rds create-db-instance \
   --master-username root \
   --master-user-password secret123 \
   --allocated-storage 20 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Connect with mysql client
 mysql -h 127.0.0.1 -P 7002 -u root -psecret123

--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -22,6 +22,21 @@
 | **Object Lock** | PutObjectLockConfiguration, GetObjectLockConfiguration, PutObjectRetention, GetObjectRetention, PutObjectLegalHold, GetObjectLegalHold |
 | **Pre-signed URLs** | Generates and validates pre-signed GET/PUT URLs |
 | **S3 Select** | SelectObjectContent |
+| **Public Access Block** | PutPublicAccessBlock, GetPublicAccessBlock, DeletePublicAccessBlock |
+
+**RestoreObject** is accepted but stubbed: Floci validates the request and returns `202 Accepted`, but no restore state machine runs.
+
+## Not Implemented
+
+These AWS S3 features have no handler in Floci. Calls will return an error (typically `404` or `NoSuchBucket`-style):
+
+- Replication (`PutBucketReplication`, `GetBucketReplication`, `DeleteBucketReplication`)
+- Website hosting (`PutBucketWebsite`, `GetBucketWebsite`, `DeleteBucketWebsite`)
+- Access logging (`PutBucketLogging`, `GetBucketLogging`)
+- Request payment (`PutBucketRequestPayment`, `GetBucketRequestPayment`)
+- Intelligent-Tiering configurations
+- Inventory configurations
+- Metrics and Analytics configurations
 
 ## Configuration
 
@@ -38,43 +53,43 @@ floci:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create bucket
-aws s3 mb s3://my-bucket --endpoint-url $AWS_ENDPOINT
+aws s3 mb s3://my-bucket --endpoint-url $AWS_ENDPOINT_URL
 
 # Upload a file
-aws s3 cp ./report.pdf s3://my-bucket/reports/report.pdf --endpoint-url $AWS_ENDPOINT
+aws s3 cp ./report.pdf s3://my-bucket/reports/report.pdf --endpoint-url $AWS_ENDPOINT_URL
 
 # Upload inline content
-echo '{"hello":"world"}' | aws s3 cp - s3://my-bucket/data.json --endpoint-url $AWS_ENDPOINT
+echo '{"hello":"world"}' | aws s3 cp - s3://my-bucket/data.json --endpoint-url $AWS_ENDPOINT_URL
 
 # Download
-aws s3 cp s3://my-bucket/data.json ./data.json --endpoint-url $AWS_ENDPOINT
+aws s3 cp s3://my-bucket/data.json ./data.json --endpoint-url $AWS_ENDPOINT_URL
 
 # Inspect object attributes without downloading the body
 aws s3api get-object-attributes \
   --bucket my-bucket \
   --key data.json \
   --object-attributes ETag ObjectSize StorageClass \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List
-aws s3 ls s3://my-bucket --endpoint-url $AWS_ENDPOINT
+aws s3 ls s3://my-bucket --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete
-aws s3 rm s3://my-bucket/data.json --endpoint-url $AWS_ENDPOINT
+aws s3 rm s3://my-bucket/data.json --endpoint-url $AWS_ENDPOINT_URL
 
 # Enable versioning
 aws s3api put-bucket-versioning \
   --bucket my-bucket \
   --versioning-configuration Status=Enabled \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Generate a pre-signed URL (valid for 1 hour)
 aws s3 presign s3://my-bucket/report.pdf \
   --expires-in 3600 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Path-Style URLs

--- a/docs/services/scheduler.md
+++ b/docs/services/scheduler.md
@@ -26,16 +26,16 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a schedule group
 aws scheduler create-schedule-group \
   --name my-group \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List schedule groups
 aws scheduler list-schedule-groups \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a schedule in the default group
 aws scheduler create-schedule \
@@ -46,7 +46,7 @@ aws scheduler create-schedule \
     "Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
     "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role"
   }' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a schedule with retry policy and dead-letter queue
 aws scheduler create-schedule \
@@ -59,12 +59,12 @@ aws scheduler create-schedule \
     "RetryPolicy": {"MaximumEventAgeInSeconds":3600,"MaximumRetryAttempts":5},
     "DeadLetterConfig": {"Arn":"arn:aws:sqs:us-east-1:000000000000:my-dlq"}
   }' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get a schedule
 aws scheduler get-schedule \
   --name my-schedule \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Update a schedule
 aws scheduler update-schedule \
@@ -76,17 +76,17 @@ aws scheduler update-schedule \
     "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role"
   }' \
   --state DISABLED \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete a schedule
 aws scheduler delete-schedule \
   --name my-schedule \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete a schedule group (cascades to all schedules in the group)
 aws scheduler delete-schedule-group \
   --name my-group \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Default Schedule Group

--- a/docs/services/secrets-manager.md
+++ b/docs/services/secrets-manager.md
@@ -35,43 +35,43 @@ floci:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a string secret
 aws secretsmanager create-secret \
   --name /app/database-url \
   --secret-string "postgresql://admin:secret@localhost/mydb" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a JSON secret
 aws secretsmanager create-secret \
   --name /app/api-keys \
   --secret-string '{"stripe":"sk_test_xxx","sendgrid":"SG.xxx"}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Retrieve a secret
 aws secretsmanager get-secret-value \
   --secret-id /app/database-url \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Update a secret
 aws secretsmanager put-secret-value \
   --secret-id /app/database-url \
   --secret-string "postgresql://admin:new-password@localhost/mydb" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List secrets
-aws secretsmanager list-secrets --endpoint-url $AWS_ENDPOINT
+aws secretsmanager list-secrets --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete (with recovery window)
 aws secretsmanager delete-secret \
   --secret-id /app/database-url \
   --recovery-window-in-days 7 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete immediately (no recovery)
 aws secretsmanager delete-secret \
   --secret-id /app/database-url \
   --force-delete-without-recovery \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -38,42 +38,42 @@ floci:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Verify sender and recipient identities
 aws ses verify-email-identity \
   --email-address sender@example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 aws ses verify-email-identity \
   --email-address recipient@example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Verify a domain
 aws ses verify-domain-identity \
   --domain example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # List all identities
 aws ses list-identities \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Send a plain-text email
 aws ses send-email \
   --from sender@example.com \
   --destination ToAddresses=recipient@example.com \
   --message "Subject={Data=Hello},Body={Text={Data=Sent from Floci SES}}" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Send a raw MIME email
 aws ses send-raw-email \
   --raw-message Data="$(printf 'Subject: Raw test\r\n\r\nHello from raw SES')" \
   --source sender@example.com \
   --destinations recipient@example.com \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Inspect locally captured messages
-curl $AWS_ENDPOINT/_aws/ses
+curl $AWS_ENDPOINT_URL/_aws/ses
 ```
 
 ## Local Inspection Endpoint
@@ -92,4 +92,27 @@ Messages are stored locally by Floci and can be persisted when SES storage is ba
 - `SendEmail` stores the text body or the HTML body as the captured message body.
 - `SetIdentityNotificationTopic` stores SNS topic ARNs and returns them via `GetIdentityNotificationAttributes`.
 - Notification topics are configuration metadata only; SES delivery, bounce, or complaint events are not emitted automatically.
-- SES currently exposes the Query API only; SMTP and SES v2 REST APIs are not implemented.
+- SMTP submission is not implemented. For the REST JSON API see [SES v2](#v2) below.
+
+## SES v2 (REST JSON) {#v2}
+
+**Protocol:** REST JSON
+**Endpoint:** `http://localhost:4566/v2/email/...`
+
+Alongside the classic Query API, Floci implements a subset of the SES v2 REST JSON API used by `aws sesv2 ...` commands and SDK v2 clients that target the modern SES surface.
+
+### Supported Operations
+
+| Method | Path | Action |
+|---|---|---|
+| `POST` | `/v2/email/identities` | `CreateEmailIdentity` |
+| `GET` | `/v2/email/identities` | `ListEmailIdentities` |
+| `GET` | `/v2/email/identities/{emailIdentity}` | `GetEmailIdentity` |
+| `DELETE` | `/v2/email/identities/{emailIdentity}` | `DeleteEmailIdentity` |
+| `PUT` | `/v2/email/identities/{emailIdentity}/dkim` | `PutEmailIdentityDkimAttributes` |
+| `PUT` | `/v2/email/identities/{emailIdentity}/feedback` | `PutEmailIdentityFeedbackAttributes` |
+| `POST` | `/v2/email/outbound-emails` | `SendEmail` (simple / raw / templated) |
+| `GET` | `/v2/email/account` | `GetAccount` |
+| `PUT` | `/v2/email/account/sending` | `PutAccountSendingAttributes` |
+
+Identity and sent-message state is shared with the v1 Query API, so messages sent through v2 appear in the same `GET /_aws/ses` inspection mailbox.

--- a/docs/services/sns.md
+++ b/docs/services/sns.md
@@ -28,36 +28,36 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a topic
 TOPIC_ARN=$(aws sns create-topic --name notifications \
   --query TopicArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Subscribe an SQS queue
 QUEUE_ARN=$(aws sqs get-queue-attributes \
-  --queue-url $AWS_ENDPOINT/000000000000/orders \
+  --queue-url $AWS_ENDPOINT_URL/000000000000/orders \
   --attribute-names QueueArn \
   --query Attributes.QueueArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 aws sns subscribe \
   --topic-arn $TOPIC_ARN \
   --protocol sqs \
   --notification-endpoint $QUEUE_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Publish a message
 aws sns publish \
   --topic-arn $TOPIC_ARN \
   --message '{"event":"user.registered"}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Fan-out: publish and verify the SQS queue received the message
 aws sqs receive-message \
-  --queue-url $AWS_ENDPOINT/000000000000/orders \
-  --endpoint-url $AWS_ENDPOINT
+  --queue-url $AWS_ENDPOINT_URL/000000000000/orders \
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## SNS → SQS Fan-Out

--- a/docs/services/sqs.md
+++ b/docs/services/sqs.md
@@ -42,48 +42,48 @@ floci:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a standard queue
-aws sqs create-queue --queue-name orders --endpoint-url $AWS_ENDPOINT
+aws sqs create-queue --queue-name orders --endpoint-url $AWS_ENDPOINT_URL
 
 # Create a FIFO queue
 aws sqs create-queue \
   --queue-name orders.fifo \
   --attributes FifoQueue=true \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Send a message
-QUEUE_URL="$AWS_ENDPOINT/000000000000/orders"
+QUEUE_URL="$AWS_ENDPOINT_URL/000000000000/orders"
 aws sqs send-message \
   --queue-url $QUEUE_URL \
   --message-body '{"event":"order.placed","id":"abc123"}' \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Receive messages
 aws sqs receive-message \
   --queue-url $QUEUE_URL \
   --max-number-of-messages 10 \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Delete a message (replace RECEIPT_HANDLE with the value from ReceiveMessage)
 aws sqs delete-message \
   --queue-url $QUEUE_URL \
   --receipt-handle "RECEIPT_HANDLE" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Set up a dead-letter queue
 DLQ_ARN=$(aws sqs get-queue-attributes \
-  --queue-url $AWS_ENDPOINT/000000000000/orders-dlq \
+  --queue-url $AWS_ENDPOINT_URL/000000000000/orders-dlq \
   --attribute-names QueueArn \
   --query Attributes.QueueArn \
   --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 aws sqs set-queue-attributes \
   --queue-url $QUEUE_URL \
   --attributes "{\"RedrivePolicy\":\"{\\\"deadLetterTargetArn\\\":\\\"$DLQ_ARN\\\",\\\"maxReceiveCount\\\":3}\"}" \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 ## Queue URL Format

--- a/docs/services/ssm.md
+++ b/docs/services/ssm.md
@@ -38,24 +38,24 @@ floci:
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Store parameters
-aws ssm put-parameter --endpoint-url $AWS_ENDPOINT \
+aws ssm put-parameter --endpoint-url $AWS_ENDPOINT_URL \
   --name /app/db/host --value "localhost" --type String
 
-aws ssm put-parameter --endpoint-url $AWS_ENDPOINT \
+aws ssm put-parameter --endpoint-url $AWS_ENDPOINT_URL \
   --name /app/db/password --value "secret" --type SecureString
 
 # Retrieve
-aws ssm get-parameter --endpoint-url $AWS_ENDPOINT \
+aws ssm get-parameter --endpoint-url $AWS_ENDPOINT_URL \
   --name /app/db/host
 
-aws ssm get-parameters-by-path --endpoint-url $AWS_ENDPOINT \
+aws ssm get-parameters-by-path --endpoint-url $AWS_ENDPOINT_URL \
   --path /app/ --recursive
 
 # Delete
-aws ssm delete-parameter --endpoint-url $AWS_ENDPOINT \
+aws ssm delete-parameter --endpoint-url $AWS_ENDPOINT_URL \
   --name /app/db/host
 ```
 

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -23,7 +23,7 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Create a state machine
 SM_ARN=$(aws stepfunctions create-state-machine \
@@ -41,22 +41,22 @@ SM_ARN=$(aws stepfunctions create-state-machine \
   }' \
   --role-arn arn:aws:iam::000000000000:role/step-functions-role \
   --query stateMachineArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Start an execution
 EXEC_ARN=$(aws stepfunctions start-execution \
   --state-machine-arn $SM_ARN \
   --input '{"key":"value"}' \
   --query executionArn --output text \
-  --endpoint-url $AWS_ENDPOINT)
+  --endpoint-url $AWS_ENDPOINT_URL)
 
 # Check status
 aws stepfunctions describe-execution \
   --execution-arn $EXEC_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get event history
 aws stepfunctions get-execution-history \
   --execution-arn $EXEC_ARN \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/sts.md
+++ b/docs/services/sts.md
@@ -17,19 +17,19 @@
 ## Examples
 
 ```bash
-export AWS_ENDPOINT=http://localhost:4566
+export AWS_ENDPOINT_URL=http://localhost:4566
 
 # Get caller identity (always works, useful for smoke testing)
-aws sts get-caller-identity --endpoint-url $AWS_ENDPOINT
+aws sts get-caller-identity --endpoint-url $AWS_ENDPOINT_URL
 
 # Assume a role
 aws sts assume-role \
   --role-arn arn:aws:iam::000000000000:role/my-role \
   --role-session-name dev-session \
-  --endpoint-url $AWS_ENDPOINT
+  --endpoint-url $AWS_ENDPOINT_URL
 
 # Get a session token
-aws sts get-session-token --endpoint-url $AWS_ENDPOINT
+aws sts get-session-token --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 `GetCallerIdentity` is commonly used in CI pipelines and integration tests as a quick connectivity check before running more complex tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,9 +86,11 @@ nav:
     - ElastiCache: services/elasticache.md
     - RDS: services/rds.md
     - EventBridge: services/eventbridge.md
+    - EventBridge Scheduler: services/scheduler.md
     - CloudWatch: services/cloudwatch.md
     - ACM: services/acm.md
     - ECS: services/ecs.md
     - OpenSearch: services/opensearch.md
     - EC2: services/ec2.md
+    - AppConfig: services/appconfig.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary

Documentation accuracy audit reconciling service docs against the current codebase, plus a `CHANGELOG.md` backfill for releases 1.1.0 through 1.5.2 (the file was empty for that release cycle).

## Changes

**CHANGELOG.md backfill**: Hand-written entries for 1.1.0 through 1.5.2 matching semantic-release format, sourced from `git log`.

**Corrected operation counts** in `docs/services/index.md` for JAX-RS REST services where one `@Path` handler fans out to multiple AWS operations (the old "approximate" counts misled readers):

- S3: `~30` → `58` (counted from dispatch branches in `S3Controller.java`)
- Lambda: `~25` → `30` (counted across `LambdaController`, URL config, tags; excluding data-plane invoker and collapsed code-signing)
- API Gateway v1: `~24` → `62` (counted from actual handlers; corrected ghost ops that the old doc claimed but code didn't implement)

**README.md services table**: Dropped the per-service `Ops` column entirely (counts drift too fast to maintain in two places). Points readers at `docs/services/index.md` as the canonical source. AppConfig + AppConfigData rows included.

**24 service docs refreshed** under `docs/services/` for accuracy. Added `Not Implemented` sections in `s3.md`, `lambda.md`, `api-gateway.md`.

**Configuration and getting-started docs** refreshed: `application-yml.md`, `docker-compose.md`, `ports.md`, `storage.md`, `initialization-hooks.md`, `aws-setup.md`, `installation.md`, `quick-start.md`, `docs/index.md`.

**`mkdocs.yml`**: Added EventBridge Scheduler and AppConfig to the services nav.

## Notable corrections caught during review

- `docs/services/s3.md` previously claimed "Object legal holds are stored but not enforced on subsequent operations." Removed: `S3Service.java:314` (`checkLockProtection`) throws `AccessDenied` when `legalHoldStatus == "ON"`, so they are enforced on delete.
- `docs/services/lambda.md` was missing `ListVersionsByFunction` from the operations table (maps to `@GET /functions/{functionName}/versions` in `LambdaController.java:297`).
- `docs/index.md` had a stale "29 AWS services" count in two places (bumped to 31 to match the canonical `docs/services/index.md`).

## Test plan

- [x] `markdownlint-cli2` run on changed files (pre-existing MD013 line-length warnings on README only; no new issues)
- [x] Internal cross-reference check: README / `docs/index.md` / `docs/services/index.md` service counts agree (31)
- [x] Operation counts verified against actual dispatch handlers, not `@Path` annotation counts
- [ ] `mkdocs build` sanity check (reviewer discretion)
- [ ] Link-check pass on rendered site (optional)