### PR TITLE
fix(secretsmanager): resolve partial ARNs without random suffix

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
@@ -307,8 +307,60 @@ class SecretsManagerTest {
                 .isEqualTo(400);
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #340 — GetSecretValue must resolve partial ARNs (no random suffix)
+    // ─────────────────────────────────────────────────────────────────────────
+
     @Test
     @Order(17)
+    @DisplayName("#340 getSecretValue resolves partial ARN (without random suffix)")
+    void getSecretValueByPartialArn() {
+        Assumptions.assumeTrue(secretArn != null, "CreateSecret must succeed first");
+
+        // Full ARN: arn:aws:secretsmanager:...:secret:<name>-XXXXXX  (7 chars: hyphen + 6)
+        // Partial:  arn:aws:secretsmanager:...:secret:<name>
+        String partialArn = secretArn.substring(0, secretArn.length() - 7);
+
+        GetSecretValueResponse response = sm.getSecretValue(GetSecretValueRequest.builder()
+                .secretId(partialArn)
+                .build());
+
+        assertThat(response.secretString()).isEqualTo(UPDATED_VALUE);
+        assertThat(response.name()).isEqualTo(secretName);
+    }
+
+    @Test
+    @Order(18)
+    @DisplayName("#340 getSecretValue resolves partial ARN for secret with slashes in name")
+    void getSecretValueByPartialArnWithSlashesInName() {
+        String slashName = "compat-340/dev/database-" + System.currentTimeMillis();
+
+        try {
+            CreateSecretResponse created = sm.createSecret(CreateSecretRequest.builder()
+                    .name(slashName)
+                    .secretString("db-pass")
+                    .build());
+
+            String partialArn = created.arn().substring(0, created.arn().length() - 7);
+
+            GetSecretValueResponse response = sm.getSecretValue(GetSecretValueRequest.builder()
+                    .secretId(partialArn)
+                    .build());
+
+            assertThat(response.secretString()).isEqualTo("db-pass");
+            assertThat(response.name()).isEqualTo(slashName);
+        } finally {
+            try {
+                sm.deleteSecret(DeleteSecretRequest.builder()
+                        .secretId(slashName)
+                        .forceDeleteWithoutRecovery(true)
+                        .build());
+            } catch (Exception ignored) {}
+        }
+    }
+
+    @Test
+    @Order(19)
     void batchGetSecretValue() {
         String s1 = "batch-secret-1-" + System.currentTimeMillis();
         String s2 = "batch-secret-2-" + System.currentTimeMillis();

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -311,15 +311,33 @@ public class SecretsManagerService {
 
     private Secret resolveSecret(String secretId, String region) {
         if (secretId.startsWith("arn:")) {
+            // 1. Exact full-ARN match
             List<Secret> found = store.scan(key -> {
                 Secret s = store.get(key).orElse(null);
                 return s != null && secretId.equals(s.getArn());
             });
-            if (found.isEmpty()) {
-                throw new AwsException("ResourceNotFoundException",
-                        "Secrets Manager can't find the specified secret.", 400);
+            if (!found.isEmpty()) {
+                return found.getFirst();
             }
-            return found.getFirst();
+
+            // 2. Partial-ARN fallback: extract region + name and do a name-based lookup.
+            //    AWS supports ARNs without the trailing "-XXXXXX" random suffix.
+            //    ARN format: arn:aws:secretsmanager:<region>:<account>:secret:<name>
+            String smPrefix = "arn:aws:secretsmanager:";
+            if (secretId.startsWith(smPrefix)) {
+                String[] parts = secretId.substring(smPrefix.length()).split(":", 4);
+                if (parts.length == 4 && "secret".equals(parts[2])) {
+                    String arnRegion = parts[0];
+                    String nameFromArn = parts[3];
+                    Secret byName = store.get(regionKey(arnRegion, nameFromArn)).orElse(null);
+                    if (byName != null) {
+                        return byName;
+                    }
+                }
+            }
+
+            throw new AwsException("ResourceNotFoundException",
+                    "Secrets Manager can't find the specified secret.", 400);
         }
 
         String storageKey = regionKey(region, secretId);

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -235,6 +235,41 @@ class SecretsManagerServiceTest {
     }
 
     @Test
+    void getSecretValueByPartialArnSucceeds() {
+        Secret secret = service.createSecret("my-secret", "value", null, null, null, null, REGION);
+        // Full ARN: arn:aws:secretsmanager:us-east-1:000000000000:secret:my-secret-XXXXXX
+        // Partial:  arn:aws:secretsmanager:us-east-1:000000000000:secret:my-secret
+        String partialArn = secret.getArn().substring(0, secret.getArn().length() - 7);
+
+        SecretVersion version = service.getSecretValue(partialArn, null, null, REGION);
+        assertEquals("value", version.getSecretString());
+    }
+
+    @Test
+    void getSecretValueByPartialArnWithSlashesInNameSucceeds() {
+        Secret secret = service.createSecret("my-app/dev/database", "db-pass", null, null, null, null, REGION);
+        String partialArn = secret.getArn().substring(0, secret.getArn().length() - 7);
+
+        SecretVersion version = service.getSecretValue(partialArn, null, null, REGION);
+        assertEquals("db-pass", version.getSecretString());
+    }
+
+    @Test
+    void getSecretValueByFullArnStillWorks() {
+        Secret secret = service.createSecret("my-secret", "value", null, null, null, null, REGION);
+
+        SecretVersion version = service.getSecretValue(secret.getArn(), null, null, REGION);
+        assertEquals("value", version.getSecretString());
+    }
+
+    @Test
+    void getSecretValueByNonExistentPartialArnThrows() {
+        String nonExistent = "arn:aws:secretsmanager:us-east-1:000000000000:secret:does-not-exist";
+        assertThrows(AwsException.class, () ->
+                service.getSecretValue(nonExistent, null, null, REGION));
+    }
+
+    @Test
     void kmsKeyIdIsPreserved() {
         String kmsKeyId = "arn:aws:kms:us-east-1:000000000000:key/my-key";
         // Signature: name, secretString, secretBinary, description, kmsKeyId, tags, region


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

GetSecretValue and all other SecretId-based operations failed with ResourceNotFoundException when the caller supplied a partial ARN (arn:aws:secretsmanager:<region>:<account>:secret :<name>) without the trailing "-XXXXXX" suffix that Floci appends at creation time.                                                                                                            
                                                                                                                                                                              
Add a fallback in resolveSecret(): after the exact-ARN scan finds nothing, extract the region and name from the partial ARN and perform the same name-based store lookup used for plain-name SecretIds.                                                                                                               
                                                                                                                                                                                
Closes #340 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
