### PR TITLE
ci(compat): parallelize sdk-test-awscli bats execution

### DIFF
--- a/compatibility-tests/sdk-test-awscli/Dockerfile
+++ b/compatibility-tests/sdk-test-awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazon/aws-cli:latest
 
-RUN yum install -y git jq bc openssl
+RUN yum install -y git jq bc openssl parallel
 
 WORKDIR /app
 

--- a/compatibility-tests/sdk-test-awscli/run-bats-in-container.sh
+++ b/compatibility-tests/sdk-test-awscli/run-bats-in-container.sh
@@ -5,7 +5,7 @@ report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
 trap 'rm -rf "$report_dir"' EXIT
 
 set +e
-/opt/bats-core/bin/bats --report-formatter junit -o "$report_dir" test/
+/opt/bats-core/bin/bats --jobs 4 --report-formatter junit -o "$report_dir" test/
 status=$?
 set -e
 

--- a/compatibility-tests/sdk-test-awscli/test/ecr.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ecr.bats
@@ -6,7 +6,7 @@
 
 setup() {
     load 'test_helper/common-setup'
-    REPO_NAME="floci-it/app-cli"
+    REPO_NAME="floci-it/app-cli-$(unique_name)"
 }
 
 teardown() {

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -3,83 +3,86 @@
 
 setup() {
     load 'test_helper/common-setup'
+    DB_ID="bats-rds-$(unique_name)"
+    DB_ID_2="bats-rds-2-$(unique_name)"
 }
 
 teardown() {
-    # Delete test instance if it exists
-    aws_cmd rds delete-db-instance --db-instance-identifier "test-cli-db" --skip-final-snapshot >/dev/null 2>&1 || true
-    aws_cmd rds delete-db-instance --db-instance-identifier "test-cli-db-2" --skip-final-snapshot >/dev/null 2>&1 || true
+    aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID" --skip-final-snapshot >/dev/null 2>&1 || true
+    aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID_2" --skip-final-snapshot >/dev/null 2>&1 || true
 }
 
 @test "RDS: create db instance returns resource identifiers" {
     run aws_cmd rds create-db-instance \
-        --db-instance-identifier "test-cli-db" \
+        --db-instance-identifier "$DB_ID" \
         --engine postgres \
         --db-instance-class db.t3.micro \
         --allocated-storage 10
-    
+
     assert_success
-    
+
     dbi_resource_id=$(json_get "$output" '.DBInstance.DbiResourceId')
     db_instance_arn=$(json_get "$output" '.DBInstance.DBInstanceArn')
-    
+
     [ -n "$dbi_resource_id" ]
     [[ "$dbi_resource_id" =~ ^db- ]]
-    
+
     [ -n "$db_instance_arn" ]
-    [[ "$db_instance_arn" =~ ^arn:aws:rds:.*:db:test-cli-db$ ]]
+    [[ "$db_instance_arn" == *":db:$DB_ID" ]]
 }
 
 @test "RDS: describe db instances filters by identifier" {
     aws_cmd rds create-db-instance \
-        --db-instance-identifier "test-cli-db" \
+        --db-instance-identifier "$DB_ID" \
         --engine postgres \
         --db-instance-class db.t3.micro \
         --allocated-storage 10
 
-    run aws_cmd rds describe-db-instances --db-instance-identifier "test-cli-db"
+    run aws_cmd rds describe-db-instances --db-instance-identifier "$DB_ID"
     assert_success
-    
+
     count=$(echo "$output" | jq '.DBInstances | length')
     [ "$count" -eq 1 ]
-    
+
     id=$(json_get "$output" '.DBInstances[0].DBInstanceIdentifier')
-    [ "$id" = "test-cli-db" ]
+    [ "$id" = "$DB_ID" ]
 }
 
 @test "RDS: describe db instances is case-insensitive" {
     aws_cmd rds create-db-instance \
-        --db-instance-identifier "test-cli-db" \
+        --db-instance-identifier "$DB_ID" \
         --engine postgres \
         --db-instance-class db.t3.micro \
         --allocated-storage 10
 
-    run aws_cmd rds describe-db-instances --db-instance-identifier "TEST-CLI-DB"
+    # shellcheck disable=SC2155
+    local upper_id=$(echo "$DB_ID" | tr '[:lower:]' '[:upper:]')
+    run aws_cmd rds describe-db-instances --db-instance-identifier "$upper_id"
     assert_success
-    
+
     count=$(echo "$output" | jq '.DBInstances | length')
     [ "$count" -eq 1 ]
-    
+
     id=$(json_get "$output" '.DBInstances[0].DBInstanceIdentifier')
-    [ "$id" = "test-cli-db" ]
+    [ "$id" = "$DB_ID" ]
 }
 
 @test "RDS: describe db instances returns all when no filter" {
     aws_cmd rds create-db-instance \
-        --db-instance-identifier "test-cli-db" \
+        --db-instance-identifier "$DB_ID" \
         --engine postgres \
         --db-instance-class db.t3.micro \
         --allocated-storage 10
-    
+
     aws_cmd rds create-db-instance \
-        --db-instance-identifier "test-cli-db-2" \
+        --db-instance-identifier "$DB_ID_2" \
         --engine postgres \
         --db-instance-class db.t3.micro \
         --allocated-storage 10
 
     run aws_cmd rds describe-db-instances
     assert_success
-    
+
     # Might have more from other tests, but at least 2
     count=$(echo "$output" | jq '.DBInstances | length')
     [ "$count" -ge 2 ]


### PR DESCRIPTION
## Summary

- Enable file-level parallelism (`--jobs 4`) for the `sdk-test-awscli` bats compatibility test suite (~9 min → target <5 min)
- Replace hardcoded resource names in `rds.bats` and `ecr.bats` with `unique_name()` to prevent cross-file collisions under parallel execution
- Matches the pattern already used by the other 13 bats files

## Changes

- `run-bats-in-container.sh`: add `--jobs 4` to bats invocation
- `rds.bats`: use `$DB_ID` / `$DB_ID_2` via `unique_name()`, dynamic case-insensitive test, exact ARN assertion
- `ecr.bats`: append `$(unique_name)` to repo name

## Review

Pre-push review by Codex (agentic) and Gemini (agentic):
- Fixed ARN assertion per Codex feedback (prefix match → exact `$DB_ID` suffix match)
- `unique_name()` collision risk assessed as theoretical only (`$$` differs per bats worker subprocess)

## Test plan

- [ ] CI: all 139 awscli compat tests pass with `--jobs 4`
- [ ] Job runtime under 5 minutes (down from ~9 min)