### PR TITLE
fix(s3): include non-versioned objects in ListObjectVersions response

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3FeaturesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3FeaturesTest.java
@@ -25,6 +25,7 @@ class S3FeaturesTest {
     private static final String BUCKET_VERSIONS  = "compat-versions-bucket";
     private static final String BUCKET_PAB       = "compat-pab-bucket";
     private static final String BUCKET_PAGINATE  = "compat-paginate-bucket";
+    private static final String BUCKET_334       = "compat-334-bucket";
 
     @BeforeAll
     static void setup() {
@@ -32,6 +33,7 @@ class S3FeaturesTest {
         createBucket(BUCKET_VERSIONS);
         createBucket(BUCKET_PAB);
         createBucket(BUCKET_PAGINATE);
+        createBucket(BUCKET_334);
     }
 
     @AfterAll
@@ -40,9 +42,11 @@ class S3FeaturesTest {
         deleteBucketContents(BUCKET_VERSIONS);
         deleteBucketContents(BUCKET_PAB);
         deleteBucketContents(BUCKET_PAGINATE);
+        deleteBucketContents(BUCKET_334);
         quietDeleteBucket(BUCKET_VERSIONS);
         quietDeleteBucket(BUCKET_PAB);
         quietDeleteBucket(BUCKET_PAGINATE);
+        quietDeleteBucket(BUCKET_334);
         s3.close();
     }
 
@@ -127,6 +131,69 @@ class S3FeaturesTest {
 
         // We put at least 5 versions total — should all be collected across pages
         assertThat(allVersions.size()).isGreaterThanOrEqualTo(5);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #334 — listObjectVersions must return non-versioned objects
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Objects uploaded to a bucket that has never had versioning enabled must appear in
+     * ListObjectVersions with VersionId="null" (the literal string, per AWS spec).
+     */
+    @Test
+    @Order(13)
+    @DisplayName("#334 listObjectVersions: non-versioned bucket returns objects with VersionId=null")
+    void listObjectVersionsNonVersionedBucketReturnsObjects() {
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_334).key("file-a.txt").build(),
+                RequestBody.fromString("content-a"));
+        s3.putObject(PutObjectRequest.builder().bucket(BUCKET_334).key("file-b.txt").build(),
+                RequestBody.fromString("content-b"));
+
+        ListObjectVersionsResponse response = s3.listObjectVersions(
+                ListObjectVersionsRequest.builder().bucket(BUCKET_334).build());
+
+        List<ObjectVersion> versions = response.versions();
+        assertThat(versions).hasSize(2);
+
+        List<String> keys = versions.stream().map(ObjectVersion::key).toList();
+        assertThat(keys).containsExactlyInAnyOrder("file-a.txt", "file-b.txt");
+
+        // AWS returns the literal string "null" for objects uploaded without versioning
+        assertThat(versions).allMatch(v -> "null".equals(v.versionId()));
+        assertThat(versions).allMatch(ObjectVersion::isLatest);
+    }
+
+    /**
+     * Objects uploaded before versioning was enabled must appear in ListObjectVersions
+     * alongside objects uploaded after versioning was enabled.
+     * Pre-versioning objects appear with VersionId="null"; post-versioning objects have a UUID.
+     */
+    @Test
+    @Order(14)
+    @DisplayName("#334 listObjectVersions: pre-versioning objects appear alongside versioned entries")
+    void listObjectVersionsPreVersioningObjectsAppearsWithNullVersionId() {
+        // plain.txt was put at order 10, before versioning was enabled at order 11.
+        // It should appear in the listing with VersionId="null".
+        ListObjectVersionsResponse response = s3.listObjectVersions(
+                ListObjectVersionsRequest.builder().bucket(BUCKET_VERSIONS).build());
+
+        List<ObjectVersion> all = response.versions();
+
+        // Pre-versioning object
+        List<ObjectVersion> plainVersions = all.stream()
+                .filter(v -> "plain.txt".equals(v.key()))
+                .toList();
+        assertThat(plainVersions).hasSize(1);
+        assertThat(plainVersions.get(0).versionId()).isEqualTo("null");
+        assertThat(plainVersions.get(0).isLatest()).isTrue();
+
+        // Versioned objects uploaded after versioning was enabled must have UUID version IDs
+        List<ObjectVersion> versioned = all.stream()
+                .filter(v -> "versioned.txt".equals(v.key()))
+                .toList();
+        assertThat(versioned).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(versioned).allMatch(v -> v.versionId() != null && !"null".equals(v.versionId()));
     }
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -949,7 +949,7 @@ public class S3Controller {
             } else {
                 xml.start("Version")
                    .elem("Key", obj.getKey())
-                   .elem("VersionId", obj.getVersionId())
+                   .elem("VersionId", obj.getVersionId() != null ? obj.getVersionId() : "null")
                    .elem("IsLatest", obj.isLatest())
                    .elem("LastModified", ISO_FORMAT.format(obj.getLastModified()))
                    .elem("ETag", obj.getETag())

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -663,6 +663,15 @@ public class S3Service {
         List<S3Object> versions = new ArrayList<>(objectStore.scan(key ->
                 key.startsWith(fullPrefix) && key.contains("#v#")));
 
+        // Also include non-versioned objects (no #v# in storage key, versionId == null).
+        // These are objects uploaded when versioning was disabled or before versioning was enabled.
+        // Versioned latest-pointer entries (also stored at the plain key) are excluded because
+        // they have a non-null versionId; their #v# entry is already captured above.
+        objectStore.scan(key -> key.startsWith(fullPrefix) && !key.contains("#v#"))
+                .stream()
+                .filter(obj -> obj.getVersionId() == null)
+                .forEach(versions::add);
+
         // Sort by key, then by lastModified descending
         versions.sort((a, b) -> {
             int keyCompare = a.getKey().compareTo(b.getKey());


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

  Objects uploaded when versioning is disabled (or before versioning was                                                                                                        
  enabled) were invisible to ListObjectVersions because the scan predicate                                                                                                      
  only matched storage keys containing "#v#". These objects are stored at                                                                                                       
  the plain bucketName/key format with a null versionId.                                                                                                                        
                                                                                                                                                                                
  Add a second scan for plain-key entries filtered by versionId == null to                                                                                                      
  capture these objects. Also emit the literal string "null" as VersionId                                                                                                       
  in the XML response, matching the AWS wire protocol expectation.                                                                                                              
                                                                                                                                                                                
  Closes #334 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
