### PR TITLE
fix(ci): restore semantic-release workflow and enable on main

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -10,6 +10,7 @@ name: Semantic Release
 on:
   push:
     branches:
+      - 'main'
       - 'release/[0-9]+.x'
       - 'release/[0-9]+.[0-9]+.x'
     paths:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,7 @@
 {
   "tagFormat": "${version}",
   "branches": [
+    "main",
     {
       "name": "release/+([0-9])?(.{+([0-9]),x}).x",
       "channel": "${name.replace(/^release\\//,'')}"


### PR DESCRIPTION
## Summary

Restores the semantic-release workflow and enables it on `main`.

## Background

Commit [494cff2](https://github.com/floci-io/floci/commit/494cff2)
("chore: release 1.5.2") moved `.github/workflows/semver.yml` one directory
up to `.github/semver.yml`. GitHub Actions only discovers workflow files
under `.github/workflows/`, so this silently disabled semantic-release.
Every merge to main since has lacked CHANGELOG.md generation.

`.releaserc.json` and the workflow trigger also only considered
`release/[0-9]+.x` branches, but work has been landing directly on `main`.
This PR adds `main` to both so releases flow from where the code actually
lives.

## Changes

- `git mv .github/semver.yml .github/workflows/semver.yml` (no content change)
- Add `main` to `.github/workflows/semver.yml` `on.push.branches`
- Add `main` to `.releaserc.json` `branches` array

## What happens after merge

The next merge to main that touches `src/**`, `pom.xml`, or any other path
in the workflow's `paths:` filter will trigger semantic-release. It will:

1. Analyse commits since the last tag (`1.5.2`).
2. Generate CHANGELOG entries for everything merged since then.
3. Bump `pom.xml` to the next version.
4. Commit `CHANGELOG.md` and `pom.xml` back to `main` and push a new tag.
5. The tag push triggers `release.yml` to build and publish Docker images.

Note: the bot's own `chore(release): x.y.z` commit back to main will
retrigger `semver.yml` because `pom.xml` is in the paths filter. Expected
to be a no-op (nothing new to release).

## Test plan

- [ ] Workflow file is discoverable under `.github/workflows/` after merge
- [ ] First main-branch merge after this lands triggers the semver workflow
- [ ] CHANGELOG.md is updated by the bot, pom.xml is bumped, new tag emitted
- [ ] Tag push triggers `release.yml` image publish