### PR TITLE
fix(elasticache,rds): prevent orphaned Docker containers on shutdown and restart

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -5,7 +5,9 @@ import io.github.hectorvent.floci.core.common.ServiceRegistry;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
+import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
+import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.ShutdownEvent;
@@ -28,18 +30,26 @@ public class EmulatorLifecycle {
     private final StorageFactory storageFactory;
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
+    private final ElastiCacheContainerManager elastiCacheContainerManager;
     private final ElastiCacheProxyManager elastiCacheProxyManager;
+    private final RdsContainerManager rdsContainerManager;
     private final RdsProxyManager rdsProxyManager;
     private final InitializationHooksRunner initializationHooksRunner;
 
     @Inject
     public EmulatorLifecycle(StorageFactory storageFactory, ServiceRegistry serviceRegistry,
-                             EmulatorConfig config, ElastiCacheProxyManager elastiCacheProxyManager,
-                             RdsProxyManager rdsProxyManager, InitializationHooksRunner initializationHooksRunner) {
+                             EmulatorConfig config,
+                             ElastiCacheContainerManager elastiCacheContainerManager,
+                             ElastiCacheProxyManager elastiCacheProxyManager,
+                             RdsContainerManager rdsContainerManager,
+                             RdsProxyManager rdsProxyManager,
+                             InitializationHooksRunner initializationHooksRunner) {
         this.storageFactory = storageFactory;
         this.serviceRegistry = serviceRegistry;
         this.config = config;
+        this.elastiCacheContainerManager = elastiCacheContainerManager;
         this.elastiCacheProxyManager = elastiCacheProxyManager;
+        this.rdsContainerManager = rdsContainerManager;
         this.rdsProxyManager = rdsProxyManager;
         this.initializationHooksRunner = initializationHooksRunner;
     }
@@ -86,6 +96,8 @@ public class EmulatorLifecycle {
         } finally {
             elastiCacheProxyManager.stopAll();
             rdsProxyManager.stopAll();
+            elastiCacheContainerManager.stopAll();
+            rdsContainerManager.stopAll();
             storageFactory.shutdownAll();
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
@@ -22,9 +22,11 @@ import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages backend Docker container lifecycle for ElastiCache replication groups.
@@ -44,6 +46,7 @@ public class ElastiCacheContainerManager {
     private final EmulatorConfig config;
     private final CloudWatchLogsService cloudWatchLogsService;
     private final RegionResolver regionResolver;
+    private final Map<String, ElastiCacheContainerHandle> activeContainers = new ConcurrentHashMap<>();
 
     @Inject
     public ElastiCacheContainerManager(DockerClient dockerClient,
@@ -75,6 +78,14 @@ public class ElastiCacheContainerManager {
                         LOG.debugv("Attaching ElastiCache container to network: {0}", network);
                     }
                 });
+
+        // Remove any stale container with the same name (from a previous interrupted run)
+        try {
+            dockerClient.removeContainerCmd(containerName).withForce(true).exec();
+            LOG.infov("Removed stale container {0} before creating new one", containerName);
+        } catch (com.github.dockerjava.api.exception.NotFoundException ignored) {
+            // No existing container — normal path
+        }
 
         CreateContainerResponse container = dockerClient.createContainerCmd(image)
                 .withName(containerName)
@@ -128,6 +139,7 @@ public class ElastiCacheContainerManager {
 
         ElastiCacheContainerHandle handle = new ElastiCacheContainerHandle(
                 containerId, groupId, backendHost, backendPort);
+        activeContainers.put(groupId, handle);
 
         String shortId = containerId.length() >= 8 ? containerId.substring(0, 8) : containerId;
         attachLogStream(handle, groupId, containerId, shortId);
@@ -139,6 +151,7 @@ public class ElastiCacheContainerManager {
         if (handle == null) {
             return;
         }
+        activeContainers.remove(handle.getGroupId());
         LOG.infov("Stopping ElastiCache container {0}", handle.getContainerId());
 
         if (handle.getLogStream() != null) {
@@ -157,6 +170,16 @@ public class ElastiCacheContainerManager {
         } catch (Exception e) {
             LOG.warnv("Error removing ElastiCache container {0}: {1}",
                     handle.getContainerId(), e.getMessage());
+        }
+    }
+
+    public void stopAll() {
+        List<ElastiCacheContainerHandle> handles = new ArrayList<>(activeContainers.values());
+        if (!handles.isEmpty()) {
+            LOG.infov("Stopping {0} ElastiCache container(s) on shutdown", handles.size());
+        }
+        for (ElastiCacheContainerHandle handle : handles) {
+            stop(handle);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -23,9 +23,11 @@ import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages backend Docker container lifecycle for RDS DB instances and clusters.
@@ -43,6 +45,7 @@ public class RdsContainerManager {
     private final EmulatorConfig config;
     private final CloudWatchLogsService cloudWatchLogsService;
     private final RegionResolver regionResolver;
+    private final Map<String, RdsContainerHandle> activeContainers = new ConcurrentHashMap<>();
 
     @Inject
     public RdsContainerManager(DockerClient dockerClient,
@@ -78,6 +81,14 @@ public class RdsContainerManager {
                         LOG.debugv("Attaching RDS container to network: {0}", network);
                     }
                 });
+
+        // Remove any stale container with the same name (from a previous interrupted run)
+        try {
+            dockerClient.removeContainerCmd(containerName).withForce(true).exec();
+            LOG.infov("Removed stale container {0} before creating new one", containerName);
+        } catch (com.github.dockerjava.api.exception.NotFoundException ignored) {
+            // No existing container — normal path
+        }
 
         List<String> envVars = buildEnvVars(engine, masterUsername, masterPassword, dbName);
         List<String> cmd = buildContainerCmd(engine);
@@ -135,6 +146,7 @@ public class RdsContainerManager {
         LOG.infov("RDS backend for instance {0}: {1}:{2}", instanceId, backendHost, backendPort);
 
         RdsContainerHandle handle = new RdsContainerHandle(containerId, instanceId, backendHost, backendPort);
+        activeContainers.put(instanceId, handle);
         String shortId = containerId.length() >= 8 ? containerId.substring(0, 8) : containerId;
         attachLogStream(handle, instanceId, containerId, shortId);
         return handle;
@@ -144,6 +156,7 @@ public class RdsContainerManager {
         if (handle == null) {
             return;
         }
+        activeContainers.remove(handle.getInstanceId());
         LOG.infov("Stopping RDS container {0}", handle.getContainerId());
 
         if (handle.getLogStream() != null) {
@@ -160,6 +173,16 @@ public class RdsContainerManager {
             dockerClient.removeContainerCmd(handle.getContainerId()).withForce(true).exec();
         } catch (Exception e) {
             LOG.warnv("Error removing RDS container {0}: {1}", handle.getContainerId(), e.getMessage());
+        }
+    }
+
+    public void stopAll() {
+        List<RdsContainerHandle> handles = new ArrayList<>(activeContainers.values());
+        if (!handles.isEmpty()) {
+            LOG.infov("Stopping {0} RDS container(s) on shutdown", handles.size());
+        }
+        for (RdsContainerHandle handle : handles) {
+            stop(handle);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -5,7 +5,9 @@ import io.github.hectorvent.floci.core.common.ServiceRegistry;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
+import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
+import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.quarkus.runtime.StartupEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +31,9 @@ class EmulatorLifecycleTest {
     @Mock private ServiceRegistry serviceRegistry;
     @Mock private EmulatorConfig config;
     @Mock private EmulatorConfig.StorageConfig storageConfig;
+    @Mock private ElastiCacheContainerManager elastiCacheContainerManager;
     @Mock private ElastiCacheProxyManager elastiCacheProxyManager;
+    @Mock private RdsContainerManager rdsContainerManager;
     @Mock private RdsProxyManager rdsProxyManager;
     @Mock private InitializationHooksRunner initializationHooksRunner;
 
@@ -42,7 +46,8 @@ class EmulatorLifecycleTest {
         when(storageConfig.persistentPath()).thenReturn("/app/data");
         emulatorLifecycle = new EmulatorLifecycle(
                 storageFactory, serviceRegistry, config,
-                elastiCacheProxyManager, rdsProxyManager, initializationHooksRunner);
+                elastiCacheContainerManager, elastiCacheProxyManager,
+                rdsContainerManager, rdsProxyManager, initializationHooksRunner);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elasticache;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.IOException;
+import java.util.List;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
@@ -41,6 +43,28 @@ class ElastiCacheIntegrationTest {
     @BeforeAll
     static void requireDocker() {
         Assumptions.assumeTrue(isDockerAvailable(), "Docker daemon must be available for ElastiCache integration tests");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        // Best-effort cleanup of any resources created during tests.
+        // Prevents orphaned containers/state if a test fails mid-way.
+        for (String groupId : List.of(CROSS_GROUP_ID, GROUP_ID, GROUP_ID + "-reused")) {
+            try {
+                given()
+                    .formParam("Action", "DeleteReplicationGroup")
+                    .formParam("ReplicationGroupId", groupId)
+                    .header("Authorization", AUTH_HEADER)
+                    .post("/");
+            } catch (Exception ignored) {}
+        }
+        try {
+            given()
+                .formParam("Action", "DeleteUser")
+                .formParam("UserId", USER_ID)
+                .header("Authorization", AUTH_HEADER)
+                .post("/");
+        } catch (Exception ignored) {}
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Force-remove stale containers by name before creating new ones in both `ElastiCacheContainerManager` and `RdsContainerManager`, preventing 409 Conflict errors after interrupted runs
- Track active containers in `ConcurrentHashMap` with `stopAll()` so `EmulatorLifecycle.onStop()` cleans up Docker containers on shutdown (not just TCP proxies)
- Correct shutdown ordering: proxies stop first (drain connections), then containers, matching the service-level delete path
- Add `@AfterAll` safety net to `ElastiCacheIntegrationTest` to prevent orphaned containers when tests fail mid-way

## Context
Deterministic container naming (`floci-valkey-{groupId}`, `floci-rds-{instanceId}`) without conflict handling meant that after an interrupted test run or unclean shutdown, restarting floci or re-running tests would fail with Docker 409 Conflict. CI was unaffected (ephemeral runners), but local development hit this reliably.

## Review
Pre-commit review by Codex (agentic) and Gemini (agentic). Both flagged shutdown ordering (containers before proxies) and thread safety in `stop()`. Shutdown order corrected. Thread safety addressed: `ConcurrentHashMap.remove(key)` is sufficient since Docker stop/remove operations are idempotent with exception handling, and `remove(key, value)` would break with reconstructed handles (service layer creates new handle objects without `equals()` override).

## Changes
- `EmulatorLifecycle.java` (inject container managers, call `stopAll()` on shutdown
- `ElastiCacheContainerManager.java`) defensive stale removal, active container tracking, `stopAll()`
- `RdsContainerManager.java` (same pattern as ElastiCache
- `EmulatorLifecycleTest.java`) updated constructor call for new dependencies
- `ElastiCacheIntegrationTest.java`, `@AfterAll` cleanup for groups and users

## Test plan
- [x] `EmulatorLifecycleTest` passes (unit, Mockito)
- [x] Full `test-compile` clean (no compilation errors)
- [ ] `ElastiCacheIntegrationTest` full run (requires Docker)