### PR TITLE
test(appconfig): edge case coverage for polling, deployments, empty configs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -204,6 +204,7 @@ class AppConfigTest {
 
     @Test
     @Order(12)
+    @DisplayName("Poll interval: requested 60s but emulator returns 15s (known deviation from AWS)")
     void requiredMinimumPollIntervalIsAcceptedButNotEnforced() {
         var sessionResponse = appConfigData.startConfigurationSession(StartConfigurationSessionRequest.builder()
                 .applicationIdentifier(applicationId)
@@ -216,11 +217,17 @@ class AppConfigTest {
         GetLatestConfigurationResponse firstResponse = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
                 .configurationToken(intervalSessionToken)
                 .build());
+
+        // Emulator always returns 15s regardless of the requested interval.
+        // AWS would return the requested 60s. Pinning current emulator behavior.
+        assertThat(firstResponse.nextPollIntervalInSeconds()).isEqualTo(15);
+        assertThat(firstResponse.nextPollConfigurationToken()).isNotNull();
+
         GetLatestConfigurationResponse secondResponse = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
                 .configurationToken(firstResponse.nextPollConfigurationToken())
                 .build());
 
-        assertThat(firstResponse.nextPollConfigurationToken()).isNotNull();
+        assertThat(secondResponse.nextPollIntervalInSeconds()).isEqualTo(15);
         assertThat(secondResponse.nextPollConfigurationToken()).isNotNull();
     }
 
@@ -255,6 +262,8 @@ class AppConfigTest {
 
         assertThat(response.configuration().asByteArray()).isEmpty();
         assertThat(response.contentType()).isEqualTo("application/octet-stream");
+        // SDK deserializes the empty Version-Label header as null.
+        // The RestAssured internal test sees "" (raw HTTP header value).
         assertThat(response.versionLabel()).isNull();
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.appconfig.AppConfigClient;
 import software.amazon.awssdk.services.appconfig.model.*;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
+import software.amazon.awssdk.services.appconfigdata.model.BadRequestException;
 import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest;
 import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse;
 import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSes
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("AppConfig")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -25,6 +27,11 @@ class AppConfigTest {
     private static String configurationProfileId;
     private static String deploymentStrategyId;
     private static String configurationToken;
+    private static String secondConfigurationToken;
+    private static String intervalSessionToken;
+    private static String emptyAppId;
+    private static String emptyEnvId;
+    private static String emptyProfileId;
 
     @BeforeAll
     static void setup() {
@@ -146,5 +153,108 @@ class AppConfigTest {
         assertThat(response.contentType()).startsWith("application/json");
         assertThat(response.versionLabel()).isEqualTo("1");
         assertThat(response.nextPollConfigurationToken()).isNotNull();
+        secondConfigurationToken = response.nextPollConfigurationToken();
+    }
+
+    @Test
+    @Order(9)
+    void staleConfigurationTokenIsRejected() {
+        assertThrows(BadRequestException.class, () -> appConfigData.getLatestConfiguration(
+                GetLatestConfigurationRequest.builder()
+                        .configurationToken(configurationToken)
+                        .build()));
+    }
+
+    @Test
+    @Order(10)
+    void invalidConfigurationTokenIsRejected() {
+        assertThrows(BadRequestException.class, () -> appConfigData.getLatestConfiguration(
+                GetLatestConfigurationRequest.builder()
+                        .configurationToken("not-a-real-token")
+                        .build()));
+    }
+
+    @Test
+    @Order(11)
+    void updatedDeploymentIsVisibleOnNextPollToken() {
+        CreateHostedConfigurationVersionResponse versionResponse = appConfig.createHostedConfigurationVersion(
+                CreateHostedConfigurationVersionRequest.builder()
+                        .applicationId(applicationId)
+                        .configurationProfileId(configurationProfileId)
+                        .content(SdkBytes.fromString("{\"key\": \"value-2\"}", StandardCharsets.UTF_8))
+                        .contentType("application/json")
+                        .build());
+        assertThat(versionResponse.versionNumber()).isEqualTo(2);
+
+        appConfig.startDeployment(StartDeploymentRequest.builder()
+                .applicationId(applicationId)
+                .environmentId(environmentId)
+                .configurationProfileId(configurationProfileId)
+                .configurationVersion("2")
+                .deploymentStrategyId(deploymentStrategyId)
+                .build());
+
+        GetLatestConfigurationResponse response = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
+                .configurationToken(secondConfigurationToken)
+                .build());
+
+        assertThat(response.configuration().asString(StandardCharsets.UTF_8)).isEqualTo("{\"key\": \"value-2\"}");
+        assertThat(response.versionLabel()).isEqualTo("2");
+    }
+
+    @Test
+    @Order(12)
+    void requiredMinimumPollIntervalIsAcceptedButNotEnforced() {
+        var sessionResponse = appConfigData.startConfigurationSession(StartConfigurationSessionRequest.builder()
+                .applicationIdentifier(applicationId)
+                .environmentIdentifier(environmentId)
+                .configurationProfileIdentifier(configurationProfileId)
+                .requiredMinimumPollIntervalInSeconds(60)
+                .build());
+
+        intervalSessionToken = sessionResponse.initialConfigurationToken();
+        GetLatestConfigurationResponse firstResponse = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
+                .configurationToken(intervalSessionToken)
+                .build());
+        GetLatestConfigurationResponse secondResponse = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
+                .configurationToken(firstResponse.nextPollConfigurationToken())
+                .build());
+
+        assertThat(firstResponse.nextPollConfigurationToken()).isNotNull();
+        assertThat(secondResponse.nextPollConfigurationToken()).isNotNull();
+    }
+
+    @Test
+    @Order(13)
+    void emptyConfigurationReturnsEmptyPayload() {
+        emptyAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name(TestFixtures.uniqueName("empty-app"))
+                .build()).id();
+
+        emptyEnvId = appConfig.createEnvironment(CreateEnvironmentRequest.builder()
+                .applicationId(emptyAppId)
+                .name("empty-env")
+                .build()).id();
+
+        emptyProfileId = appConfig.createConfigurationProfile(CreateConfigurationProfileRequest.builder()
+                .applicationId(emptyAppId)
+                .name("empty-config")
+                .locationUri("hosted")
+                .type("AWS.Freeform")
+                .build()).id();
+
+        String emptyToken = appConfigData.startConfigurationSession(StartConfigurationSessionRequest.builder()
+                .applicationIdentifier(emptyAppId)
+                .environmentIdentifier(emptyEnvId)
+                .configurationProfileIdentifier(emptyProfileId)
+                .build()).initialConfigurationToken();
+
+        GetLatestConfigurationResponse response = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
+                .configurationToken(emptyToken)
+                .build());
+
+        assertThat(response.configuration().asByteArray()).isEmpty();
+        assertThat(response.contentType()).isEqualTo("application/octet-stream");
+        assertThat(response.versionLabel()).isNull();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -181,6 +182,7 @@ class AppConfigIntegrationTest {
     }
 
     @Test @Order(12)
+    @DisplayName("Poll interval: requested 60s but emulator returns 15s (known deviation from AWS)")
     void requiredMinimumPollIntervalIsStoredButNotEnforced() {
         intervalToken = given()
                 .contentType(ContentType.JSON)
@@ -248,6 +250,8 @@ class AppConfigIntegrationTest {
                 .then()
                 .statusCode(200)
                 .header("Content-Type", equalTo("application/octet-stream"))
+                // HTTP transport returns "" for empty Version-Label.
+                // SDK deserializes this as null (see AppConfigTest).
                 .header("Version-Label", equalTo(""))
                 .body(equalTo(""));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -21,6 +21,11 @@ class AppConfigIntegrationTest {
     private static String profileId;
     private static String strategyId;
     private static String configToken;
+    private static String nextConfigToken;
+    private static String intervalToken;
+    private static String emptyAppId;
+    private static String emptyEnvId;
+    private static String emptyProfileId;
 
     @BeforeAll
     static void setup() {
@@ -112,7 +117,7 @@ class AppConfigIntegrationTest {
 
     @Test @Order(8)
     void getLatestConfiguration() {
-        given()
+        nextConfigToken = given()
                 .queryParam("configuration_token", configToken)
                 .when().get("/configuration")
                 .then()
@@ -120,6 +125,130 @@ class AppConfigIntegrationTest {
                 .header("Content-Type", startsWith("application/json"))
                 .header("Version-Label", equalTo("1"))
                 .header("Next-Poll-Configuration-Token", notNullValue())
-                .body("foo", equalTo("bar"));
+                .header("Next-Poll-Interval-In-Seconds", equalTo("15"))
+                .body("foo", equalTo("bar"))
+                .extract().header("Next-Poll-Configuration-Token");
+    }
+
+    @Test @Order(9)
+    void staleConfigurationTokenIsRejected() {
+        given()
+                .queryParam("configuration_token", configToken)
+                .when().get("/configuration")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("Invalid configuration token"));
+    }
+
+    @Test @Order(10)
+    void invalidConfigurationTokenIsRejected() {
+        given()
+                .queryParam("configuration_token", "not-a-real-token")
+                .when().get("/configuration")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("Invalid configuration token"));
+    }
+
+    @Test @Order(11)
+    void updatedDeploymentIsVisibleOnNextPollToken() {
+        given()
+                .header("Content-Type", "application/json")
+                .header("Description", "v2")
+                .body("{\"foo\": \"baz\"}".getBytes())
+                .when().post("/applications/" + appId + "/configurationprofiles/" + profileId + "/hostedconfigurationversions")
+                .then()
+                .statusCode(201)
+                .header("Version-Number", equalTo("2"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ConfigurationProfileId\": \"" + profileId + "\", \"ConfigurationVersion\": \"2\", \"DeploymentStrategyId\": \"" + strategyId + "\"}")
+                .when().post("/applications/" + appId + "/environments/" + envId + "/deployments")
+                .then()
+                .statusCode(201)
+                .body("State", equalTo("COMPLETE"));
+
+        given()
+                .queryParam("configuration_token", nextConfigToken)
+                .when().get("/configuration")
+                .then()
+                .statusCode(200)
+                .header("Version-Label", equalTo("2"))
+                .body("foo", equalTo("baz"));
+    }
+
+    @Test @Order(12)
+    void requiredMinimumPollIntervalIsStoredButNotEnforced() {
+        intervalToken = given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 60}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(201)
+                .body("InitialConfigurationToken", notNullValue())
+                .extract().path("InitialConfigurationToken");
+
+        String immediateNextToken = given()
+                .queryParam("configuration_token", intervalToken)
+                .when().get("/configuration")
+                .then()
+                .statusCode(200)
+                .header("Next-Poll-Configuration-Token", notNullValue())
+                .header("Next-Poll-Interval-In-Seconds", equalTo("15"))
+                .extract().header("Next-Poll-Configuration-Token");
+
+        given()
+                .queryParam("configuration_token", immediateNextToken)
+                .when().get("/configuration")
+                .then()
+                .statusCode(200)
+                .header("Next-Poll-Configuration-Token", notNullValue());
+    }
+
+    @Test @Order(13)
+    void emptyConfigurationReturnsEmptyPayload() {
+        emptyAppId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"empty-app\"}")
+                .when().post("/applications")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        emptyEnvId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"empty-env\"}")
+                .when().post("/applications/" + emptyAppId + "/environments")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        emptyProfileId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"empty-profile\", \"LocationUri\": \"hosted\", \"Type\": \"AWS.Freeform\"}")
+                .when().post("/applications/" + emptyAppId + "/configurationprofiles")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        String emptyToken = given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + emptyAppId + "\", \"EnvironmentIdentifier\": \"" + emptyEnvId + "\", \"ConfigurationProfileIdentifier\": \"" + emptyProfileId + "\"}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(201)
+                .extract().path("InitialConfigurationToken");
+
+        given()
+                .queryParam("configuration_token", emptyToken)
+                .when().get("/configuration")
+                .then()
+                .statusCode(200)
+                .header("Content-Type", equalTo("application/octet-stream"))
+                .header("Version-Label", equalTo(""))
+                .body(equalTo(""));
     }
 }


### PR DESCRIPTION
## Summary
- Add SDK and RestAssured tests covering stale/invalid token rejection, config updates visible on next poll token, empty configuration payloads, and poll interval behavior
- Document known emulator deviations via `@DisplayName` annotations

## Details
**SDK tests** (`AppConfigTest.java`): 5 new ordered test cases exercising the AppConfigData polling lifecycle end-to-end.

**Internal tests** (`AppConfigIntegrationTest.java`): Matching RestAssured coverage at the HTTP transport layer, verifying raw header values (e.g. `Version-Label: ""` vs SDK's `null` deserialization).

Both suites follow the same progression: stale token rejection, invalid token rejection, deploy v2 and poll, interval parameter behavior, empty config payload.

## Known deviations from AWS
- **Poll interval**: emulator returns `15` for `Next-Poll-Interval-In-Seconds` regardless of `RequiredMinimumPollIntervalInSeconds` value. Tests pin current behavior with `@DisplayName` explaining the deviation.
- **Empty config `Version-Label`**: SDK deserializes as `null`, HTTP transport returns `""`. Both behaviors tested and documented inline.

## Test plan
- [x] SDK: stale token BadRequestException
- [x] SDK: invalid token BadRequestException
- [x] SDK: updated deployment visible on next poll token
- [x] SDK: poll interval stored but returns 15s (known deviation)
- [x] SDK: empty config returns empty payload with octet-stream content type
- [x] RestAssured: matching HTTP-level coverage for all 5 scenarios
- [x] Codex + Gemini review (rounds 5-7). No critical findings.