### PR TITLE
feat(kinesis): implement EnableEnhancedMonitoring and DisableEnhancedMonitoring

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -14,10 +14,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
 public class KinesisJsonHandler {
@@ -57,6 +59,8 @@ public class KinesisJsonHandler {
             case "ListShards" -> handleListShards(request, region);
             case "IncreaseStreamRetentionPeriod" -> handleIncreaseStreamRetentionPeriod(request, region);
             case "DecreaseStreamRetentionPeriod" -> handleDecreaseStreamRetentionPeriod(request, region);
+            case "EnableEnhancedMonitoring" -> handleEnableEnhancedMonitoring(request, region);
+            case "DisableEnhancedMonitoring" -> handleDisableEnhancedMonitoring(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -125,6 +129,8 @@ public class KinesisJsonHandler {
             desc.put("KeyId", stream.getKeyId());
         }
 
+        addEnhancedMonitoringNode(desc, stream);
+
         ArrayNode shards = desc.putArray("Shards");
         for (KinesisShard shard : stream.getShards()) {
             ObjectNode sNode = shards.addObject();
@@ -163,7 +169,15 @@ public class KinesisJsonHandler {
         if (stream.getKeyId() != null) {
             summary.put("KeyId", stream.getKeyId());
         }
+
+        addEnhancedMonitoringNode(summary, stream);
+
         return Response.ok(response).build();
+    }
+
+    private void addEnhancedMonitoringNode(ObjectNode parent, KinesisStream stream) {
+        ArrayNode shardLevelMetrics = parent.putArray("EnhancedMonitoring").addObject().putArray("ShardLevelMetrics");
+        stream.getEnhancedMonitoringMetrics().stream().sorted().forEach(shardLevelMetrics::add);
     }
 
     private Response handleRegisterStreamConsumer(JsonNode request, String region) {
@@ -406,6 +420,44 @@ public class KinesisJsonHandler {
 
         response.putNull("NextToken");
 
+        return Response.ok(response).build();
+    }
+
+    private Response handleEnableEnhancedMonitoring(JsonNode request, String region) {
+        String streamName = resolveStreamName(request);
+
+        List<String> metrics = new ArrayList<>();
+        request.path("ShardLevelMetrics").forEach(m -> metrics.add(m.asText()));
+
+        Set<String> currentMetrics = service.enableEnhancedMonitoring(streamName, metrics, region);
+        KinesisStream updated = service.describeStream(streamName, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("StreamName", streamName);
+        response.put("StreamARN", updated.getStreamArn());
+        ArrayNode current = response.putArray("CurrentShardLevelMetrics");
+        currentMetrics.stream().sorted().forEach(current::add);
+        ArrayNode desired = response.putArray("DesiredShardLevelMetrics");
+        updated.getEnhancedMonitoringMetrics().stream().sorted().forEach(desired::add);
+        return Response.ok(response).build();
+    }
+
+    private Response handleDisableEnhancedMonitoring(JsonNode request, String region) {
+        String streamName = resolveStreamName(request);
+
+        List<String> metrics = new ArrayList<>();
+        request.path("ShardLevelMetrics").forEach(m -> metrics.add(m.asText()));
+
+        Set<String> currentMetrics = service.disableEnhancedMonitoring(streamName, metrics, region);
+        KinesisStream updated = service.describeStream(streamName, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("StreamName", streamName);
+        response.put("StreamARN", updated.getStreamArn());
+        ArrayNode current = response.putArray("CurrentShardLevelMetrics");
+        currentMetrics.stream().sorted().forEach(current::add);
+        ArrayNode desired = response.putArray("DesiredShardLevelMetrics");
+        updated.getEnhancedMonitoringMetrics().stream().sorted().forEach(desired::add);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -21,6 +21,11 @@ import java.util.concurrent.atomic.AtomicLong;
 @ApplicationScoped
 public class KinesisService {
     private static final Logger LOG = Logger.getLogger(KinesisService.class);
+    private static final Set<String> VALID_SHARD_LEVEL_METRICS = Set.of(
+            "IncomingBytes", "IncomingRecords", "OutgoingBytes", "OutgoingRecords",
+            "WriteProvisionedThroughputExceeded", "ReadProvisionedThroughputExceeded",
+            "IteratorAgeMilliseconds", "ALL");
+
     private final StorageBackend<String, KinesisStream> store;
     private final StorageBackend<String, KinesisConsumer> consumerStore;
     private final RegionResolver regionResolver;
@@ -184,6 +189,46 @@ public class KinesisService {
         stream.setRetentionPeriodHours(retentionPeriodHours);
         store.put(regionKey(region, streamName), stream);
         LOG.infov("Decreased retention period for stream {0} to {1} hours", streamName, retentionPeriodHours);
+    }
+
+    public Set<String> enableEnhancedMonitoring(String streamName, List<String> metrics, String region) {
+        KinesisStream stream = resolveStream(streamName, region);
+        Set<String> current = new HashSet<>(stream.getEnhancedMonitoringMetrics());
+        Set<String> desired = resolveMetrics(metrics);
+        stream.getEnhancedMonitoringMetrics().addAll(desired);
+        store.put(regionKey(region, streamName), stream);
+        LOG.infov("Enabled enhanced monitoring for stream {0}: {1}", streamName, desired);
+        return current;
+    }
+
+    public Set<String> disableEnhancedMonitoring(String streamName, List<String> metrics, String region) {
+        KinesisStream stream = resolveStream(streamName, region);
+        Set<String> current = new HashSet<>(stream.getEnhancedMonitoringMetrics());
+        Set<String> toRemove = resolveMetrics(metrics);
+        stream.getEnhancedMonitoringMetrics().removeAll(toRemove);
+        store.put(regionKey(region, streamName), stream);
+        LOG.infov("Disabled enhanced monitoring for stream {0}: {1}", streamName, toRemove);
+        return current;
+    }
+
+    private Set<String> resolveMetrics(List<String> metrics) {
+        if (metrics.isEmpty()) {
+            throw new AwsException("InvalidArgumentException",
+                    "ShardLevelMetrics must contain at least one metric", 400);
+        }
+        // Validate all entries before expanding ALL
+        for (String m : metrics) {
+            if (!VALID_SHARD_LEVEL_METRICS.contains(m)) {
+                throw new AwsException("InvalidArgumentException",
+                        "Invalid ShardLevelMetric: " + m, 400);
+            }
+        }
+        if (metrics.contains("ALL")) {
+            Set<String> all = new HashSet<>(VALID_SHARD_LEVEL_METRICS);
+            all.remove("ALL");
+            return all;
+        }
+        return new HashSet<>(metrics);
     }
 
     public void stopStreamEncryption(String streamName, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisStream.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisStream.java
@@ -6,8 +6,10 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +24,7 @@ public class KinesisStream {
     private String encryptionType = "NONE";
     private String keyId;
     private String streamMode = "PROVISIONED";
+    private Set<String> enhancedMonitoringMetrics = new HashSet<>();
 
     public KinesisStream() {}
 
@@ -61,4 +64,7 @@ public class KinesisStream {
 
     public String getStreamMode() { return streamMode; }
     public void setStreamMode(String streamMode) { this.streamMode = streamMode; }
+
+    public Set<String> getEnhancedMonitoringMetrics() { return enhancedMonitoringMetrics; }
+    public void setEnhancedMonitoringMetrics(Set<String> enhancedMonitoringMetrics) { this.enhancedMonitoringMetrics = enhancedMonitoringMetrics; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -156,6 +156,72 @@ class KinesisJsonHandlerTest {
     }
 
     @Test
+    void enableEnhancedMonitoringReturnsMetrics() {
+        createStream("test-stream");
+
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("StreamName", "test-stream");
+        req.putArray("ShardLevelMetrics").add("IncomingBytes").add("OutgoingBytes");
+        Response resp = handler.handle("EnableEnhancedMonitoring", req, REGION);
+        assertThat(resp.getStatus(), is(200));
+
+        ObjectNode body = responseEntity(resp);
+        assertEquals("test-stream", body.get("StreamName").asText());
+        assertEquals(0, body.get("CurrentShardLevelMetrics").size());
+        assertEquals(2, body.get("DesiredShardLevelMetrics").size());
+    }
+
+    @Test
+    void disableEnhancedMonitoringReturnsMetrics() {
+        createStream("test-stream");
+
+        ObjectNode enableReq = MAPPER.createObjectNode();
+        enableReq.put("StreamName", "test-stream");
+        enableReq.putArray("ShardLevelMetrics").add("IncomingBytes").add("OutgoingBytes");
+        handler.handle("EnableEnhancedMonitoring", enableReq, REGION);
+
+        ObjectNode disableReq = MAPPER.createObjectNode();
+        disableReq.put("StreamName", "test-stream");
+        disableReq.putArray("ShardLevelMetrics").add("IncomingBytes");
+        Response resp = handler.handle("DisableEnhancedMonitoring", disableReq, REGION);
+        assertThat(resp.getStatus(), is(200));
+
+        ObjectNode body = responseEntity(resp);
+        assertEquals(2, body.get("CurrentShardLevelMetrics").size());
+        assertEquals(1, body.get("DesiredShardLevelMetrics").size());
+    }
+
+    @Test
+    void describeStreamIncludesEnhancedMonitoring() {
+        createStream("test-stream");
+
+        ObjectNode enableReq = MAPPER.createObjectNode();
+        enableReq.put("StreamName", "test-stream");
+        enableReq.putArray("ShardLevelMetrics").add("IncomingBytes");
+        handler.handle("EnableEnhancedMonitoring", enableReq, REGION);
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStream", descReq, REGION);
+        ObjectNode desc = (ObjectNode) responseEntity(resp).get("StreamDescription");
+        assertEquals(1, desc.get("EnhancedMonitoring").size());
+        assertEquals(1, desc.get("EnhancedMonitoring").get(0).get("ShardLevelMetrics").size());
+        assertEquals("IncomingBytes", desc.get("EnhancedMonitoring").get(0).get("ShardLevelMetrics").get(0).asText());
+    }
+
+    @Test
+    void describeStreamSummaryIncludesEnhancedMonitoring() {
+        createStream("test-stream");
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStreamSummary", descReq, REGION);
+        ObjectNode summary = (ObjectNode) responseEntity(resp).get("StreamDescriptionSummary");
+        assertEquals(1, summary.get("EnhancedMonitoring").size());
+        assertEquals(0, summary.get("EnhancedMonitoring").get(0).get("ShardLevelMetrics").size());
+    }
+
+    @Test
     void streamNameTakesPrecedenceOverArn() {
         createStream("by-name");
 

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -189,6 +190,76 @@ class KinesisServiceTest {
         assertTrue(updated.getShards().get(0).isClosed());
         assertTrue(updated.getShards().get(1).isClosed());
         assertFalse(updated.getShards().get(2).isClosed());
+    }
+
+    @Test
+    void enableEnhancedMonitoring() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        Set<String> before = kinesisService.enableEnhancedMonitoring(
+                "my-stream", List.of("IncomingBytes", "OutgoingBytes"), REGION);
+
+        assertTrue(before.isEmpty());
+        KinesisStream stream = kinesisService.describeStream("my-stream", REGION);
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("IncomingBytes"));
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("OutgoingBytes"));
+    }
+
+    @Test
+    void enableEnhancedMonitoringAll() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.enableEnhancedMonitoring("my-stream", List.of("ALL"), REGION);
+
+        KinesisStream stream = kinesisService.describeStream("my-stream", REGION);
+        assertEquals(7, stream.getEnhancedMonitoringMetrics().size());
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("IncomingBytes"));
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("IteratorAgeMilliseconds"));
+    }
+
+    @Test
+    void disableEnhancedMonitoring() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.enableEnhancedMonitoring(
+                "my-stream", List.of("IncomingBytes", "OutgoingBytes", "IncomingRecords"), REGION);
+        Set<String> before = kinesisService.disableEnhancedMonitoring(
+                "my-stream", List.of("OutgoingBytes"), REGION);
+
+        assertEquals(3, before.size());
+        KinesisStream stream = kinesisService.describeStream("my-stream", REGION);
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("IncomingBytes"));
+        assertTrue(stream.getEnhancedMonitoringMetrics().contains("IncomingRecords"));
+        assertFalse(stream.getEnhancedMonitoringMetrics().contains("OutgoingBytes"));
+    }
+
+    @Test
+    void disableEnhancedMonitoringAll() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.enableEnhancedMonitoring(
+                "my-stream", List.of("IncomingBytes", "OutgoingBytes"), REGION);
+        kinesisService.disableEnhancedMonitoring("my-stream", List.of("ALL"), REGION);
+
+        KinesisStream stream = kinesisService.describeStream("my-stream", REGION);
+        assertTrue(stream.getEnhancedMonitoringMetrics().isEmpty());
+    }
+
+    @Test
+    void enableEnhancedMonitoringInvalidMetric() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        assertThrows(AwsException.class, () ->
+                kinesisService.enableEnhancedMonitoring("my-stream", List.of("BogusMetric"), REGION));
+    }
+
+    @Test
+    void enableEnhancedMonitoringEmptyListThrows() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        assertThrows(AwsException.class, () ->
+                kinesisService.enableEnhancedMonitoring("my-stream", List.of(), REGION));
+    }
+
+    @Test
+    void enableEnhancedMonitoringAllWithInvalidThrows() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        assertThrows(AwsException.class, () ->
+                kinesisService.enableEnhancedMonitoring("my-stream", List.of("ALL", "BogusMetric"), REGION));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Implement `EnableEnhancedMonitoring` and `DisableEnhancedMonitoring` Kinesis API operations that were returning `UnsupportedOperation`, breaking Terraform when `shard_level_metrics` is configured
- Store enhanced monitoring metrics on the stream model and return them in `DescribeStream` and `DescribeStreamSummary` responses
- Validate metric names against the 7 valid AWS shard-level metrics, with `ALL` expansion support
- Reject empty `ShardLevelMetrics` and mixed valid/invalid lists per AWS API contract

## Review

Internal two-pass review (Opus + Sonnet) plus Codex and Gemini external review. Fixes applied:
- Extracted `addEnhancedMonitoringNode()` helper to deduplicate DescribeStream/DescribeStreamSummary
- Removed redundant pre-call `describeStream` in handler methods
- Moved `VALID_SHARD_LEVEL_METRICS` constant to class top
- Full input validation before `ALL` expansion (Codex finding)
- Removed dead `ALL` check in disable path (Gemini finding)
- Added empty-list and ALL+invalid edge-case tests

## Changes

```
 KinesisJsonHandler.java     | +52
 KinesisService.java         | +42
 KinesisStream.java          | +6
 KinesisJsonHandlerTest.java | +66
 KinesisServiceTest.java     | +71
 5 files changed, +240
```

## Test plan

- [x] 11 new unit tests covering enable, disable, ALL expansion, empty list rejection, invalid metric rejection, ALL+invalid rejection, DescribeStream/DescribeStreamSummary EnhancedMonitoring in response
- [x] All 37 Kinesis tests pass (15 handler + 22 service)
- [ ] Integration test with Terraform `shard_level_metrics` configuration

Closes #410