### PR TITLE
fix(cloudformation): populate SQS queue ARN in resource attributes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -204,7 +204,10 @@ public class CloudFormationResourceProvisioner {
             attrs.put("VisibilityTimeout", engine.resolve(props.get("VisibilityTimeout")));
         }
         var queue = sqsService.createQueue(queueName, attrs, region);
-        String queueArn = queue.getAttributes().getOrDefault("QueueArn", "");
+        // QueueArn is computed on demand in SqsService#getQueueAttributes and is not
+        // stored on the Queue object, so build it here from region + accountId + queueName.
+        // Without this, Fn::GetAtt [Queue, Arn] references resolve to an empty string.
+        String queueArn = "arn:aws:sqs:" + region + ":" + accountId + ":" + queueName;
         r.setPhysicalId(queue.getQueueUrl());
         r.getAttributes().put("Arn", queueArn);
         r.getAttributes().put("QueueName", queueName);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1583,6 +1583,73 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_withEventBridgeRule_resolvesFnGetAttOnTargetArn() {
+        // This template uses Fn::GetAtt to reference the SQS queue's ARN as an EventBridge
+        // rule target — the pattern produced by AWS CDK when wiring an SqsQueue target.
+        // The queue ARN must be resolved during target provisioning, otherwise the rule
+        // ends up with an empty target ARN and events are never delivered.
+        String template = """
+            {
+              "Resources": {
+                "TargetQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-eb-getatt-queue"
+                  }
+                },
+                "MyRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-getatt-rule",
+                    "EventPattern": {
+                      "source": ["my.getatt.test"]
+                    },
+                    "Targets": [
+                      {
+                        "Id": "Target0",
+                        "Arn": {"Fn::GetAtt": ["TargetQueue", "Arn"]}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-getatt-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eb-getatt-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-eb-getatt-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets[0].Id", equalTo("Target0"))
+            .body("Targets[0].Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:cfn-eb-getatt-queue"));
+    }
+
+    @Test
     void createStack_withEventBridgeRuleAutoName() {
         String template = """
             {


### PR DESCRIPTION
## Summary

When provisioning `AWS::SQS::Queue` via CloudFormation, the resource's `Arn` attribute was being read from `Queue#getAttributes()`, but `QueueArn` is a computed attribute in `SqsService#getQueueAttributes()` — it is not stored on the `Queue` object itself. As a result, the `Arn` attribute was set to an empty string.

This broke `Fn::GetAtt` references to queue ARNs. For example, an EventBridge Rule target built with CDK's `SqsQueue` target construct would end up with an empty Arn, silently dropping all events:

```json
"Targets": [{
  "Arn": {"Fn::GetAtt": ["MyQueue", "Arn"]}
}]
```

## Fix

Build the ARN from `region + accountId + queueName` in `provisionSqsQueue`, matching the format used by `SqsService#getQueueAttributes`.

## Test plan

- [x] Added integration test `createStack_withEventBridgeRule_resolvesFnGetAttOnTargetArn` that verifies `Fn::GetAtt` resolves correctly when used for an EventBridge Rule target ARN
- [x] All existing EventBridge + CloudFormation tests still pass (4/4)
- [x] Verified end-to-end with a CDK stack deploying EventBridge rules with `SqsQueue` targets — events are now correctly delivered to the queue