### PR TITLE
chore(ci): CI hygiene batch (concurrency, timeouts, action pinning, Dependabot)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS for floci
+#
+# Scopes release-sensitive paths to the primary maintainer so CI, release
+# config, and Dockerfile changes always trigger a review ping. Add more
+# owners as the maintainer roster grows.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: no global owner (unowned files fall through to normal review rules).
+
+# CI, release automation, workflow hygiene
+/.github/                @hectorvent
+/.releaserc.json         @hectorvent
+/pom.xml                 @hectorvent
+
+# Container build surface
+/Dockerfile              @hectorvent
+/Dockerfile.jvm-package  @hectorvent
+/Dockerfile.native       @hectorvent
+/Dockerfile.native-package @hectorvent

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "java"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     open-pull-requests-limit: 10
     groups:
       maven-minor-patch:
@@ -18,8 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     open-pull-requests-limit: 5
     groups:
       actions-minor-patch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,10 +19,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build floci image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -35,10 +40,10 @@ jobs:
       - name: Build JVM artifact
         run: mvn clean package -DskipTests -q
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -108,10 +113,10 @@ jobs:
         with:
           sparse-checkout: compatibility-tests
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build test image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: compatibility-tests/${{ matrix.test }}
           load: true
@@ -141,7 +146,7 @@ jobs:
 
       - name: Generate test summary
         if: always() && steps.tests.outcome != 'skipped'
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2
         with:
           paths: test-results/*.xml
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -16,10 +16,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-edge:
     name: Build and push edge image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -35,15 +40,15 @@ jobs:
       - name: Build JVM artifact
         run: mvn clean package -DskipTests -q
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push edge image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,20 @@ on:
 permissions:
   contents: read
 
+# Per-tag concurrency. Back-to-back tag pushes (e.g. 1.5.3 and 1.6.0 landing
+# minutes apart) resolve to different ${{ github.ref }} values, so they run
+# in parallel rather than cancelling each other. Re-runs of the same tag
+# supersede in-flight builds of that tag.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ── Build JVM artifact ────────────────────────────────────────────────────
   build-jvm:
     name: Build JVM artifact
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -45,11 +54,12 @@ jobs:
   build-native-amd64:
     name: Build native artifact (amd64)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           java-version: '24'
           distribution: 'mandrel'
@@ -73,11 +83,12 @@ jobs:
   build-native-arm64:
     name: Build native artifact (arm64)
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1
         with:
           java-version: '24'
           distribution: 'mandrel'
@@ -102,6 +113,7 @@ jobs:
     name: Push JVM Docker image
     needs: build-jvm
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -110,9 +122,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -123,7 +135,7 @@ jobs:
           path: target/quarkus-app/
 
       - name: Build and push JVM image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -138,7 +150,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
 
       - name: Build and push JVM image (With AWS CLI)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.jvm-package
@@ -156,6 +168,7 @@ jobs:
     name: Push native Docker images
     needs: [build-native-amd64, build-native-arm64]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -164,9 +177,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -188,7 +201,7 @@ jobs:
           chmod +x target/*-runner
 
       - name: Build and push amd64 native image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.native-package
@@ -206,7 +219,7 @@ jobs:
           chmod +x target/*-runner
 
       - name: Build and push arm64 native image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.native-package

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current stable release line receives security fixes. Older
+releases are best-effort and may not get patches. The stable line is the
+most recent minor version tagged on this repo (see
+[Releases](https://github.com/floci-io/floci/releases)).
+
+## Reporting a Vulnerability
+
+Please do **not** open public GitHub issues for security vulnerabilities.
+
+Report them privately via
+[GitHub private vulnerability reporting](https://github.com/floci-io/floci/security/advisories/new).
+This is the only supported reporting channel and produces a private
+thread with the maintainers.
+
+Expect an initial acknowledgement within a few business days. Once the
+report is confirmed, we will coordinate a fix, a release, and (where
+appropriate) a security advisory with CVE assignment.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#reporting-security-issues) for the
+corresponding contributor-facing note.


### PR DESCRIPTION
## Summary

Rework of #350 with release-related changes removed per maintainer feedback on #348 (semantic-release intentionally disabled while main stabilizes).

- **Concurrency groups** on all workflows: cancel superseded runs on the same branch/tag
- **timeout-minutes** on all jobs: prevent stuck builds from consuming runner quota
- **SHA-pinned third-party actions**: supply chain hardening for docker/build-push-action, docker/setup-buildx-action, docker/login-action, graalvm/setup-graalvm, test-summary/action
- **Dependabot config**: weekly Maven dependency + GitHub Actions version updates, grouped minor/patch PRs
- **CODEOWNERS**: routes `.github/`, release config, Dockerfiles to @hectorvent for review
- **SECURITY.md**: private vulnerability reporting via GitHub Security Advisories

No changes to semver.yml or .releaserc.json. Release workflow is untouched beyond concurrency/timeout/pinning.

## Test plan
- [ ] CI passes on this PR (concurrency + timeout don't affect test logic)
- [ ] Verify Dependabot starts opening grouped PRs after merge
- [ ] Verify CODEOWNERS triggers review requests on workflow changes