### PR TITLE
fix(cognito): return sub UUID as UserSub in SignUp response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -352,7 +352,7 @@ public class CognitoJsonHandler {
         );
         ObjectNode response = objectMapper.createObjectNode();
         response.put("UserConfirmed", "CONFIRMED".equals(user.getUserStatus()));
-        response.put("UserSub", user.getUsername());
+        response.put("UserSub", user.getAttributes().get("sub"));
         ObjectNode delivery = response.putObject("CodeDeliveryDetails");
         delivery.put("AttributeName", "email");
         delivery.put("DeliveryMedium", "EMAIL");

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -37,6 +37,39 @@ class CognitoJsonHandlerTest {
     }
 
     @Test
+    void signUpReturnsGeneratedSubAsUserSub() {
+        ObjectNode poolReq = mapper.createObjectNode();
+        poolReq.put("PoolName", "signup-pool");
+        JsonNode poolBody = (JsonNode) handler.handle("CreateUserPool", poolReq, "us-east-1").getEntity();
+        String poolId = poolBody.get("UserPool").get("Id").asText();
+
+        ObjectNode clientReq = mapper.createObjectNode();
+        clientReq.put("UserPoolId", poolId);
+        clientReq.put("ClientName", "signup-client");
+        JsonNode clientBody = (JsonNode) handler.handle("CreateUserPoolClient", clientReq, "us-east-1").getEntity();
+        String clientId = clientBody.get("UserPoolClient").get("ClientId").asText();
+
+        ObjectNode signUpReq = mapper.createObjectNode();
+        signUpReq.put("ClientId", clientId);
+        signUpReq.put("Username", "test@example.com");
+        signUpReq.put("Password", "Password123!");
+        ArrayNode attrs = signUpReq.putArray("UserAttributes");
+        ObjectNode emailAttr = attrs.addObject();
+        emailAttr.put("Name", "email");
+        emailAttr.put("Value", "test@example.com");
+
+        Response response = handler.handle("SignUp", signUpReq, "us-east-1");
+        assertEquals(200, response.getStatus());
+
+        JsonNode body = (JsonNode) response.getEntity();
+        String userSub = body.get("UserSub").asText();
+        assertNotEquals("test@example.com", userSub,
+                "UserSub must be the generated UUID, not the username");
+        assertTrue(userSub.matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
+                "UserSub should be a UUID, got: " + userSub);
+    }
+
+    @Test
     void createUserPoolReturnsRichResponse() {
         ObjectNode request = mapper.createObjectNode();
         request.put("PoolName", "test-pool");


### PR DESCRIPTION
## Summary
- `SignUp` was returning the username (email) as `UserSub` instead of the generated UUID, breaking SDKs/Terraform that rely on `UserSub` as a stable immutable identifier
- `CognitoService.signUp` already generates and stores a `sub` UUID on the user; the handler just needs to read it
- One-line fix in `CognitoJsonHandler.handleSignUp` plus a handler-level test

## Fixes
Fixes #346

## Test plan
- [x] New test `signUpReturnsGeneratedSubAsUserSub` drives the handler end-to-end (CreateUserPool → CreateUserPoolClient → SignUp) and asserts the returned `UserSub` is a UUID, not the username
- [x] `CognitoJsonHandlerTest` green (2/2)
- [x] Second-opinion review via Gemini: approved, verified consistency with `AdminGetUser`/`ListUsers` sub handling