### PR TITLE
fix(cognito): correct HMAC signature computation in USER_SRP_AUTH

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoSrpTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoSrpTest.java
@@ -1,0 +1,111 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Cognito SRP Authentication (Issue #310)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CognitoSrpTest {
+
+    private static final BigInteger G = BigInteger.valueOf(2);
+    private static final BigInteger N = new BigInteger(
+            "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1" +
+            "29024E088A67CC74020BBEA63B139B22514A08798E3404DD" +
+            "EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
+            "E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED" +
+            "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D" +
+            "C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F" +
+            "83655D23DCA3AD961C62F356208552BB9ED529077096966D" +
+            "670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B" +
+            "E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9" +
+            "DE2BCBF6955817183995497CEA956AE515D2261898FA0510" +
+            "15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64" +
+            "ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7" +
+            "ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6B" +
+            "F12FFA06D98A0864D87602733EC86A64521F2B18177B200C" +
+            "BBE117577A615D6C770988C0BAD946E208E24FA074E5AB31" +
+            "43DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF", 16);
+
+    private static CognitoIdentityProviderClient cognito;
+    private static String poolId;
+    private static String clientId;
+    private static final String USERNAME = "srp-user-" + UUID.randomUUID();
+    private static final String PASSWORD = "SrpPass1!";
+
+    @BeforeAll
+    static void setup() {
+        cognito = TestFixtures.cognitoClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (cognito == null) return;
+        try {
+            if (poolId != null) {
+                cognito.deleteUserPool(b -> b.userPoolId(poolId));
+            }
+        } catch (Exception ignored) {}
+        cognito.close();
+    }
+
+    @Test
+    @Order(1)
+    void createPoolAndClient() {
+        CreateUserPoolResponse poolResp = cognito.createUserPool(b -> b.poolName("srp-test-pool"));
+        poolId = poolResp.userPool().id();
+
+        CreateUserPoolClientResponse clientResp = cognito.createUserPoolClient(b -> b
+                .userPoolId(poolId)
+                .clientName("srp-test-client")
+                .explicitAuthFlows(ExplicitAuthFlowsType.ALLOW_USER_SRP_AUTH));
+        clientId = clientResp.userPoolClient().clientId();
+
+        assertThat(poolId).isNotBlank();
+        assertThat(clientId).isNotBlank();
+    }
+
+    @Test
+    @Order(2)
+    void createUser() {
+        cognito.adminCreateUser(b -> b
+                .userPoolId(poolId)
+                .username(USERNAME)
+                .messageAction(MessageActionType.SUPPRESS));
+        
+        cognito.adminSetUserPassword(b -> b
+                .userPoolId(poolId)
+                .username(USERNAME)
+                .password(PASSWORD)
+                .permanent(true));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Verify USER_SRP_AUTH returns PASSWORD_VERIFIER challenge")
+    void srpAuthReturnsChallenge() {
+        BigInteger a = new BigInteger(256, new SecureRandom());
+        BigInteger A = G.modPow(a, N);
+
+        InitiateAuthResponse authResp = cognito.initiateAuth(b -> b
+                .authFlow(AuthFlowType.USER_SRP_AUTH)
+                .clientId(clientId)
+                .authParameters(Map.of(
+                        "USERNAME", USERNAME,
+                        "SRP_A", A.toString(16)
+                )));
+
+        assertThat(authResp.challengeName()).isEqualTo(ChallengeNameType.PASSWORD_VERIFIER);
+        Map<String, String> params = authResp.challengeParameters();
+        assertThat(params).containsKey("SRP_B");
+        assertThat(params).containsKey("SALT");
+        assertThat(params).containsKey("SECRET_BLOCK");
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoSrpHelper.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoSrpHelper.java
@@ -154,7 +154,8 @@ final class CognitoSrpHelper {
      * Computes the expected PASSWORD_CLAIM_SIGNATURE.
      *
      * @param sessionKey   derived session key bytes
-     * @param userPoolId   full user pool ID (e.g., "us-east-1_ABC123")
+     * @param userPoolId   full user pool ID (e.g., "us-east-1_ABC123") or short name ("ABC123");
+     *                     only the part after the underscore is used in the HMAC message.
      * @param username     Cognito username
      * @param secretBlock  raw bytes of the SECRET_BLOCK
      * @param timestamp    formatted timestamp string sent by the client
@@ -165,7 +166,7 @@ final class CognitoSrpHelper {
             byte[] hkdfKey = hkdf(sessionKey, INFO_BITS);
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(hkdfKey, "HmacSHA256"));
-            mac.update(userPoolId.getBytes(StandardCharsets.UTF_8));
+            mac.update(extractPoolName(userPoolId).getBytes(StandardCharsets.UTF_8));
             mac.update(username.getBytes(StandardCharsets.UTF_8));
             mac.update(secretBlock);
             mac.update(timestamp.getBytes(StandardCharsets.UTF_8));
@@ -177,6 +178,9 @@ final class CognitoSrpHelper {
 
     /**
      * Verifies the client's PASSWORD_CLAIM_SIGNATURE.
+     *
+     * @param userPoolId full user pool ID (e.g., "us-east-1_ABC123") or short name ("ABC123");
+     *                   only the part after the underscore is used in the HMAC message.
      */
     static boolean verifySignature(byte[] sessionKey, String userPoolId, String username,
                                    byte[] secretBlock, String timestamp, String claimSignatureBase64) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSrpHelperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSrpHelperTest.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CognitoSrpHelperTest {
+
+    @Test
+    void verifySignatureUsesShortPoolNameNotFullPoolId() {
+        String fullPoolId = "us-east-1_TestPool123";
+        String poolName   = "TestPool123";
+        String username   = "alice";
+        String password   = "Password1!";
+        String saltHex    = CognitoSrpHelper.generateSalt();
+
+        // Store verifier with short name (as CognitoService does)
+        String verifierHex = CognitoSrpHelper.computeVerifier(poolName, username, password, saltHex);
+
+        // Generate server B
+        String[] serverB  = CognitoSrpHelper.generateServerB(verifierHex);
+        String bHex       = serverB[0];
+        String bPublicHex = serverB[1];
+
+        // Simulate a client A (use a known non-trivial value)
+        BigInteger a      = new BigInteger(256, new SecureRandom());
+        BigInteger A      = CognitoSrpHelper.G.modPow(a, CognitoSrpHelper.N);
+        String aHex       = A.toString(16);
+
+        // Compute session key (server side)
+        byte[] sessionKey = CognitoSrpHelper.computeSessionKey(aHex, bHex, bPublicHex, verifierHex);
+
+        // Simulate client behavior: compute signature using short pool name
+        // (This is what the fix enables: the server now also uses the short name
+        // even if passed the full pool ID).
+        byte[] secretBlock = new byte[16];
+        new SecureRandom().nextBytes(secretBlock);
+        String timestamp = "Wed Apr  9 12:00:00 UTC 2026";
+        
+        // Manual client-side computation (mocking how Amplify/SDK does it)
+        // In real AWS SRP, the message fed to HMAC uses the short pool name.
+        byte[] sig = CognitoSrpHelper.computeSignature(sessionKey, poolName, username, secretBlock, timestamp);
+        String sigBase64 = Base64.getEncoder().encodeToString(sig);
+
+        // verifySignature must accept the full pool ID and match correctly
+        assertTrue(CognitoSrpHelper.verifySignature(sessionKey, fullPoolId, username, secretBlock, timestamp, sigBase64),
+                "Signature verification failed when using full pool ID");
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
 - Updated CognitoSrpHelper to use the short pool name instead of the full User Pool ID during HMAC signature computation.
 - Aligned server-side verification with standard client-side (Amplify/SDK) behavior to prevent incorrect "Incorrect username or password" errors.
 - Added CognitoSrpHelperTest for targeted unit validation.
 - Added CognitoSrpTest to the Java SDK compatibility suite to verify the USER_SRP_AUTH flow.
   
Closes #310

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
