### PR TITLE
fix(apigatewayv2): add missing JSON handler operations and stageName auto-deploy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -334,13 +334,20 @@ public class ApiGatewayV2JsonHandler {
             if (!key.isEmpty() && Character.isUpperCase(key.charAt(0))) {
                 key = Character.toLowerCase(key.charAt(0)) + key.substring(1);
             }
-            Object value = entry.getValue();
-            if (value instanceof Map) {
-                value = toLowerCamelCase((Map<String, Object>) value);
-            }
-            result.put(key, value);
+            result.put(key, normalizeValue(entry.getValue()));
         }
         return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object normalizeValue(Object value) {
+        if (value instanceof Map) {
+            return toLowerCamelCase((Map<String, Object>) value);
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::normalizeValue).toList();
+        }
+        return value;
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +50,10 @@ public class ApiGatewayV2JsonHandler {
                 case "GetStages" -> handleGetStages(request, region);
                 case "DeleteStage" -> handleDeleteStage(request, region);
                 case "CreateDeployment" -> handleCreateDeployment(request, region);
+                case "GetDeployment" -> handleGetDeployment(request, region);
                 case "GetDeployments" -> handleGetDeployments(request, region);
+                case "DeleteDeployment" -> handleDeleteDeployment(request, region);
+                case "DeleteIntegration" -> handleDeleteIntegration(request, region);
                 default -> JsonErrorResponseUtils.createUnknownOperationErrorResponse(action);
             };
         } catch (AwsException e) {
@@ -61,7 +65,7 @@ public class ApiGatewayV2JsonHandler {
 
     private Response handleCreateApi(JsonNode request, String region) {
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Api api = service.createApi(region, map);
         return Response.status(201).entity(toApiNode(api).toString()).build();
     }
@@ -90,7 +94,7 @@ public class ApiGatewayV2JsonHandler {
     private Response handleCreateAuthorizer(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Authorizer auth = service.createAuthorizer(region, apiId, map);
         return Response.status(201).entity(toAuthorizerNode(auth).toString()).build();
     }
@@ -122,7 +126,7 @@ public class ApiGatewayV2JsonHandler {
     private Response handleCreateRoute(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Route route = service.createRoute(region, apiId, map);
         return Response.status(201).entity(toRouteNode(route).toString()).build();
     }
@@ -154,7 +158,7 @@ public class ApiGatewayV2JsonHandler {
     private Response handleCreateIntegration(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Integration integration = service.createIntegration(region, apiId, map);
         return Response.status(201).entity(toIntegrationNode(integration).toString()).build();
     }
@@ -179,7 +183,7 @@ public class ApiGatewayV2JsonHandler {
     private Response handleCreateStage(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Stage stage = service.createStage(region, apiId, map);
         return Response.status(201).entity(toStageNode(stage).toString()).build();
     }
@@ -211,9 +215,15 @@ public class ApiGatewayV2JsonHandler {
     private Response handleCreateDeployment(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         @SuppressWarnings("unchecked")
-        Map<String, Object> map = objectMapper.convertValue(request, Map.class);
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
         Deployment deployment = service.createDeployment(region, apiId, map);
         return Response.status(201).entity(toDeploymentNode(deployment).toString()).build();
+    }
+
+    private Response handleGetDeployment(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String deploymentId = request.path("DeploymentId").asText();
+        return Response.ok(toDeploymentNode(service.getDeployment(region, apiId, deploymentId)).toString()).build();
     }
 
     private Response handleGetDeployments(JsonNode request, String region) {
@@ -223,6 +233,20 @@ public class ApiGatewayV2JsonHandler {
         ArrayNode items = root.putArray("Items");
         deployments.forEach(d -> items.add(toDeploymentNode(d)));
         return Response.ok(root.toString()).build();
+    }
+
+    private Response handleDeleteDeployment(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String deploymentId = request.path("DeploymentId").asText();
+        service.deleteDeployment(region, apiId, deploymentId);
+        return Response.noContent().build();
+    }
+
+    private Response handleDeleteIntegration(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        service.deleteIntegration(region, apiId, integrationId);
+        return Response.noContent().build();
     }
 
     // ──────────────────────────── Serializers ────────────────────────────
@@ -295,6 +319,28 @@ public class ApiGatewayV2JsonHandler {
         node.put("CreatedDate", d.getCreatedDate() / 1000.0);
         if (d.getDescription() != null) node.put("Description", d.getDescription());
         return node;
+    }
+
+    /**
+     * Converts PascalCase map keys to lowerCamelCase so the service layer's
+     * field lookups work regardless of whether the request arrived via the
+     * REST path (lowerCamelCase body) or JSON 1.1 path (PascalCase body).
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> toLowerCamelCase(Map<String, Object> map) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            if (!key.isEmpty() && Character.isUpperCase(key.charAt(0))) {
+                key = Character.toLowerCase(key.charAt(0)) + key.substring(1);
+            }
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                value = toLowerCamelCase((Map<String, Object>) value);
+            }
+            result.put(key, value);
+        }
+        return result;
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -264,6 +264,16 @@ public class ApiGatewayV2Service {
 
     public Deployment createDeployment(String region, String apiId, Map<String, Object> request) {
         getApi(region, apiId);
+
+        // Validate stage exists before creating deployment to avoid orphans
+        String stageName = (String) request.get("stageName");
+        Stage stage = null;
+        if (stageName != null && !stageName.isBlank()) {
+            stage = stageStore.get(stageKey(region, apiId, stageName))
+                    .orElseThrow(() -> new AwsException("NotFoundException",
+                            "Stage " + stageName + " not found", 404));
+        }
+
         Deployment deployment = new Deployment();
         deployment.setDeploymentId(shortId(8));
         deployment.setDeploymentStatus("DEPLOYED");
@@ -272,11 +282,7 @@ public class ApiGatewayV2Service {
 
         deploymentStore.put(deploymentKey(region, apiId, deployment.getDeploymentId()), deployment);
 
-        String stageName = (String) request.get("stageName");
-        if (stageName != null && !stageName.isBlank()) {
-            Stage stage = stageStore.get(stageKey(region, apiId, stageName))
-                    .orElseThrow(() -> new AwsException("NotFoundException",
-                            "Stage " + stageName + " not found", 404));
+        if (stage != null) {
             stage.setDeploymentId(deployment.getDeploymentId());
             stage.setLastUpdatedDate(System.currentTimeMillis());
             stageStore.put(stageKey(region, apiId, stageName), stage);

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -271,6 +271,17 @@ public class ApiGatewayV2Service {
         deployment.setCreatedDate(System.currentTimeMillis());
 
         deploymentStore.put(deploymentKey(region, apiId, deployment.getDeploymentId()), deployment);
+
+        String stageName = (String) request.get("stageName");
+        if (stageName != null && !stageName.isBlank()) {
+            Stage stage = stageStore.get(stageKey(region, apiId, stageName))
+                    .orElseThrow(() -> new AwsException("NotFoundException",
+                            "Stage " + stageName + " not found", 404));
+            stage.setDeploymentId(deployment.getDeploymentId());
+            stage.setLastUpdatedDate(System.currentTimeMillis());
+            stageStore.put(stageKey(region, apiId, stageName), stage);
+        }
+
         return deployment;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
@@ -1,7 +1,9 @@
 package io.github.hectorvent.floci.services.apigatewayv2;
 
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -15,85 +17,113 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * Tests for API Gateway v2 fixes:
  * - createDeployment stageName auto-deploy
- * - GetDeployment, DeleteDeployment, DeleteIntegration via REST path
- *
- * The JSON 1.1 handler's PascalCase normalization and missing switch cases
- * delegate to the same service methods tested here.
+ * - GetDeployment, DeleteDeployment, DeleteIntegration
+ * - JSON 1.1 handler PascalCase normalization and missing switch cases
  */
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ApiGatewayV2JsonHandlerTest {
 
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
     private static String apiId;
     private static String integrationId;
     private static String deploymentId;
 
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── JSON 1.1 handler path ────────────────────────────
+
     @Test
     @Order(1)
-    void createApi() {
+    void json11CreateApiWithPascalCaseKeys() {
         apiId = given()
-                .contentType(ContentType.JSON)
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
                 .body("""
-                        {"name":"v2-handler-test","protocolType":"HTTP"}
+                        {"Name":"json11-test","ProtocolType":"HTTP"}
                         """)
-                .when().post("/v2/apis")
+                .when().post("/")
                 .then()
                 .statusCode(201)
-                .body("apiId", notNullValue())
-                .extract().path("apiId");
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("json11-test"))
+                .body("ProtocolType", equalTo("HTTP"))
+                .extract().path("ApiId");
     }
 
     @Test
     @Order(2)
-    void createIntegration() {
+    void json11CreateIntegrationWithPascalCaseKeys() {
         integrationId = given()
-                .contentType(ContentType.JSON)
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateIntegration")
+                .header("Authorization", AUTH_HEADER)
                 .body("""
-                        {"integrationType":"AWS_PROXY","integrationUri":"arn:aws:lambda:us-east-1:000000000000:function:test","payloadFormatVersion":"2.0"}
-                        """)
-                .when().post("/v2/apis/" + apiId + "/integrations")
+                        {"ApiId":"%s","IntegrationType":"AWS_PROXY","IntegrationUri":"arn:aws:lambda:us-east-1:000000000000:function:test","PayloadFormatVersion":"2.0"}
+                        """.formatted(apiId))
+                .when().post("/")
                 .then()
                 .statusCode(201)
-                .body("integrationId", notNullValue())
-                .extract().path("integrationId");
+                .body("IntegrationId", notNullValue())
+                .extract().path("IntegrationId");
     }
 
     @Test
     @Order(3)
-    void createDeploymentAndStage() {
+    void json11CreateDeploymentAndStage() {
         deploymentId = given()
-                .contentType(ContentType.JSON)
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateDeployment")
+                .header("Authorization", AUTH_HEADER)
                 .body("""
-                        {"description":"initial"}
-                        """)
-                .when().post("/v2/apis/" + apiId + "/deployments")
+                        {"ApiId":"%s","Description":"initial"}
+                        """.formatted(apiId))
+                .when().post("/")
                 .then()
                 .statusCode(201)
-                .body("deploymentId", notNullValue())
-                .extract().path("deploymentId");
+                .body("DeploymentId", notNullValue())
+                .extract().path("DeploymentId");
 
         given()
-                .contentType(ContentType.JSON)
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateStage")
+                .header("Authorization", AUTH_HEADER)
                 .body("""
-                        {"stageName":"prod","deploymentId":"%s"}
-                        """.formatted(deploymentId))
-                .when().post("/v2/apis/" + apiId + "/stages")
+                        {"ApiId":"%s","StageName":"prod","DeploymentId":"%s"}
+                        """.formatted(apiId, deploymentId))
+                .when().post("/")
                 .then()
                 .statusCode(201)
-                .body("stageName", equalTo("prod"))
-                .body("deploymentId", equalTo(deploymentId));
+                .body("StageName", equalTo("prod"))
+                .body("DeploymentId", equalTo(deploymentId));
     }
 
     @Test
     @Order(4)
-    void getDeploymentReturnsCreatedDeployment() {
+    void json11GetDeployment() {
         given()
-                .when().get("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","DeploymentId":"%s"}
+                        """.formatted(apiId, deploymentId))
+                .when().post("/")
                 .then()
                 .statusCode(200)
-                .body("deploymentId", equalTo(deploymentId))
-                .body("description", equalTo("initial"));
+                .body("DeploymentId", equalTo(deploymentId))
+                .body("Description", equalTo("initial"));
     }
+
+    // ──────────────────────────── stageName auto-deploy ────────────────────────────
 
     @Test
     @Order(5)
@@ -109,7 +139,6 @@ class ApiGatewayV2JsonHandlerTest {
                 .body("deploymentId", notNullValue())
                 .extract().path("deploymentId");
 
-        // Verify the stage's deploymentId was updated
         given()
                 .when().get("/v2/apis/" + apiId + "/stages/prod")
                 .then()
@@ -120,7 +149,13 @@ class ApiGatewayV2JsonHandlerTest {
 
     @Test
     @Order(6)
-    void createDeploymentWithMissingStageName404s() {
+    void createDeploymentWithMissingStageName404sWithoutOrphan() {
+        // Count deployments before
+        int beforeCount = given()
+                .when().get("/v2/apis/" + apiId + "/deployments")
+                .then().statusCode(200)
+                .extract().jsonPath().getList("items").size();
+
         given()
                 .contentType(ContentType.JSON)
                 .body("""
@@ -129,26 +164,47 @@ class ApiGatewayV2JsonHandlerTest {
                 .when().post("/v2/apis/" + apiId + "/deployments")
                 .then()
                 .statusCode(404);
+
+        // Verify no orphan deployment was created
+        int afterCount = given()
+                .when().get("/v2/apis/" + apiId + "/deployments")
+                .then().statusCode(200)
+                .extract().jsonPath().getList("items").size();
+
+        org.junit.jupiter.api.Assertions.assertEquals(beforeCount, afterCount,
+                "No orphan deployment should be created when stageName is invalid");
     }
+
+    // ──────────────────────────── JSON 1.1 delete operations ────────────────────────────
 
     @Test
     @Order(7)
-    void deleteIntegrationRemovesIntegration() {
-        given().when().delete("/v2/apis/" + apiId + "/integrations/" + integrationId)
-                .then().statusCode(204);
-
-        given().when().get("/v2/apis/" + apiId + "/integrations/" + integrationId)
-                .then().statusCode(404);
+    void json11DeleteIntegration() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
     }
 
     @Test
     @Order(8)
-    void deleteDeploymentRemovesDeployment() {
-        given().when().delete("/v2/apis/" + apiId + "/deployments/" + deploymentId)
-                .then().statusCode(204);
-
-        given().when().get("/v2/apis/" + apiId + "/deployments/" + deploymentId)
-                .then().statusCode(404);
+    void json11DeleteDeployment() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","DeploymentId":"%s"}
+                        """.formatted(apiId, deploymentId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
@@ -1,0 +1,160 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Tests for API Gateway v2 fixes:
+ * - createDeployment stageName auto-deploy
+ * - GetDeployment, DeleteDeployment, DeleteIntegration via REST path
+ *
+ * The JSON 1.1 handler's PascalCase normalization and missing switch cases
+ * delegate to the same service methods tested here.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2JsonHandlerTest {
+
+    private static String apiId;
+    private static String integrationId;
+    private static String deploymentId;
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"v2-handler-test","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+    }
+
+    @Test
+    @Order(2)
+    void createIntegration() {
+        integrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationType":"AWS_PROXY","integrationUri":"arn:aws:lambda:us-east-1:000000000000:function:test","payloadFormatVersion":"2.0"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(201)
+                .body("integrationId", notNullValue())
+                .extract().path("integrationId");
+    }
+
+    @Test
+    @Order(3)
+    void createDeploymentAndStage() {
+        deploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"initial"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .body("deploymentId", notNullValue())
+                .extract().path("deploymentId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"stageName":"prod","deploymentId":"%s"}
+                        """.formatted(deploymentId))
+                .when().post("/v2/apis/" + apiId + "/stages")
+                .then()
+                .statusCode(201)
+                .body("stageName", equalTo("prod"))
+                .body("deploymentId", equalTo(deploymentId));
+    }
+
+    @Test
+    @Order(4)
+    void getDeploymentReturnsCreatedDeployment() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .then()
+                .statusCode(200)
+                .body("deploymentId", equalTo(deploymentId))
+                .body("description", equalTo("initial"));
+    }
+
+    @Test
+    @Order(5)
+    void createDeploymentWithStageNameAutoDeploysToStage() {
+        String newDeploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"auto-deploy","stageName":"prod"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .body("deploymentId", notNullValue())
+                .extract().path("deploymentId");
+
+        // Verify the stage's deploymentId was updated
+        given()
+                .when().get("/v2/apis/" + apiId + "/stages/prod")
+                .then()
+                .statusCode(200)
+                .body("deploymentId", equalTo(newDeploymentId))
+                .body("deploymentId", not(equalTo(deploymentId)));
+    }
+
+    @Test
+    @Order(6)
+    void createDeploymentWithMissingStageName404s() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"bad stage","stageName":"nonexistent"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @Order(7)
+    void deleteIntegrationRemovesIntegration() {
+        given().when().delete("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then().statusCode(204);
+
+        given().when().get("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then().statusCode(404);
+    }
+
+    @Test
+    @Order(8)
+    void deleteDeploymentRemovesDeployment() {
+        given().when().delete("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .then().statusCode(204);
+
+        given().when().get("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .then().statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void cleanup() {
+        given().when().delete("/v2/apis/" + apiId + "/stages/prod").then().statusCode(204);
+        given().when().delete("/v2/apis/" + apiId).then().statusCode(204);
+    }
+}


### PR DESCRIPTION
## Summary
- Add missing `GetDeployment`, `DeleteDeployment`, `DeleteIntegration` operations to the JSON 1.1 handler
- Normalize PascalCase keys from JSON 1.1 requests to lowerCamelCase before passing to the service layer
- Implement `stageName` auto-deploy in `createDeployment`: updates the named stage's `deploymentId` and `lastUpdatedDate`, throws `NotFoundException` for missing stages

## Detail

The JSON 1.1 handler (`ApiGatewayV2JsonHandler`) serves `X-Amz-Target` based requests as an alternative to the REST path. Three operations were missing from the switch statement, returning `UnknownOperation` errors.

The handler also had a casing mismatch: `objectMapper.convertValue(request, Map.class)` preserves PascalCase keys from the JSON 1.1 payload, but service methods read lowerCamelCase keys (e.g., `request.get("name")`). The `toLowerCamelCase()` normalizer fixes this so both paths work consistently.

`createDeployment` previously ignored the `stageName` parameter. AWS auto-deploys to the named stage when this field is set. The fix updates the stage's deployment pointer and timestamp, matching AWS behavior.

## Test plan
- [x] 9 new integration tests: API creation, deployment lifecycle, stageName auto-deploy (verified stage updates), missing-stage 404, delete operations
- [x] Full non-Docker suite green (1881 passed, 0 failed)