### PR TITLE
feat(sfn): add SQS sendMessage integrations

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -575,6 +575,15 @@ public class AslExecutor {
     }
 
     private JsonNode invokeOptimizedSqsSendMessage(JsonNode input, String region) {
+        ObjectNode request = normalizeSqsSendMessageInput(input);
+        return invokeSqsAction("SendMessage", request, region, "SQS.");
+    }
+
+    private JsonNode invokeAwsSdkSqsSendMessage(JsonNode input, String region) {
+        return invokeSqsAction("SendMessage", normalizeSqsSendMessageInput(input), region, "Sqs.", true);
+    }
+
+    private ObjectNode normalizeSqsSendMessageInput(JsonNode input) {
         ObjectNode request = input != null && input.isObject()
                 ? ((ObjectNode) input.deepCopy())
                 : objectMapper.createObjectNode();
@@ -583,12 +592,7 @@ public class AslExecutor {
         if (messageBody != null && !messageBody.isTextual() && !messageBody.isNull()) {
             request.put("MessageBody", messageBody.toString());
         }
-
-        return invokeSqsAction("SendMessage", request, region, "SQS.");
-    }
-
-    private JsonNode invokeAwsSdkSqsSendMessage(JsonNode input, String region) {
-        return invokeSqsAction("SendMessage", input, region, "Sqs.", true);
+        return request;
     }
 
     private JsonNode invokeSqsAction(String action, JsonNode input, String region, String errorPrefix) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -351,11 +351,10 @@ public class AslExecutor {
             return invokeOptimizedSqsSendMessage(input, region);
         }
 
-        // AWS SDK service integrations: SQS
-        if (resource.startsWith("arn:aws:states:::aws-sdk:sqs:")) {
-            String camelCaseAction = resource.substring("arn:aws:states:::aws-sdk:sqs:".length());
+        // AWS SDK service integration: SQS SendMessage
+        if (resource.equals("arn:aws:states:::aws-sdk:sqs:sendMessage")) {
             String region = extractRegionFromArn(sm.getStateMachineArn());
-            return invokeAwsSdkSqs(camelCaseAction, input, region);
+            return invokeAwsSdkSqsSendMessage(input, region);
         }
 
         // Nested state machine integration
@@ -588,17 +587,20 @@ public class AslExecutor {
         return invokeSqsAction("SendMessage", request, region, "SQS.");
     }
 
-    private JsonNode invokeAwsSdkSqs(String camelCaseAction, JsonNode input, String region) {
-        String pascalAction = Character.toUpperCase(camelCaseAction.charAt(0)) + camelCaseAction.substring(1);
-        return invokeSqsAction(pascalAction, input, region, "Sqs.");
+    private JsonNode invokeAwsSdkSqsSendMessage(JsonNode input, String region) {
+        return invokeSqsAction("SendMessage", input, region, "Sqs.", true);
     }
 
     private JsonNode invokeSqsAction(String action, JsonNode input, String region, String errorPrefix) {
+        return invokeSqsAction(action, input, region, errorPrefix, false);
+    }
+
+    private JsonNode invokeSqsAction(String action, JsonNode input, String region, String errorPrefix, boolean awsSdkStyleErrors) {
         jakarta.ws.rs.core.Response response;
         try {
             response = sqsJsonHandler.handle(action, input, region);
         } catch (AwsException e) {
-            throw new FailStateException(errorPrefix + e.getErrorCode(), e.getMessage());
+            throw new FailStateException(errorPrefix + normalizeSqsErrorCode(e.getErrorCode(), awsSdkStyleErrors), e.getMessage());
         } catch (Exception e) {
             throw new FailStateException(errorPrefix + "InternalServerError",
                     e.getMessage() != null ? e.getMessage() : "SQS error");
@@ -609,10 +611,10 @@ public class AslExecutor {
 
         if (status >= 400) {
             if (entity instanceof AwsErrorResponse err) {
-                throw new FailStateException(errorPrefix + err.type(), err.message());
+                throw new FailStateException(errorPrefix + normalizeSqsErrorCode(err.type(), awsSdkStyleErrors), err.message());
             }
             if (entity instanceof JsonNode errorNode) {
-                String errorName = errorNode.path("__type").asText("UnknownError");
+                String errorName = normalizeSqsErrorCode(errorNode.path("__type").asText("UnknownError"), awsSdkStyleErrors);
                 String errorMessage = errorNode.path("message").asText(
                         errorNode.path("Message").asText("SQS operation failed"));
                 throw new FailStateException(errorPrefix + errorName, errorMessage);
@@ -624,6 +626,24 @@ public class AslExecutor {
             return jsonNode;
         }
         return objectMapper.createObjectNode();
+    }
+
+    private String normalizeSqsErrorCode(String errorCode, boolean awsSdkStyleErrors) {
+        if (!awsSdkStyleErrors || errorCode == null || errorCode.isBlank()) {
+            return errorCode;
+        }
+        return switch (errorCode) {
+            case "AWS.SimpleQueueService.NonExistentQueue" -> "QueueDoesNotExistException";
+            case "UnsupportedOperation" -> "UnsupportedOperationException";
+            case "ReceiptHandleIsInvalid" -> "ReceiptHandleIsInvalidException";
+            case "QueueAlreadyExists" -> "QueueNameExistsException";
+            case "InvalidAddress" -> "InvalidAddressException";
+            case "InvalidSecurity" -> "InvalidSecurityException";
+            case "InvalidMessageContents" -> "InvalidMessageContentsException";
+            case "OverLimit" -> "OverLimitException";
+            case "RequestThrottled" -> "RequestThrottledException";
+            default -> errorCode;
+        };
     }
 
     private StateResult executeChoiceState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) throws Exception {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
 import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
@@ -48,6 +49,7 @@ public class AslExecutor {
     private final LambdaFunctionStore functionStore;
     private final DynamoDbService dynamoDbService;
     private final DynamoDbJsonHandler dynamoDbJsonHandler;
+    private final SqsJsonHandler sqsJsonHandler;
     private final ObjectMapper objectMapper;
     private final JsonataEvaluator jsonataEvaluator;
     private final Instance<StepFunctionsService> sfnService;
@@ -60,12 +62,14 @@ public class AslExecutor {
     @Inject
     public AslExecutor(LambdaExecutorService lambdaExecutor, LambdaFunctionStore functionStore,
                        DynamoDbService dynamoDbService, DynamoDbJsonHandler dynamoDbJsonHandler,
+                       SqsJsonHandler sqsJsonHandler,
                        ObjectMapper objectMapper, JsonataEvaluator jsonataEvaluator,
                        Instance<StepFunctionsService> sfnService) {
         this.lambdaExecutor = lambdaExecutor;
         this.functionStore = functionStore;
         this.dynamoDbService = dynamoDbService;
         this.dynamoDbJsonHandler = dynamoDbJsonHandler;
+        this.sqsJsonHandler = sqsJsonHandler;
         this.objectMapper = objectMapper;
         this.jsonataEvaluator = jsonataEvaluator;
         this.sfnService = sfnService;
@@ -341,6 +345,19 @@ public class AslExecutor {
             return invokeAwsSdkDynamoDb(camelCaseAction, input, region);
         }
 
+        // SQS optimized integration
+        if (resource.equals("arn:aws:states:::sqs:sendMessage")) {
+            String region = extractRegionFromArn(sm.getStateMachineArn());
+            return invokeOptimizedSqsSendMessage(input, region);
+        }
+
+        // AWS SDK service integrations: SQS
+        if (resource.startsWith("arn:aws:states:::aws-sdk:sqs:")) {
+            String camelCaseAction = resource.substring("arn:aws:states:::aws-sdk:sqs:".length());
+            String region = extractRegionFromArn(sm.getStateMachineArn());
+            return invokeAwsSdkSqs(camelCaseAction, input, region);
+        }
+
         // Nested state machine integration
         if (resource.startsWith("arn:aws:states:::states:startExecution")) {
             String mode = resource.substring("arn:aws:states:::states:startExecution".length());
@@ -550,6 +567,57 @@ public class AslExecutor {
                 throw new FailStateException("DynamoDb." + errorName, errorMessage);
             }
             throw new FailStateException("DynamoDb.ServiceException", "DynamoDB operation failed");
+        }
+
+        if (entity instanceof JsonNode jsonNode) {
+            return jsonNode;
+        }
+        return objectMapper.createObjectNode();
+    }
+
+    private JsonNode invokeOptimizedSqsSendMessage(JsonNode input, String region) {
+        ObjectNode request = input != null && input.isObject()
+                ? ((ObjectNode) input.deepCopy())
+                : objectMapper.createObjectNode();
+
+        JsonNode messageBody = request.get("MessageBody");
+        if (messageBody != null && !messageBody.isTextual() && !messageBody.isNull()) {
+            request.put("MessageBody", messageBody.toString());
+        }
+
+        return invokeSqsAction("SendMessage", request, region, "SQS.");
+    }
+
+    private JsonNode invokeAwsSdkSqs(String camelCaseAction, JsonNode input, String region) {
+        String pascalAction = Character.toUpperCase(camelCaseAction.charAt(0)) + camelCaseAction.substring(1);
+        return invokeSqsAction(pascalAction, input, region, "Sqs.");
+    }
+
+    private JsonNode invokeSqsAction(String action, JsonNode input, String region, String errorPrefix) {
+        jakarta.ws.rs.core.Response response;
+        try {
+            response = sqsJsonHandler.handle(action, input, region);
+        } catch (AwsException e) {
+            throw new FailStateException(errorPrefix + e.getErrorCode(), e.getMessage());
+        } catch (Exception e) {
+            throw new FailStateException(errorPrefix + "InternalServerError",
+                    e.getMessage() != null ? e.getMessage() : "SQS error");
+        }
+
+        Object entity = response.getEntity();
+        int status = response.getStatus();
+
+        if (status >= 400) {
+            if (entity instanceof AwsErrorResponse err) {
+                throw new FailStateException(errorPrefix + err.type(), err.message());
+            }
+            if (entity instanceof JsonNode errorNode) {
+                String errorName = errorNode.path("__type").asText("UnknownError");
+                String errorMessage = errorNode.path("message").asText(
+                        errorNode.path("Message").asText("SQS operation failed"));
+                throw new FailStateException(errorPrefix + errorName, errorMessage);
+            }
+            throw new FailStateException(errorPrefix + "ServiceException", "SQS operation failed");
         }
 
         if (entity instanceof JsonNode jsonNode) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
@@ -180,7 +180,9 @@ class StepFunctionsSqsIntegrationTest {
                         {"QueueUrl":"%s"}
                         """.formatted(queue))
                 .when()
-                .post("/");
+                .post("/")
+                .then()
+                .statusCode(200);
     }
 
     private String executeSfn(String nameSuffix, String resource, String parameters) throws Exception {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
@@ -107,18 +107,18 @@ class StepFunctionsSqsIntegrationTest {
 
     @Test
     @Order(4)
-    void awsSdk_unsupportedOperation_fails_withSqsPrefix() throws Exception {
-        String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:unsupportedAction", """
+    void awsSdk_nonExistentQueue_fails_withSdkStyleErrorName() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:sendMessage", """
                 {
-                    "QueueUrl": "%s",
+                    "QueueUrl": "http://localhost:4566/000000000000/does-not-exist",
                     "MessageBody": "noop"
                 }
-                """.formatted(queueUrl));
+                """);
 
-        String smArn = createStateMachine("aws-sdk-sqs-unsupported-" + System.currentTimeMillis(), definition);
+        String smArn = createStateMachine("aws-sdk-sqs-missing-queue-" + System.currentTimeMillis(), definition);
         String execArn = startExecution(smArn, "{}");
         Response failed = waitForFailedExecution(execArn);
-        assertEquals("Sqs.UnsupportedOperation", failed.jsonPath().getString("error"));
+        assertEquals("Sqs.QueueDoesNotExistException", failed.jsonPath().getString("error"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
@@ -107,6 +107,35 @@ class StepFunctionsSqsIntegrationTest {
 
     @Test
     @Order(4)
+    void awsSdk_waitForTaskToken_serializesMessageBodyObject() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:sendMessage.waitForTaskToken", """
+                {
+                    "QueueUrl": "%s",
+                    "MessageBody": {
+                        "Message": "aws sdk callback requested",
+                        "TaskToken.$": "$$.Task.Token"
+                    }
+                }
+                """.formatted(callbackQueueUrl));
+
+        String smArn = createStateMachine("aws-sdk-wait-token-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+
+        JsonNode message = receiveSingleMessage(callbackQueueUrl);
+        JsonNode body = mapper.readTree(message.path("Body").asText());
+        assertEquals("aws sdk callback requested", body.path("Message").asText());
+        String taskToken = body.path("TaskToken").asText();
+        assertFalse(taskToken.isBlank());
+
+        sendTaskSuccess(taskToken, "{\"delivered\":true}");
+        String output = waitForExecution(execArn);
+        assertTrue(mapper.readTree(output).path("delivered").asBoolean());
+
+        deleteMessage(callbackQueueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(5)
     void awsSdk_nonExistentQueue_fails_withSdkStyleErrorName() throws Exception {
         String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:sendMessage", """
                 {
@@ -122,7 +151,7 @@ class StepFunctionsSqsIntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void cleanup_deleteQueues() {
         deleteQueue(queueUrl);
         deleteQueue(callbackQueueUrl);

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
@@ -1,0 +1,310 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StepFunctionsSqsIntegrationTest {
+
+    private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String SQS_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static String queueUrl;
+    private static String callbackQueueUrl;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(0)
+    void setup_createQueues() {
+        queueUrl = createQueue("sfn-sqs-integration-queue");
+        callbackQueueUrl = createQueue("sfn-sqs-callback-queue");
+    }
+
+    @Test
+    @Order(1)
+    void optimized_sendMessage() throws Exception {
+        String output = executeSfn("optimized-send", "arn:aws:states:::sqs:sendMessage", """
+                {
+                    "QueueUrl": "%s",
+                    "MessageBody": "hello optimized"
+                }
+                """.formatted(queueUrl));
+
+        JsonNode result = mapper.readTree(output);
+        assertTrue(result.has("MessageId"));
+        assertTrue(result.has("MD5OfMessageBody"));
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        assertEquals("hello optimized", message.path("Body").asText());
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(2)
+    void awsSdk_sendMessage() throws Exception {
+        String output = executeSfn("aws-sdk-send", "arn:aws:states:::aws-sdk:sqs:sendMessage", """
+                {
+                    "QueueUrl": "%s",
+                    "MessageBody": "hello aws-sdk"
+                }
+                """.formatted(queueUrl));
+
+        JsonNode result = mapper.readTree(output);
+        assertTrue(result.has("MessageId"));
+        assertTrue(result.has("MD5OfMessageBody"));
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        assertEquals("hello aws-sdk", message.path("Body").asText());
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(3)
+    void optimized_waitForTaskToken_serializesMessageBodyObject() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::sqs:sendMessage.waitForTaskToken", """
+                {
+                    "QueueUrl": "%s",
+                    "MessageBody": {
+                        "Message": "callback requested",
+                        "TaskToken.$": "$$.Task.Token"
+                    }
+                }
+                """.formatted(callbackQueueUrl));
+
+        String smArn = createStateMachine("optimized-wait-token-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+
+        JsonNode message = receiveSingleMessage(callbackQueueUrl);
+        JsonNode body = mapper.readTree(message.path("Body").asText());
+        assertEquals("callback requested", body.path("Message").asText());
+        String taskToken = body.path("TaskToken").asText();
+        assertFalse(taskToken.isBlank());
+
+        sendTaskSuccess(taskToken, "{\"delivered\":true}");
+        String output = waitForExecution(execArn);
+        assertTrue(mapper.readTree(output).path("delivered").asBoolean());
+
+        deleteMessage(callbackQueueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(4)
+    void awsSdk_unsupportedOperation_fails_withSqsPrefix() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:unsupportedAction", """
+                {
+                    "QueueUrl": "%s",
+                    "MessageBody": "noop"
+                }
+                """.formatted(queueUrl));
+
+        String smArn = createStateMachine("aws-sdk-sqs-unsupported-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+        Response failed = waitForFailedExecution(execArn);
+        assertEquals("Sqs.UnsupportedOperation", failed.jsonPath().getString("error"));
+    }
+
+    @Test
+    @Order(5)
+    void cleanup_deleteQueues() {
+        deleteQueue(queueUrl);
+        deleteQueue(callbackQueueUrl);
+    }
+
+    private static String createQueue(String queueName) {
+        Response resp = given()
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueName":"%s"}
+                        """.formatted(queueName))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("QueueUrl");
+    }
+
+    private JsonNode receiveSingleMessage(String queue) throws Exception {
+        Response resp = given()
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s","MaxNumberOfMessages":1,"WaitTimeSeconds":1}
+                        """.formatted(queue))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        JsonNode messages = mapper.readTree(resp.body().asString()).path("Messages");
+        assertEquals(1, messages.size(), "Expected one message");
+        return messages.get(0);
+    }
+
+    private static void deleteMessage(String queue, String receiptHandle) {
+        given()
+                .header("X-Amz-Target", "AmazonSQS.DeleteMessage")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s","ReceiptHandle":"%s"}
+                        """.formatted(queue, receiptHandle))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private static void deleteQueue(String queue) {
+        if (queue == null) {
+            return;
+        }
+        given()
+                .header("X-Amz-Target", "AmazonSQS.DeleteQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s"}
+                        """.formatted(queue))
+                .when()
+                .post("/");
+    }
+
+    private String executeSfn(String nameSuffix, String resource, String parameters) throws Exception {
+        String definition = buildStateMachineDefinition(resource, parameters);
+        String smArn = createStateMachine(nameSuffix + "-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+        return waitForExecution(execArn);
+    }
+
+    private String buildStateMachineDefinition(String resource, String parameters) {
+        return """
+                {
+                    "StartAt": "Action",
+                    "States": {
+                        "Action": {
+                            "Type": "Task",
+                            "Resource": "%s",
+                            "Parameters": %s,
+                            "End": true
+                        }
+                    }
+                }
+                """.formatted(resource, parameters.strip());
+    }
+
+    private String createStateMachine(String name, String definition) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "name": "%s",
+                            "definition": %s,
+                            "roleArn": "%s"
+                        }
+                        """.formatted(name, quote(definition), ROLE_ARN))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("stateMachineArn");
+    }
+
+    private String startExecution(String smArn, String input) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "stateMachineArn": "%s",
+                            "input": %s
+                        }
+                        """.formatted(smArn, quote(input)))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("executionArn");
+    }
+
+    private void sendTaskSuccess(String taskToken, String output) {
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.SendTaskSuccess")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "taskToken": %s,
+                            "output": %s
+                        }
+                        """.formatted(quote(taskToken), quote(output)))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private String waitForExecution(String execArn) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Response resp = describeExecution(execArn);
+            String status = resp.jsonPath().getString("status");
+            if ("SUCCEEDED".equals(status)) {
+                return resp.jsonPath().getString("output");
+            }
+            if ("FAILED".equals(status) || "ABORTED".equals(status)) {
+                fail("Execution " + status + ": " + resp.body().asString());
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution did not complete within timeout");
+        return null;
+    }
+
+    private Response waitForFailedExecution(String execArn) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Response resp = describeExecution(execArn);
+            String status = resp.jsonPath().getString("status");
+            if ("FAILED".equals(status)) {
+                return resp;
+            }
+            if ("SUCCEEDED".equals(status)) {
+                fail("Execution should have failed but succeeded: " + resp.body().asString());
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution did not complete within timeout");
+        return null;
+    }
+
+    private Response describeExecution(String execArn) {
+        return given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(execArn))
+                .when()
+                .post("/");
+    }
+
+    private static String quote(String raw) {
+        return "\"" + raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                + "\"";
+    }
+}


### PR DESCRIPTION
## Summary

Add Step Functions support for Amazon SQS `sendMessage` using both the optimized integration ARN and the AWS SDK integration ARN.

This follows the DynamoDB Step Functions integration approach from #103 by wiring Step Functions into the existing service handler instead of adding per-action glue in multiple places.

## Root cause

Floci already implements SQS itself, but the Step Functions executor only dispatches Lambda, DynamoDB, nested state machines, and activities. As a result, state machines that use `arn:aws:states:::sqs:sendMessage` or `arn:aws:states:::aws-sdk:sqs:sendMessage` fail with `Unsupported resource`.

## Changes

- inject `SqsJsonHandler` into `AslExecutor`
- add optimized `arn:aws:states:::sqs:sendMessage` support
- add AWS SDK `arn:aws:states:::aws-sdk:sqs:sendMessage` support using the existing SQS JSON handler
- serialize structured optimized `MessageBody` values to JSON strings before calling SQS
- normalize AWS SDK SQS errors to SDK-style names such as `Sqs.QueueDoesNotExistException`
- add Step Functions integration tests for optimized sendMessage, aws-sdk sendMessage, waitForTaskToken, and aws-sdk missing-queue failure

## Validation

- `./mvnw -q -Dtest=StepFunctionsSqsIntegrationTest test`
- `./mvnw -q -Dtest=StepFunctionsDynamoDbIntegrationTest,StepFunctionsSqsIntegrationTest test`
