### PR TITLE
fix(apigatewayv2): fix route matching for path-parameter routes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -185,12 +185,19 @@ public class ApiGatewayV2Service {
         String pattern = routeKey.substring(space + 1);
         if (!method.equalsIgnoreCase(httpMethod)) return false;
 
-        // Convert path template to regex: {param} → [^/]+, {proxy+} → .+
-        String regex = "^" + Pattern.quote(pattern)
-                .replace("\\{proxy+\\}", "\\E.+\\Q")
-                .replace("\\{", "\\E[^/]+\\Q")
-                .replaceAll("\\\\Q\\\\E", "") + "$";
-        return path.matches(regex);
+        // Build regex from path template: {proxy+} -> .+, {param} -> [^/]+
+        // Quote literal segments to avoid regex injection from path patterns
+        StringBuilder regex = new StringBuilder("^");
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile("\\{([^}]*)}").matcher(pattern);
+        int last = 0;
+        while (m.find()) {
+            regex.append(Pattern.quote(pattern.substring(last, m.start())));
+            regex.append(m.group(1).endsWith("+") ? ".+" : "[^/]+");
+            last = m.end();
+        }
+        regex.append(Pattern.quote(pattern.substring(last)));
+        regex.append("$");
+        return path.matches(regex.toString());
     }
 
     // ──────────────────────────── Integration CRUD ────────────────────────────


### PR DESCRIPTION
## Summary
- Fix broken route matching for parameterized API Gateway v2 routes ({id}, {proxy+})
- Routes like `GET /users/{id}` and `ANY /{proxy+}` can now match incoming request paths

## Details
`routeKeyMatchesPath()` used `String.replace()` on `Pattern.quote()` output. Since `Pattern.quote()` wraps the entire pattern in `\Q...\E`, the literal `replace()` calls looked for `\{` (the escaped brace inside `\Q...\E`) but never found it because `replace()` does exact string matching, not regex.

Rewritten to iterate over `{param}` placeholders using a regex `Matcher`, quoting only the literal path segments between them. `{param}` maps to `[^/]+` and `{proxy+}` maps to `.+`.

## Test plan
- [x] Clean compile
- [ ] Phase 7 execute-api dispatch compat suite (pending test branch rebase)