### PR TITLE
chore: align config between YAML files and docs; add missing service sections

### DIFF
--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -29,7 +29,7 @@ See [Docker Compose — Multi-container networking](./docker-compose.md#multi-co
 
 ## Full Reference
 
-The block below mirrors `src/main/resources/application.yml`, it's the effective set of keys Floci ships with. Any key not listed here (for example `floci.init-hooks.*` or some `ecs.*` knobs) is available only as a code-level override via environment variables.
+The block below mirrors `src/main/resources/application.yml`, it's the effective set of keys Floci ships with. Some supported keys are omitted here (for example `floci.init-hooks.*`) but can still be provided via YAML or environment variables.
 
 ```yaml
 floci:
@@ -103,6 +103,9 @@ floci:
     apigateway:
       enabled: true
 
+    apigatewayv2:
+      enabled: true
+
     iam:
       enabled: true
 
@@ -172,6 +175,23 @@ floci:
     ecs:
       enabled: true
       mock: false                             # true = tasks go to RUNNING without Docker (useful for CI)
+
+    appconfig:
+      enabled: true
+
+    appconfigdata:
+      enabled: true
+
+    ecr:
+      enabled: true
+      registry-image: "registry:2"
+      registry-container-name: floci-ecr-registry
+      registry-base-port: 5100
+      registry-max-port: 5199
+      data-path: ./data/ecr
+      tls-enabled: false
+      keep-running-on-shutdown: true
+      uri-style: hostname                     # hostname | path
 ```
 
 ### Initialization hooks

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,8 @@ floci:
       container-idle-timeout-seconds: 300
     apigateway:
       enabled: true
+    apigatewayv2:
+      enabled: true
     iam:
       enabled: true
     elasticache:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,6 +29,8 @@ floci:
         flush-interval-ms: 60000
       secretsmanager:
         flush-interval-ms: 60000
+      acm:
+        flush-interval-ms: 60000
       opensearch:
         flush-interval-ms: 60000
 
@@ -60,6 +62,8 @@ floci:
       enabled: true
     apigateway:
       enabled: true
+    apigatewayv2:
+      enabled: true
     iam:
       enabled: true
     elasticache:
@@ -69,7 +73,7 @@ floci:
       default-image: "valkey/valkey:8"
     rds:
       enabled: true
-      proxy-base-port: 7000
+      proxy-base-port: 7001
       proxy-max-port: 7099
       default-postgres-image: "postgres:16-alpine"
       default-mysql-image: "mysql:8.0"
@@ -96,11 +100,17 @@ floci:
       enabled: true
     cloudformation:
       enabled: true
+    acm:
+      enabled: true
+      validation-wait-seconds: 0
     ses:
       enabled: true
     opensearch:
       enabled: true
       mode: mock
+      default-image: "opensearchproject/opensearch:2"
+      proxy-base-port: 9400
+      proxy-max-port: 9499
     ec2:
       enabled: true
     ecs:
@@ -109,5 +119,6 @@ floci:
     appconfig:
       enabled: true
     appconfigdata:
+      enabled: true
     ecr:
       enabled: true


### PR DESCRIPTION
## Summary
- Fix `rds.proxy-base-port` drift in test YAML (`7000` → `7001` to match main YAML)
- Add missing `apigatewayv2` section to main YAML, test YAML, and docs
- Add missing `acm`, `opensearch` proxy ports, `appconfigdata` value, and `acm` storage flush to test YAML
- Add `appconfig`, `appconfigdata`, and full `ecr` config to docs reference
- Clarify note about unlisted keys in docs

## Review
Pre-reviewed by Codex and Gemini. Findings:
- Codex: improved docs note wording (applied)
- Gemini: trailing newline fix (applied), flagged pre-existing RDS code default drift (out of scope, Java source)
- Both confirmed apigatewayv2/acm/opensearch/appconfig/ecr additions are consistent across files

## Changes
```
 docs/configuration/application-yml.md | +22 -1
 src/main/resources/application.yml    | +2  -0
 src/test/resources/application.yml    | +15 -2
```

### Intentional test YAML differences (not drift)
- `ecs.mock: true` (test) vs `false` (main): CI doesn't need Docker for ECS tasks
- ECR minimal config in test: unit tests don't spin up a Docker registry
- `storage.wal.compaction-interval-ms: 60000` (test) vs `30000` (main): slower compaction during tests

## Test plan
- [x] `mvn test -B` passes (1885/1886, 1 pre-existing ElastiCache failure unrelated to config)
- [x] Verified service ordering matches across all three files
- [x] Verified storage flush service ordering matches main YAML
- [x] Diff reviewed for accuracy against main YAML as source of truth