### PR TITLE
feat(cognito-idp): adding create/list/delete user pool client secret cognito-idp actions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.cognito.model.ResourceServer;
 import io.github.hectorvent.floci.services.cognito.model.ResourceServerScope;
 import io.github.hectorvent.floci.services.cognito.model.UserPool;
 import io.github.hectorvent.floci.services.cognito.model.UserPoolClient;
+import io.github.hectorvent.floci.services.cognito.model.UserPoolClientSecret;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -73,6 +74,9 @@ public class CognitoJsonHandler {
             case "AdminRemoveUserFromGroup" -> handleAdminRemoveUserFromGroup(request);
             case "AdminListGroupsForUser" -> handleAdminListGroupsForUser(request);
             case "GetTokensFromRefreshToken" -> handleGetTokensFromRefreshToken(request);
+            case "ListUserPoolClientSecrets" -> handleListUserPoolClientSecrets(request);
+            case "AddUserPoolClientSecret" -> handleAddUserPoolClientSecret(request);
+            case "DeleteUserPoolClientSecret" -> handleDeleteUserPoolClientSecret(request);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -615,6 +619,53 @@ public class CognitoJsonHandler {
         if (g.getRoleArn() != null) node.put("RoleArn", g.getRoleArn());
         node.put("CreationDate", g.getCreationDate());
         node.put("LastModifiedDate", g.getLastModifiedDate());
+        return node;
+    }
+
+    private Response handleListUserPoolClientSecrets(JsonNode request) {
+        List<UserPoolClientSecret> clientSecrets =
+                service.listUserPoolClientSecrets(
+                        request.path("UserPoolId").asText(),
+                        request.path("ClientId").asText()
+                );
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode items = response.putArray("ClientSecrets");
+        clientSecrets.forEach(cs -> items.add(clientSecretToNode(cs, false)));
+        return Response.ok(response).build();
+    }
+
+    private Response handleAddUserPoolClientSecret(JsonNode request) {
+        String clientId = request.path("ClientId").asText();
+        String clientSecret = request.path("ClientSecret").asText(null);
+        String userPoolId = request.path("UserPoolId").asText();
+
+        UserPoolClientSecret cs = service.addUserPoolClientSecret(
+                clientId, clientSecret, userPoolId
+        );
+
+        boolean includeClientSecretValue = clientSecret == null;
+        ObjectNode response = clientSecretToNode(cs, includeClientSecretValue);
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteUserPoolClientSecret(JsonNode request) {
+        String clientId = request.path("ClientId").asText();
+        String clientSecretId = request.path("ClientSecretId").asText();
+        String userPoolId = request.path("UserPoolId").asText();
+
+        service.deleteUserPoolClientSecret(clientId, clientSecretId, userPoolId);
+
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private ObjectNode clientSecretToNode(UserPoolClientSecret cs,
+                                          boolean includeClientSecretValue) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ClientSecretId", cs.getClientSecretId());
+        if (includeClientSecretValue) {
+            node.put("ClientSecretValue", cs.getClientSecretValue());
+        }
+        node.put("ClientSecretCreateDate", cs.getClientSecretCreateDate());
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -644,8 +644,9 @@ public class CognitoJsonHandler {
         );
 
         boolean includeClientSecretValue = clientSecret == null;
-        ObjectNode response = clientSecretToNode(cs, includeClientSecretValue);
-        return Response.ok(response).build();
+        ObjectNode wrapper = objectMapper.createObjectNode();
+        wrapper.set("ClientSecretDescriptor", clientSecretToNode(cs, includeClientSecretValue));
+        return Response.ok(wrapper).build();
     }
 
     private Response handleDeleteUserPoolClientSecret(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1,29 +1,18 @@
 package io.github.hectorvent.floci.services.cognito;
 
-import io.github.hectorvent.floci.core.common.AwsException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
-import com.fasterxml.jackson.core.type.TypeReference;
-import io.github.hectorvent.floci.services.cognito.model.CognitoGroup;
-import io.github.hectorvent.floci.services.cognito.model.CognitoUser;
-import io.github.hectorvent.floci.services.cognito.model.ResourceServer;
-import io.github.hectorvent.floci.services.cognito.model.ResourceServerScope;
-import io.github.hectorvent.floci.services.cognito.model.UserPool;
-import io.github.hectorvent.floci.services.cognito.model.UserPoolClient;
+import io.github.hectorvent.floci.services.cognito.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.MessageDigest;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Signature;
+import java.security.*;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -177,7 +166,17 @@ public class CognitoService {
         client.setAllowedOAuthFlows(normalizeStringList(allowedOAuthFlows));
         client.setAllowedOAuthScopes(normalizeStringList(allowedOAuthScopes));
         if (generateSecret) {
-            client.setClientSecret(generateSecretValue());
+            String clientSecret = generateSecretValue();
+            client.setClientSecret(clientSecret);
+
+            long epochMillis = System.currentTimeMillis();
+            UserPoolClientSecret userPoolClientSecret = new UserPoolClientSecret(
+                    clientId + "--" + epochMillis,
+                    epochMillis / 1000,
+                    clientSecret
+            );
+
+            client.getUserPoolClientSecrets().add(userPoolClientSecret);
         }
         clientStore.put(clientId, client);
         LOG.infov("Created User Pool Client: {0} for pool {1}", clientId, userPoolId);
@@ -200,6 +199,68 @@ public class CognitoService {
     public void deleteUserPoolClient(String userPoolId, String clientId) {
         describeUserPoolClient(userPoolId, clientId);
         clientStore.delete(clientId);
+    }
+
+    public List<UserPoolClientSecret> listUserPoolClientSecrets(String userPoolId, String clientId) {
+        UserPoolClient client = clientStore.get(clientId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool client not found", 404));
+        if (!client.getUserPoolId().equals(userPoolId)) {
+            throw new AwsException("ResourceNotFoundException", "User pool client not found", 404);
+        }
+        return client.getUserPoolClientSecrets();
+    }
+
+    public UserPoolClientSecret addUserPoolClientSecret(String clientId, String clientSecret, String userPoolId) {
+        UserPoolClient client = clientStore.get(clientId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool client not found", 404));
+        if (!client.getUserPoolId().equals(userPoolId)) {
+            throw new AwsException("ResourceNotFoundException", "User pool client not found", 404);
+        }
+
+        if (client.getUserPoolClientSecrets().size() >= 2) {
+            throw new AwsException("LimitExceededException", "Client secrets cannot exceed limit of 2 secrets.", 400);
+        }
+
+        if (clientSecret == null) {
+            clientSecret = generateSecretValue();
+        }
+        long epochMillis = System.currentTimeMillis();
+        UserPoolClientSecret userPoolClientSecret = new UserPoolClientSecret(
+                clientId + "--" + epochMillis,
+                epochMillis / 1000,
+                clientSecret
+        );
+
+        client.getUserPoolClientSecrets().add(userPoolClientSecret);
+
+        return userPoolClientSecret;
+    }
+
+    public void deleteUserPoolClientSecret(String clientId, String clientSecretId, String userPoolId) {
+        UserPoolClient client = clientStore.get(clientId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool client not found", 404));
+        if (!client.getUserPoolId().equals(userPoolId)) {
+            throw new AwsException("ResourceNotFoundException", "User pool client not found", 404);
+        }
+
+        UserPoolClientSecret userPoolClientSecret = client.getUserPoolClientSecrets().stream()
+                .filter(s -> s.getClientSecretId().equals(clientSecretId))
+                .findFirst()
+                .orElseThrow(() -> new AwsException(
+                        "ResourceNotFoundException", "Client secret does not exist", 404));
+
+        if (client.getUserPoolClientSecrets().size() <= 1) {
+            throw new AwsException(
+                    "InvalidParameterException", "Cannot delete the only " +
+                    "client secret.", 400
+            );
+        }
+
+        if (userPoolClientSecret.getClientSecretValue().equals(client.getClientSecret())) {
+            client.setClientSecret(null);
+        }
+
+        client.getUserPoolClientSecrets().remove(userPoolClientSecret);
     }
 
     // ──────────────────────────── Resource Servers ────────────────────────────
@@ -961,15 +1022,23 @@ public class CognitoService {
 
     private void validateClientSecret(UserPoolClient client, String clientSecret) {
         String expectedSecret = client.getClientSecret();
-        if (expectedSecret == null || expectedSecret.isBlank() || !client.isGenerateSecret()) {
+        if (client.getUserPoolClientSecrets().isEmpty()
+                && (expectedSecret == null || expectedSecret.isBlank() || !client.isGenerateSecret())) {
             throw new AwsException("InvalidClientException", "Client must have a secret for client_credentials", 400);
         }
         if (clientSecret == null || clientSecret.isBlank()) {
             throw new AwsException("InvalidClientException", "Client secret is required", 400);
         }
-        if (!expectedSecret.equals(clientSecret)) {
-            throw new AwsException("InvalidClientException", "Client secret is invalid", 400);
+        for (UserPoolClientSecret userPoolClientSecret : client.getUserPoolClientSecrets()) {
+            if (clientSecret.equals(userPoolClientSecret.getClientSecretValue())) {
+                return;
+            }
         }
+        // for "legacy" clients
+        if (expectedSecret != null && expectedSecret.equals(clientSecret)) {
+            return;
+        }
+        throw new AwsException("InvalidClientException", "Client secret is invalid", 400);
     }
 
     private void validateClientAllowsClientCredentials(UserPoolClient client) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -18,6 +18,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -223,6 +224,9 @@ public class CognitoService {
 
         if (clientSecret == null) {
             clientSecret = generateSecretValue();
+        } else if (!clientSecret.matches("\\w{24,64}")) {
+            throw new AwsException("InvalidParameterException",
+                    "Client secret format is invalid.", 400);
         }
         long epochMillis = System.currentTimeMillis();
         UserPoolClientSecret userPoolClientSecret = new UserPoolClientSecret(

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClient.java
@@ -13,6 +13,7 @@ public class UserPoolClient {
     private String userPoolId;
     private String clientName;
     private String clientSecret;
+    private List<UserPoolClientSecret> userPoolClientSecrets = new ArrayList<>();
     private boolean generateSecret;
     private boolean allowedOAuthFlowsUserPoolClient;
     private List<String> allowedOAuthFlows = new ArrayList<>();
@@ -37,6 +38,13 @@ public class UserPoolClient {
 
     public String getClientSecret() { return clientSecret; }
     public void setClientSecret(String clientSecret) { this.clientSecret = clientSecret; }
+
+    public List<UserPoolClientSecret> getUserPoolClientSecrets() {
+        return userPoolClientSecrets;
+    }
+    public void setUserPoolClientSecrets(List<UserPoolClientSecret> userPoolClientSecrets) {
+        this.userPoolClientSecrets = userPoolClientSecrets;
+    }
 
     public boolean isGenerateSecret() { return generateSecret; }
     public void setGenerateSecret(boolean generateSecret) { this.generateSecret = generateSecret; }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClientSecret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClientSecret.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.cognito.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UserPoolClientSecret {
+    private String clientSecretId;
+    private String clientSecretValue;
+    private long clientSecretCreateDate;
+
+    public UserPoolClientSecret(String clientSecretId,
+                                long clientSecretCreateDate, String clientSecretValue) {
+        this.clientSecretCreateDate = clientSecretCreateDate;
+        this.clientSecretId = clientSecretId;
+        this.clientSecretValue = clientSecretValue;
+    }
+
+    public long getClientSecretCreateDate() {
+        return clientSecretCreateDate;
+    }
+    public void setClientSecretCreateDate(long clientSecretCreateDate) {
+        this.clientSecretCreateDate = clientSecretCreateDate;
+    }
+
+    public String getClientSecretId() {
+        return clientSecretId;
+    }
+    public void setClientSecretId(String clientSecretId) {
+        this.clientSecretId = clientSecretId;
+    }
+
+    public String getClientSecretValue() {
+        return clientSecretValue;
+    }
+    public void setClientSecretValue(String clientSecretValue) {
+        this.clientSecretValue = clientSecretValue;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClientSecret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPoolClientSecret.java
@@ -10,6 +10,10 @@ public class UserPoolClientSecret {
     private String clientSecretValue;
     private long clientSecretCreateDate;
 
+    public UserPoolClientSecret() {
+        // empty constructor for jackson deserialisation
+    }
+
     public UserPoolClientSecret(String clientSecretId,
                                 long clientSecretCreateDate, String clientSecretValue) {
         this.clientSecretCreateDate = clientSecretCreateDate;

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -498,7 +498,214 @@ class CognitoIntegrationTest {
         assertNotNull(refreshed.path("AuthenticationResult").path("IdToken").asText(null));
     }
 
+    // ── Client Secrets ────────────────────────────────────────────────
+
+    private static String clientSecretId1;
+    private static String clientSecretId2;
+
+    @Test
+    @Order(80)
+    void listUserPoolClientSecretsInitiallyEmpty() throws Exception {
+        JsonNode resp = cognitoJson("ListUserPoolClientSecrets", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId));
+        assertEquals(0, resp.path("ClientSecrets").size());
+    }
+
+    @Test
+    @Order(81)
+    void addUserPoolClientSecretAutoGeneratesValue() throws Exception {
+        JsonNode resp = cognitoJson("AddUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId));
+        clientSecretId1 = resp.path("ClientSecretId").asText();
+        assertNotNull(clientSecretId1);
+        assertTrue(clientSecretId1.startsWith(clientId + "--"),
+                "ClientSecretId should be prefixed with the ClientId");
+        assertNotNull(resp.path("ClientSecretValue").asText(null),
+                "Auto-generated secret should include ClientSecretValue in response");
+        assertTrue(resp.path("ClientSecretCreateDate").asLong() > 0);
+    }
+
+    @Test
+    @Order(82)
+    void addUserPoolClientSecretWithExplicitValue() throws Exception {
+        String clientSecretValue = UUID.randomUUID().toString().replaceAll("-", "");
+        JsonNode resp = cognitoJson("AddUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s",
+                  "ClientSecret": "%s"
+                }
+                """.formatted(clientId, poolId, clientSecretValue));
+        clientSecretId2 = resp.path("ClientSecretId").asText();
+        assertNotNull(clientSecretId2);
+        assertTrue(resp.path("ClientSecretValue").isMissingNode(),
+                "Explicit secret should not include ClientSecretValue in response");
+    }
+
+    @Test
+    @Order(83)
+    void listUserPoolClientSecretsReturnsTwo() throws Exception {
+        JsonNode resp = cognitoJson("ListUserPoolClientSecrets", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId));
+        assertEquals(2, resp.path("ClientSecrets").size());
+    }
+
+    @Test
+    @Order(84)
+    void addUserPoolClientSecretExceedsLimit() {
+        cognitoAction("AddUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @Order(85)
+    void deleteUserPoolClientSecretNotFound() {
+        cognitoAction("DeleteUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "ClientSecretId": "nonexistent",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId))
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(86)
+    void deleteUserPoolClientSecretCannotDeleteOnlyOne() {
+        cognitoAction("DeleteUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "ClientSecretId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, clientSecretId1, poolId))
+                .then()
+                .statusCode(200);
+
+        cognitoAction("DeleteUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "ClientSecretId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, clientSecretId2, poolId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @Order(87)
+    void listUserPoolClientSecretsAfterDelete() throws Exception {
+        JsonNode resp = cognitoJson("ListUserPoolClientSecrets", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(clientId, poolId));
+        assertEquals(1, resp.path("ClientSecrets").size());
+        assertEquals(clientSecretId2, resp.path("ClientSecrets").get(0).path("ClientSecretId").asText());
+    }
+
+    @Test
+    @Order(88)
+    void fullRotateScenario() throws Exception {
+        // Set up a resource server so the OAuth client_credentials flow has valid scopes
+        cognitoJson("CreateResourceServer", """
+                {
+                  "UserPoolId": "%s",
+                  "Identifier": "api",
+                  "Name": "API",
+                  "Scopes": [
+                    { "ScopeName": "read", "ScopeDescription": "Read access" }
+                  ]
+                }
+                """.formatted(poolId));
+
+        // Create a confidential client with client_credentials flow enabled
+        JsonNode clientResp = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "rotation-client",
+                  "GenerateSecret": true,
+                  "AllowedOAuthFlowsUserPoolClient": true,
+                  "AllowedOAuthFlows": ["client_credentials"],
+                  "AllowedOAuthScopes": ["api/read"]
+                }
+                """.formatted(poolId));
+        String rotClientId = clientResp.path("UserPoolClient").path("ClientId").asText();
+        String secret1Value = clientResp.path("UserPoolClient").path("ClientSecret").asText();
+
+        // client-secret-1 is still valid — authenticate with client-credentials successfully
+        oauthToken(rotClientId, secret1Value).then().statusCode(200);
+
+        // grab secret-1's ID so we can delete it later
+        JsonNode secrets = cognitoJson("ListUserPoolClientSecrets", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(rotClientId, poolId));
+        assertEquals(1, secrets.path("ClientSecrets").size());
+        String secret1Id = secrets.path("ClientSecrets").get(0).path("ClientSecretId").asText();
+
+        // add new client-secret (auto-generated)
+        JsonNode addResp = cognitoJson("AddUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(rotClientId, poolId));
+        String secret2Value = addResp.path("ClientSecretValue").asText();
+        assertNotNull(secret2Value);
+
+        // authenticate with new client-credentials successfully
+        oauthToken(rotClientId, secret2Value).then().statusCode(200);
+
+        // delete client-credentials 1
+        cognitoAction("DeleteUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "ClientSecretId": "%s",
+                  "UserPoolId": "%s"
+                }
+                """.formatted(rotClientId, secret1Id, poolId))
+                .then()
+                .statusCode(200);
+
+        // authentication with client credentials 1 fails
+        oauthToken(rotClientId, secret1Value).then().statusCode(400);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────
+
+    private static Response oauthToken(String oauthClientId, String oauthClientSecret) {
+        return given()
+                .formParam("grant_type", "client_credentials")
+                .formParam("client_id", oauthClientId)
+                .formParam("client_secret", oauthClientSecret)
+        .when()
+                .post("/cognito-idp/oauth2/token");
+    }
 
     private static Response cognitoAction(String action, String body) {
         return given()

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -524,13 +524,14 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s"
                 }
                 """.formatted(clientId, poolId));
-        clientSecretId1 = resp.path("ClientSecretId").asText();
+        JsonNode clientSecretDescriptor = resp.path("ClientSecretDescriptor");
+        clientSecretId1 = clientSecretDescriptor.path("ClientSecretId").asText();
         assertNotNull(clientSecretId1);
         assertTrue(clientSecretId1.startsWith(clientId + "--"),
                 "ClientSecretId should be prefixed with the ClientId");
-        assertNotNull(resp.path("ClientSecretValue").asText(null),
+        assertNotNull(clientSecretDescriptor.path("ClientSecretValue").asText(null),
                 "Auto-generated secret should include ClientSecretValue in response");
-        assertTrue(resp.path("ClientSecretCreateDate").asLong() > 0);
+        assertTrue(clientSecretDescriptor.path("ClientSecretCreateDate").asLong() > 0);
     }
 
     @Test
@@ -544,9 +545,9 @@ class CognitoIntegrationTest {
                   "ClientSecret": "%s"
                 }
                 """.formatted(clientId, poolId, clientSecretValue));
-        clientSecretId2 = resp.path("ClientSecretId").asText();
+        clientSecretId2 = resp.path("ClientSecretDescriptor").path("ClientSecretId").asText();
         assertNotNull(clientSecretId2);
-        assertTrue(resp.path("ClientSecretValue").isMissingNode(),
+        assertTrue(resp.path("ClientSecretDescriptor").path("ClientSecretValue").isMissingNode(),
                 "Explicit secret should not include ClientSecretValue in response");
     }
 
@@ -675,7 +676,8 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s"
                 }
                 """.formatted(rotClientId, poolId));
-        String secret2Value = addResp.path("ClientSecretValue").asText();
+        String secret2Value = addResp.path("ClientSecretDescriptor")
+                .path("ClientSecretValue").asText();
         assertNotNull(secret2Value);
 
         // authenticate with new client-credentials successfully
@@ -694,6 +696,9 @@ class CognitoIntegrationTest {
 
         // authentication with client credentials 1 fails
         oauthToken(rotClientId, secret1Value).then().statusCode(400);
+
+        // secret 2 still works after rotation
+        oauthToken(rotClientId, secret2Value).then().statusCode(200);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -5,11 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -19,6 +25,7 @@ import java.security.Signature;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -515,8 +522,31 @@ class CognitoIntegrationTest {
         assertEquals(0, resp.path("ClientSecrets").size());
     }
 
-    @Test
+    @ParameterizedTest
     @Order(81)
+    @MethodSource("generateInvalidUserPoolSecret")
+    void addUserPoolClientSecretInvalid(String clientSecret) {
+        cognitoAction("AddUserPoolClientSecret", """
+                {
+                  "ClientId": "%s",
+                  "UserPoolId": "%s",
+                  "ClientSecret": "%s"
+                }
+                """.formatted(clientId, poolId, clientSecret))
+                .then()
+                .statusCode(400);
+    }
+
+    public static Stream<Arguments> generateInvalidUserPoolSecret() {
+        return Stream.of(
+            Arguments.of("a".repeat(23)), // too short
+            Arguments.of("a".repeat(65)), // too large
+            Arguments.of("$".repeat(32)) // contains invalid characters
+        );
+    }
+
+    @Test
+    @Order(82)
     void addUserPoolClientSecretAutoGeneratesValue() throws Exception {
         JsonNode resp = cognitoJson("AddUserPoolClientSecret", """
                 {
@@ -535,7 +565,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(82)
+    @Order(83)
     void addUserPoolClientSecretWithExplicitValue() throws Exception {
         String clientSecretValue = UUID.randomUUID().toString().replaceAll("-", "");
         JsonNode resp = cognitoJson("AddUserPoolClientSecret", """
@@ -552,7 +582,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(83)
+    @Order(84)
     void listUserPoolClientSecretsReturnsTwo() throws Exception {
         JsonNode resp = cognitoJson("ListUserPoolClientSecrets", """
                 {
@@ -564,7 +594,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(84)
+    @Order(85)
     void addUserPoolClientSecretExceedsLimit() {
         cognitoAction("AddUserPoolClientSecret", """
                 {
@@ -577,7 +607,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(85)
+    @Order(86)
     void deleteUserPoolClientSecretNotFound() {
         cognitoAction("DeleteUserPoolClientSecret", """
                 {
@@ -591,7 +621,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(86)
+    @Order(87)
     void deleteUserPoolClientSecretCannotDeleteOnlyOne() {
         cognitoAction("DeleteUserPoolClientSecret", """
                 {
@@ -615,7 +645,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(87)
+    @Order(88)
     void listUserPoolClientSecretsAfterDelete() throws Exception {
         JsonNode resp = cognitoJson("ListUserPoolClientSecrets", """
                 {
@@ -628,7 +658,7 @@ class CognitoIntegrationTest {
     }
 
     @Test
-    @Order(88)
+    @Order(89)
     void fullRotateScenario() throws Exception {
         // Set up a resource server so the OAuth client_credentials flow has valid scopes
         cognitoJson("CreateResourceServer", """


### PR DESCRIPTION
## Summary

Closes https://github.com/floci-io/floci/issues/344

Introduces 3 new actions for the Cognito IDP service, the 3 of them related to a new capability in Cognito that allows to have more than one Client Secret to allow no-downtime rotations.


## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->
* aws-cli/2.34.28 

## Checklist

- [X] `./mvnw test` passes locally (1723/1723)
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
