### PR TITLE
feat: add HEALTHCHECK to all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ VOLUME /app/data
 
 EXPOSE 4566 6379-6399
 
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD wget -q --spider http://localhost:4566/_floci/health || exit 1
+
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
 

--- a/Dockerfile.jvm-package
+++ b/Dockerfile.jvm-package
@@ -21,6 +21,9 @@ COPY --chown=1001:root target/quarkus-app quarkus-app/
 
 EXPOSE 4566 6379-6399
 
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD wget -q --spider http://localhost:4566/_floci/health || exit 1
+
 USER 1001
 
 ENTRYPOINT ["java", "-jar", "quarkus-app/quarkus-run.jar", "-Dquarkus.http.host=0.0.0.0"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -25,6 +25,9 @@ VOLUME /app/data
 
 EXPOSE 4566
 
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD bash -c 'echo -e "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4566' || exit 1
+
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
 

--- a/Dockerfile.native-package
+++ b/Dockerfile.native-package
@@ -18,6 +18,9 @@ COPY --chown=1001:root target/*-runner /app/application
 
 EXPOSE 4566
 
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD curl -f http://localhost:4566/_floci/health || exit 1
+
 USER 1001
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
## Summary

Adds a Docker `HEALTHCHECK` instruction to all four Dockerfiles (`Dockerfile`, `Dockerfile.jvm-package`, `Dockerfile.native`, `Dockerfile.native-package`) so orchestration tools can detect readiness without a custom healthcheck definition. This makes the Floci image a better drop-in replacement for LocalStack, which includes a built-in healthcheck.

Uses the existing `/_floci/health` endpoint. Each Dockerfile uses a different healthcheck tool based on what's already available in the base image to avoid installing extra dependencies:

- **Dockerfile** & **Dockerfile.jvm-package** (Alpine-based): `wget` (included in Alpine by default)
- **Dockerfile.native** (quarkus-micro-image): bash `/dev/tcp` (minimal image with no HTTP clients, but bash is available)
- **Dockerfile.native-package** (ubi9-minimal): `curl` (included in ubi9-minimal)

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A — infrastructure-only change, no wire protocol impact.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — N/A (Dockerfile-only change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)