### PR TITLE
fix(eventbridge): implement advanced content filtering operators

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeTest.java
@@ -193,6 +193,46 @@ class EventBridgeTest {
         assertThat(msg.messages()).isEmpty();
     }
 
+    @Test
+    @Order(25)
+    void putEventsWithPrefixPatternDeliveredToSqsTarget() {
+        String prefixRuleName = TestFixtures.uniqueName("eb-prefix-rule");
+        eb.putRule(PutRuleRequest.builder()
+                .name(prefixRuleName)
+                .eventPattern("{\"source\":[{\"prefix\":\"com.example\"}]}")
+                .state(RuleState.ENABLED)
+                .build());
+
+        eb.putTargets(PutTargetsRequest.builder()
+                .rule(prefixRuleName)
+                .targets(Target.builder().id("prefix-sqs-target").arn(sinkQueueArn).build())
+                .build());
+
+        // Matching source
+        eb.putEvents(PutEventsRequest.builder()
+                .entries(PutEventsRequestEntry.builder()
+                        .source("com.example.myapp")
+                        .detailType("Test")
+                        .detail("{}")
+                        .build())
+                .build());
+
+        ReceiveMessageResponse msg = sqs.receiveMessage(ReceiveMessageRequest.builder()
+                .queueUrl(sinkQueueUrl)
+                .maxNumberOfMessages(1)
+                .waitTimeSeconds(2)
+                .build());
+        
+        try {
+            assertThat(msg.messages()).hasSize(1);
+            assertThat(msg.messages().get(0).body()).contains("com.example.myapp");
+        } finally {
+            // Cleanup for this specific test
+            eb.removeTargets(RemoveTargetsRequest.builder().rule(prefixRuleName).ids("prefix-sqs-target").build());
+            eb.deleteRule(DeleteRuleRequest.builder().name(prefixRuleName).build());
+        }
+    }
+
     // ──────────────────────────── InputTransformer ────────────────────────────
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -447,10 +447,49 @@ public class EventBridgeService {
     }
 
     private boolean matchesArrayField(JsonNode arrayNode, String value) {
-        if (value == null) return false;
         for (JsonNode element : arrayNode) {
-            if (value.equals(element.asText())) {
+            if (matchesSingleElement(element, value)) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesSingleElement(JsonNode element, String value) {
+        // Exact string match
+        if (element.isTextual()) {
+            return value != null && value.equals(element.asText());
+        }
+        // Null literal match
+        if (element.isNull()) {
+            return value == null;
+        }
+        // Content filter object
+        if (element.isObject()) {
+            if (element.has("prefix")) {
+                return value != null && value.startsWith(element.get("prefix").asText());
+            }
+            if (element.has("suffix")) {
+                return value != null && value.endsWith(element.get("suffix").asText());
+            }
+            if (element.has("equals-ignore-case")) {
+                return value != null && value.equalsIgnoreCase(element.get("equals-ignore-case").asText());
+            }
+            if (element.has("anything-but")) {
+                JsonNode anythingBut = element.get("anything-but");
+                if (anythingBut.isArray()) {
+                    for (JsonNode v : anythingBut) {
+                        if (v.isTextual() && v.asText().equals(value)) return false;
+                    }
+                    return value != null;
+                }
+                if (anythingBut.isObject() && anythingBut.has("prefix")) {
+                    return value != null && !value.startsWith(anythingBut.get("prefix").asText());
+                }
+            }
+            if (element.has("exists")) {
+                boolean shouldExist = element.get("exists").asBoolean();
+                return shouldExist ? (value != null) : (value == null);
             }
         }
         return false;

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -401,4 +401,83 @@ class EventBridgeServiceTest {
         assertNotNull(result.entries().getFirst().get("EventId"));
         verify(invokerMock).invokeTarget(eq(target), any(String.class), eq(REGION));
     }
-}
+
+    @Test
+    void matchesPatternBySourcePrefix_matches() {
+        Map<String, Object> event = Map.of("Source", "com.example.myapp", "DetailType", "Order");
+        assertTrue(service.matchesPattern(event, "{\"source\":[{\"prefix\":\"com.example\"}]}"));
+    }
+
+    @Test
+    void matchesPatternBySourcePrefix_noMatch() {
+        Map<String, Object> event = Map.of("Source", "org.example.myapp", "DetailType", "Order");
+        assertFalse(service.matchesPattern(event, "{\"source\":[{\"prefix\":\"com.example\"}]}"));
+    }
+
+    @Test
+    void matchesPatternBySuffix_matches() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "order.json");
+        assertTrue(service.matchesPattern(event, "{\"detail-type\":[{\"suffix\":\".json\"}]}"));
+    }
+
+    @Test
+    void matchesPatternBySuffix_noMatch() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "order.xml");
+        assertFalse(service.matchesPattern(event, "{\"detail-type\":[{\"suffix\":\".json\"}]}"));
+    }
+
+    @Test
+    void matchesPatternByEqualsIgnoreCase_matches() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "PROD");
+        assertTrue(service.matchesPattern(event, "{\"detail-type\":[{\"equals-ignore-case\":\"prod\"}]}"));
+    }
+
+    @Test
+    void matchesPatternByEqualsIgnoreCase_noMatch() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "PROD");
+        assertFalse(service.matchesPattern(event, "{\"detail-type\":[{\"equals-ignore-case\":\"dev\"}]}"));
+    }
+
+    @Test
+    void matchesPatternByAnythingBut_matches() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Order");
+        assertTrue(service.matchesPattern(event, "{\"detail-type\":[{\"anything-but\":[\"Payment\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternByAnythingBut_noMatch() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Payment");
+        assertFalse(service.matchesPattern(event, "{\"detail-type\":[{\"anything-but\":[\"Payment\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternByAnythingButPrefix_matches() {
+        Map<String, Object> event = Map.of("Source", "com.example.app", "DetailType", "Order");
+        assertTrue(service.matchesPattern(event, "{\"source\":[{\"anything-but\":{\"prefix\":\"aws.\"}}]}"));
+    }
+
+    @Test
+    void matchesPatternByAnythingButPrefix_noMatch() {
+        Map<String, Object> event = Map.of("Source", "aws.events", "DetailType", "Order");
+        assertFalse(service.matchesPattern(event, "{\"source\":[{\"anything-but\":{\"prefix\":\"aws.\"}}]}"));
+    }
+
+    @Test
+    void matchesPatternByDetailPrefixField_matches() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"status\":\"CONFIRMED_BY_USER\"}"
+        );
+        assertTrue(service.matchesPattern(event, "{\"detail\":{\"status\":[{\"prefix\":\"CONFIRMED\"}]}}"));
+    }
+
+    @Test
+    void matchesPatternByExists_matches() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"status\":\"CONFIRMED\"}"
+        );
+        assertTrue(service.matchesPattern(event, "{\"detail\":{\"status\":[{\"exists\":true}]}}"));
+        assertTrue(service.matchesPattern(event, "{\"detail\":{\"other\":[{\"exists\":false}]}}"));
+    }
+    }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

- Added support for prefix, suffix, and equals-ignore-case operators.
- Added support for anything-but (list and nested prefix) and exists operators.
- Fixed a bug where object-based filter patterns were ignored during matching.
- Added comprehensive unit tests for all pattern matching operators.
- Added Java SDK compatibility test for prefix pattern matching.

Closes #306


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
