### PR TITLE
fix(kinesis): accept same-value Increase/DecreaseStreamRetentionPeriod (#342)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -147,11 +147,18 @@ public class KinesisService {
             throw new AwsException("InvalidArgumentException",
                     "Retention period must not exceed 8760 hours (365 days)", 400);
         }
-        if (retentionPeriodHours <= stream.getRetentionPeriodHours()) {
+        if (retentionPeriodHours < stream.getRetentionPeriodHours()) {
             throw new AwsException("InvalidArgumentException",
                     "Requested retention period (" + retentionPeriodHours +
-                    " hours) must be greater than current retention period (" +
+                    " hours) must not be less than current retention period (" +
                     stream.getRetentionPeriodHours() + " hours)", 400);
+        }
+        // Same value is a no-op on real AWS despite the API doc wording ("must be more than
+        // current"). Proof: terraform-provider-aws calls IncreaseStreamRetentionPeriod on
+        // stream creation unconditionally when retention_period is set (stream.go Create path),
+        // so every default-retention TF stream would fail if AWS rejected same-value. See #342.
+        if (retentionPeriodHours == stream.getRetentionPeriodHours()) {
+            return;
         }
         stream.setRetentionPeriodHours(retentionPeriodHours);
         store.put(regionKey(region, streamName), stream);
@@ -164,11 +171,15 @@ public class KinesisService {
             throw new AwsException("InvalidArgumentException",
                     "Retention period must not be less than 24 hours", 400);
         }
-        if (retentionPeriodHours >= stream.getRetentionPeriodHours()) {
+        if (retentionPeriodHours > stream.getRetentionPeriodHours()) {
             throw new AwsException("InvalidArgumentException",
                     "Requested retention period (" + retentionPeriodHours +
-                    " hours) must be less than current retention period (" +
+                    " hours) must not be greater than current retention period (" +
                     stream.getRetentionPeriodHours() + " hours)", 400);
+        }
+        // Same value is a no-op on real AWS (mirrors IncreaseStreamRetentionPeriod). See #342.
+        if (retentionPeriodHours == stream.getRetentionPeriodHours()) {
+            return;
         }
         stream.setRetentionPeriodHours(retentionPeriodHours);
         store.put(regionKey(region, streamName), stream);

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -396,6 +396,66 @@ class KinesisIntegrationTest {
 
     @Test
     @Order(12)
+    void increaseRetentionPeriodSameValueIsNoOp() {
+        // Stream is currently at 48 (from Order 11). Increase to 48 should be a no-op,
+        // not an InvalidArgumentException. See #342: real AWS accepts same-value
+        // (terraform-provider-aws stream.go Create path calls this unconditionally on
+        // stream creation with the configured retention_period, so every default-retention
+        // TF stream would fail on first apply if AWS rejected same-value).
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.IncreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 48}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.RetentionPeriodHours", equalTo(48));
+    }
+
+    @Test
+    @Order(13)
+    void decreaseRetentionPeriodSameValueIsNoOp() {
+        // Stream is still at 48. Decrease to 48 should also be a no-op.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DecreaseStreamRetentionPeriod")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test", "RetentionPeriodHours": 48}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "retention-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.RetentionPeriodHours", equalTo(48));
+    }
+
+    @Test
+    @Order(14)
     void listShardsForNonExistentStream() {
         given()
             .header("X-Amz-Target", "Kinesis_20131202.ListShards")


### PR DESCRIPTION
## Summary
- `IncreaseStreamRetentionPeriod` and `DecreaseStreamRetentionPeriod` now accept the same-value case as a no-op instead of returning `InvalidArgumentException`.
- Fixes #342. Required for Terraform idempotency.

## Why

`terraform-provider-aws` calls `IncreaseStreamRetentionPeriod` unconditionally on stream creation whenever `retention_period` is set (see `internal/service/kinesis/stream.go` Create path, around line 218). The schema default is 24, which matches the new stream's own default, so the call fires with the same value on every default-retention stream. If real AWS rejected same-value, this would break every `aws_kinesis_stream` resource on first apply. It doesn't, so real AWS accepts same-value as a no-op despite the API docs wording ("must be more than the current retention period").

The previous strict `<=` / `>=` checks (introduced in #305) diverged from real AWS here and caused Terraform to taint Kinesis stream resources when the outer TF config couldn't override a nested module's hardcoded 24h retention. See the #342 reproduction for the full user-facing impact.

## Changes

- `KinesisService.java`: `<=` → `<` on Increase, `>=` → `>` on Decrease, plus an explicit same-value no-op guard that returns early without touching the store or logging an update. Error messages for genuinely invalid direction changes updated for accuracy ("must not be less/greater than" rather than "must be greater/less than"). Comment cites the Terraform provider evidence inline so the behavioral deviation from the API docs is documented at the point of enforcement.
- `KinesisIntegrationTest.java`: two new ordered tests (`increaseRetentionPeriodSameValueIsNoOp`, `decreaseRetentionPeriodSameValueIsNoOp`) that assert 200 + unchanged retention. Existing rejection tests (lower-than-current on Increase, too-low bounds) still pass — only the same-value case was relaxed.

## Test plan
- [x] `./mvnw test -Dtest=KinesisIntegrationTest` → 18/18 pass (16 prior + 2 new)
- [x] Existing `increaseRetentionPeriodRejectsLowerValue` (48 → 24) still errors as `InvalidArgumentException`
- [x] Existing `decreaseRetentionPeriodRejectsTooLow` (12h) still errors with the min-24 bounds message
- [x] Reviewed by Codex (two passes, second pass cleared after inline Terraform evidence was added)