### PR TITLE
fix(sqs): use queue-level VisibilityTimeout as fallback in ReceiveMes…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -479,7 +479,13 @@ public class SqsService {
             return Collections.emptyList();
         }
 
-        int effectiveTimeout = visibilityTimeout >= 0 ? visibilityTimeout : defaultVisibilityTimeout;
+        int effectiveTimeout;
+        if (visibilityTimeout >= 0) {
+            effectiveTimeout = visibilityTimeout;
+        } else {
+            String queueVt = queue.getAttributes().get("VisibilityTimeout");
+            effectiveTimeout = queueVt != null ? Integer.parseInt(queueVt) : defaultVisibilityTimeout;
+        }
 
         RedrivePolicy rp = getOrParseRedrivePolicy(queue, storageKey);
         int maxReceiveCount = rp != null ? rp.maxReceiveCount() : -1;

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -288,4 +288,27 @@ class SqsServiceTest {
         assertThrows(AwsException.class, () ->
                 sqsService.sendMessage(queue.getQueueUrl(), "msg", 0, "group1", null));
     }
+
+    @Test
+    void receiveMessageUsesQueueVisibilityTimeoutWhenNotSpecified() {
+        // Create queue with a short visibility timeout (1 second)
+        Queue queue = sqsService.createQueue("short-vt-queue",
+                Map.of("VisibilityTimeout", "1"));
+        sqsService.sendMessage(queue.getQueueUrl(), "test-msg", 0);
+
+        // Receive without specifying visibility timeout (-1 means "use queue default")
+        List<Message> first = sqsService.receiveMessage(queue.getQueueUrl(), 1, -1, 0);
+        assertEquals(1, first.size());
+
+        // Message should be invisible immediately after receive
+        List<Message> second = sqsService.receiveMessage(queue.getQueueUrl(), 1, -1, 0);
+        assertTrue(second.isEmpty());
+
+        // Wait for the queue's visibility timeout (1s) to expire, not the global default (30s)
+        try { Thread.sleep(1100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        // Message should now be visible again
+        List<Message> third = sqsService.receiveMessage(queue.getQueueUrl(), 1, -1, 0);
+        assertEquals(1, third.size(), "Message should become visible after queue's VisibilityTimeout (1s), not global default (30s)");
+    }
 }


### PR DESCRIPTION
…sage

When ReceiveMessage does not specify a VisibilityTimeout parameter, doReceiveMessage falls back to the global default (30s) instead of the queue's own VisibilityTimeout attribute. This causes messages to stay invisible far longer than expected, which in turn breaks DLQ redrive for queues configured with a short visibility timeout — the message never becomes visible within a reasonable window for the receive-count check to trigger.   

## Summary

SqsService.doReceiveMessage() uses the global defaultVisibilityTimeout (30s) when the ReceiveMessage request omits VisibilityTimeout, ignoring the queue's own VisibilityTimeout attribute set at creation time. This breaks DLQ redrive for queues with short visibility timeouts since messages stay invisible  for 30s instead of the configured value.
The fix reads the queue's VisibilityTimeout attribute as the intermediate fallback: request parameter > queue attribute > global default. This matches https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#configuring-visibility-timeout.  

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

In real AWS SQS, when ReceiveMessage does not include a VisibilityTimeout parameter, the queue's default visibility timeout (set via CreateQueue or SetQueueAttributes) is used — not a global server default. Verified against AWS SDK v2 (software.amazon.awssdk:sqs:2.29.52) with a Spring Cloud AWS SQS listener that does not specify visibility timeout per-request.                                                                                                                                                                                                                                                                                                               The incorrect behavior: a queue created with VisibilityTimeout=1 had its messages stay invisible for 30 seconds after receive, preventing timely DLQ redrive.     

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
