### PR TITLE
fix(s3): return XML error responses for presigned POST failures

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1590,6 +1590,16 @@ public class S3Controller {
     }
 
     private Response handlePresignedPost(String bucket, String contentType, byte[] body) {
+        try {
+            return doHandlePresignedPost(bucket, contentType, body);
+        } catch (AwsException e) {
+            // Presigned POST errors must be returned as XML (matching LocalStack/AWS),
+            // not JSON which is what the global AwsExceptionMapper would produce.
+            return xmlErrorResponse(e);
+        }
+    }
+
+    private Response doHandlePresignedPost(String bucket, String contentType, byte[] body) {
         String boundary = extractBoundary(contentType);
         if (boundary == null) {
             throw new AwsException("InvalidArgument",

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -374,6 +375,47 @@ class S3PresignedPostIntegrationTest {
             .body(hasXPath("/Error/Message", equalTo(
                     "Invalid according to Policy: Policy Condition failed: "
                             + "[\"starts-with\", \"$key\", \"uploads/\"]")));
+    }
+
+    @Test
+    @Order(94)
+    void presignedPostReturnsXmlErrorResponseBody() {
+        // Verify the raw XML wire format matches what AWS S3 and LocalStack return.
+        // This ensures clients that parse the raw response body (e.g. seadn) see the
+        // expected XML structure with &quot;-encoded quotes, not JSON.
+        String key = "uploads/xml-error-check.png";
+        String fileContent = "not a real png";
+
+        String policy = buildPolicy(BUCKET, key, "image/png", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        String responseBody =
+            given()
+                .multiPart("key", key)
+                .multiPart("Content-Type", "image/gif")
+                .multiPart("policy", policyBase64)
+                .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+                .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+                .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+                .multiPart("x-amz-signature", "dummysignature")
+                .multiPart("file", "xml-error-check.png", fileContent.getBytes(StandardCharsets.UTF_8), "image/gif")
+            .when()
+                .post("/" + BUCKET)
+            .then()
+                .statusCode(403)
+                .contentType("application/xml")
+                .extract().body().asString();
+
+        // Assert the exact XML structure, matching what AWS S3 and LocalStack return.
+        // The RequestId is a random UUID, so we match it with a regex.
+        assertThat(responseBody, matchesRegex(
+                "\\Q<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\E"
+                        + "\\Q<Error>\\E"
+                        + "\\Q<Code>AccessDenied</Code>\\E"
+                        + "\\Q<Message>Invalid according to Policy: Policy Condition failed: \\E"
+                        + "\\Q[&quot;eq&quot;, &quot;$Content-Type&quot;, &quot;image/png&quot;]</Message>\\E"
+                        + "<RequestId>[0-9a-f\\-]+</RequestId>"
+                        + "\\Q</Error>\\E"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Presigned POST errors (e.g. policy condition failures) were thrown as `AwsException` and caught by the global `AwsExceptionMapper`, which returns JSON. Real AWS S3 returns XML error responses for presigned POST operations.

This PR wraps `handlePresignedPost` in a try/catch that converts `AwsException` to XML via `xmlErrorResponse()`, matching AWS/LocalStack behavior.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Presigned POST policy violations returned JSON error responses instead of XML. AWS S3 returns XML for all S3 error responses, including presigned POST failures.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)