### PR TITLE
fix(s3): implement S3 Control ListTagsForResource, TagResource, Untag…

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -60,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3control</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssm</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -16,6 +16,9 @@ import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3control.S3ControlClient;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sfn.SfnClient;
@@ -128,6 +131,22 @@ public final class TestFixtures {
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)
                 .forcePathStyle(true)
+                .build();
+    }
+
+    /**
+     * S3 Control client for the S3 Control API (/v20180820/...).
+     * Host prefix injection (account-ID prepended to host) is disabled so requests
+     * go to the configured endpoint directly rather than 000000000000.localhost:4566.
+     */
+    public static S3ControlClient s3ControlClient() {
+        return S3ControlClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .putAdvancedOption(SdkAdvancedClientOption.DISABLE_HOST_PREFIX_INJECTION, true)
+                        .build())
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -16,9 +16,9 @@ import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.services.s3control.S3ControlClient;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.services.s3control.endpoints.S3ControlEndpointProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sfn.SfnClient;
@@ -140,13 +140,13 @@ public final class TestFixtures {
      * go to the configured endpoint directly rather than 000000000000.localhost:4566.
      */
     public static S3ControlClient s3ControlClient() {
+        URI endpoint = ENDPOINT;
         return S3ControlClient.builder()
-                .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)
-                .overrideConfiguration(ClientOverrideConfiguration.builder()
-                        .putAdvancedOption(SdkAdvancedClientOption.DISABLE_HOST_PREFIX_INJECTION, true)
-                        .build())
+                .endpointProvider((S3ControlEndpointProvider) params ->
+                        java.util.concurrent.CompletableFuture.completedFuture(
+                                Endpoint.builder().url(endpoint).build()))
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionUrlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionUrlTest.java
@@ -1,0 +1,146 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Lambda Function URL Config")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaFunctionUrlTest {
+
+    private static LambdaClient lambda;
+    private static final String FUNCTION_NAME = "sdk-url-test-fn";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    @BeforeAll
+    static void setup() {
+        lambda = TestFixtures.lambdaClient();
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.minimalZip()))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda != null) {
+            try {
+                lambda.deleteFunctionUrlConfig(DeleteFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            lambda.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createFunctionUrlConfig() {
+        CreateFunctionUrlConfigResponse response = lambda.createFunctionUrlConfig(
+                CreateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.NONE)
+                        .build());
+
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.authTypeAsString()).isEqualTo("NONE");
+        assertThat(response.invokeMode()).isNotNull();
+        assertThat(response.creationTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(2)
+    void getFunctionUrlConfig() {
+        GetFunctionUrlConfigResponse response = lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.authTypeAsString()).isEqualTo("NONE");
+        assertThat(response.creationTime()).isNotBlank();
+        assertThat(response.lastModifiedTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(3)
+    void updateFunctionUrlConfig() {
+        UpdateFunctionUrlConfigResponse response = lambda.updateFunctionUrlConfig(
+                UpdateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.AWS_IAM)
+                        .build());
+
+        assertThat(response.authTypeAsString()).isEqualTo("AWS_IAM");
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.lastModifiedTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(4)
+    void getFunctionUrlConfigAfterUpdate() {
+        GetFunctionUrlConfigResponse response = lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.authTypeAsString()).isEqualTo("AWS_IAM");
+    }
+
+    @Test
+    @Order(5)
+    void deleteFunctionUrlConfig() {
+        lambda.deleteFunctionUrlConfig(DeleteFunctionUrlConfigRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .build());
+
+        assertThatThrownBy(() -> lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(6)
+    void getFunctionUrlConfigForNonExistentFunction() {
+        assertThatThrownBy(() -> lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName("does-not-exist-" + TestFixtures.uniqueName())
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(7)
+    void createFunctionUrlConfigConflict() {
+        // Re-create URL config
+        lambda.createFunctionUrlConfig(CreateFunctionUrlConfigRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .authType(FunctionUrlAuthType.NONE)
+                .build());
+
+        // Creating again should fail with conflict
+        assertThatThrownBy(() -> lambda.createFunctionUrlConfig(
+                CreateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.NONE)
+                        .build()))
+                .hasMessageContaining("already exists");
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3ControlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3ControlTest.java
@@ -1,0 +1,216 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketTaggingResponse;
+import software.amazon.awssdk.services.s3.model.PutBucketTaggingRequest;
+import software.amazon.awssdk.services.s3.model.Tag;
+import software.amazon.awssdk.services.s3.model.Tagging;
+import software.amazon.awssdk.services.s3control.S3ControlClient;
+import software.amazon.awssdk.services.s3control.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.s3control.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.s3control.model.TagResourceRequest;
+import software.amazon.awssdk.services.s3control.model.UntagResourceRequest;
+import software.amazon.awssdk.services.s3control.model.S3ControlException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for S3 Control API (issue #341).
+ *
+ * Verifies ListTagsForResource, TagResource, and UntagResource work correctly
+ * via the real AWS SDK S3ControlClient against Floci.
+ *
+ * Terraform AWS provider v6.x calls ListTagsForResource during bucket read-back;
+ * without this API the provider marks buckets as errored even when they are created.
+ */
+@DisplayName("S3 Control API — ListTagsForResource / TagResource / UntagResource (#341)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ControlTest {
+
+    private static S3Client s3;
+    private static S3ControlClient s3control;
+
+    private static final String BUCKET      = "compat-341-bucket";
+    private static final String ACCOUNT_ID  = "000000000000";
+    private static final String REGION_NAME = "us-east-1";
+
+    private static String bucketArn() {
+        return "arn:aws:s3:" + REGION_NAME + ":" + ACCOUNT_ID + ":bucket/" + BUCKET;
+    }
+
+    @BeforeAll
+    static void setup() {
+        s3 = TestFixtures.s3Client();
+        s3control = TestFixtures.s3ControlClient();
+
+        try {
+            s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+        } catch (BucketAlreadyOwnedByYouException ignored) {}
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (s3 != null) {
+            try {
+                s3.deleteBucketTagging(DeleteBucketTaggingRequest.builder().bucket(BUCKET).build());
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
+            } catch (Exception ignored) {}
+            s3.close();
+        }
+        if (s3control != null) {
+            s3control.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("listTagsForResource: returns tags set via standard PutBucketTagging")
+    void listTagsForResourceReturnsBucketTags() {
+        s3.putBucketTagging(PutBucketTaggingRequest.builder()
+                .bucket(BUCKET)
+                .tagging(Tagging.builder()
+                        .tagSet(
+                                Tag.builder().key("Environment").value("dev").build(),
+                                Tag.builder().key("ManagedBy").value("terraform").build())
+                        .build())
+                .build());
+
+        ListTagsForResourceResponse response = s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn(bucketArn())
+                        .build());
+
+        Map<String, String> tags = response.tags().stream()
+                .collect(Collectors.toMap(
+                        software.amazon.awssdk.services.s3control.model.Tag::key,
+                        software.amazon.awssdk.services.s3control.model.Tag::value));
+
+        assertThat(tags).containsEntry("Environment", "dev")
+                        .containsEntry("ManagedBy", "terraform");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("listTagsForResource: untagged bucket returns empty tag list")
+    void listTagsForResourceEmptyBucket() {
+        s3.deleteBucketTagging(DeleteBucketTaggingRequest.builder().bucket(BUCKET).build());
+
+        ListTagsForResourceResponse response = s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn(bucketArn())
+                        .build());
+
+        assertThat(response.tags()).isEmpty();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("tagResource: tags set via S3 Control are visible through standard GetBucketTagging")
+    void tagResourceVisibleThroughStandardApi() {
+        s3control.tagResource(TagResourceRequest.builder()
+                .accountId(ACCOUNT_ID)
+                .resourceArn(bucketArn())
+                .tags(
+                        software.amazon.awssdk.services.s3control.model.Tag.builder()
+                                .key("Team").value("platform").build(),
+                        software.amazon.awssdk.services.s3control.model.Tag.builder()
+                                .key("CostCenter").value("engineering").build())
+                .build());
+
+        GetBucketTaggingResponse tagging = s3.getBucketTagging(
+                GetBucketTaggingRequest.builder().bucket(BUCKET).build());
+
+        Map<String, String> tags = tagging.tagSet().stream()
+                .collect(Collectors.toMap(Tag::key, Tag::value));
+
+        assertThat(tags).containsEntry("Team", "platform")
+                        .containsEntry("CostCenter", "engineering");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("tagResource: replaces all existing tags (not a merge)")
+    void tagResourceReplacesAllTags() {
+        // tagResource replaces — only the new tags should remain
+        s3control.tagResource(TagResourceRequest.builder()
+                .accountId(ACCOUNT_ID)
+                .resourceArn(bucketArn())
+                .tags(software.amazon.awssdk.services.s3control.model.Tag.builder()
+                        .key("NewOnly").value("yes").build())
+                .build());
+
+        ListTagsForResourceResponse response = s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn(bucketArn())
+                        .build());
+
+        Map<String, String> tags = response.tags().stream()
+                .collect(Collectors.toMap(
+                        software.amazon.awssdk.services.s3control.model.Tag::key,
+                        software.amazon.awssdk.services.s3control.model.Tag::value));
+
+        assertThat(tags).containsOnlyKeys("NewOnly");
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("untagResource: removes specific keys, leaves others intact")
+    void untagResourceRemovesSpecificKeys() {
+        // Set two tags first
+        s3control.tagResource(TagResourceRequest.builder()
+                .accountId(ACCOUNT_ID)
+                .resourceArn(bucketArn())
+                .tags(
+                        software.amazon.awssdk.services.s3control.model.Tag.builder()
+                                .key("Keep").value("me").build(),
+                        software.amazon.awssdk.services.s3control.model.Tag.builder()
+                                .key("Remove").value("me").build())
+                .build());
+
+        s3control.untagResource(UntagResourceRequest.builder()
+                .accountId(ACCOUNT_ID)
+                .resourceArn(bucketArn())
+                .tagKeys(List.of("Remove"))
+                .build());
+
+        ListTagsForResourceResponse response = s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn(bucketArn())
+                        .build());
+
+        Map<String, String> tags = response.tags().stream()
+                .collect(Collectors.toMap(
+                        software.amazon.awssdk.services.s3control.model.Tag::key,
+                        software.amazon.awssdk.services.s3control.model.Tag::value));
+
+        assertThat(tags).containsEntry("Keep", "me")
+                        .doesNotContainKey("Remove");
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("listTagsForResource: non-existent bucket returns 404 NoSuchBucket")
+    void listTagsForResourceNonExistentBucketThrows() {
+        assertThatThrownBy(() -> s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn("arn:aws:s3:" + REGION_NAME + ":" + ACCOUNT_ID + ":bucket/does-not-exist-341")
+                        .build()))
+                .isInstanceOf(S3ControlException.class)
+                .satisfies(e -> assertThat(((S3ControlException) e).statusCode()).isEqualTo(404));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsNamespaces.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsNamespaces.java
@@ -14,6 +14,7 @@ public final class AwsNamespaces {
     public static final String EC  = "http://elasticache.amazonaws.com/doc/2015-02-02/";
     public static final String CW  = "http://monitoring.amazonaws.com/doc/2010-08-01/";
     public static final String S3  = "http://s3.amazonaws.com/doc/2006-03-01/";
+    public static final String S3_CONTROL = "http://awss3control.amazonaws.com/doc/2018-08-20/";
     public static final String SES = "http://ses.amazonaws.com/doc/2010-12-01/";
     public static final String EC2 = "http://ec2.amazonaws.com/doc/2016-11-15/";
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -467,7 +467,10 @@ public class LambdaService {
     public LambdaUrlConfig createFunctionUrlConfig(String region, String functionName, String qualifier, Map<String, Object> request) {
         LambdaUrlConfig urlConfig = new LambdaUrlConfig();
         urlConfig.setAuthType((String) request.getOrDefault("AuthType", "NONE"));
-        
+        if (request.containsKey("InvokeMode")) {
+            urlConfig.setInvokeMode((String) request.get("InvokeMode"));
+        }
+
         String urlId = UUID.nameUUIDFromBytes((region + functionName + (qualifier != null ? qualifier : "")).getBytes()).toString().replace("-", "").substring(0, 32);
         String baseHost = config.effectiveBaseUrl().replaceFirst("https?://", "");
         String url = String.format("http://%s.lambda-url.%s.%s/", urlId, region, baseHost);
@@ -496,6 +499,7 @@ public class LambdaService {
             if (alias.getUrlConfig() != null) {
                 throw new AwsException("ResourceConflictException", "Function URL config already exists for alias: " + qualifier, 409);
             }
+            urlConfig.setFunctionArn(alias.getAliasArn());
             alias.setUrlConfig(urlConfig);
             if (aliasStore != null) aliasStore.save(region, alias);
         } else {
@@ -503,6 +507,7 @@ public class LambdaService {
             if (fn.getUrlConfig() != null) {
                 throw new AwsException("ResourceConflictException", "Function URL config already exists for function: " + functionName, 409);
             }
+            urlConfig.setFunctionArn(fn.getFunctionArn());
             fn.setUrlConfig(urlConfig);
             functionStore.save(region, fn);
         }
@@ -530,6 +535,9 @@ public class LambdaService {
         
         if (request.containsKey("AuthType")) {
             urlConfig.setAuthType((String) request.get("AuthType"));
+        }
+        if (request.containsKey("InvokeMode")) {
+            urlConfig.setInvokeMode((String) request.get("InvokeMode"));
         }
 
         String now = DateTimeFormatter.ISO_INSTANT.format(Instant.now().atOffset(ZoneOffset.UTC));

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaUrlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaUrlController.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * AWS Lambda Function URL configuration API.
  */
-@Path("/2021-10-31/functions/{FunctionName}/url-config")
+@Path("/2021-10-31/functions/{FunctionName}/url")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class LambdaUrlController {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaUrlConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaUrlConfig.java
@@ -1,16 +1,32 @@
 package io.github.hectorvent.floci.services.lambda.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LambdaUrlConfig {
 
+    @JsonProperty("FunctionUrl")
     private String functionUrl;
+
+    @JsonProperty("FunctionArn")
+    private String functionArn;
+
+    @JsonProperty("AuthType")
     private String authType; // NONE or AWS_IAM
+
+    @JsonProperty("InvokeMode")
+    private String invokeMode = "BUFFERED";
+
+    @JsonProperty("CreationTime")
     private String creationTime;
+
+    @JsonProperty("LastModifiedTime")
     private String lastModifiedTime;
+
+    @JsonProperty("Cors")
     private Cors cors;
 
     public LambdaUrlConfig() {}
@@ -18,8 +34,14 @@ public class LambdaUrlConfig {
     public String getFunctionUrl() { return functionUrl; }
     public void setFunctionUrl(String functionUrl) { this.functionUrl = functionUrl; }
 
+    public String getFunctionArn() { return functionArn; }
+    public void setFunctionArn(String functionArn) { this.functionArn = functionArn; }
+
     public String getAuthType() { return authType; }
     public void setAuthType(String authType) { this.authType = authType; }
+
+    public String getInvokeMode() { return invokeMode; }
+    public void setInvokeMode(String invokeMode) { this.invokeMode = invokeMode; }
 
     public String getCreationTime() { return creationTime; }
     public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
@@ -32,11 +54,22 @@ public class LambdaUrlConfig {
 
     @RegisterForReflection
     public static class Cors {
+        @JsonProperty("AllowCredentials")
         private boolean allowCredentials;
+
+        @JsonProperty("AllowHeaders")
         private String[] allowHeaders;
+
+        @JsonProperty("AllowMethods")
         private String[] allowMethods;
+
+        @JsonProperty("AllowOrigins")
         private String[] allowOrigins;
+
+        @JsonProperty("ExposeHeaders")
         private String[] exposeHeaders;
+
+        @JsonProperty("MaxAge")
         private Integer maxAge;
 
         public boolean isAllowCredentials() { return allowCredentials; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
@@ -1,0 +1,120 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.AwsNamespaces;
+import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.core.common.XmlParser;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * S3 Control API endpoints used by Terraform AWS provider v6.x and other tools.
+ * All endpoints are under /v20180820 matching the S3 Control API version.
+ *
+ * Protocol: REST-XML
+ * Namespace: http://awss3control.amazonaws.com/doc/2018-08-20/
+ */
+@Path("/v20180820")
+@Produces(MediaType.APPLICATION_XML)
+public class S3ControlController {
+
+    private final S3Service s3Service;
+
+    @Inject
+    public S3ControlController(S3Service s3Service) {
+        this.s3Service = s3Service;
+    }
+
+    /**
+     * ListTagsForResource — returns all tags on the specified S3 bucket.
+     * Used by Terraform AWS provider v6.x during bucket read-back.
+     *
+     * GET /v20180820/tags/{resourceArn+}
+     * Header: x-amz-account-id
+     */
+    @GET
+    @Path("/tags/{resourceArn: .+}")
+    public Response listTagsForResource(
+            @PathParam("resourceArn") String resourceArn,
+            @HeaderParam("x-amz-account-id") String accountId) {
+
+        String bucketName = extractBucketName(resourceArn);
+        Map<String, String> tags = s3Service.getBucketTagging(bucketName);
+
+        XmlBuilder xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("ListTagsForResourceResult", AwsNamespaces.S3_CONTROL)
+                .start("Tags");
+        tags.forEach((k, v) ->
+                xml.start("Tag").elem("Key", k).elem("Value", v).end("Tag"));
+        xml.end("Tags").end("ListTagsForResourceResult");
+        return Response.ok(xml.build()).build();
+    }
+
+    /**
+     * TagResource — replaces all tags on the specified S3 bucket.
+     *
+     * POST /v20180820/tags/{resourceArn+}
+     * Header: x-amz-account-id
+     * Body: XML containing {@code <Tags><Tag><Key>…</Key><Value>…</Value></Tag></Tags>}
+     */
+    @POST
+    @Path("/tags/{resourceArn: .+}")
+    @Consumes(MediaType.WILDCARD)
+    public Response tagResource(
+            @PathParam("resourceArn") String resourceArn,
+            @HeaderParam("x-amz-account-id") String accountId,
+            byte[] body) {
+
+        String bucketName = extractBucketName(resourceArn);
+        String xml = new String(body, StandardCharsets.UTF_8);
+        Map<String, String> tags = XmlParser.extractPairs(xml, "Tag", "Key", "Value");
+        s3Service.putBucketTagging(bucketName, tags);
+        return Response.noContent().build();
+    }
+
+    /**
+     * UntagResource — removes specific tags from the specified S3 bucket.
+     *
+     * DELETE /v20180820/tags/{resourceArn+}?tagKeys=Key1&tagKeys=Key2
+     * Header: x-amz-account-id
+     */
+    @DELETE
+    @Path("/tags/{resourceArn: .+}")
+    public Response untagResource(
+            @PathParam("resourceArn") String resourceArn,
+            @HeaderParam("x-amz-account-id") String accountId,
+            @QueryParam("tagKeys") List<String> tagKeys) {
+
+        String bucketName = extractBucketName(resourceArn);
+        Map<String, String> existing = new HashMap<>(s3Service.getBucketTagging(bucketName));
+        tagKeys.forEach(existing::remove);
+        s3Service.putBucketTagging(bucketName, existing);
+        return Response.noContent().build();
+    }
+
+    private String extractBucketName(String resourceArn) {
+        int idx = resourceArn.lastIndexOf(":bucket/");
+        if (idx < 0) {
+            throw new AwsException("InvalidRequest",
+                    "Unsupported resource type. Only S3 bucket ARNs are supported " +
+                    "(arn:aws:s3:<region>:<account>:bucket/<name>).", 400);
+        }
+        return resourceArn.substring(idx + ":bucket/".length());
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -55,6 +55,12 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         URI uri = requestContext.getUriInfo().getRequestUri();
         String path = uri.getRawPath();
 
+        // Do not rewrite S3 Control API paths — the account ID appears as a host label
+        // in the S3ControlClient but the path belongs to the S3 Control service, not S3.
+        if (path.startsWith("/v20180820/")) {
+            return;
+        }
+
         // Rewrite path from /key to /bucket/key
         String newPath = "/" + bucket + (path.startsWith("/") ? "" : "/") + path;
 


### PR DESCRIPTION
…Resource (#341)

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Add S3ControlController handling GET/POST/DELETE /v20180820/tags/{resourceArn+} so Terraform AWS provider v6.x can read and write bucket tags via the S3 Control API without marking resources as errored.                                       
                                                                                                                                                                              
Fix S3VirtualHostFilter to skip path rewriting for /v20180820/ paths, the S3ControlClient injects the account ID as a host label (e.g. 000000000000.localhost:4566) via endpoint rules, which the virtual-host filter was incorrectly treating as a bucket name, causing requests to be routed to S3Controller instead of S3ControlController.                                                                                                                                  
                                                                                                                                                                              
Add AwsNamespaces.S3_CONTROL constant and SDK compatibility tests covering listTagsForResource, tagResource, untagResource, and 404 on missing bucket.  

Closes #341

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
