### PR TITLE
fix(sns): recognize attributes set during creation of a subscription

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -115,7 +115,8 @@ public class SnsJsonHandler {
         String topicArn = request.path("TopicArn").asText(null);
         String protocol = request.path("Protocol").asText(null);
         String endpoint = request.path("Endpoint").asText(null);
-        Subscription sub = snsService.subscribe(topicArn, protocol, endpoint, region);
+        Map<String, String> attributes = jsonNodeToMap(request.path("Attributes"));
+        Subscription sub = snsService.subscribe(topicArn, protocol, endpoint, region, attributes);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("SubscriptionArn", sub.getSubscriptionArn());
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -123,8 +123,9 @@ public class SnsQueryHandler {
         String topicArn = getParam(params, "TopicArn");
         String protocol = getParam(params, "Protocol");
         String endpoint = getParam(params, "Endpoint");
+        Map<String, String> attributes = extractSnsAttributes(params, "Attributes");
         try {
-            Subscription sub = snsService.subscribe(topicArn, protocol, endpoint, region);
+            Subscription sub = snsService.subscribe(topicArn, protocol, endpoint, region, attributes);
 
             String result = new XmlBuilder().elem("SubscriptionArn", sub.getSubscriptionArn()).build();
             return Response.ok(AwsQueryResponse.envelope("Subscribe", AwsNamespaces.SNS, result)).build();

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -179,7 +179,7 @@ public class SnsService {
         topicStore.put(key, topic);
     }
 
-    public Subscription subscribe(String topicArn, String protocol, String endpoint, String region) {
+    public Subscription subscribe(String topicArn, String protocol, String endpoint, String region, Map<String, String> attributes) {
         String topicKey = topicKey(region, topicArn);
         if (topicStore.get(topicKey).isEmpty()) {
             throw new AwsException("NotFound", "Topic does not exist.", 404);
@@ -198,6 +198,7 @@ public class SnsService {
         String subscriptionArn = topicArn + ":" + UUID.randomUUID().toString();
         Subscription subscription = new Subscription(subscriptionArn, topicArn, protocol, endpoint,
                 regionResolver.getAccountId());
+        if (attributes != null) subscription.getAttributes().putAll(attributes);
 
         if (PENDING_CONFIRMATION_PROTOCOLS.contains(protocol)) {
             String token = UUID.randomUUID().toString().replace("-", "")
@@ -209,7 +210,11 @@ public class SnsService {
         }
 
         subscriptionStore.put(subKey(region, subscriptionArn), subscription);
-        LOG.infov("Subscribed {0} ({1}) to topic {2} in {3}", endpoint, protocol, topicArn, region);
+        if (attributes == null || attributes.isEmpty()) {
+            LOG.infov("Subscribed {0} ({1}) to topic {2} in {3}", endpoint, protocol, topicArn, region);
+        } else {
+            LOG.infov("Subscribed {0} ({1}) to topic {2} in {3} with attributes: {4}", endpoint, protocol, topicArn, region, attributes);
+        }
         return subscription;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -647,6 +647,8 @@ class SnsIntegrationTest {
             .formParam("TopicArn", topicArn)
             .formParam("Protocol", "sqs")
             .formParam("Endpoint", rawDeliveryQueueUrl)
+            .formParam("Attributes.entry.1.key", "RawMessageDelivery")
+            .formParam("Attributes.entry.1.value", "true")
         .when()
             .post("/")
         .then()
@@ -664,21 +666,6 @@ class SnsIntegrationTest {
         .then()
             .statusCode(200)
             .extract().xmlPath().getString("SubscribeResponse.SubscribeResult.SubscriptionArn");
-    }
-
-    @Test
-    @Order(51)
-    void rawDelivery_setSubscriptionAttribute() {
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "SetSubscriptionAttributes")
-            .formParam("SubscriptionArn", rawDeliverySubArn)
-            .formParam("AttributeName", "RawMessageDelivery")
-            .formParam("AttributeValue", "true")
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -74,7 +74,7 @@ class SnsServiceTest {
     @Test
     void deleteTopic_removesTopicAndSubscriptions() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
-        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue-url", REGION);
+        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue-url", REGION, Map.of());
         snsService.deleteTopic(topic.getTopicArn(), REGION);
 
         assertTrue(snsService.listTopics(REGION).isEmpty());
@@ -101,20 +101,22 @@ class SnsServiceTest {
     void subscribe_returnsSubscription() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         Subscription sub = snsService.subscribe(topic.getTopicArn(), "sqs",
-                "http://localhost:4566/000000000000/my-queue", REGION);
+                "http://localhost:4566/000000000000/my-queue", REGION,
+                Map.of("attr1", "value1", "attr2", "value2"));
         assertNotNull(sub.getSubscriptionArn());
         assertEquals(topic.getTopicArn(), sub.getTopicArn());
         assertEquals("sqs", sub.getProtocol());
         assertEquals(ACCOUNT, sub.getOwner());
+        assertEquals(Map.of("attr1", "value1", "attr2", "value2"), sub.getAttributes());
     }
 
     @Test
     void subscribe_idempotent() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         Subscription sub1 = snsService.subscribe(topic.getTopicArn(), "sqs",
-                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION);
+                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION, Map.of());
         Subscription sub2 = snsService.subscribe(topic.getTopicArn(), "sqs",
-                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION);
+                "arn:aws:sqs:us-east-1:000000000000:my-queue", REGION, Map.of());
         assertEquals(sub1.getSubscriptionArn(), sub2.getSubscriptionArn());
         assertEquals(1, snsService.listSubscriptions(REGION).size());
     }
@@ -123,9 +125,9 @@ class SnsServiceTest {
     void subscribe_differentEndpoints_createsSeparateSubscriptions() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         snsService.subscribe(topic.getTopicArn(), "sqs",
-                "arn:aws:sqs:us-east-1:000000000000:queue-1", REGION);
+                "arn:aws:sqs:us-east-1:000000000000:queue-1", REGION, Map.of());
         snsService.subscribe(topic.getTopicArn(), "sqs",
-                "arn:aws:sqs:us-east-1:000000000000:queue-2", REGION);
+                "arn:aws:sqs:us-east-1:000000000000:queue-2", REGION, Map.of());
         assertEquals(2, snsService.listSubscriptions(REGION).size());
     }
 
@@ -133,21 +135,21 @@ class SnsServiceTest {
     void subscribe_throwsForMissingTopic() {
         assertThrows(AwsException.class,
             () -> snsService.subscribe("arn:aws:sns:us-east-1:000000000000:nonexistent",
-                    "sqs", "http://queue", REGION));
+                    "sqs", "http://queue", REGION, Map.of()));
     }
 
     @Test
     void subscribe_requiresProtocol() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         assertThrows(AwsException.class,
-            () -> snsService.subscribe(topic.getTopicArn(), null, "http://queue", REGION));
+            () -> snsService.subscribe(topic.getTopicArn(), null, "http://queue", REGION, Map.of()));
     }
 
     @Test
     void unsubscribe_removesSubscription() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         Subscription sub = snsService.subscribe(topic.getTopicArn(), "sqs",
-                "http://queue", REGION);
+                "http://queue", REGION, Map.of());
         snsService.unsubscribe(sub.getSubscriptionArn(), REGION);
         assertTrue(snsService.listSubscriptions(REGION).isEmpty());
     }
@@ -156,9 +158,9 @@ class SnsServiceTest {
     void listSubscriptionsByTopic_filtersCorrectly() {
         Topic topicA = snsService.createTopic("topic-a", null, null, REGION);
         Topic topicB = snsService.createTopic("topic-b", null, null, REGION);
-        snsService.subscribe(topicA.getTopicArn(), "sqs", "http://queue1", REGION);
-        snsService.subscribe(topicA.getTopicArn(), "sqs", "http://queue2", REGION);
-        snsService.subscribe(topicB.getTopicArn(), "sqs", "http://queue3", REGION);
+        snsService.subscribe(topicA.getTopicArn(), "sqs", "http://queue1", REGION, Map.of());
+        snsService.subscribe(topicA.getTopicArn(), "sqs", "http://queue2", REGION, Map.of());
+        snsService.subscribe(topicB.getTopicArn(), "sqs", "http://queue3", REGION, Map.of());
 
         assertEquals(2, snsService.listSubscriptionsByTopic(topicA.getTopicArn(), REGION).size());
         assertEquals(1, snsService.listSubscriptionsByTopic(topicB.getTopicArn(), REGION).size());
@@ -168,7 +170,7 @@ class SnsServiceTest {
     void publish_withSqsSubscriber_returnsMessageId() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         snsService.subscribe(topic.getTopicArn(), "sqs",
-                BASE_URL + "/" + ACCOUNT + "/fanout-queue", REGION);
+                BASE_URL + "/" + ACCOUNT + "/fanout-queue", REGION, Map.of());
         // Fanout delivery is exercised — message ID returned confirms success
         String messageId = snsService.publish(topic.getTopicArn(), null, "Hello SNS!", null, REGION);
         assertNotNull(messageId);
@@ -221,8 +223,8 @@ class SnsServiceTest {
     @Test
     void subscriptionsConfirmed_countsCorrectly() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
-        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue1", REGION);
-        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue2", REGION);
+        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue1", REGION, Map.of());
+        snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue2", REGION, Map.of());
         Map<String, String> attrs = snsService.getTopicAttributes(topic.getTopicArn(), REGION);
         assertEquals("2", attrs.get("SubscriptionsConfirmed"));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
@@ -42,7 +42,7 @@ class SnsSqsFanoutFifoDeliveryTest {
 
         snsService.createTopic("fifo-topic.fifo", Map.of("FifoTopic", "true"), null, REGION);
         String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":fifo-topic.fifo";
-        snsService.subscribe(topicArn, "sqs", queueArn, REGION);
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of());
 
         // Act
         String messageId = snsService.publish(topicArn, null, null, "hello fifo",
@@ -65,7 +65,7 @@ class SnsSqsFanoutFifoDeliveryTest {
         snsService.createTopic("fifo-cbd-topic.fifo",
                 Map.of("FifoTopic", "true", "ContentBasedDeduplication", "true"), null, REGION);
         String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":fifo-cbd-topic.fifo";
-        snsService.subscribe(topicArn, "sqs", queueArn, REGION);
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of());
 
         // Act — no explicit dedup ID; topic derives one from message content
         String messageId = snsService.publish(topicArn, null, null, "cbd message",
@@ -87,7 +87,7 @@ class SnsSqsFanoutFifoDeliveryTest {
 
         snsService.createTopic("fifo-batch-topic.fifo", Map.of("FifoTopic", "true"), null, REGION);
         String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":fifo-batch-topic.fifo";
-        snsService.subscribe(topicArn, "sqs", queueArn, REGION);
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of());
 
         // Act
         var entries = List.<Map<String, Object>>of(
@@ -120,7 +120,7 @@ class SnsSqsFanoutFifoDeliveryTest {
         snsService.createTopic("fifo-batch-cbd-topic.fifo",
                 Map.of("FifoTopic", "true", "ContentBasedDeduplication", "true"), null, REGION);
         String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":fifo-batch-cbd-topic.fifo";
-        snsService.subscribe(topicArn, "sqs", queueArn, REGION);
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of());
 
         // Act — no explicit dedup IDs; topic derives them from message content
         var entries = List.<Map<String, Object>>of(
@@ -150,7 +150,7 @@ class SnsSqsFanoutFifoDeliveryTest {
 
         snsService.createTopic("fifo-dedup-topic.fifo", Map.of("FifoTopic", "true"), null, REGION);
         String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":fifo-dedup-topic.fifo";
-        snsService.subscribe(topicArn, "sqs", queueArn, REGION);
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of());
 
         // Act — publish same dedup ID twice
         snsService.publish(topicArn, null, null, "first",


### PR DESCRIPTION
## Summary

Currently, all attributes set during the creation of a SNS subscription are silently ignore. This PR fixes that behaviour and ensure that the attributes are set on the subscription.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS API spec for SNS clearly states that attributes can be set during subscription, although they are optional: https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
