### PR TITLE
chore(deps): pin json-schema-validator below 2.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "com.networknt:json-schema-validator"
+        versions: [">=2.0.0"]
     labels:
       - "dependencies"
       - "java"


### PR DESCRIPTION
## Summary
- Pin `com.networknt:json-schema-validator` to `< 2.0.0` in dependabot config
- 2.x has breaking API refactors; 3.x requires Jackson 3 (`tools.jackson.*`), incompatible with the Jackson 2 (`com.fasterxml.jackson.*`) used throughout the project
- Prevents Dependabot raising unmergeable bumps like #381

## Test plan
- [x] Config-only change, no code impact
- [ ] Verify Dependabot no longer proposes 2.x/3.x bumps on next schedule