### PR TITLE
chore(ci): gate release builds on tests; add Rust SDK to compat matrix

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -76,6 +76,7 @@ jobs:
           - sdk-test-java
           - sdk-test-go
           - sdk-test-awscli
+          - sdk-test-rust
           - compat-cdk
           - compat-terraform
           - compat-opentofu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── Run tests ────────────────────────────────────────────────────────────
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run tests
+        run: mvn test -B
+
   # ── Build JVM artifact ────────────────────────────────────────────────────
   build-jvm:
     name: Build JVM artifact
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -53,6 +72,7 @@ jobs:
   # ── Build native artifact — amd64 ────────────────────────────────────────
   build-native-amd64:
     name: Build native artifact (amd64)
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -82,6 +102,7 @@ jobs:
   # ── Build native artifact — arm64 ────────────────────────────────────────
   build-native-arm64:
     name: Build native artifact (arm64)
+    needs: test
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
 


### PR DESCRIPTION
## Summary

- Add a `test` job to the release workflow that runs `mvn test -B` before any build jobs can start. All three build jobs (`build-jvm`, `build-native-amd64`, `build-native-arm64`) now depend on it via `needs: test`. Build steps keep `-DskipTests` since native builds use GraalVM/Mandrel, not the Temurin JDK used for testing.
- Add `sdk-test-rust` to the compatibility test matrix. The Rust suite already exists with Dockerfile, nextest JUnit output, and 16 service test files but was not wired into CI.

## Test plan

- [ ] Verify release workflow graph shows `test` -> `build-*` -> `push-*` dependency chain
- [ ] Verify `sdk-test-rust` appears as a new matrix entry in compatibility workflow on this PR
- [ ] Confirm existing compat tests still pass (no changes to their steps)