### PR TITLE
refactor(test): narrow Lambda dispatch probe to transport-level exceptions

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/kms.bats
+++ b/compatibility-tests/sdk-test-awscli/test/kms.bats
@@ -88,7 +88,7 @@ teardown() {
 @test "KMS: create alias" {
     out=$(aws_cmd kms create-key --description "bats-test-key")
     KEY_ID=$(json_get "$out" '.KeyMetadata.KeyId')
-    alias_name="alias/bats-test-$(date +%s)"
+    alias_name="alias/bats-test-$(unique_name)"
 
     run aws_cmd kms create-alias --alias-name "$alias_name" --target-key-id "$KEY_ID"
     assert_success
@@ -100,7 +100,7 @@ teardown() {
 @test "KMS: list aliases" {
     out=$(aws_cmd kms create-key --description "bats-test-key")
     KEY_ID=$(json_get "$out" '.KeyMetadata.KeyId')
-    alias_name="alias/bats-test-$(date +%s)"
+    alias_name="alias/bats-test-$(unique_name)"
 
     aws_cmd kms create-alias --alias-name "$alias_name" --target-key-id "$KEY_ID" >/dev/null
 
@@ -116,7 +116,7 @@ teardown() {
 @test "KMS: delete alias" {
     out=$(aws_cmd kms create-key --description "bats-test-key")
     KEY_ID=$(json_get "$out" '.KeyMetadata.KeyId')
-    alias_name="alias/bats-test-$(date +%s)"
+    alias_name="alias/bats-test-$(unique_name)"
 
     aws_cmd kms create-alias --alias-name "$alias_name" --target-key-id "$KEY_ID" >/dev/null
 

--- a/compatibility-tests/sdk-test-awscli/test/s3-notifications.bats
+++ b/compatibility-tests/sdk-test-awscli/test/s3-notifications.bats
@@ -4,9 +4,9 @@
 load 'test_helper/common-setup'
 
 setup_file() {
-    export TEST_BUCKET="s3-notif-filter-bucket-$(date +%s)"
-    export TEST_QUEUE="s3-notif-filter-queue-$(date +%s)"
-    export TEST_TOPIC="s3-notif-filter-topic-$(date +%s)"
+    export TEST_BUCKET="$(unique_name s3-notif-filter-bucket)"
+    export TEST_QUEUE="$(unique_name s3-notif-filter-queue)"
+    export TEST_TOPIC="$(unique_name s3-notif-filter-topic)"
     export ACCOUNT_ID="000000000000"
     export QUEUE_ARN="arn:aws:sqs:us-east-1:${ACCOUNT_ID}:${TEST_QUEUE}"
 

--- a/compatibility-tests/sdk-test-awscli/test/ses.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ses.bats
@@ -4,8 +4,8 @@
 load 'test_helper/common-setup'
 
 setup_file() {
-    export TEST_EMAIL="test-$(date +%s)@example.com"
-    export TEST_DOMAIN="test-$(date +%s).example.com"
+    export TEST_EMAIL="$(unique_name test)@example.com"
+    export TEST_DOMAIN="$(unique_name test).example.com"
 }
 
 teardown_file() {

--- a/compatibility-tests/sdk-test-go/tests/lambda_test.go
+++ b/compatibility-tests/sdk-test-go/tests/lambda_test.go
@@ -3,6 +3,8 @@ package tests
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net"
 	"testing"
 
 	"floci-sdk-test-go/internal/testutil"
@@ -54,9 +56,13 @@ func TestLambda(t *testing.T) {
 			Payload:      payload,
 		})
 		if err != nil {
-			// In CI without Docker-in-Docker, Lambda container dispatch is unavailable.
-			// Skip instead of failing so non-Docker tests still run.
-			t.Skipf("Lambda REQUEST_RESPONSE dispatch unavailable in this environment: %v", err)
+			// Only skip on transport-level failures (timeout, connection refused).
+			// Let unexpected service errors fail the test.
+			var netErr net.Error
+			if errors.As(err, &netErr) {
+				t.Skipf("Lambda REQUEST_RESPONSE dispatch unavailable (transport error): %v", err)
+			}
+			require.NoError(t, err)
 		}
 		assert.Equal(t, int32(200), r.StatusCode)
 		assert.Nil(t, r.FunctionError)

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -47,7 +47,6 @@ import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.Runtime;
 
 import java.io.ByteArrayOutputStream;
-import java.net.ConnectException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -162,8 +161,6 @@ public final class TestFixtures {
             } catch (SdkClientException e) {
                 // SDK-level timeout or connection failure (wraps ConnectException,
                 // ApiCallTimeoutException, etc.)
-                lambdaDispatchAvailable = false;
-            } catch (ConnectException e) {
                 lambdaDispatchAvailable = false;
             } finally {
                 try {

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -47,12 +47,15 @@ import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.Runtime;
 
 import java.io.ByteArrayOutputStream;
+import java.net.ConnectException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 /**
  * Shared test utilities and AWS client factories.
@@ -125,9 +128,9 @@ public final class TestFixtures {
      * Thread-safe: uses double-checked locking so parallel test classes don't
      * race the probe.
      *
-     * Returns false on any transport-level failure (timeout, connection refused,
-     * SDK timeout) so that tests can skip cleanly when Docker-in-Docker is
-     * unavailable in CI.
+     * Returns false on transport-level failures (timeout, connection refused,
+     * SDK client timeout) so tests skip cleanly when Docker-in-Docker is
+     * unavailable in CI. Unexpected service errors propagate as test failures.
      */
     public static boolean isLambdaDispatchAvailable() {
         if (lambdaDispatchAvailable != null) {
@@ -156,7 +159,11 @@ public final class TestFixtures {
                         .overrideConfiguration(c -> c.apiCallTimeout(Duration.ofSeconds(30)))
                         .build());
                 lambdaDispatchAvailable = response.statusCode() == 200;
-            } catch (Exception e) {
+            } catch (SdkClientException e) {
+                // SDK-level timeout or connection failure (wraps ConnectException,
+                // ApiCallTimeoutException, etc.)
+                lambdaDispatchAvailable = false;
+            } catch (ConnectException e) {
                 lambdaDispatchAvailable = false;
             } finally {
                 try {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2ExecuteTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2ExecuteTest.java
@@ -172,7 +172,8 @@ class ApiGatewayV2ExecuteTest {
             JsonNode warmupBody = JSON.readTree(warmup.body());
             lambdaDispatchAvailable = warmup.statusCode() == 200
                     && warmupBody.path("statusCode").asInt() == 200;
-        } catch (Exception e) {
+        } catch (java.net.http.HttpTimeoutException | ConnectException e) {
+            // Transport-level failure: endpoint unreachable or timed out
             lambdaDispatchAvailable = false;
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #387. The broad `catch(Exception)` in the Lambda dispatch probe and APIGW warmup swallowed all errors, silently skipping tests on real service regressions (5xx, bad config, SDK bugs) instead of failing them.

- **Java probe** (`TestFixtures.isLambdaDispatchAvailable`): `catch(Exception)` → `catch(SdkClientException | ConnectException)`
- **APIGW warmup** (`ApiGatewayV2ExecuteTest`): `catch(Exception)` → `catch(HttpTimeoutException | ConnectException)`
- **Go invoke** (`lambda_test.go`): `if err != nil { skip }` → skip only on `net.Error`, otherwise fail

Only transport-level failures (timeout, connection refused) now trigger a skip. Unexpected errors propagate as test failures.

## Test plan
- [x] Codex (o3) and Gemini (2.5-pro) reviewed the narrowed catch clauses
- [ ] CI compat suite passes with Docker available (exceptions don't fire)
- [ ] CI compat suite skips cleanly without Docker (transport errors trigger skip)