### PR TITLE
fix(cognito): return only description fields in ListUserPoolClients

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/cognito.bats
+++ b/compatibility-tests/sdk-test-awscli/test/cognito.bats
@@ -32,6 +32,33 @@ teardown() {
     [ -n "$CLIENT_ID" ]
 }
 
+@test "Cognito: list user pool clients returns only description fields" {
+    out=$(aws_cmd cognito-idp create-user-pool --pool-name "bats-test-pool-$(unique_name)")
+    POOL_ID=$(json_get "$out" '.UserPool.Id')
+
+    aws_cmd cognito-idp create-user-pool-client \
+        --user-pool-id "$POOL_ID" \
+        --client-name "bats-list-client" \
+        --generate-secret >/dev/null
+
+    run aws_cmd cognito-idp list-user-pool-clients --user-pool-id "$POOL_ID"
+    assert_success
+
+    # Should have the required fields
+    client_id=$(echo "$output" | jq -r '.UserPoolClients[0].ClientId')
+    [ -n "$client_id" ]
+    client_name=$(echo "$output" | jq -r '.UserPoolClients[0].ClientName')
+    [ "$client_name" = "bats-list-client" ]
+
+    # Must NOT have fields that belong to the full UserPoolClient type
+    has_secret=$(echo "$output" | jq 'any(.UserPoolClients[]; has("ClientSecret"))')
+    [ "$has_secret" = "false" ]
+    has_generate=$(echo "$output" | jq 'any(.UserPoolClients[]; has("GenerateSecret"))')
+    [ "$has_generate" = "false" ]
+    has_flows=$(echo "$output" | jq 'any(.UserPoolClients[]; has("AllowedOAuthFlows"))')
+    [ "$has_flows" = "false" ]
+}
+
 @test "Cognito: admin create user" {
     out=$(aws_cmd cognito-idp create-user-pool --pool-name "bats-test-pool-$(unique_name)")
     POOL_ID=$(json_get "$out" '.UserPool.Id')

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -152,7 +152,7 @@ public class CognitoJsonHandler {
         List<UserPoolClient> clients = service.listUserPoolClients(request.path("UserPoolId").asText());
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode items = response.putArray("UserPoolClients");
-        clients.forEach(c -> items.add(clientToNode(c)));
+        clients.forEach(c -> items.add(clientToDescriptionNode(c)));
         return Response.ok(response).build();
     }
 
@@ -462,6 +462,14 @@ public class CognitoJsonHandler {
         node.set("AccountRecoverySetting", objectMapper.valueToTree(p.getAccountRecoverySetting() != null ? p.getAccountRecoverySetting() : new HashMap<>()));
         node.put("UserPoolTier", p.getUserPoolTier() != null ? p.getUserPoolTier() : "ESSENTIALS");
 
+        return node;
+    }
+
+    private ObjectNode clientToDescriptionNode(UserPoolClient c) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ClientId", c.getClientId());
+        node.put("ClientName", c.getClientName());
+        node.put("UserPoolId", c.getUserPoolId());
         return node;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -358,6 +358,70 @@ class CognitoIntegrationTest {
                 "IdToken should not contain client_id");
     }
 
+    // ── Issue #416: ListUserPoolClients response matches spec ──────────
+
+    @Test
+    @Order(35)
+    void listUserPoolClientsReturnsOnlyDescriptionFields() throws Exception {
+        // Create a client with a secret to ensure extra fields exist
+        JsonNode secretClient = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "secret-client",
+                  "GenerateSecret": true,
+                  "AllowedOAuthFlows": ["code"],
+                  "AllowedOAuthScopes": ["openid"]
+                }
+                """.formatted(poolId));
+        String secretClientId = secretClient.path("UserPoolClient").path("ClientId").asText();
+        assertNotNull(secretClient.path("UserPoolClient").path("ClientSecret").asText(null),
+                "Created client should have a ClientSecret");
+
+        // List clients and verify only description fields are returned
+        JsonNode listResp = cognitoJson("ListUserPoolClients", """
+                { "UserPoolId": "%s" }
+                """.formatted(poolId));
+
+        assertTrue(listResp.path("UserPoolClients").size() >= 2,
+                "Should list at least 2 clients");
+
+        for (JsonNode client : listResp.path("UserPoolClients")) {
+            // Required fields
+            assertTrue(client.has("ClientId"), "Must have ClientId");
+            assertTrue(client.has("ClientName"), "Must have ClientName");
+            assertTrue(client.has("UserPoolId"), "Must have UserPoolId");
+
+            // Fields that must NOT appear per AWS spec (UserPoolClientDescription)
+            assertTrue(client.path("ClientSecret").isMissingNode(),
+                    "ListUserPoolClients must not include ClientSecret");
+            assertTrue(client.path("GenerateSecret").isMissingNode(),
+                    "ListUserPoolClients must not include GenerateSecret");
+            assertTrue(client.path("AllowedOAuthFlows").isMissingNode(),
+                    "ListUserPoolClients must not include AllowedOAuthFlows");
+            assertTrue(client.path("AllowedOAuthScopes").isMissingNode(),
+                    "ListUserPoolClients must not include AllowedOAuthScopes");
+            assertTrue(client.path("AllowedOAuthFlowsUserPoolClient").isMissingNode(),
+                    "ListUserPoolClients must not include AllowedOAuthFlowsUserPoolClient");
+            assertTrue(client.path("CreationDate").isMissingNode(),
+                    "ListUserPoolClients must not include CreationDate");
+            assertTrue(client.path("LastModifiedDate").isMissingNode(),
+                    "ListUserPoolClients must not include LastModifiedDate");
+        }
+
+        // Verify DescribeUserPoolClient still returns full details
+        JsonNode describeResp = cognitoJson("DescribeUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientId": "%s"
+                }
+                """.formatted(poolId, secretClientId));
+        JsonNode fullClient = describeResp.path("UserPoolClient");
+        assertNotNull(fullClient.path("ClientSecret").asText(null),
+                "DescribeUserPoolClient must include ClientSecret");
+        assertTrue(fullClient.has("GenerateSecret"),
+                "DescribeUserPoolClient must include GenerateSecret");
+    }
+
     // ── Issue #229: Password verification ──────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #416

## Summary
- `ListUserPoolClients` was returning full `UserPoolClient` objects (including `ClientSecret`, `GenerateSecret`, OAuth config, timestamps)
- Per the [AWS API spec](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUserPoolClients.html), this action returns `UserPoolClientDescription` with only `ClientId`, `ClientName`, and `UserPoolId`
- Add `clientToDescriptionNode()` for the list response, matching the existing pattern where `ListUserPools` uses `userPoolToDescriptionNode()`
- `DescribeUserPoolClient` / `CreateUserPoolClient` / `UpdateUserPoolClient` continue to return full details via `clientToNode()`

## Review
Pre-push review by Codex (agentic) and Gemini (agentic): no issues found.

## Changes
```
 CognitoJsonHandler.java      | 10 +++-  (new summary method + wiring)
 CognitoIntegrationTest.java  | 64 ++++  (list vs describe field assertions)
 cognito.bats                 | 27 ++++  (AWS CLI compat test)
```

## Test plan
- [x] New integration test: creates client with secret/OAuth, lists clients, asserts only 3 description fields present and 7 extra fields absent, verifies `DescribeUserPoolClient` still returns full object
- [x] New bats test: creates client with `--generate-secret`, lists via AWS CLI, asserts `ClientSecret`/`GenerateSecret`/`AllowedOAuthFlows` absent
- [x] Full Cognito integration suite passes (26 tests, 0 failures)