### PR TITLE
fix: topologically sort CloudFormation resources before provisioning

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -15,6 +15,8 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -219,11 +221,10 @@ public class CloudFormationService {
             }
 
             if (resources.isObject()) {
-                Iterator<Map.Entry<String, JsonNode>> it = resources.fields();
-                while (it.hasNext()) {
-                    var entry = it.next();
-                    String logicalId = entry.getKey();
-                    JsonNode resDef = entry.getValue();
+                List<String> sortedLogicalIds = topologicalSort(resources, conditions);
+
+                for (String logicalId : sortedLogicalIds) {
+                    JsonNode resDef = resources.get(logicalId);
                     String type = resDef.path("Type").asText();
                     JsonNode props = resDef.path("Properties");
 
@@ -480,6 +481,146 @@ public class CloudFormationService {
                     "Stack with id " + stackName + " does not exist", 400);
         }
         return stack;
+    }
+
+    private List<String> topologicalSort(JsonNode resources, Map<String, Boolean> conditions) {
+        Set<String> allIds = new LinkedHashSet<>();
+        resources.fieldNames().forEachRemaining(allIds::add);
+
+        Map<String, Set<String>> dependencies = new HashMap<>();
+        for (String logicalId : allIds) {
+            JsonNode resDef = resources.get(logicalId);
+
+            String condition = resDef.path("Condition").asText(null);
+            if (condition != null && !conditions.getOrDefault(condition, false)) {
+                continue;
+            }
+
+            Set<String> deps = new LinkedHashSet<>();
+            collectDependencies(resDef.path("Properties"), allIds, deps);
+
+            JsonNode dependsOn = resDef.path("DependsOn");
+            if (dependsOn.isTextual()) {
+                deps.add(dependsOn.asText());
+            } else if (dependsOn.isArray()) {
+                for (JsonNode d : dependsOn) {
+                    deps.add(d.asText());
+                }
+            }
+
+            dependencies.put(logicalId, deps);
+        }
+
+        Map<String, Integer> inDegree = new HashMap<>();
+        for (String id : allIds) {
+            inDegree.put(id, 0);
+        }
+        for (var entry : dependencies.entrySet()) {
+            for (String dep : entry.getValue()) {
+                if (inDegree.containsKey(dep)) {
+                    inDegree.put(entry.getKey(), inDegree.get(entry.getKey()) + 1);
+                }
+            }
+        }
+
+        Deque<String> queue = new ArrayDeque<>();
+        for (String id : allIds) {
+            if (inDegree.get(id) == 0) {
+                queue.add(id);
+            }
+        }
+
+        List<String> sorted = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            String current = queue.poll();
+            sorted.add(current);
+            for (var entry : dependencies.entrySet()) {
+                if (entry.getValue().contains(current)) {
+                    int newDegree = inDegree.get(entry.getKey()) - 1;
+                    inDegree.put(entry.getKey(), newDegree);
+                    if (newDegree == 0) {
+                        queue.add(entry.getKey());
+                    }
+                }
+            }
+        }
+
+        for (String id : allIds) {
+            if (!sorted.contains(id)) {
+                sorted.add(id);
+            }
+        }
+
+        return sorted;
+    }
+
+    private static final Pattern SUB_VAR_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+
+    private void collectDependencies(JsonNode node, Set<String> allIds, Set<String> deps) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return;
+        }
+        if (node.isObject()) {
+            if (node.has("Ref")) {
+                String ref = node.get("Ref").asText();
+                if (allIds.contains(ref)) {
+                    deps.add(ref);
+                }
+                return;
+            }
+            if (node.has("Fn::GetAtt")) {
+                JsonNode getAtt = node.get("Fn::GetAtt");
+                String logicalId;
+                if (getAtt.isArray() && getAtt.size() >= 1) {
+                    logicalId = getAtt.get(0).asText();
+                } else {
+                    logicalId = getAtt.asText().split("\\.", 2)[0];
+                }
+                if (allIds.contains(logicalId)) {
+                    deps.add(logicalId);
+                }
+                return;
+            }
+            if (node.has("Fn::Sub")) {
+                collectSubDependencies(node.get("Fn::Sub"), allIds, deps);
+                return;
+            }
+            node.fields().forEachRemaining(e -> collectDependencies(e.getValue(), allIds, deps));
+        } else if (node.isArray()) {
+            for (JsonNode item : node) {
+                collectDependencies(item, allIds, deps);
+            }
+        }
+    }
+
+    private void collectSubDependencies(JsonNode sub, Set<String> allIds, Set<String> deps) {
+        String template;
+        Set<String> explicitVars = new HashSet<>();
+
+        if (sub.isTextual()) {
+            template = sub.textValue();
+        } else if (sub.isArray() && sub.size() >= 1) {
+            template = sub.get(0).asText();
+            if (sub.size() >= 2 && sub.get(1).isObject()) {
+                sub.get(1).fieldNames().forEachRemaining(explicitVars::add);
+                collectDependencies(sub.get(1), allIds, deps);
+            }
+        } else {
+            return;
+        }
+
+        Matcher matcher = SUB_VAR_PATTERN.matcher(template);
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            if (varName.startsWith("AWS::") || explicitVars.contains(varName)) {
+                continue;
+            }
+            int dot = varName.indexOf('.');
+            String resourcePart = dot > 0 ? varName.substring(0, dot) : varName;
+            if (allIds.contains(resourcePart)) {
+                deps.add(resourcePart);
+            }
+        }
     }
 
     private static String key(String stackName, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1577,6 +1577,183 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_dependencyOrdering_refBeforeTarget() {
+        String template = """
+            {
+              "Resources": {
+                "ParamForQueue": {
+                  "Type": "AWS::SSM::Parameter",
+                  "Properties": {
+                    "Name": "/dep-order/ref-queue-name",
+                    "Type": "String",
+                    "Value": {"Ref": "DepOrderQueue"}
+                  }
+                },
+                "DepOrderQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "dep-order-ref-queue"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "dep-order-ref-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "dep-order-ref-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {"Name": "/dep-order/ref-queue-name", "WithDecryption": true}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Value", containsString("dep-order-ref-queue"));
+    }
+
+    @Test
+    void createStack_dependencyOrdering_getAttBeforeTarget() {
+        String template = """
+            {
+              "Resources": {
+                "ArnParam": {
+                  "Type": "AWS::SSM::Parameter",
+                  "Properties": {
+                    "Name": "/dep-order/getatt-table-arn",
+                    "Type": "String",
+                    "Value": {"Fn::GetAtt": ["DepOrderTable", "Arn"]}
+                  }
+                },
+                "DepOrderTable": {
+                  "Type": "AWS::DynamoDB::Table",
+                  "Properties": {
+                    "TableName": "dep-order-getatt-table",
+                    "AttributeDefinitions": [
+                      {"AttributeName": "pk", "AttributeType": "S"}
+                    ],
+                    "KeySchema": [
+                      {"AttributeName": "pk", "KeyType": "HASH"}
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "dep-order-getatt-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "dep-order-getatt-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {"Name": "/dep-order/getatt-table-arn", "WithDecryption": true}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Value", startsWith("arn:aws:dynamodb:"));
+    }
+
+    @Test
+    void createStack_dependencyOrdering_fnSubBeforeTarget() {
+        String template = """
+            {
+              "Resources": {
+                "SubParam": {
+                  "Type": "AWS::SSM::Parameter",
+                  "Properties": {
+                    "Name": "/dep-order/sub-queue-arn",
+                    "Type": "String",
+                    "Value": {"Fn::Sub": "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${DepSubQueue}"}
+                  }
+                },
+                "DepSubQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "dep-order-sub-queue"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "dep-order-sub-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "dep-order-sub-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {"Name": "/dep-order/sub-queue-arn", "WithDecryption": true}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Value", containsString("dep-order-sub-queue"));
+    }
+
+    @Test
     void deleteStack_withEventBridgeRule() {
         String template = """
             {


### PR DESCRIPTION
## Summary

Fixes #331

`CloudFormationService.executeTemplate` provisioned resources in JSON/YAML field iteration order with no dependency analysis. If a resource referenced another via `Ref`, `Fn::GetAtt`, or `Fn::Sub`, and the referenced resource appeared later in the template, the intrinsic function fell back to a literal string (e.g. `CredentialsQueue.Arn` instead of the actual ARN).

Adds a topological sort (Kahn's algorithm) that scans resource `Properties` for `Ref`, `Fn::GetAtt`, `Fn::Sub` variable references (including `${Resource}` and `${Resource.Attr}` shorthand), and explicit `DependsOn` declarations. Resources with false conditions are excluded from the graph. Cycles fall back to original ordering.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

CloudFormation provisions resources respecting implicit dependencies from `Ref`, `Fn::GetAtt`, `Fn::Sub`, and explicit `DependsOn`. Without dependency ordering, templates where a resource appears before its dependency in the file would fail to resolve intrinsic functions correctly.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)