### PR TITLE
fix(s3): remove XML declaration from GetBucketLocation response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1147,17 +1147,17 @@ public class S3Controller {
 
     private Response handleGetBucketLocation(String bucket) {
         String region = s3Service.getBucketRegion(bucket);
-        XmlBuilder xml = new XmlBuilder()
-                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        String xml;
         if (region == null || "us-east-1".equals(region)) {
-            xml.start("LocationConstraint", AwsNamespaces.S3)
-                    .end("LocationConstraint");
+            xml = "<LocationConstraint xmlns=\"" + AwsNamespaces.S3 + "\"/>";
         } else {
-            xml.start("LocationConstraint", AwsNamespaces.S3)
+            xml = new XmlBuilder()
+                    .start("LocationConstraint", AwsNamespaces.S3)
                     .raw(XmlBuilder.escape(region))
-                    .end("LocationConstraint");
+                    .end("LocationConstraint")
+                    .build();
         }
-        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
+        return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
 
     // --- Bucket Tagging ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1289,6 +1289,7 @@ class S3IntegrationTest {
             .get("/" + bucket + "?location")
         .then()
             .statusCode(200)
+            .body(not(containsString("<?xml")))
             .body(containsString("<LocationConstraint"))
             .body(not(containsString("us-east-1")));
 
@@ -1318,6 +1319,7 @@ class S3IntegrationTest {
             .get("/" + bucket + "?location")
         .then()
             .statusCode(200)
+            .body(not(containsString("<?xml")))
             .body(containsString("eu-central-1"));
 
         given().when().delete("/" + bucket);


### PR DESCRIPTION
## Summary

The `GetBucketLocation` response includes a `<?xml version="1.0" encoding="UTF-8"?>` declaration that AWS does not return. AWS SDK v2 uses a regex `>(.+)<\/Location` to parse this response, and the `?>` in the XML declaration provides a `>` that the greedy `.+` matches from, causing the SDK to capture garbage instead of the actual region value. This breaks tools like Serverless Framework that rely on SDK v2's parsed `LocationConstraint` for bucket region validation.

Also uses a self-closing `<LocationConstraint ... />` element for us-east-1 buckets to exactly match the AWS wire format.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Response included `<?xml version="1.0" encoding="UTF-8"?>` prefix which AWS does not return for this API. This caused AWS SDK v2's regex-based parser to produce incorrect `LocationConstraint` values.

**Correct behavior (AWS):** Response body is just the `<LocationConstraint>` element with no XML declaration. For us-east-1, a self-closing `<LocationConstraint xmlns="..."/>`. For other regions, `<LocationConstraint xmlns="...">region</LocationConstraint>`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)