### PR TITLE
chore(ci): CI/release hygiene batch (Dependabot, CODEOWNERS, SECURITY.md, concurrency, action pinning)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS for floci
+#
+# Scopes release-sensitive paths to the primary maintainer so CI, release
+# config, and Dockerfile changes always trigger a review ping. Add more
+# owners as the maintainer roster grows.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: no global owner (unowned files fall through to normal review rules).
+
+# CI, release automation, workflow hygiene
+/.github/                @hectorvent
+/.releaserc.json         @hectorvent
+/pom.xml                 @hectorvent
+
+# Container build surface
+/Dockerfile              @hectorvent
+/Dockerfile.jvm-package  @hectorvent
+/Dockerfile.native       @hectorvent
+/Dockerfile.native-package @hectorvent

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "java"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,10 +20,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build floci image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Build JVM artifact
         run: mvn clean package -DskipTests -q
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -114,10 +114,10 @@ jobs:
         with:
           sparse-checkout: compatibility-tests
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build test image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: compatibility-tests/${{ matrix.test }}
           load: true
@@ -139,7 +139,7 @@ jobs:
 
       - name: Generate test summary
         if: always() && steps.tests.outcome != 'skipped'
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
         with:
           paths: test-results/*.xml
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -16,10 +16,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-edge:
     name: Build and push edge image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -40,15 +40,15 @@ jobs:
       - name: Build JVM artifact
         run: mvn clean package -DskipTests -q
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push edge image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,20 @@ on:
 permissions:
   contents: read
 
+# Per-tag concurrency. Back-to-back tag pushes (e.g. 1.5.3 and 1.6.0 landing
+# minutes apart) resolve to different ${{ github.ref }} values, so they run
+# in parallel rather than cancelling each other. Re-runs of the same tag
+# supersede in-flight builds of that tag.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Build JVM artifact ────────────────────────────────────────────────────
   build-jvm:
     name: Build JVM artifact
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -45,6 +54,7 @@ jobs:
   build-native-amd64:
     name: Build native artifact (amd64)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +83,7 @@ jobs:
   build-native-arm64:
     name: Build native artifact (arm64)
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +113,7 @@ jobs:
     name: Push JVM Docker image
     needs: build-jvm
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -156,6 +168,7 @@ jobs:
     name: Push native Docker images
     needs: [build-native-amd64, build-native-arm64]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           java-version: '24'
           distribution: 'mandrel'
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           java-version: '24'
           distribution: 'mandrel'
@@ -122,9 +122,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
           path: target/quarkus-app/
 
       - name: Build and push JVM image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -150,7 +150,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
 
       - name: Build and push JVM image (With AWS CLI)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -177,9 +177,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -201,7 +201,7 @@ jobs:
           chmod +x target/*-runner
 
       - name: Build and push amd64 native image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.native-package
@@ -219,7 +219,7 @@ jobs:
           chmod +x target/*-runner
 
       - name: Build and push arm64 native image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.native-package

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -31,10 +31,18 @@ on:
 permissions:
   contents: write
 
+# Static group so racing version bumps serialize. If two commits land on
+# main in quick succession, the second run cancels the first rather than
+# both racing to tag and push back to main.
+concurrency:
+  group: semver-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -10,6 +10,7 @@ name: Semantic Release
 on:
   push:
     branches:
+      - 'main'
       - 'release/[0-9]+.x'
       - 'release/[0-9]+.[0-9]+.x'
     paths:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -58,7 +58,7 @@ jobs:
           cache: maven
 
       - name: Run semantic-release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4 # v4.2.2
         with:
           extra_plugins: |
             @semantic-release/changelog

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,7 @@
 {
   "tagFormat": "${version}",
   "branches": [
+    "main",
     {
       "name": "release/+([0-9])?(.{+([0-9]),x}).x",
       "channel": "${name.replace(/^release\\//,'')}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current stable release line receives security fixes. Older
+releases are best-effort and may not get patches. The stable line is the
+most recent minor version tagged on this repo (see
+[Releases](https://github.com/floci-io/floci/releases)).
+
+## Reporting a Vulnerability
+
+Please do **not** open public GitHub issues for security vulnerabilities.
+
+Report them privately via
+[GitHub private vulnerability reporting](https://github.com/floci-io/floci/security/advisories/new).
+This is the only supported reporting channel and produces a private
+thread with the maintainers.
+
+Expect an initial acknowledgement within a few business days. Once the
+report is confirmed, we will coordinate a fix, a release, and (where
+appropriate) a security advisory with CVE assignment.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues) for the
+corresponding contributor-facing note.


### PR DESCRIPTION
## Summary

Batch of low-risk CI/release hygiene improvements surfaced during a second-opinion scan with Codex and Gemini. Each commit stands alone and can be cherry-picked if any item draws pushback.

> **Stacked on #348.** This branch includes the semver-restore commit from that PR. Once #348 merges, the diff here reduces to just the 5 hygiene commits. Review can happen in parallel.

## Changes (5 commits)

**1. Dependabot config** (`.github/dependabot.yml`)

Weekly updates for Maven and GitHub Actions ecosystems. Patch/minor updates grouped per ecosystem to reduce PR noise, majors still land individually so breaking changes get surfaced on their own. No Docker base image scanning (can be added later).

**2. CODEOWNERS** (`.github/CODEOWNERS`)

Scopes `.github/**`, `.releaserc.json`, `/pom.xml`, and the Dockerfiles to `@hectorvent` so any change to CI, release automation, or the container build surface always pings the maintainer for review. No global owner, so the rest of the tree falls through to normal review rules. Expand with more owners as the maintainer roster grows.

**3. SECURITY.md** (root)

Surfaces the existing "Reporting Security Issues" section from `CONTRIBUTING.md` at the repo root so GitHub's Security tab exposes the policy UI and private vulnerability reporting flow. Supported-versions wording is deliberately unpinned ("current stable release line") so it doesn't drift as new minors land.

**4. Concurrency groups and timeouts** (all workflows)

Adds `concurrency` blocks to every workflow and `timeout-minutes` to every job. Currently only the compatibility matrix has a timeout, so a stuck job in ci/edge/release/semver could burn up to 6h of runner time before GitHub kills it.

- `ci`, `compatibility`, `docs`, `edge`: per-workflow+ref group with `cancel-in-progress: true`, so pushing a new commit to a branch cancels the prior PR run instead of letting both finish.
- `release`: per-tag group (`workflow+ref`), so back-to-back tag pushes (e.g. `1.5.3` and `1.6.0` landing minutes apart) run in parallel rather than cancelling each other. Re-runs of the same tag still supersede.
- `semver`: `semver-${ref}` static-prefixed group on the ref, so racing version bumps on main serialize rather than both trying to tag and push back.

Timeouts sized above current observed runtimes (native builds ~15min, JVM builds ~3min) with headroom for transient slowdowns.

**5. Pin third-party actions to SHAs**

Pins every third-party GitHub Action to an immutable commit SHA with the original version tag preserved as a trailing comment:

- `cycjimmy/semantic-release-action@16ca923e6ccbb50770c415a0ccd43709a8c5f7a4` (v4.2.2)
- `docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8` (v6)
- `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9` (v3)
- `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` (v3)
- `test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86` (v2)
- `graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994` (v1)

**`actions/*` (checkout, setup-java, setup-python, upload-artifact, download-artifact) are intentionally left on version tags.** They are maintained by GitHub itself, have a much smaller attack surface than third-party marketplace actions, and the dependabot `github-actions` ecosystem will keep SHA-pinned third-party actions current automatically. Happy to pin them too if the maintainer prefers consistent hygiene.

## Not included

These came up in the scan but are M-effort tool/policy choices the maintainer should decide on rather than having forced on them in a drive-by PR:

- JaCoCo + Codecov coverage integration
- SpotBugs / Checkstyle / PMD static analysis
- Trivy / Grype image scanning
- cyclonedx-maven-plugin SBOM generation
- SLSA provenance attestations

Happy to open these as separate issues if there's interest.

## Review passes done locally

- **Codex** (agentic review vs `fix/restore-semantic-release`): flagged SECURITY.md email fallback (no address) and hardcoded `1.5.x` version. Both addressed before opening this PR. Confirmed release-tag concurrency semantics correct.
- **Gemini** (agentic review vs `fix/restore-semantic-release`): flagged missing `pom.xml` in CODEOWNERS and missing SECURITY.md email address. Both addressed. Verified all six pinned SHAs against upstream tags and confirmed they match.

## Test plan

- [ ] CI runs on the PR itself (ci.yml path filter excludes this PR since only `.github/workflows/ci.yml` is touched, so this may no-op, which is expected)
- [ ] Dependabot schedule picks up the new config on the next Monday run after merge
- [ ] After #348 lands and a merge to main triggers `semver.yml`, verify the new concurrency group serializes correctly and the pinned `cycjimmy/semantic-release-action` SHA is picked up
- [ ] SECURITY.md shows up in the GitHub Security tab and private reporting flow works
- [ ] CODEOWNERS: touching any scoped path in a subsequent PR auto-requests review from `@hectorvent`