### PR TITLE
feat(iam): seed AWS managed policies at startup

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.iam;
+
+import java.util.List;
+
+/**
+ * Catalog of commonly-used AWS managed policies seeded at startup.
+ * Policy documents use a permissive wildcard because floci does not
+ * enforce IAM policy evaluation.
+ */
+final class AwsManagedPolicies {
+
+    static final String ARN_PREFIX = "arn:aws:iam::aws:policy";
+
+    static final String PERMISSIVE_DOCUMENT =
+            "{\"Version\":\"2012-10-17\",\"Statement\":"
+            + "[{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}]}";
+
+    record ManagedPolicyDef(String name, String path, String description) {
+        String arn() {
+            return ARN_PREFIX + path + name;
+        }
+    }
+
+    static final List<ManagedPolicyDef> POLICIES = List.of(
+        new ManagedPolicyDef("AdministratorAccess", "/",
+                "Provides full access to AWS services and resources."),
+        new ManagedPolicyDef("PowerUserAccess", "/",
+                "Provides full access to AWS services and resources, but does not allow management of Users and groups."),
+        new ManagedPolicyDef("ReadOnlyAccess", "/",
+                "Provides read-only access to AWS services and resources."),
+        new ManagedPolicyDef("IAMFullAccess", "/",
+                "Provides full access to IAM."),
+        new ManagedPolicyDef("AmazonS3FullAccess", "/",
+                "Provides full access to all buckets via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonS3ReadOnlyAccess", "/",
+                "Provides read-only access to all buckets via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonDynamoDBFullAccess", "/",
+                "Provides full access to Amazon DynamoDB via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonEC2FullAccess", "/",
+                "Provides full access to Amazon EC2 via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonSQSFullAccess", "/",
+                "Provides full access to Amazon SQS via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonSNSFullAccess", "/",
+                "Provides full access to Amazon SNS via the AWS Management Console."),
+        new ManagedPolicyDef("AmazonVPCFullAccess", "/",
+                "Provides full access to Amazon VPC via the AWS Management Console."),
+        new ManagedPolicyDef("CloudWatchFullAccess", "/",
+                "Provides full access to CloudWatch."),
+        new ManagedPolicyDef("AWSLambdaBasicExecutionRole", "/service-role/",
+                "Provides write permissions to CloudWatch Logs."),
+        new ManagedPolicyDef("AWSLambdaFullAccess", "/",
+                "Provides full access to Lambda, S3, DynamoDB, CloudWatch Metrics and Logs.")
+    );
+
+    private AwsManagedPolicies() {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -345,7 +345,15 @@ public class IamService {
                         "Policy " + policyArn + " does not exist.", 404));
     }
 
+    private void rejectIfAwsManaged(String policyArn) {
+        if (policyArn != null && policyArn.startsWith(AwsManagedPolicies.ARN_PREFIX)) {
+            throw new AwsException("AccessDenied",
+                    "Cannot modify or delete AWS managed policy: " + policyArn, 403);
+        }
+    }
+
     public void deletePolicy(String policyArn) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         if (policy.getAttachmentCount() > 0) {
             throw new AwsException("DeleteConflict",
@@ -356,6 +364,14 @@ public class IamService {
     }
 
     public List<IamPolicy> listPolicies(String scope, String pathPrefix) {
+        if (scope != null && !scope.isBlank()
+                && !"All".equalsIgnoreCase(scope)
+                && !"AWS".equalsIgnoreCase(scope)
+                && !"Local".equalsIgnoreCase(scope)) {
+            throw new AwsException("ValidationError",
+                    "Value '" + scope + "' at 'scope' failed to satisfy constraint: "
+                            + "Member must satisfy enum value set: [All, AWS, Local]", 400);
+        }
         String prefix = pathPrefix != null ? pathPrefix : "/";
         return policies.scan(k -> true).stream()
                 .filter(p -> p.getPath().startsWith(prefix))
@@ -371,6 +387,7 @@ public class IamService {
     }
 
     public PolicyVersion createPolicyVersion(String policyArn, String document, boolean setAsDefault) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         int nextVersionNum = policy.getVersions().size() + 1;
         if (nextVersionNum > 5) {
@@ -400,6 +417,7 @@ public class IamService {
     }
 
     public void deletePolicyVersion(String policyArn, String versionId) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         if (versionId.equals(policy.getDefaultVersionId())) {
             throw new AwsException("DeleteConflict",
@@ -418,6 +436,7 @@ public class IamService {
     }
 
     public void setDefaultPolicyVersion(String policyArn, String versionId) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         if (!policy.getVersions().containsKey(versionId)) {
             throw new AwsException("NoSuchEntity",
@@ -430,12 +449,14 @@ public class IamService {
     }
 
     public void tagPolicy(String policyArn, Map<String, String> newTags) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         policy.getTags().putAll(newTags);
         policies.put(policyArn, policy);
     }
 
     public void untagPolicy(String policyArn, List<String> tagKeys) {
+        rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);
         tagKeys.forEach(policy.getTags()::remove);
         policies.put(policyArn, policy);

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.iam.model.IamUser;
 import io.github.hectorvent.floci.services.iam.model.InstanceProfile;
 import io.github.hectorvent.floci.services.iam.model.PolicyVersion;
 import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -67,6 +68,25 @@ public class IamService {
         this.accessKeys = accessKeys;
         this.instanceProfiles = instanceProfiles;
         this.accountId = accountId;
+    }
+
+    @PostConstruct
+    void seedAwsManagedPolicies() {
+        int seeded = 0;
+        for (AwsManagedPolicies.ManagedPolicyDef def : AwsManagedPolicies.POLICIES) {
+            String arn = def.arn();
+            if (policies.get(arn).isPresent()) {
+                continue;
+            }
+            String policyId = "ANPA" + randomId(16);
+            IamPolicy policy = new IamPolicy(policyId, def.name(), def.path(), arn,
+                    def.description(), AwsManagedPolicies.PERMISSIVE_DOCUMENT);
+            policies.put(arn, policy);
+            seeded++;
+        }
+        if (seeded > 0) {
+            LOG.infov("Seeded {0} AWS managed policies", seeded);
+        }
     }
 
     // =========================================================================
@@ -339,6 +359,14 @@ public class IamService {
         String prefix = pathPrefix != null ? pathPrefix : "/";
         return policies.scan(k -> true).stream()
                 .filter(p -> p.getPath().startsWith(prefix))
+                .filter(p -> {
+                    if ("AWS".equalsIgnoreCase(scope)) {
+                        return p.getArn().startsWith(AwsManagedPolicies.ARN_PREFIX);
+                    } else if ("Local".equalsIgnoreCase(scope)) {
+                        return !p.getArn().startsWith(AwsManagedPolicies.ARN_PREFIX);
+                    }
+                    return true;
+                })
                 .toList();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -74,6 +74,55 @@ class IamIntegrationTest {
     }
 
     // =========================================================================
+    // AWS Managed Policies (seeded at startup)
+    // =========================================================================
+
+    @Test
+    @Order(5)
+    void getManagedPolicy() {
+        given()
+            .formParam("Action", "GetPolicy")
+            .formParam("PolicyArn", "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName",
+                    equalTo("AWSLambdaBasicExecutionRole"))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Arn",
+                    equalTo("arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"));
+    }
+
+    @Test
+    @Order(35)
+    void attachManagedPolicyToRole() {
+        given()
+            .formParam("Action", "CreateRole")
+            .formParam("RoleName", "ManagedPolicyTestRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "AttachRolePolicy")
+            .formParam("RoleName", "ManagedPolicyTestRole")
+            .formParam("PolicyArn", "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    // =========================================================================
     // Users
     // =========================================================================
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -491,6 +491,42 @@ class IamServiceTest {
     }
 
     @Test
+    void awsManagedPolicyDeleteRejected() {
+        iamService.seedAwsManagedPolicies();
+        String arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+        AwsException ex = assertThrows(AwsException.class, () -> iamService.deletePolicy(arn));
+        assertEquals("AccessDenied", ex.getErrorCode());
+    }
+
+    @Test
+    void awsManagedPolicyCreateVersionRejected() {
+        iamService.seedAwsManagedPolicies();
+        String arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+        assertThrows(AwsException.class, () -> iamService.createPolicyVersion(arn, "{}", false));
+    }
+
+    @Test
+    void awsManagedPolicyTagRejected() {
+        iamService.seedAwsManagedPolicies();
+        String arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+        assertThrows(AwsException.class, () -> iamService.tagPolicy(arn, Map.of("k", "v")));
+    }
+
+    @Test
+    void awsManagedPolicyUntagRejected() {
+        iamService.seedAwsManagedPolicies();
+        String arn = "arn:aws:iam::aws:policy/AdministratorAccess";
+        assertThrows(AwsException.class, () -> iamService.untagPolicy(arn, List.of("k")));
+    }
+
+    @Test
+    void listPoliciesInvalidScopeRejected() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> iamService.listPolicies("Invalid", "/"));
+        assertEquals("ValidationError", ex.getErrorCode());
+    }
+
+    @Test
     void listPoliciesScopeFiltering() {
         iamService.seedAwsManagedPolicies();
         iamService.createPolicy("MyCustomPolicy", "/", null, "{}", null);

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -445,4 +445,65 @@ class IamServiceTest {
         assertEquals(1, profiles.size());
         assertEquals("P1", profiles.getFirst().getInstanceProfileName());
     }
+
+    // =========================================================================
+    // AWS Managed Policy Seeding
+    // =========================================================================
+
+    @Test
+    void seedAwsManagedPolicies() {
+        iamService.seedAwsManagedPolicies();
+
+        IamPolicy admin = iamService.getPolicy("arn:aws:iam::aws:policy/AdministratorAccess");
+        assertEquals("AdministratorAccess", admin.getPolicyName());
+        assertEquals("/", admin.getPath());
+        assertTrue(admin.getPolicyId().startsWith("ANPA"));
+        assertEquals("v1", admin.getDefaultVersionId());
+
+        IamPolicy lambda = iamService.getPolicy(
+                "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
+        assertEquals("AWSLambdaBasicExecutionRole", lambda.getPolicyName());
+        assertEquals("/service-role/", lambda.getPath());
+    }
+
+    @Test
+    void seedIsIdempotent() {
+        iamService.seedAwsManagedPolicies();
+        String firstId = iamService.getPolicy("arn:aws:iam::aws:policy/AdministratorAccess").getPolicyId();
+
+        iamService.seedAwsManagedPolicies();
+        String secondId = iamService.getPolicy("arn:aws:iam::aws:policy/AdministratorAccess").getPolicyId();
+
+        assertEquals(firstId, secondId);
+    }
+
+    @Test
+    void attachManagedPolicyToRole() {
+        iamService.seedAwsManagedPolicies();
+        iamService.createRole("LambdaExec", "/", "{}", null, 0, null);
+
+        String policyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole";
+        iamService.attachRolePolicy("LambdaExec", policyArn);
+
+        List<IamPolicy> attached = iamService.listAttachedRolePolicies("LambdaExec", null);
+        assertEquals(1, attached.size());
+        assertEquals(policyArn, attached.getFirst().getArn());
+    }
+
+    @Test
+    void listPoliciesScopeFiltering() {
+        iamService.seedAwsManagedPolicies();
+        iamService.createPolicy("MyCustomPolicy", "/", null, "{}", null);
+
+        List<IamPolicy> awsOnly = iamService.listPolicies("AWS", "/");
+        assertTrue(awsOnly.stream().allMatch(p -> p.getArn().startsWith("arn:aws:iam::aws:policy")));
+        assertFalse(awsOnly.isEmpty());
+
+        List<IamPolicy> localOnly = iamService.listPolicies("Local", "/");
+        assertTrue(localOnly.stream().noneMatch(p -> p.getArn().startsWith("arn:aws:iam::aws:policy")));
+        assertEquals(1, localOnly.size());
+
+        List<IamPolicy> all = iamService.listPolicies(null, "/");
+        assertEquals(awsOnly.size() + localOnly.size(), all.size());
+    }
 }


### PR DESCRIPTION
## Summary

- Seed 14 commonly-used AWS managed policies (e.g. `AWSLambdaBasicExecutionRole`, `AdministratorAccess`) into the IAM policy store at startup via `@PostConstruct`
- Enables documented examples like `attach-role-policy --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole` to work out of the box
- Adds `Scope` filter support (`AWS`/`Local`/`All`) to `ListPolicies` API

## Details

### Seeding mechanism
- New `AwsManagedPolicies` class provides a static catalog of 14 policies with ARN prefix `arn:aws:iam::aws:policy`
- `IamService.seedAwsManagedPolicies()` runs on `@PostConstruct`, idempotent (skips if already present in persistent storage)
- Policy documents use a permissive wildcard since floci does not enforce IAM policy evaluation

### Seeded policies

`AdministratorAccess`, `PowerUserAccess`, `ReadOnlyAccess`, `IAMFullAccess`, `AmazonS3FullAccess`, `AmazonS3ReadOnlyAccess`, `AmazonDynamoDBFullAccess`, `AmazonEC2FullAccess`, `AmazonSQSFullAccess`, `AmazonSNSFullAccess`, `AmazonVPCFullAccess`, `CloudWatchFullAccess`, `AWSLambdaBasicExecutionRole`, `AWSLambdaFullAccess`

Closes #329