### PR TITLE
fix(lambda): resolve handler paths with subdirectories in deployment package

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -647,11 +647,18 @@ public class LambdaService {
             fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());
             fn.setCodeSizeBytes(zipBytes.length);
 
-            // For non-Java runtimes, verify handler file exists
-            if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java")) {
+            // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
+            if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {
                 String handlerFile = fn.getHandler().split("\\.")[0];
                 boolean found = Files.walk(codePath)
-                        .anyMatch(p -> p.getFileName().toString().startsWith(handlerFile));
+                        .filter(Files::isRegularFile)
+                        .anyMatch(p -> {
+                            String relative = codePath.relativize(p).toString();
+                            String withoutExt = relative.contains(".")
+                                    ? relative.substring(0, relative.lastIndexOf('.'))
+                                    : relative;
+                            return withoutExt.equals(handlerFile);
+                        });
                 if (!found) {
                     throw new AwsException("InvalidParameterValueException",
                             "Handler file '" + handlerFile + "' not found in deployment package", 400);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -9,9 +9,13 @@ import io.github.hectorvent.floci.services.lambda.zip.ZipExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -157,6 +161,70 @@ class LambdaServiceTest {
         AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
         assertEquals("InvalidParameterValueException", ex.getErrorCode());
         assertTrue(ex.getMessage().contains("Handler"));
+    }
+
+    private static String createZipBase64(String... entryPaths) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (String path : entryPaths) {
+                zos.putNextEntry(new ZipEntry(path));
+                zos.write("exports.handler = async () => ({});\n".getBytes());
+                zos.closeEntry();
+            }
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    @Test
+    void createFunctionWithSubdirectoryHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "subdir-handler-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "src/index.handler",
+                "Code", Map.of("ZipFile", createZipBase64("src/index.js"))
+        ));
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("src/index.handler", fn.getHandler());
+    }
+
+    @Test
+    void createFunctionWithRootHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "root-handler-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "index.handler",
+                "Code", Map.of("ZipFile", createZipBase64("index.js"))
+        ));
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("index.handler", fn.getHandler());
+    }
+
+    @Test
+    void createFunctionWithMissingHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "missing-handler-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "src/index.handler",
+                "Code", Map.of("ZipFile", createZipBase64("other.js"))
+        ));
+        AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
+        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+    }
+
+    @Test
+    void createDotnetFunctionWithAssemblyHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "dotnet-fn",
+                "Runtime", "dotnet6",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "blank-net-lambda::blank_net_lambda.Function::FunctionHandler",
+                "Code", Map.of("ZipFile", createZipBase64("blank-net-lambda.dll"))
+        ));
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("blank-net-lambda::blank_net_lambda.Function::FunctionHandler", fn.getHandler());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Lambda handler validation fails when the handler path includes a subdirectory (e.g., `src/index.handler`). The existing code uses `Path.getFileName()` which strips the directory, then compares the bare filename against the full handler path including the directory prefix. For example, `"index.js".startsWith("src/index")` is always false.

Fixed by comparing the relative path from the code root instead of just the filename, and matching against the path without extension.

Additionally, .NET runtimes are now excluded from file-based handler validation. .NET handlers use the `Assembly::Namespace.Class::Method` format (e.g., `blank-net-lambda::blank_net_lambda.Function::FunctionHandler`), which is incompatible with the file-based validation logic. The .NET runtime resolves the assembly, class, and method at invocation time, not deployment time. This matches real AWS behavior.

Closes #407

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior (subdirectory handlers):** `CreateFunction` with handler `src/index.handler` and a deployment package containing `src/index.js` throws `InvalidParameterValueException: Handler file 'src/index' not found in deployment package`.

**Incorrect behavior (.NET handlers):** `CreateFunction` with handler `blank-net-lambda::blank_net_lambda.Function::FunctionHandler` and runtime `dotnet6` throws `InvalidParameterValueException: Handler file 'blank-net-lambda::blank_net_lambda' not found in deployment package`.

**Correct behavior:** Subdirectory handler paths are resolved correctly against the extracted deployment package. .NET runtimes skip file-based handler validation entirely.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)