### PR TITLE
fix(lambda): correct Function URL config path from /url-config to /url

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionUrlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionUrlTest.java
@@ -1,0 +1,146 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Lambda Function URL Config")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaFunctionUrlTest {
+
+    private static LambdaClient lambda;
+    private static final String FUNCTION_NAME = "sdk-url-test-fn";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    @BeforeAll
+    static void setup() {
+        lambda = TestFixtures.lambdaClient();
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.minimalZip()))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda != null) {
+            try {
+                lambda.deleteFunctionUrlConfig(DeleteFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            lambda.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createFunctionUrlConfig() {
+        CreateFunctionUrlConfigResponse response = lambda.createFunctionUrlConfig(
+                CreateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.NONE)
+                        .build());
+
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.authTypeAsString()).isEqualTo("NONE");
+        assertThat(response.invokeMode()).isNotNull();
+        assertThat(response.creationTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(2)
+    void getFunctionUrlConfig() {
+        GetFunctionUrlConfigResponse response = lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.authTypeAsString()).isEqualTo("NONE");
+        assertThat(response.creationTime()).isNotBlank();
+        assertThat(response.lastModifiedTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(3)
+    void updateFunctionUrlConfig() {
+        UpdateFunctionUrlConfigResponse response = lambda.updateFunctionUrlConfig(
+                UpdateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.AWS_IAM)
+                        .build());
+
+        assertThat(response.authTypeAsString()).isEqualTo("AWS_IAM");
+        assertThat(response.functionUrl()).isNotBlank();
+        assertThat(response.functionArn()).isNotNull().contains(FUNCTION_NAME);
+        assertThat(response.lastModifiedTime()).isNotBlank();
+    }
+
+    @Test
+    @Order(4)
+    void getFunctionUrlConfigAfterUpdate() {
+        GetFunctionUrlConfigResponse response = lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.authTypeAsString()).isEqualTo("AWS_IAM");
+    }
+
+    @Test
+    @Order(5)
+    void deleteFunctionUrlConfig() {
+        lambda.deleteFunctionUrlConfig(DeleteFunctionUrlConfigRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .build());
+
+        assertThatThrownBy(() -> lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(6)
+    void getFunctionUrlConfigForNonExistentFunction() {
+        assertThatThrownBy(() -> lambda.getFunctionUrlConfig(
+                GetFunctionUrlConfigRequest.builder()
+                        .functionName("does-not-exist-" + TestFixtures.uniqueName())
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(7)
+    void createFunctionUrlConfigConflict() {
+        // Re-create URL config
+        lambda.createFunctionUrlConfig(CreateFunctionUrlConfigRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .authType(FunctionUrlAuthType.NONE)
+                .build());
+
+        // Creating again should fail with conflict
+        assertThatThrownBy(() -> lambda.createFunctionUrlConfig(
+                CreateFunctionUrlConfigRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .authType(FunctionUrlAuthType.NONE)
+                        .build()))
+                .hasMessageContaining("already exists");
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -467,7 +467,10 @@ public class LambdaService {
     public LambdaUrlConfig createFunctionUrlConfig(String region, String functionName, String qualifier, Map<String, Object> request) {
         LambdaUrlConfig urlConfig = new LambdaUrlConfig();
         urlConfig.setAuthType((String) request.getOrDefault("AuthType", "NONE"));
-        
+        if (request.containsKey("InvokeMode")) {
+            urlConfig.setInvokeMode((String) request.get("InvokeMode"));
+        }
+
         String urlId = UUID.nameUUIDFromBytes((region + functionName + (qualifier != null ? qualifier : "")).getBytes()).toString().replace("-", "").substring(0, 32);
         String baseHost = config.effectiveBaseUrl().replaceFirst("https?://", "");
         String url = String.format("http://%s.lambda-url.%s.%s/", urlId, region, baseHost);
@@ -496,6 +499,7 @@ public class LambdaService {
             if (alias.getUrlConfig() != null) {
                 throw new AwsException("ResourceConflictException", "Function URL config already exists for alias: " + qualifier, 409);
             }
+            urlConfig.setFunctionArn(alias.getAliasArn());
             alias.setUrlConfig(urlConfig);
             if (aliasStore != null) aliasStore.save(region, alias);
         } else {
@@ -503,6 +507,7 @@ public class LambdaService {
             if (fn.getUrlConfig() != null) {
                 throw new AwsException("ResourceConflictException", "Function URL config already exists for function: " + functionName, 409);
             }
+            urlConfig.setFunctionArn(fn.getFunctionArn());
             fn.setUrlConfig(urlConfig);
             functionStore.save(region, fn);
         }
@@ -530,6 +535,9 @@ public class LambdaService {
         
         if (request.containsKey("AuthType")) {
             urlConfig.setAuthType((String) request.get("AuthType"));
+        }
+        if (request.containsKey("InvokeMode")) {
+            urlConfig.setInvokeMode((String) request.get("InvokeMode"));
         }
 
         String now = DateTimeFormatter.ISO_INSTANT.format(Instant.now().atOffset(ZoneOffset.UTC));

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaUrlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaUrlController.java
@@ -25,7 +25,7 @@ import java.util.Map;
 /**
  * AWS Lambda Function URL configuration API.
  */
-@Path("/2021-10-31/functions/{FunctionName}/url-config")
+@Path("/2021-10-31/functions/{FunctionName}/url")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class LambdaUrlController {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaUrlConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaUrlConfig.java
@@ -1,16 +1,32 @@
 package io.github.hectorvent.floci.services.lambda.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LambdaUrlConfig {
 
+    @JsonProperty("FunctionUrl")
     private String functionUrl;
+
+    @JsonProperty("FunctionArn")
+    private String functionArn;
+
+    @JsonProperty("AuthType")
     private String authType; // NONE or AWS_IAM
+
+    @JsonProperty("InvokeMode")
+    private String invokeMode = "BUFFERED";
+
+    @JsonProperty("CreationTime")
     private String creationTime;
+
+    @JsonProperty("LastModifiedTime")
     private String lastModifiedTime;
+
+    @JsonProperty("Cors")
     private Cors cors;
 
     public LambdaUrlConfig() {}
@@ -18,8 +34,14 @@ public class LambdaUrlConfig {
     public String getFunctionUrl() { return functionUrl; }
     public void setFunctionUrl(String functionUrl) { this.functionUrl = functionUrl; }
 
+    public String getFunctionArn() { return functionArn; }
+    public void setFunctionArn(String functionArn) { this.functionArn = functionArn; }
+
     public String getAuthType() { return authType; }
     public void setAuthType(String authType) { this.authType = authType; }
+
+    public String getInvokeMode() { return invokeMode; }
+    public void setInvokeMode(String invokeMode) { this.invokeMode = invokeMode; }
 
     public String getCreationTime() { return creationTime; }
     public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
@@ -32,11 +54,22 @@ public class LambdaUrlConfig {
 
     @RegisterForReflection
     public static class Cors {
+        @JsonProperty("AllowCredentials")
         private boolean allowCredentials;
+
+        @JsonProperty("AllowHeaders")
         private String[] allowHeaders;
+
+        @JsonProperty("AllowMethods")
         private String[] allowMethods;
+
+        @JsonProperty("AllowOrigins")
         private String[] allowOrigins;
+
+        @JsonProperty("ExposeHeaders")
         private String[] exposeHeaders;
+
+        @JsonProperty("MaxAge")
         private Integer maxAge;
 
         public boolean isAllowCredentials() { return allowCredentials; }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Requests to POST/GET/PUT/DELETE /2021-10-31/functions/{name}/url were misrouted to S3Controller because LambdaUrlController was registered at /url-config instead of the correct AWS path /url.                                                                                                                             
                                                                                                                                                                              
Also adds missing FunctionArn and InvokeMode fields to LambdaUrlConfig, applies PascalCase @JsonProperty annotations for AWS wire protocol compatibility, and populates FunctionArn from the function/alias ARN on create.   

Closes #338                                                                                                                                                                     
          

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
