### PR TITLE
chore: add .coderabbit.yaml for automated PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,59 @@
+reviews:
+  poem: false
+  sequence_diagrams: true
+  auto_review:
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!**/target/**"
+    - "!**/*.lock"
+    - "!compatibility-tests/sdk-test-*/target/**"
+  path_instructions:
+    - path: "docs/services/*.md"
+      instructions: |
+        Verify the operation count listed for this service matches the row in
+        docs/services/index.md. Counts come from controller dispatch handlers
+        (not @Path annotation totals), so one @Path can serve multiple AWS
+        operations via query-string or header markers. If a new operation is
+        added to the table, check the corresponding Java handler exists in
+        src/main/java/io/github/hectorvent/floci/services/.
+    - path: "src/main/java/io/github/hectorvent/floci/services/**/*Controller.java"
+      instructions: |
+        When adding a new @Path handler or AWS operation branch:
+        1. Check that the corresponding docs/services/{service}.md Supported
+           Operations table and the row in docs/services/index.md are updated
+           in the same PR. The repo has a history of doc drift; flag any new
+           operation that lacks a docs update.
+        2. Verify error responses map to the correct AWS error code, HTTP
+           status, and wire format (XML for S3/SQS/SNS/IAM, JSON for most
+           others). Real AWS clients parse these strictly.
+        3. Flag any shared mutable state (static fields, singleton beans,
+           in-memory stores) that is not thread-safe. Prefer ConcurrentHashMap
+           or explicit synchronization.
+    - path: "CHANGELOG.md"
+      instructions: |
+        Generated/maintained via semantic-release. Skip review of formatting
+        and content; only flag entries that reference non-existent commits or
+        issue numbers.
+    - path: "compatibility-tests/sdk-test-*/**/*Test.java"
+      instructions: |
+        Prefer reusing fixtures from TestFixtures.java over duplicating setup
+        inline. Flag hard-coded credentials, region strings, or endpoint URLs
+        that should live in shared helpers.
+    - path: "pom.xml"
+      instructions: |
+        Review dependency changes for version conflicts, transitive upgrades,
+        and license compatibility. Flag new dependencies without clear
+        justification. Ensure the Quarkus BOM drives version alignment for
+        Quarkus extensions rather than pinning individual versions.
+    - path: "**/Dockerfile*"
+      instructions: |
+        Prefer multi-stage builds, pinned base image tags (never :latest),
+        and minimal final layers. Flag any RUN steps that could be combined
+        or that leave package manager caches in the image.
+    - path: "**/*.sh"
+      instructions: |
+        Flag unquoted variable expansions, missing `set -euo pipefail`, and
+        portability issues. shellcheck runs automatically but add context on
+        intent where a warning is intentionally suppressed.


### PR DESCRIPTION
Adds `.coderabbit.yaml` for [CodeRabbit](https://www.coderabbit.ai/) in
case the maintainers want automated PR reviews. Free for open-source
public repos, no credit card needed.

The file sits dormant until the GitHub App is installed. Nothing breaks
if this merges without enabling.

## How to enable

1. Install from https://github.com/marketplace/coderabbitai and grant
   access to `floci-io/floci` (pick "Only select repositories").
2. The next non-draft PR gets a welcome comment and an automated review.
   No workflow file, no secrets, no CI changes.
3. Optional: sign in at https://app.coderabbit.ai with GitHub to see
   review history and per-repo settings.

CodeRabbit reads `.coderabbit.yaml` from the **head branch of the PR
under review**, so config tweaks take effect in the same PR that changes
them.

### Opt-out mechanics

- **Skip one PR**: add `@coderabbitai ignore` to the PR **description**
  (not a comment) before the first review runs.
- **Temporarily pause**: post `@coderabbitai pause` as a PR comment,
  resume with `@coderabbitai resume`.
- **Disable entirely**: uninstall the app or revoke repo access in
  GitHub App settings.

Full command list: https://docs.coderabbit.ai/guides/commands

## What this config does

- `poem: false` disables the default poem comment
- `sequence_diagrams: true` renders Mermaid diagrams for controller
  call chains, useful for an AWS emulator where one `@Path` can fan
  out to multiple operations
- `auto_review.drafts: false` skips WIP PRs, scoped to `main`
- `path_filters` excludes `target/`, lock files, sdk-test targets
- Seven `path_instructions`:
  - `docs/services/*.md`: verify op counts match `docs/services/index.md`
  - service `*Controller.java`: update docs table, verify AWS error
    code / HTTP status / wire-format parity (XML vs JSON), flag
    non-thread-safe shared state
  - `CHANGELOG.md`: skip (semantic-release owned)
  - SDK compatibility tests: prefer `TestFixtures.java` reuse
  - `pom.xml`: dependency hygiene, Quarkus BOM alignment
  - `**/Dockerfile*`: multi-stage, pinned tags, layer hygiene
  - `**/*.sh`: quoted expansions, strict mode, shellcheck context

Everything else is CodeRabbit defaults (markdownlint, actionlint,
gitleaks, shellcheck, hadolint, PMD, linked-issue assessment) so no
explicit `tools:` block is needed.

Defaults also keep `profile: chill` and `request_changes_workflow:
false`: the bot leaves review comments but does not submit GitHub
"Request Changes" reviews, so it can't gate merges via required-review
rules.

## Test plan

- [x] YAML validated against CodeRabbit schema docs (https://docs.coderabbit.ai/reference/yaml-template)
- [x] Second-opinion review pass with Codex + Gemini on config scope and PR accuracy
- [ ] Maintainers decide whether to install the GitHub App (config is inert until then)