### PR TITLE
feat(s3): preserve Content-Disposition on object responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -397,11 +397,13 @@ public class S3Controller {
             byte[] data = decodeAwsChunked(body, contentEncoding, contentSha256);
             validateChecksumHeaders(httpHeaders, data);
             String persistedEncoding = toPersistedContentEncoding(contentEncoding);
+            String contentDisposition = httpHeaders.getHeaderString("Content-Disposition");
             String cacheControl = httpHeaders.getHeaderString("Cache-Control");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     httpHeaders.getHeaderString("x-amz-storage-class"),
                     persistedEncoding,
                     lockMode, retainUntil, legalHold,
+                    contentDisposition,
                     cacheControl);
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
@@ -1303,6 +1305,9 @@ public class S3Controller {
         if (obj.getContentEncoding() != null) {
             resp.header("Content-Encoding", obj.getContentEncoding());
         }
+        if (obj.getContentDisposition() != null) {
+            resp.header("Content-Disposition", obj.getContentDisposition());
+        }
         if (obj.getCacheControl() != null) {
             resp.header("Cache-Control", obj.getCacheControl());
         }
@@ -1350,6 +1355,7 @@ public class S3Controller {
         String sourceKey = decodedSource.substring(slashIndex + 1);
 
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
+        String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
         S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
                 httpHeaders.getHeaderString("x-amz-metadata-directive"),
@@ -1357,6 +1363,7 @@ public class S3Controller {
                 httpHeaders.getHeaderString("x-amz-storage-class"),
                 contentType,
                 copyContentEncoding,
+                copyContentDisposition,
                 copyCacheControl);
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -729,7 +729,9 @@ public class S3Controller {
 
             if (hasQueryParam(uriInfo, "uploads")) {
                 MultipartUpload upload = s3Service.initiateMultipartUpload(bucket, key, contentType,
-                        extractUserMetadata(httpHeaders), httpHeaders.getHeaderString("x-amz-storage-class"));
+                        extractUserMetadata(httpHeaders),
+                        httpHeaders.getHeaderString("x-amz-storage-class"),
+                        httpHeaders.getHeaderString("Content-Disposition"));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("InitiateMultipartUploadResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -913,17 +913,24 @@ public class S3Service {
     // --- Multipart Upload Operations ---
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType) {
-        return initiateMultipartUpload(bucket, key, contentType, null, null);
+        return initiateMultipartUpload(bucket, key, contentType, null, null, null);
     }
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass) {
+        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, null);
+    }
+
+    public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
+                                                   Map<String, String> metadata, String storageClass,
+                                                   String contentDisposition) {
         ensureBucketExists(bucket);
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
         if (metadata != null) {
             upload.getMetadata().putAll(metadata);
         }
         upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
+        upload.setContentDisposition(contentDisposition);
 
         if (inMemory) {
             memoryMultipartStore.put(upload.getUploadId(), new ConcurrentHashMap<>());
@@ -1029,7 +1036,8 @@ public class S3Service {
                     .toList();
             S3Checksum checksum = buildChecksum(allData, completedParts, true);
             S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
-                    upload.getStorageClass(), checksum, completedParts, null, null, null);
+                    upload.getStorageClass(), checksum, completedParts, null, null, null,
+                    null, upload.getContentDisposition(), null);
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -184,30 +184,30 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, storageClass, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String contentEncoding,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                              String cacheControl) {
+                              String contentDisposition, String cacheControl) {
         S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, cacheControl);
+                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
     }
@@ -218,7 +218,7 @@ public class S3Service {
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
         return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
-                null, null, null, null, null);
+                null, null, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
@@ -226,14 +226,14 @@ public class S3Service {
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return storeObject(bucketName, key, data, contentType, metadata, storageClass, checksum, parts,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata, String storageClass,
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                                 String contentEncoding, String cacheControl) {
+                                 String contentEncoding, String contentDisposition, String cacheControl) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
@@ -246,6 +246,7 @@ public class S3Service {
         object.setChecksum(checksum != null ? copyChecksum(checksum) : buildChecksum(data, parts, false));
         object.setParts(copyParts(parts));
         object.setContentEncoding(contentEncoding);
+        object.setContentDisposition(contentDisposition);
         object.setCacheControl(cacheControl);
 
         if (bucket.isVersioningEnabled()) {
@@ -599,14 +600,14 @@ public class S3Service {
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType) {
         return copyObject(sourceBucket, sourceKey, destBucket, destKey, metadataDirective,
-                replacementMetadata, storageClass, contentType, null, null);
+                replacementMetadata, storageClass, contentType, null, null, null);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey,
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType, String contentEncoding,
-                               String cacheControl) {
+                               String contentDisposition, String cacheControl) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
 
@@ -619,10 +620,11 @@ public class S3Service {
         String effectiveContentType = replaceMetadata && contentType != null ? contentType : source.getContentType();
         String effectiveStorageClass = storageClass != null ? storageClass : source.getStorageClass();
         String effectiveContentEncoding = replaceMetadata && contentEncoding != null ? contentEncoding : source.getContentEncoding();
+        String effectiveContentDisposition = replaceMetadata && contentDisposition != null ? contentDisposition : source.getContentDisposition();
         String effectiveCacheControl = replaceMetadata && cacheControl != null ? cacheControl : source.getCacheControl();
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
                 effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null,
-                effectiveContentEncoding, effectiveCacheControl);
+                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl);
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
@@ -1573,6 +1575,7 @@ public class S3Service {
         copy.setMetadata(new HashMap<>(source.getMetadata()));
         copy.setContentType(source.getContentType());
         copy.setContentEncoding(source.getContentEncoding());
+        copy.setContentDisposition(source.getContentDisposition());
         copy.setCacheControl(source.getCacheControl());
         copy.setSize(source.getSize());
         copy.setLastModified(source.getLastModified());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -16,6 +16,7 @@ public class MultipartUpload {
     private String key;
     private String contentType;
     private String storageClass;
+    private String contentDisposition;
     private Map<String, String> metadata;
     private Instant initiated;
     private final Map<Integer, Part> parts = new ConcurrentHashMap<>();
@@ -49,6 +50,9 @@ public class MultipartUpload {
 
     public String getStorageClass() { return storageClass; }
     public void setStorageClass(String storageClass) { this.storageClass = storageClass; }
+
+    public String getContentDisposition() { return contentDisposition; }
+    public void setContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; }
 
     public Map<String, String> getMetadata() { return metadata; }
     public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -22,6 +22,7 @@ public class S3Object {
     private Map<String, String> metadata;
     private String contentType;
     private String contentEncoding;
+    private String contentDisposition;
     private String cacheControl;
     private long size;
     private Instant lastModified;
@@ -81,6 +82,9 @@ public class S3Object {
 
     public String getContentEncoding() { return contentEncoding; }
     public void setContentEncoding(String contentEncoding) { this.contentEncoding = contentEncoding; }
+
+    public String getContentDisposition() { return contentDisposition; }
+    public void setContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; }
 
     public String getCacheControl() { return cacheControl; }
     public void setCacheControl(String cacheControl) { this.cacheControl = cacheControl; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -993,7 +993,7 @@ class S3IntegrationTest {
     // --- Content-Disposition header preservation ---
 
     @Test
-    @Order(93)
+    @Order(130)
     void createContentDispositionBucketAndPutObject() {
         String disposition = "attachment; filename=\"download.txt\"";
 
@@ -1014,7 +1014,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(94)
+    @Order(131)
     void getObjectReturnsContentDisposition() {
         given()
         .when()
@@ -1025,7 +1025,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(95)
+    @Order(132)
     void headObjectReturnsContentDisposition() {
         given()
         .when()
@@ -1036,7 +1036,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(96)
+    @Order(133)
     void copyObjectPreservesContentDisposition() {
         given()
             .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
@@ -1055,7 +1055,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(97)
+    @Order(134)
     void copyObjectReplaceContentDisposition() {
         given()
             .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
@@ -1076,7 +1076,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(98)
+    @Order(135)
     void cleanupContentDispositionBucket() {
         given().delete("/content-disposition-bucket/disposition.txt");
         given().delete("/content-disposition-bucket/disposition-copy.txt");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1025,7 +1025,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(94)
+    @Order(95)
     void headObjectReturnsContentDisposition() {
         given()
         .when()
@@ -1036,7 +1036,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(95)
+    @Order(96)
     void copyObjectPreservesContentDisposition() {
         given()
             .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
@@ -1055,7 +1055,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(95)
+    @Order(97)
     void copyObjectReplaceContentDisposition() {
         given()
             .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
@@ -1076,7 +1076,7 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(96)
+    @Order(98)
     void cleanupContentDispositionBucket() {
         given().delete("/content-disposition-bucket/disposition.txt");
         given().delete("/content-disposition-bucket/disposition-copy.txt");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -990,6 +990,100 @@ class S3IntegrationTest {
         given().delete("/cache-control-bucket");
     }
 
+    // --- Content-Disposition header preservation ---
+
+    @Test
+    @Order(93)
+    void createContentDispositionBucketAndPutObject() {
+        String disposition = "attachment; filename=\"download.txt\"";
+
+        given()
+            .put("/content-disposition-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("text/plain")
+            .header("Content-Disposition", disposition)
+            .body("disposition-content")
+        .when()
+            .put("/content-disposition-bucket/disposition.txt")
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue());
+    }
+
+    @Test
+    @Order(94)
+    void getObjectReturnsContentDisposition() {
+        given()
+        .when()
+            .get("/content-disposition-bucket/disposition.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"download.txt\""));
+    }
+
+    @Test
+    @Order(94)
+    void headObjectReturnsContentDisposition() {
+        given()
+        .when()
+            .head("/content-disposition-bucket/disposition.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"download.txt\""));
+    }
+
+    @Test
+    @Order(95)
+    void copyObjectPreservesContentDisposition() {
+        given()
+            .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
+        .when()
+            .put("/content-disposition-bucket/disposition-copy.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .head("/content-disposition-bucket/disposition-copy.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"download.txt\""));
+    }
+
+    @Test
+    @Order(95)
+    void copyObjectReplaceContentDisposition() {
+        given()
+            .header("x-amz-copy-source", "/content-disposition-bucket/disposition.txt")
+            .header("x-amz-metadata-directive", "REPLACE")
+            .header("Content-Disposition", "inline; filename=\"inline.txt\"")
+        .when()
+            .put("/content-disposition-bucket/disposition-inline.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .head("/content-disposition-bucket/disposition-inline.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("inline; filename=\"inline.txt\""));
+    }
+
+    @Test
+    @Order(96)
+    void cleanupContentDispositionBucket() {
+        given().delete("/content-disposition-bucket/disposition.txt");
+        given().delete("/content-disposition-bucket/disposition-copy.txt");
+        given().delete("/content-disposition-bucket/disposition-inline.txt");
+        given().delete("/content-disposition-bucket");
+    }
+
     // --- S3 Notification Configuration with Filter ---
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -32,6 +32,7 @@ class S3MultipartIntegrationTest {
             .contentType("application/octet-stream")
             .header("x-amz-meta-owner", "team-a")
             .header("x-amz-storage-class", "STANDARD_IA")
+            .header("Content-Disposition", "attachment; filename=\"multipart.bin\"")
         .when()
             .post("/" + BUCKET + "/" + KEY + "?uploads")
         .then()
@@ -125,6 +126,7 @@ class S3MultipartIntegrationTest {
             .get("/" + BUCKET + "/" + KEY)
         .then()
             .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"multipart.bin\""))
             .header("x-amz-meta-owner", equalTo("team-a"))
             .header("x-amz-storage-class", equalTo("STANDARD_IA"))
             .body(equalTo("Part1Data-HelloPart2Data-World"));


### PR DESCRIPTION
## Summary

Preserve S3 object `Content-Disposition` across PutObject, multipart upload completion, GetObject, HeadObject, and CopyObject.

This mirrors the existing `Cache-Control` handling added in #313 and keeps Floci closer to AWS behavior for object download metadata.

## Root cause

Floci stored and replayed `Content-Encoding` and `Cache-Control`, but it never persisted `Content-Disposition` on `S3Object`. As a result, GET and HEAD responses dropped the header and CopyObject could neither preserve nor replace it. Multipart uploads also dropped the header between initiation and completion.

## Changes

- add `contentDisposition` to `S3Object`
- capture `Content-Disposition` in `S3Controller.putObject`
- replay `Content-Disposition` from `appendObjectHeaders()` for GET/HEAD
- thread `Content-Disposition` through `S3Service.copyObject()` with REPLACE support
- persist `Content-Disposition` across multipart upload initiation and completion
- add integration tests for put/get/head/copy-preserve/copy-replace/cleanup and multipart completion

## Validation

- `./mvnw -q -Dtest=S3IntegrationTest,S3MultipartIntegrationTest test`
