### PR TITLE
fix(sqs): make per-queue message operations atomic

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -1,0 +1,216 @@
+package io.github.hectorvent.floci.services.sqs;
+
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.sqs.model.Message;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Thread-safe wrapper around a per-queue message list. All operations acquire a
+ * {@link ReentrantLock} so that compound read-modify-write sequences (e.g., claim
+ * visible messages) are atomic with respect to each other.
+ */
+class GuardedMessageQueue {
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final List<Message> messages;
+    private final StorageBackend<String, List<Message>> messageStore;
+    private final String storageKey;
+
+    @FunctionalInterface
+    private interface Guard extends AutoCloseable {
+        @Override
+        void close(); // no checked exception
+    }
+
+    private Guard hold() {
+        lock.lock();
+        return lock::unlock;
+    }
+
+    GuardedMessageQueue(StorageBackend<String, List<Message>> messageStore, String storageKey) {
+        this(new ArrayList<>(), messageStore, storageKey);
+    }
+
+    GuardedMessageQueue(List<Message> initial, StorageBackend<String, List<Message>> messageStore, String storageKey) {
+        this.messages = new ArrayList<>(initial);
+        this.messageStore = messageStore;
+        this.storageKey = storageKey;
+    }
+
+    record ClaimResult(List<Message> claimed, List<Message> dlqCandidates) {
+    }
+
+    void addMessage(Message message) {
+        try (var _ = hold()) {
+            messages.add(message);
+            persist();
+        }
+    }
+
+    void addAll(List<Message> toAdd) {
+        try (var _ = hold()) {
+            messages.addAll(toAdd);
+            persist();
+        }
+    }
+
+    ClaimResult claimVisibleMessages(int maxMessages, int effectiveTimeout,
+                                     boolean fifo, int maxReceiveCount,
+                                     String deadLetterTargetArn) {
+        try (var _ = hold()) {
+            List<Message> claimed = new ArrayList<>();
+            List<Message> dlqCandidates = new ArrayList<>();
+
+            if (fifo) {
+                claimFifo(maxMessages, effectiveTimeout, maxReceiveCount, deadLetterTargetArn,
+                        claimed, dlqCandidates);
+            } else {
+                claimStandard(maxMessages, effectiveTimeout, maxReceiveCount, deadLetterTargetArn,
+                        claimed, dlqCandidates);
+            }
+
+            if (!dlqCandidates.isEmpty()) {
+                messages.removeAll(dlqCandidates);
+                for (Message msg : dlqCandidates) {
+                    msg.setVisibleAt(null);
+                    msg.setReceiptHandle(null);
+                }
+                persist();
+            } else if (!claimed.isEmpty()) {
+                persist();
+            }
+
+            return new ClaimResult(claimed, dlqCandidates);
+        }
+    }
+
+    private boolean tryClaim(Message msg, int effectiveTimeout, int maxReceiveCount,
+                             String deadLetterTargetArn, List<Message> claimed,
+                             List<Message> dlqCandidates) {
+        msg.setReceiveCount(msg.getReceiveCount() + 1);
+
+        if (maxReceiveCount > 0 && deadLetterTargetArn != null
+                && msg.getReceiveCount() > maxReceiveCount) {
+            dlqCandidates.add(msg);
+            return false;
+        }
+
+        msg.setReceiptHandle(UUID.randomUUID().toString());
+        msg.setVisibleAt(Instant.now().plusSeconds(effectiveTimeout));
+        claimed.add(msg);
+        return true;
+    }
+
+    private void claimStandard(int maxMessages, int effectiveTimeout,
+                               int maxReceiveCount, String deadLetterTargetArn,
+                               List<Message> claimed, List<Message> dlqCandidates) {
+        for (Message msg : messages) {
+            if (claimed.size() >= maxMessages) break;
+            if (!msg.isVisible()) continue;
+            tryClaim(msg, effectiveTimeout, maxReceiveCount, deadLetterTargetArn, claimed, dlqCandidates);
+        }
+    }
+
+    private void claimFifo(int maxMessages, int effectiveTimeout,
+                           int maxReceiveCount, String deadLetterTargetArn,
+                           List<Message> claimed, List<Message> dlqCandidates) {
+        Set<String> groupsWithInFlight;
+        Set<String> groupsDelivered = new HashSet<>();
+
+        groupsWithInFlight =
+                messages.stream().filter(msg -> !msg.isVisible() && msg.getMessageGroupId() != null)
+                        .map(Message::getMessageGroupId).collect(Collectors.toSet());
+
+        for (Message msg : messages) {
+            if (claimed.size() >= maxMessages) break;
+            if (!msg.isVisible()) continue;
+
+            String groupId = msg.getMessageGroupId();
+            if (groupId != null && groupsWithInFlight.contains(groupId)) continue;
+            if (groupId != null && groupsDelivered.contains(groupId)) continue;
+
+            if (tryClaim(msg, effectiveTimeout, maxReceiveCount, deadLetterTargetArn, claimed, dlqCandidates)
+                    && groupId != null) {
+                groupsDelivered.add(groupId);
+            }
+        }
+    }
+
+    boolean removeByReceiptHandle(String receiptHandle) {
+        try (var _ = hold()) {
+            boolean removed = messages.removeIf(m -> receiptHandle.equals(m.getReceiptHandle()));
+            if (removed) {
+                persist();
+            }
+            return removed;
+        }
+    }
+
+    boolean changeVisibility(String receiptHandle, int visibilityTimeout) {
+        try (var _ = hold()) {
+            for (Message msg : messages) {
+                if (receiptHandle.equals(msg.getReceiptHandle())) {
+                    msg.setVisibleAt(Instant.now().plusSeconds(visibilityTimeout));
+                    persist();
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    void purge() {
+        try (var _ = hold()) {
+            messages.clear();
+            persist();
+        }
+    }
+
+    List<Message> drainAll() {
+        try (var _ = hold()) {
+            List<Message> drained = new ArrayList<>(messages);
+            messages.clear();
+            persist();
+            return drained;
+        }
+    }
+
+    record MessageCounts(long visible, long inFlight) {
+    }
+
+    MessageCounts messageCounts() {
+        try (var _ = hold()) {
+            long visible = 0;
+            long inFlight = 0;
+            for (Message m : messages) {
+                if (m.isVisible()) visible++;
+                else inFlight++;
+            }
+            return new MessageCounts(visible, inFlight);
+        }
+    }
+
+    boolean isEmpty() {
+        try (var _ = hold()) {
+            return messages.isEmpty();
+        }
+    }
+
+    Message findByDeduplicationId(String dedupId) {
+        try (var _ = hold()) {
+            return messages.stream().filter(msg -> dedupId.equals(msg.getMessageDeduplicationId()))
+                    .findFirst().orElse(null);
+        }
+    }
+
+    private void persist() {
+        if (messageStore == null || storageKey == null) {
+            return;
+        }
+        messageStore.put(storageKey, new ArrayList<>(messages));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -73,14 +73,7 @@ class GuardedMessageQueue {
                         claimed, dlqCandidates);
             }
 
-            if (!dlqCandidates.isEmpty()) {
-                messages.removeAll(dlqCandidates);
-                for (Message msg : dlqCandidates) {
-                    msg.setVisibleAt(null);
-                    msg.setReceiptHandle(null);
-                }
-                persist();
-            } else if (!claimed.isEmpty()) {
+            if (!claimed.isEmpty() || !dlqCandidates.isEmpty()) {
                 persist();
             }
 
@@ -160,6 +153,13 @@ class GuardedMessageQueue {
                 }
             }
             return false;
+        }
+    }
+
+    void removeMessages(List<Message> toRemove) {
+        try (var _ = hold()) {
+            messages.removeAll(toRemove);
+            persist();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -19,6 +19,7 @@ class GuardedMessageQueue {
     private final List<Message> messages;
     private final StorageBackend<String, List<Message>> messageStore;
     private final String storageKey;
+    private volatile boolean closed;
 
     @FunctionalInterface
     private interface Guard extends AutoCloseable {
@@ -207,8 +208,12 @@ class GuardedMessageQueue {
         }
     }
 
+    void close() {
+        closed = true;
+    }
+
     private void persist() {
-        if (messageStore == null || storageKey == null) {
+        if (closed || messageStore == null || storageKey == null) {
             return;
         }
         messageStore.put(storageKey, new ArrayList<>(messages));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -16,7 +16,6 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
@@ -28,13 +27,15 @@ public class SqsService {
     private final StorageBackend<String, Queue> queueStore;
     private final StorageBackend<String, List<Message>> messageStore;
     private final StorageBackend<String, Map<String, Long>> dedupStore;
-    private final ConcurrentHashMap<String, ConcurrentLinkedDeque<Message>> messagesByQueue = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, GuardedMessageQueue> messagesByQueue = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Object> queueLocks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, RedrivePolicy> redrivePolicyCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Instant>> deduplicationCache = new ConcurrentHashMap<>();
     private final AtomicLong sequenceCounter = new AtomicLong(0);
 
-    private record RedrivePolicy(int maxReceiveCount, String deadLetterTargetArn) {}
+    private record RedrivePolicy(int maxReceiveCount, String deadLetterTargetArn) {
+    }
+
     private final int defaultVisibilityTimeout;
     private final int maxMessageSize;
     private final String baseUrl;
@@ -89,7 +90,7 @@ public class SqsService {
         }
         for (String key : messageStore.keys()) {
             messageStore.get(key).ifPresent(msgs ->
-                    messagesByQueue.put(key, new ConcurrentLinkedDeque<>(msgs)));
+                    messagesByQueue.put(key, new GuardedMessageQueue(msgs, messageStore, key)));
         }
     }
 
@@ -114,18 +115,9 @@ public class SqsService {
         }
     }
 
-    private void persistMessages(String storageKey) {
-        if (messageStore == null) {
-            return;
-        }
-
-        var messages = messagesByQueue.get(storageKey);
-        if (messages != null) {
-            // Weakly-consistent snapshot; messages modified concurrently may or may not appear.
-            messageStore.put(storageKey, new ArrayList<>(messages));
-        } else {
-            messageStore.delete(storageKey);
-        }
+    private GuardedMessageQueue getOrCreateQueue(String storageKey) {
+        return messagesByQueue.computeIfAbsent(storageKey,
+                k -> new GuardedMessageQueue(messageStore, k));
     }
 
     private void persistDedup(String storageKey) {
@@ -199,7 +191,7 @@ public class SqsService {
         }
 
         queueStore.put(storageKey, queue);
-        messagesByQueue.put(storageKey, new ConcurrentLinkedDeque<>());
+        messagesByQueue.put(storageKey, new GuardedMessageQueue(messageStore, storageKey));
         LOG.infov("Created {0} queue: {1} in region {2}", queue.isFifo() ? "FIFO" : "standard", queueName, region);
         return queue;
     }
@@ -276,17 +268,9 @@ public class SqsService {
         attrs.put("CreatedTimestamp", String.valueOf(queue.getCreatedTimestamp().getEpochSecond()));
         attrs.put("LastModifiedTimestamp", String.valueOf(queue.getLastModifiedTimestamp().getEpochSecond()));
 
-        var messages = messagesByQueue.getOrDefault(storageKey, new ConcurrentLinkedDeque<>());
-        long visible = 0, inFlight = 0;
-        for (Message m : messages) {
-            if (m.isVisible()) {
-                visible++;
-            } else {
-                inFlight++;
-            }
-        }
-        attrs.put("ApproximateNumberOfMessages", String.valueOf(visible));
-        attrs.put("ApproximateNumberOfMessagesNotVisible", String.valueOf(inFlight));
+        var counts = getOrCreateQueue(storageKey).messageCounts();
+        attrs.put("ApproximateNumberOfMessages", String.valueOf(counts.visible()));
+        attrs.put("ApproximateNumberOfMessagesNotVisible", String.valueOf(counts.inFlight()));
 
         if (attributeNames == null || attributeNames.contains("All")) {
             return attrs;
@@ -339,7 +323,7 @@ public class SqsService {
             // Resolve deduplication ID
             String dedupId = messageDeduplicationId;
             if (dedupId == null || dedupId.isEmpty()) {
-                if ("true" .equalsIgnoreCase(queue.getAttributes().get("ContentBasedDeduplication"))) {
+                if ("true".equalsIgnoreCase(queue.getAttributes().get("ContentBasedDeduplication"))) {
                     dedupId = computeMd5(body);
                 } else {
                     throw new AwsException("InvalidParameterValue",
@@ -356,11 +340,9 @@ public class SqsService {
             persistDedup(storageKey);
             if (previous != null && Instant.now().isBefore(previous)) {
                 // Duplicate within window — return the original message idempotently
-                var messages = messagesByQueue.getOrDefault(storageKey, new ConcurrentLinkedDeque<>());
-                for (Message msg : messages) {
-                    if (dedupId.equals(msg.getMessageDeduplicationId())) {
-                        return msg;
-                    }
+                Message existing = getOrCreateQueue(storageKey).findByDeduplicationId(dedupId);
+                if (existing != null) {
+                    return existing;
                 }
             }
 
@@ -373,8 +355,7 @@ public class SqsService {
                 message.updateMd5OfMessageAttributes();
             }
 
-            messagesByQueue.computeIfAbsent(storageKey, k -> new ConcurrentLinkedDeque<>()).add(message);
-            persistMessages(storageKey);
+            getOrCreateQueue(storageKey).addMessage(message);
             notifyReceivers(storageKey);
             LOG.debugv("Sent FIFO message {0} to queue {1}, group={2}, seq={3}",
                     message.getMessageId(), queueUrl, messageGroupId, message.getSequenceNumber());
@@ -391,8 +372,7 @@ public class SqsService {
             message.updateMd5OfMessageAttributes();
         }
 
-        messagesByQueue.computeIfAbsent(storageKey, k -> new ConcurrentLinkedDeque<>()).add(message);
-        persistMessages(storageKey);
+        getOrCreateQueue(storageKey).addMessage(message);
         notifyReceivers(storageKey);
         LOG.debugv("Sent message {0} to queue {1}", message.getMessageId(), queueUrl);
         return message;
@@ -480,8 +460,8 @@ public class SqsService {
             try {
                 var rp = new com.fasterxml.jackson.databind.ObjectMapper().readTree(rawPolicy);
                 return new RedrivePolicy(
-                    rp.has("maxReceiveCount") ? rp.get("maxReceiveCount").asInt() : -1,
-                    rp.has("deadLetterTargetArn") ? rp.get("deadLetterTargetArn").asText() : null
+                        rp.has("maxReceiveCount") ? rp.get("maxReceiveCount").asInt() : -1,
+                        rp.has("deadLetterTargetArn") ? rp.get("deadLetterTargetArn").asText() : null
                 );
             } catch (Exception e) {
                 LOG.warnv("Failed to parse RedrivePolicy for queue {0}", queue.getQueueUrl());
@@ -497,101 +477,26 @@ public class SqsService {
         }
 
         int effectiveTimeout = visibilityTimeout >= 0 ? visibilityTimeout : defaultVisibilityTimeout;
-        var messages = messagesByQueue.getOrDefault(storageKey, new ConcurrentLinkedDeque<>());
-        List<Message> result = new ArrayList<>();
-        List<Message> dlqMoves = new ArrayList<>();
 
         RedrivePolicy rp = getOrParseRedrivePolicy(queue, storageKey);
         int maxReceiveCount = rp != null ? rp.maxReceiveCount() : -1;
         String deadLetterTargetArn = rp != null ? rp.deadLetterTargetArn() : null;
 
-        if (queue.isFifo()) {
-            // FIFO: enforce per-group ordering — skip groups with in-flight messages
-            Set<String> groupsWithInFlight = new HashSet<>();
-            Set<String> groupsDelivered = new HashSet<>();
+        var guardedQueue = getOrCreateQueue(storageKey);
+        var claimResult = guardedQueue.claimVisibleMessages(
+                maxMessages, effectiveTimeout, queue.isFifo(), maxReceiveCount, deadLetterTargetArn);
 
-            // First pass: find groups with in-flight (invisible) messages
-            for (Message msg : messages) {
-                if (!msg.isVisible() && msg.getMessageGroupId() != null) {
-                    groupsWithInFlight.add(msg.getMessageGroupId());
-                }
-            }
-
-            // Second pass: deliver next visible message per group
-            for (Message msg : messages) {
-                if (result.size() >= maxMessages) {
-                    break;
-                }
-                if (!msg.isVisible()) {
-                    continue;
-                }
-                String groupId = msg.getMessageGroupId();
-                if (groupId != null && groupsWithInFlight.contains(groupId)) {
-                    continue;
-                }
-                if (groupId != null && groupsDelivered.contains(groupId)) {
-                    continue;
-                }
-
-                msg.setReceiveCount(msg.getReceiveCount() + 1);
-
-                // Check DLQ routing
-                if (maxReceiveCount > 0 && deadLetterTargetArn != null && msg.getReceiveCount() > maxReceiveCount) {
-                    dlqMoves.add(msg);
-                    continue;
-                }
-
-                msg.setReceiptHandle(UUID.randomUUID().toString());
-                msg.setVisibleAt(Instant.now().plusSeconds(effectiveTimeout));
-                result.add(msg);
-                if (groupId != null) {
-                    groupsDelivered.add(groupId);
-                }
-            }
-        } else {
-            // Standard queue: deliver any visible message
-            for (Message msg : messages) {
-                if (result.size() >= maxMessages) {
-                    break;
-                }
-                if (msg.isVisible()) {
-                    msg.setReceiveCount(msg.getReceiveCount() + 1);
-
-                    // Check DLQ routing
-                    if (maxReceiveCount > 0 && deadLetterTargetArn != null && msg.getReceiveCount() > maxReceiveCount) {
-                        dlqMoves.add(msg);
-                        continue;
-                    }
-
-                    msg.setReceiptHandle(UUID.randomUUID().toString());
-                    msg.setVisibleAt(Instant.now().plusSeconds(effectiveTimeout));
-                    result.add(msg);
-                }
-            }
-        }
-
-        // Process DLQ moves
-        if (!dlqMoves.isEmpty()) {
+        // Route DLQ candidates to the dead-letter queue
+        if (!claimResult.dlqCandidates().isEmpty() && deadLetterTargetArn != null) {
             String dlqUrl = queueUrlFromArn(deadLetterTargetArn, region);
             if (dlqUrl != null) {
                 String dlqStorageKey = regionKey(region, dlqUrl);
-                var dlqMessages = messagesByQueue.computeIfAbsent(dlqStorageKey, k -> new ConcurrentLinkedDeque<>());
-                for (Message msg : dlqMoves) {
-                    messages.remove(msg);
-                    // Reset visibility and receipt handle for the new queue
-                    msg.setVisibleAt(null);
-                    msg.setReceiptHandle(null);
-                    dlqMessages.add(msg);
-                }
-                persistMessages(storageKey);
-                persistMessages(dlqStorageKey);
-                LOG.infov("Moved {0} messages to DLQ {1}", dlqMoves.size(), dlqUrl);
+                getOrCreateQueue(dlqStorageKey).addAll(claimResult.dlqCandidates());
+                LOG.infov("Moved {0} messages to DLQ {1}", claimResult.dlqCandidates().size(), dlqUrl);
             }
-        } else if (!result.isEmpty()) {
-            persistMessages(storageKey);
         }
 
-        return result;
+        return claimResult.claimed();
     }
 
     private String queueUrlFromArn(String arn, String region) {
@@ -615,15 +520,12 @@ public class SqsService {
         String storageKey = regionKey(region, queueUrl);
         ensureQueueExists(storageKey);
 
-        var messages = messagesByQueue.getOrDefault(storageKey, new ConcurrentLinkedDeque<>());
-        boolean removed = messages.removeIf(m ->
-                receiptHandle.equals(m.getReceiptHandle()));
+        boolean removed = getOrCreateQueue(storageKey).removeByReceiptHandle(receiptHandle);
 
         if (!removed) {
             throw new AwsException("ReceiptHandleIsInvalid",
                     "The input receipt handle is not a valid receipt handle.", 400);
         }
-        persistMessages(storageKey);
         LOG.debugv("Deleted message with receipt handle {0}", receiptHandle);
     }
 
@@ -635,15 +537,11 @@ public class SqsService {
         String storageKey = regionKey(region, queueUrl);
         ensureQueueExists(storageKey);
 
-        var messages = messagesByQueue.getOrDefault(storageKey, new ConcurrentLinkedDeque<>());
-        for (Message msg : messages) {
-            if (receiptHandle.equals(msg.getReceiptHandle())) {
-                msg.setVisibleAt(Instant.now().plusSeconds(visibilityTimeout));
-                return;
-            }
+        boolean found = getOrCreateQueue(storageKey).changeVisibility(receiptHandle, visibilityTimeout);
+        if (!found) {
+            throw new AwsException("ReceiptHandleIsInvalid",
+                    "The input receipt handle is not a valid receipt handle.", 400);
         }
-        throw new AwsException("ReceiptHandleIsInvalid",
-                "The input receipt handle is not a valid receipt handle.", 400);
     }
 
     public void purgeQueue(String queueUrl) {
@@ -653,11 +551,7 @@ public class SqsService {
     public void purgeQueue(String queueUrl, String region) {
         String storageKey = regionKey(region, queueUrl);
         ensureQueueExists(storageKey);
-        var messages = messagesByQueue.get(storageKey);
-        if (messages != null) {
-            messages.clear();
-        }
-        persistMessages(storageKey);
+        getOrCreateQueue(storageKey).purge();
         LOG.infov("Purged queue: {0}", queueUrl);
     }
 
@@ -705,16 +599,13 @@ public class SqsService {
         String srcKey = regionKey(region, sourceUrl);
         ensureQueueExists(srcKey);
 
-        var srcMessages = messagesByQueue.getOrDefault(srcKey, new ConcurrentLinkedDeque<>());
+        var srcQueue = getOrCreateQueue(srcKey);
+        List<Message> drained = srcQueue.drainAll();
         if (destUrl != null) {
             String destKey = regionKey(region, destUrl);
             ensureQueueExists(destKey);
-            var destMessages = messagesByQueue.computeIfAbsent(destKey, k -> new ConcurrentLinkedDeque<>());
-            destMessages.addAll(srcMessages);
-            persistMessages(destKey);
+            getOrCreateQueue(destKey).addAll(drained);
         }
-        srcMessages.clear();
-        persistMessages(srcKey);
 
         LOG.infov("Moved messages from {0} to {1}", sourceArn, destinationArn != null ? destinationArn : "original source");
         return "task-" + UUID.randomUUID().toString();

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -486,13 +486,19 @@ public class SqsService {
         var claimResult = guardedQueue.claimVisibleMessages(
                 maxMessages, effectiveTimeout, queue.isFifo(), maxReceiveCount, deadLetterTargetArn);
 
-        // Route DLQ candidates to the dead-letter queue
+        // Route DLQ candidates to the dead-letter queue only if the destination resolves
         if (!claimResult.dlqCandidates().isEmpty() && deadLetterTargetArn != null) {
             String dlqUrl = queueUrlFromArn(deadLetterTargetArn, region);
             if (dlqUrl != null) {
+                var dlqCandidates = claimResult.dlqCandidates();
+                guardedQueue.removeMessages(dlqCandidates);
+                for (Message msg : dlqCandidates) {
+                    msg.setVisibleAt(null);
+                    msg.setReceiptHandle(null);
+                }
                 String dlqStorageKey = regionKey(region, dlqUrl);
-                getOrCreateQueue(dlqStorageKey).addAll(claimResult.dlqCandidates());
-                LOG.infov("Moved {0} messages to DLQ {1}", claimResult.dlqCandidates().size(), dlqUrl);
+                getOrCreateQueue(dlqStorageKey).addAll(dlqCandidates);
+                LOG.infov("Moved {0} messages to DLQ {1}", dlqCandidates.size(), dlqUrl);
             }
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -207,7 +207,10 @@ public class SqsService {
                     "The specified queue does not exist.", 400);
         }
         queueStore.delete(storageKey);
-        messagesByQueue.remove(storageKey);
+        var removed = messagesByQueue.remove(storageKey);
+        if (removed != null) {
+            removed.close();
+        }
         deduplicationCache.remove(storageKey);
         if (messageStore != null) {
             messageStore.delete(storageKey);

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -182,17 +182,23 @@ class GuardedMessageQueueTest {
     // --- DLQ ---
 
     @Test
-    void dlqCandidatesReturnedWhenMaxReceiveCountExceeded() {
+    void dlqCandidatesReturnedButNotRemovedFromSource() {
         queue.addMessage(new Message("msg"));
 
         // Claim and release (visibility=0) to bump receiveCount
         var r1 = queue.claimVisibleMessages(1, 0, false, -1, null);
         assertEquals(1, r1.claimed().get(0).getReceiveCount());
 
-        // Claim again — now receiveCount = 2, maxReceiveCount = 1 → DLQ
+        // Claim again — now receiveCount = 2, maxReceiveCount = 1 → DLQ candidate
         var r2 = queue.claimVisibleMessages(1, 0, false, 1, "arn:aws:sqs:us-east-1:000000000000:dlq");
         assertTrue(r2.claimed().isEmpty());
         assertEquals(1, r2.dlqCandidates().size());
+
+        // Message stays in source until explicitly removed
+        assertFalse(queue.isEmpty());
+
+        queue.removeMessages(r2.dlqCandidates());
+        assertTrue(queue.isEmpty());
     }
 
     // --- Concurrency: the core bug fix ---
@@ -259,7 +265,6 @@ class GuardedMessageQueueTest {
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CyclicBarrier barrier = new CyclicBarrier(threadCount);
         AtomicInteger claimedCount = new AtomicInteger();
-        AtomicInteger deletedCount = new AtomicInteger();
 
         List<Future<?>> futures = new ArrayList<>();
         // Half the threads receive, half delete
@@ -277,9 +282,7 @@ class GuardedMessageQueueTest {
                     claimedCount.addAndGet(result.claimed().size());
                     // Immediately delete claimed messages
                     for (Message m : result.claimed()) {
-                        if (queue.removeByReceiptHandle(m.getReceiptHandle())) {
-                            deletedCount.incrementAndGet();
-                        }
+                        queue.removeByReceiptHandle(m.getReceiptHandle());
                     }
                 } else {
                     // Competitor — also tries to receive

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -1,0 +1,300 @@
+package io.github.hectorvent.floci.services.sqs;
+
+import io.github.hectorvent.floci.services.sqs.model.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GuardedMessageQueueTest {
+
+    private GuardedMessageQueue queue;
+
+    @BeforeEach
+    void setUp() {
+        queue = new GuardedMessageQueue(null, null);
+    }
+
+    // --- Basic operations ---
+
+    @Test
+    void addAndClaimSingleMessage() {
+        queue.addMessage(new Message("hello"));
+
+        var result = queue.claimVisibleMessages(1, 30, false, -1, null);
+        assertEquals(1, result.claimed().size());
+        assertEquals("hello", result.claimed().get(0).getBody());
+        assertNotNull(result.claimed().get(0).getReceiptHandle());
+        assertEquals(1, result.claimed().get(0).getReceiveCount());
+        assertTrue(result.dlqCandidates().isEmpty());
+    }
+
+    @Test
+    void claimEmptyQueueReturnsEmpty() {
+        var result = queue.claimVisibleMessages(1, 30, false, -1, null);
+        assertTrue(result.claimed().isEmpty());
+        assertTrue(result.dlqCandidates().isEmpty());
+    }
+
+    @Test
+    void claimedMessageBecomesInvisible() {
+        queue.addMessage(new Message("msg1"));
+
+        var first = queue.claimVisibleMessages(1, 30, false, -1, null);
+        assertEquals(1, first.claimed().size());
+
+        var second = queue.claimVisibleMessages(1, 30, false, -1, null);
+        assertTrue(second.claimed().isEmpty());
+    }
+
+    @Test
+    void claimMultipleMessages() {
+        queue.addMessage(new Message("msg1"));
+        queue.addMessage(new Message("msg2"));
+        queue.addMessage(new Message("msg3"));
+
+        var result = queue.claimVisibleMessages(3, 30, false, -1, null);
+        assertEquals(3, result.claimed().size());
+    }
+
+    @Test
+    void claimRespectsMaxMessages() {
+        queue.addMessage(new Message("msg1"));
+        queue.addMessage(new Message("msg2"));
+        queue.addMessage(new Message("msg3"));
+
+        var result = queue.claimVisibleMessages(2, 30, false, -1, null);
+        assertEquals(2, result.claimed().size());
+    }
+
+    @Test
+    void removeByReceiptHandle() {
+        queue.addMessage(new Message("to-delete"));
+
+        var claimed = queue.claimVisibleMessages(1, 30, false, -1, null);
+        String handle = claimed.claimed().get(0).getReceiptHandle();
+
+        assertTrue(queue.removeByReceiptHandle(handle));
+
+        // Message should be gone even with visibility timeout 0
+        var result = queue.claimVisibleMessages(1, 0, false, -1, null);
+        assertTrue(result.claimed().isEmpty());
+    }
+
+    @Test
+    void removeByReceiptHandleInvalidReturnsFalse() {
+        assertFalse(queue.removeByReceiptHandle("nonexistent"));
+    }
+
+    @Test
+    void changeVisibility() {
+        queue.addMessage(new Message("msg"));
+
+        var claimed = queue.claimVisibleMessages(1, 30, false, -1, null);
+        String handle = claimed.claimed().get(0).getReceiptHandle();
+
+        // Set visibility to 0 — message becomes visible immediately
+        assertTrue(queue.changeVisibility(handle, 0));
+
+        var reClaimed = queue.claimVisibleMessages(1, 30, false, -1, null);
+        assertEquals(1, reClaimed.claimed().size());
+    }
+
+    @Test
+    void changeVisibilityInvalidReturnsFalse() {
+        assertFalse(queue.changeVisibility("nonexistent", 0));
+    }
+
+    @Test
+    void purge() {
+        queue.addMessage(new Message("msg1"));
+        queue.addMessage(new Message("msg2"));
+
+        queue.purge();
+
+        var result = queue.claimVisibleMessages(10, 30, false, -1, null);
+        assertTrue(result.claimed().isEmpty());
+    }
+
+    @Test
+    void drainAllAndAddAll() {
+        queue.addMessage(new Message("msg1"));
+        queue.addMessage(new Message("msg2"));
+
+        List<Message> drained = queue.drainAll();
+        assertEquals(2, drained.size());
+        assertTrue(queue.isEmpty());
+
+        var target = new GuardedMessageQueue(null, null);
+        target.addAll(drained);
+
+        var result = target.claimVisibleMessages(10, 30, false, -1, null);
+        assertEquals(2, result.claimed().size());
+    }
+
+    @Test
+    void messageCountsReturnsVisibleAndInFlight() {
+        queue.addMessage(new Message("msg1"));
+        queue.addMessage(new Message("msg2"));
+        queue.addMessage(new Message("msg3"));
+
+        var counts = queue.messageCounts();
+        assertEquals(3, counts.visible());
+        assertEquals(0, counts.inFlight());
+
+        queue.claimVisibleMessages(2, 30, false, -1, null);
+
+        var afterClaim = queue.messageCounts();
+        assertEquals(1, afterClaim.visible());
+        assertEquals(2, afterClaim.inFlight());
+    }
+
+    // --- FIFO ---
+
+    @Test
+    void fifoClaimRespectsGroupOrdering() {
+        Message g1m1 = new Message("g1-msg1");
+        g1m1.setMessageGroupId("group1");
+        Message g1m2 = new Message("g1-msg2");
+        g1m2.setMessageGroupId("group1");
+        Message g2m1 = new Message("g2-msg1");
+        g2m1.setMessageGroupId("group2");
+
+        queue.addMessage(g1m1);
+        queue.addMessage(g1m2);
+        queue.addMessage(g2m1);
+
+        // Should get first from each group
+        var first = queue.claimVisibleMessages(10, 30, true, -1, null);
+        assertEquals(2, first.claimed().size());
+        assertEquals("g1-msg1", first.claimed().get(0).getBody());
+        assertEquals("g2-msg1", first.claimed().get(1).getBody());
+
+        // Both groups blocked
+        var second = queue.claimVisibleMessages(10, 30, true, -1, null);
+        assertTrue(second.claimed().isEmpty());
+    }
+
+    // --- DLQ ---
+
+    @Test
+    void dlqCandidatesReturnedWhenMaxReceiveCountExceeded() {
+        queue.addMessage(new Message("msg"));
+
+        // Claim and release (visibility=0) to bump receiveCount
+        var r1 = queue.claimVisibleMessages(1, 0, false, -1, null);
+        assertEquals(1, r1.claimed().get(0).getReceiveCount());
+
+        // Claim again — now receiveCount = 2, maxReceiveCount = 1 → DLQ
+        var r2 = queue.claimVisibleMessages(1, 0, false, 1, "arn:aws:sqs:us-east-1:000000000000:dlq");
+        assertTrue(r2.claimed().isEmpty());
+        assertEquals(1, r2.dlqCandidates().size());
+    }
+
+    // --- Concurrency: the core bug fix ---
+
+    @Test
+    void concurrentReceiveNeverProducesDuplicateDeliveries() throws Exception {
+        int messageCount = 100;
+        int threadCount = 8;
+
+        for (int i = 0; i < messageCount; i++) {
+            queue.addMessage(new Message("msg-" + i));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        ConcurrentLinkedDeque<Message> allClaimed = new ConcurrentLinkedDeque<>();
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (int t = 0; t < threadCount; t++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                // Each thread claims as many as possible
+                var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                allClaimed.addAll(result.claimed());
+            }));
+        }
+
+        for (var f : futures) {
+            f.get(10, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        // Every message should be claimed exactly once
+        assertEquals(messageCount, allClaimed.size());
+
+        // No duplicate receipt handles
+        Set<String> handles = new HashSet<>();
+        for (Message m : allClaimed) {
+            assertTrue(handles.add(m.getReceiptHandle()),
+                    "Duplicate receipt handle: " + m.getReceiptHandle());
+        }
+
+        // No duplicate message IDs
+        Set<String> ids = new HashSet<>();
+        for (Message m : allClaimed) {
+            assertTrue(ids.add(m.getMessageId()),
+                    "Duplicate message ID (delivered twice): " + m.getMessageId());
+        }
+    }
+
+    @Test
+    void concurrentReceiveAndDeleteDoesNotCorruptState() throws Exception {
+        int messageCount = 50;
+        int threadCount = 4;
+
+        for (int i = 0; i < messageCount; i++) {
+            queue.addMessage(new Message("msg-" + i));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        AtomicInteger claimedCount = new AtomicInteger();
+        AtomicInteger deletedCount = new AtomicInteger();
+
+        List<Future<?>> futures = new ArrayList<>();
+        // Half the threads receive, half delete
+        for (int t = 0; t < threadCount; t++) {
+            final int threadIdx = t;
+            futures.add(executor.submit(() -> {
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                if (threadIdx % 2 == 0) {
+                    // Receiver
+                    var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                    claimedCount.addAndGet(result.claimed().size());
+                    // Immediately delete claimed messages
+                    for (Message m : result.claimed()) {
+                        if (queue.removeByReceiptHandle(m.getReceiptHandle())) {
+                            deletedCount.incrementAndGet();
+                        }
+                    }
+                } else {
+                    // Competitor — also tries to receive
+                    var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                    claimedCount.addAndGet(result.claimed().size());
+                }
+            }));
+        }
+
+        for (var f : futures) {
+            f.get(10, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        // Total claimed should equal message count (each message claimed exactly once)
+        assertEquals(messageCount, claimedCount.get());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -4,11 +4,22 @@ import io.github.hectorvent.floci.services.sqs.model.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GuardedMessageQueueTest {
 
@@ -213,43 +224,43 @@ class GuardedMessageQueueTest {
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        ConcurrentLinkedDeque<Message> allClaimed = new ConcurrentLinkedDeque<>();
+        try {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            ConcurrentLinkedDeque<Message> allClaimed = new ConcurrentLinkedDeque<>();
 
-        List<Future<?>> futures = new ArrayList<>();
-        for (int t = 0; t < threadCount; t++) {
-            futures.add(executor.submit(() -> {
-                try {
-                    barrier.await();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                // Each thread claims as many as possible
-                var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
-                allClaimed.addAll(result.claimed());
-            }));
-        }
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threadCount; t++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                    allClaimed.addAll(result.claimed());
+                }));
+            }
 
-        for (var f : futures) {
-            f.get(10, TimeUnit.SECONDS);
-        }
-        executor.shutdown();
+            for (var f : futures) {
+                f.get(10, TimeUnit.SECONDS);
+            }
 
-        // Every message should be claimed exactly once
-        assertEquals(messageCount, allClaimed.size());
+            // Every message should be claimed exactly once
+            assertEquals(messageCount, allClaimed.size());
 
-        // No duplicate receipt handles
-        Set<String> handles = new HashSet<>();
-        for (Message m : allClaimed) {
-            assertTrue(handles.add(m.getReceiptHandle()),
-                    "Duplicate receipt handle: " + m.getReceiptHandle());
-        }
+            Set<String> handles = new HashSet<>();
+            for (Message m : allClaimed) {
+                assertTrue(handles.add(m.getReceiptHandle()),
+                        "Duplicate receipt handle: " + m.getReceiptHandle());
+            }
 
-        // No duplicate message IDs
-        Set<String> ids = new HashSet<>();
-        for (Message m : allClaimed) {
-            assertTrue(ids.add(m.getMessageId()),
-                    "Duplicate message ID (delivered twice): " + m.getMessageId());
+            Set<String> ids = new HashSet<>();
+            for (Message m : allClaimed) {
+                assertTrue(ids.add(m.getMessageId()),
+                        "Duplicate message ID (delivered twice): " + m.getMessageId());
+            }
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -263,41 +274,39 @@ class GuardedMessageQueueTest {
         }
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        CyclicBarrier barrier = new CyclicBarrier(threadCount);
-        AtomicInteger claimedCount = new AtomicInteger();
+        try {
+            CyclicBarrier barrier = new CyclicBarrier(threadCount);
+            AtomicInteger claimedCount = new AtomicInteger();
 
-        List<Future<?>> futures = new ArrayList<>();
-        // Half the threads receive, half delete
-        for (int t = 0; t < threadCount; t++) {
-            final int threadIdx = t;
-            futures.add(executor.submit(() -> {
-                try {
-                    barrier.await();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-                if (threadIdx % 2 == 0) {
-                    // Receiver
-                    var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
-                    claimedCount.addAndGet(result.claimed().size());
-                    // Immediately delete claimed messages
-                    for (Message m : result.claimed()) {
-                        queue.removeByReceiptHandle(m.getReceiptHandle());
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threadCount; t++) {
+                final int threadIdx = t;
+                futures.add(executor.submit(() -> {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
                     }
-                } else {
-                    // Competitor — also tries to receive
-                    var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
-                    claimedCount.addAndGet(result.claimed().size());
-                }
-            }));
-        }
+                    if (threadIdx % 2 == 0) {
+                        var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                        claimedCount.addAndGet(result.claimed().size());
+                        for (Message m : result.claimed()) {
+                            queue.removeByReceiptHandle(m.getReceiptHandle());
+                        }
+                    } else {
+                        var result = queue.claimVisibleMessages(messageCount, 30, false, -1, null);
+                        claimedCount.addAndGet(result.claimed().size());
+                    }
+                }));
+            }
 
-        for (var f : futures) {
-            f.get(10, TimeUnit.SECONDS);
-        }
-        executor.shutdown();
+            for (var f : futures) {
+                f.get(10, TimeUnit.SECONDS);
+            }
 
-        // Total claimed should equal message count (each message claimed exactly once)
-        assertEquals(messageCount, claimedCount.get());
+            assertEquals(messageCount, claimedCount.get());
+        } finally {
+            executor.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
 ## Summary

 Introduce `GuardedMessageQueue` to wrap the per-queue message list with a
  `ReentrantLock`, preventing data corruption from concurrent message operations.

  Without locking, concurrent threads can interleave multi-step read-modify-write
  sequences on the shared message collection, leading to corrupted message state
  (garbled receiveCount, lost receipt handles) and inconsistent persistence
  snapshots. For FIFO queues specifically, this also violated the exactly-once
  delivery contract.

  All message operations (send, receive, delete, change visibility, purge, move)
  now acquire the lock before touching the list, and persistence runs inside the
  lock boundary for consistent snapshots.

  ## Type of change

  - [x] Bug fix (`fix:`)
  - [ ] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore

  ## AWS Compatibility

  Concurrent message operations (receive, delete, change visibility) could
  interleave without synchronization, corrupting internal message state —
  including garbled receiveCount on standard queues, which broke DLQ routing
  based on maxReceiveCount. Persistence snapshots were also inconsistent
  ("weakly-consistent"). For FIFO queues, this additionally violated the
  exactly-once delivery guarantee.

  ## Checklist

  - [x] `./mvnw test` passes locally
  - [x] New or updated integration test added
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)