### PR TITLE
fix(eventbridge): apply InputPath when delivering events to targets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
@@ -43,6 +43,8 @@ public class EventBridgeInvoker {
         String payload;
         if (target.getInput() != null) {
             payload = target.getInput();
+        } else if (target.getInputPath() != null) {
+            payload = applyInputPath(target.getInputPath(), eventJson);
         } else if (target.getInputTransformer() != null) {
             payload = applyInputTransformer(target.getInputTransformer(), eventJson);
         } else {
@@ -69,6 +71,14 @@ public class EventBridgeInvoker {
         } catch (Exception e) {
             LOG.warnv("EventBridge failed to deliver to target {0}: {1}", arn, e.getMessage());
         }
+    }
+
+    String applyInputPath(String inputPath, String eventJson) {
+        if (inputPath == null || "$".equals(inputPath)) {
+            return eventJson;
+        }
+        String extracted = extractJsonPath(inputPath, eventJson);
+        return extracted != null ? extracted : eventJson;
     }
 
     String applyInputTransformer(InputTransformer transformer, String eventJson) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
@@ -51,6 +51,31 @@ class EventBridgeInvokerTest {
     }
 
     @Test
+    void applyInputPath_extractsNestedField() {
+        String event = "{\"source\":\"aws.s3\",\"detail\":{\"bucket\":\"my-bucket\",\"key\":\"file.txt\"}}";
+        String result = invoker.applyInputPath("$.detail", event);
+        assertEquals("{\"bucket\":\"my-bucket\",\"key\":\"file.txt\"}", result);
+    }
+
+    @Test
+    void applyInputPath_dollarSignReturnsFullEvent() {
+        String event = "{\"source\":\"aws.s3\"}";
+        assertEquals(event, invoker.applyInputPath("$", event));
+    }
+
+    @Test
+    void applyInputPath_missingField_returnsFullEvent() {
+        String event = "{\"source\":\"aws.s3\"}";
+        assertEquals(event, invoker.applyInputPath("$.detail", event));
+    }
+
+    @Test
+    void applyInputPath_scalarField_returnsText() {
+        String event = "{\"detail\":{\"name\":\"test\"}}";
+        assertEquals("test", invoker.applyInputPath("$.detail.name", event));
+    }
+
+    @Test
     void applyInputTransformer_substitutesVariables() {
         String eventJson = "{\"source\":\"aws.s3\",\"detail\":{\"bucket\":{\"name\":\"my-bucket\"},\"object\":{\"key\":\"photos/cat.jpg\"}}}";
         InputTransformer transformer = new InputTransformer(


### PR DESCRIPTION
## Summary

`EventBridgeInvoker.invokeTarget` handled `Input` and `InputTransformer` but ignored `InputPath`. When a rule target specified `InputPath: $.detail`, the full event envelope was delivered instead of the extracted subfield.

Adds `InputPath` support using the same JSON pointer approach already used by `extractJsonPath`. Falls back to the full event when the path is missing or `$`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

EventBridge `InputPath` extracts a portion of the matched event before passing it to the target. Without this, targets received the full event envelope instead of the selected subfield. See [AWS docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)