### PR TITLE
fix(lambda): raise Jackson maxStringLength for large inline zip uploads (#412)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/JacksonConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/JacksonConfig.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.core.common;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.inject.Singleton;
+
+/**
+ * Raises this application's Jackson string-length limit so that large inline payloads
+ * (e.g. base64-encoded Lambda ZipFile up to ~67 MB) are accepted.
+ * AWS allows 50 MB direct upload; base64 expands that by ~33%.
+ */
+@Singleton
+public class JacksonConfig implements ObjectMapperCustomizer {
+
+    private static final int MAX_STRING_LENGTH = 100_000_000; // 100 MB
+
+    @Override
+    public void customize(ObjectMapper mapper) {
+        mapper.getFactory().setStreamReadConstraints(
+                StreamReadConstraints.builder()
+                        .maxStringLength(MAX_STRING_LENGTH)
+                        .build());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -165,5 +170,52 @@ class LambdaIntegrationTest {
             .get(BASE_PATH + "/functions/hello-world")
         .then()
             .statusCode(404);
+    }
+
+    @Test
+    @Order(11)
+    void createFunctionWithLargeInlineZip() throws Exception {
+        // Build a valid zip with a handler file + 16 MB padding so the base64
+        // encoding exceeds Jackson's former 20 MB maxStringLength default.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write("def handler(event, context): return 'ok'".getBytes());
+            zos.closeEntry();
+
+            // 16 MB padding file using incompressible data so the zip (and its
+            // base64 encoding) actually exceeds Jackson's former 20 MB limit
+            zos.putNextEntry(new ZipEntry("padding.bin"));
+            byte[] chunk = new byte[1024 * 1024];
+            java.util.Random rng = new java.util.Random(42);
+            for (int i = 0; i < 16; i++) {
+                rng.nextBytes(chunk);
+                zos.write(chunk);
+            }
+            zos.closeEntry();
+        }
+        String base64Zip = Base64.getEncoder().encodeToString(baos.toByteArray());
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "large-zip-fn",
+                    "Runtime": "python3.10",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "handler.handler",
+                    "Code": {
+                        "ZipFile": "%s"
+                    }
+                }
+                """.formatted(base64Zip))
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201)
+            .body("FunctionName", equalTo("large-zip-fn"));
+
+        // cleanup
+        given().delete(BASE_PATH + "/functions/large-zip-fn");
     }
 }


### PR DESCRIPTION
## Summary
- Add `ObjectMapperCustomizer` that raises Jackson's `StreamReadConstraints.maxStringLength` from 20 MB to 100 MB, allowing Lambda `CreateFunction` with inline `ZipFile` payloads up to the AWS 50 MB direct upload limit (~67 MB base64)
- Add integration test that sends a >20 MB base64 payload to verify large inline zips are accepted

Closes #412

## Review
- Internal review caught that the test's all-zero padding bytes would compress to nothing under DEFLATE, failing to exercise the Jackson limit. Fixed by using seeded random bytes.
- Javadoc narrowed to clarify the limit applies to the application's ObjectMapper, not a global Jackson default.

## Changes
```
 JacksonConfig.java (new, +25)        — ObjectMapperCustomizer bean
 LambdaIntegrationTest.java (+52)     — large inline zip test
```

## Test plan
- [x] `LambdaIntegrationTest#createFunctionWithLargeInlineZip` passes (16 MB random zip, >20 MB base64)
- [x] Full `LambdaIntegrationTest` suite passes (11 tests)
- [x] `S3IntegrationTest#putLargeObject` passes (no regression)