### PR TITLE
fix(dynamodb): implement DELETE action for set attributes (#312)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -892,8 +892,8 @@ public class DynamoDbService {
                 remaining = remaining.substring(4).trim();
                 remaining = applyAddClause(item, remaining, exprAttrNames, exprAttrValues);
             } else if (upper.startsWith("DELETE ")) {
-                // DELETE is for sets — skip for now
-                break;
+                remaining = remaining.substring(7).trim();
+                remaining = applyDeleteClause(item, remaining, exprAttrNames, exprAttrValues);
             } else {
                 break;
             }
@@ -1169,6 +1169,100 @@ public class DynamoDbService {
 
         // Unsupported type for ADD — just set the value
         return addValue;
+    }
+
+    private String applyDeleteClause(ObjectNode item, String clause,
+                                     JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        while (!clause.isEmpty()) {
+            String upper = clause.toUpperCase();
+            if (upper.startsWith("SET ") || upper.startsWith("REMOVE ") || upper.startsWith("ADD ") || upper.startsWith("DELETE ")) {
+                break;
+            }
+
+            // Parse "attr :val"
+            String[] parts = clause.split("\\s+", 3);
+            if (parts.length < 2) break;
+
+            String attrName = resolveAttributeName(parts[0], exprAttrNames);
+            String valuePlaceholder = parts[1].replaceAll(",.*", "").trim();
+
+            if (valuePlaceholder.startsWith(":") && exprAttrValues != null) {
+                JsonNode deleteValue = exprAttrValues.get(valuePlaceholder);
+                if (deleteValue != null) {
+                    JsonNode existingValue = item.get(attrName);
+                    if (existingValue != null) {
+                        JsonNode newValue = applyDeleteOperation(existingValue, deleteValue);
+                        if (newValue == null) {
+                            item.remove(attrName);
+                        } else {
+                            item.set(attrName, newValue);
+                        }
+                    }
+                }
+            }
+
+            // Advance past this assignment
+            int commaIdx = findNextComma(clause);
+            if (commaIdx >= 0) {
+                clause = clause.substring(commaIdx + 1).trim();
+            } else {
+                int nextClause = findNextClauseKeyword(clause);
+                clause = nextClause >= 0 ? clause.substring(nextClause).trim() : "";
+            }
+        }
+        return clause;
+    }
+
+    /**
+     * Implements DynamoDB DELETE operation semantics:
+     * removes the specified elements from a set attribute (SS, NS, BS).
+     * Returns null if the resulting set is empty (caller should remove the attribute).
+     * Returns the existing value unchanged if types don't match or the value isn't a set.
+     */
+    private JsonNode applyDeleteOperation(JsonNode existingValue, JsonNode deleteValue) {
+        ObjectNode result = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+
+        if (deleteValue.has("SS") && existingValue.has("SS")) {
+            java.util.Set<String> toRemove = new java.util.LinkedHashSet<>();
+            deleteValue.get("SS").forEach(n -> toRemove.add(n.asText()));
+            java.util.List<String> remaining = new java.util.ArrayList<>();
+            existingValue.get("SS").forEach(n -> {
+                if (!toRemove.contains(n.asText())) remaining.add(n.asText());
+            });
+            if (remaining.isEmpty()) return null;
+            var arrayNode = result.putArray("SS");
+            remaining.forEach(arrayNode::add);
+            return result;
+        }
+
+        if (deleteValue.has("NS") && existingValue.has("NS")) {
+            java.util.Set<String> toRemove = new java.util.LinkedHashSet<>();
+            deleteValue.get("NS").forEach(n -> toRemove.add(n.asText()));
+            java.util.List<String> remaining = new java.util.ArrayList<>();
+            existingValue.get("NS").forEach(n -> {
+                if (!toRemove.contains(n.asText())) remaining.add(n.asText());
+            });
+            if (remaining.isEmpty()) return null;
+            var arrayNode = result.putArray("NS");
+            remaining.forEach(arrayNode::add);
+            return result;
+        }
+
+        if (deleteValue.has("BS") && existingValue.has("BS")) {
+            java.util.Set<String> toRemove = new java.util.LinkedHashSet<>();
+            deleteValue.get("BS").forEach(n -> toRemove.add(n.asText()));
+            java.util.List<String> remaining = new java.util.ArrayList<>();
+            existingValue.get("BS").forEach(n -> {
+                if (!toRemove.contains(n.asText())) remaining.add(n.asText());
+            });
+            if (remaining.isEmpty()) return null;
+            var arrayNode = result.putArray("BS");
+            remaining.forEach(arrayNode::add);
+            return result;
+        }
+
+        // DELETE on non-set types or mismatched set types is a no-op per DynamoDB spec
+        return existingValue;
     }
 
     String resolveAttributeName(String nameOrPlaceholder, JsonNode exprAttrNames) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -886,6 +886,208 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    @Order(29)
+    void deleteElementsFromStringSet() {
+        // Create table
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Put item with a String Set
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "Item": {"pk": {"S": "k1"}, "tags": {"SS": ["a", "b", "c"]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // DELETE "a" from the set
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "Key": {"pk": {"S": "k1"}},
+                    "UpdateExpression": "DELETE tags :val",
+                    "ExpressionAttributeValues": {":val": {"SS": ["a"]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify "a" was removed, "b" and "c" remain
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "Key": {"pk": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.tags.SS.size()", equalTo(2))
+            .body("Item.tags.SS", hasItems("b", "c"))
+            .body("Item.tags.SS", not(hasItem("a")));
+
+        // DELETE remaining elements to verify attribute removal on empty set
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "Key": {"pk": {"S": "k1"}},
+                    "UpdateExpression": "DELETE tags :val",
+                    "ExpressionAttributeValues": {":val": {"SS": ["b", "c"]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify attribute is removed entirely (DynamoDB doesn't allow empty sets)
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteSetTable",
+                    "Key": {"pk": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.tags", nullValue());
+
+        // Cleanup
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "DeleteSetTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(30)
+    void deleteFromSetWithAddInSameExpression() {
+        // Create table
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteAddComboTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Put item with a String Set
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteAddComboTable",
+                    "Item": {"pk": {"S": "k1"}, "tags": {"SS": ["a", "b"]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Combined: ADD "c" then DELETE "a" in the same expression
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteAddComboTable",
+                    "Key": {"pk": {"S": "k1"}},
+                    "UpdateExpression": "ADD tags :toAdd DELETE tags :toRemove",
+                    "ExpressionAttributeValues": {
+                        ":toAdd": {"SS": ["c"]},
+                        ":toRemove": {"SS": ["a"]}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify: should have "b" and "c", not "a"
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteAddComboTable",
+                    "Key": {"pk": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.tags.SS.size()", equalTo(2))
+            .body("Item.tags.SS", hasItems("b", "c"))
+            .body("Item.tags.SS", not(hasItem("a")));
+
+        // Cleanup
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "DeleteAddComboTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedOperation() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateGlobalTable")


### PR DESCRIPTION
## Summary
- Implement the `DELETE` clause in DynamoDB `UpdateExpression` for set attributes (SS, NS, BS)
- The clause was previously stubbed out with a `break`, silently ignoring all DELETE operations on sets
- Empty sets after element removal trigger attribute deletion per the DynamoDB spec

Closes #312

## Changes
- `DynamoDbService.java`: Replace `break` stub with `applyDeleteClause` + `applyDeleteOperation` methods mirroring the existing `ADD` implementation
- `DynamoDbIntegrationTest.java`: Two new integration tests covering partial removal, full removal (empty set = attribute deleted), and combined `ADD`+`DELETE` in a single expression

## Review
- Internal review (2-agent, Opus + Sonnet): clean on correctness, 2 polish fixes applied (guard clause consistency, comment accuracy)
- External review (Codex + Gemini): confirmed approach correctness, flagged pre-existing limitations (nested paths, legacy API) as out of scope

## Test plan
- [x] `deleteElementsFromStringSet`: partial SS removal + full removal verifies attribute deletion on empty set
- [x] `deleteFromSetWithAddInSameExpression`: combined `ADD tags :toAdd DELETE tags :toRemove` in single expression
- [x] Full DynamoDB test suite regression (33/33 pass)