### PR TITLE
fix(s3): return empty LocationConstraint for us-east-1 buckets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1147,16 +1147,17 @@ public class S3Controller {
 
     private Response handleGetBucketLocation(String bucket) {
         String region = s3Service.getBucketRegion(bucket);
-        if (region == null) {
-            region = regionResolver.getDefaultRegion();
+        XmlBuilder xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        if (region == null || "us-east-1".equals(region)) {
+            xml.start("LocationConstraint", AwsNamespaces.S3)
+                    .end("LocationConstraint");
+        } else {
+            xml.start("LocationConstraint", AwsNamespaces.S3)
+                    .raw(XmlBuilder.escape(region))
+                    .end("LocationConstraint");
         }
-        String xml = new XmlBuilder()
-                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
-                .start("LocationConstraint", AwsNamespaces.S3)
-                .raw(XmlBuilder.escape(region))
-                .end("LocationConstraint")
-                .build();
-        return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
     }
 
     // --- Bucket Tagging ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1272,4 +1272,54 @@ class S3IntegrationTest {
         given().when().delete("/pag-test-bucket/c.txt");
         given().when().delete("/pag-test-bucket");
     }
+
+    @Test
+    @Order(120)
+    void getBucketLocation_usEast1ReturnsEmptyLocationConstraint() {
+        String bucket = "location-us-east-1-bucket";
+
+        given()
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucket + "?location")
+        .then()
+            .statusCode(200)
+            .body(containsString("<LocationConstraint"))
+            .body(not(containsString("us-east-1")));
+
+        given().when().delete("/" + bucket);
+    }
+
+    @Test
+    @Order(121)
+    void getBucketLocation_nonUsEast1ReturnsRegionInBody() {
+        String bucket = "location-eu-central-bucket";
+        String createBucketConfiguration = """
+                <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <LocationConstraint>eu-central-1</LocationConstraint>
+                </CreateBucketConfiguration>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .body(createBucketConfiguration)
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucket + "?location")
+        .then()
+            .statusCode(200)
+            .body(containsString("eu-central-1"));
+
+        given().when().delete("/" + bucket);
+    }
 }


### PR DESCRIPTION
## Summary

GetBucketLocation returns the literal string `us-east-1` inside the LocationConstraint element for buckets created without a LocationConstraint. Per the [AWS S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html), us-east-1 buckets must return an empty `<LocationConstraint/>` element. This causes AWS SDK clients and tools like Serverless Framework to fail region validation.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `GetBucketLocation` returned `<LocationConstraint>us-east-1</LocationConstraint>` for buckets in us-east-1.

**Correct behavior (AWS):** Returns an empty `<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>` element. The string `us-east-1` is never a valid value in the response — it is represented by null/empty.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)