### PR TITLE
fix(dynamodb): support REMOVE for nested map paths (#402)

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
+++ b/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
@@ -597,3 +597,38 @@ teardown() {
     count=$(json_get "$output" '.Count')
     [ "$count" = "1" ]
 }
+
+# --- DynamoDB REMOVE nested map key tests (GH #402) ---
+
+@test "DynamoDB: REMOVE key from nested map" {
+    aws_cmd dynamodb create-table \
+        --table-name "$TABLE_NAME" \
+        --attribute-definitions AttributeName=pk,AttributeType=S AttributeName=sk,AttributeType=S \
+        --key-schema AttributeName=pk,KeyType=HASH AttributeName=sk,KeyType=RANGE \
+        --billing-mode PAY_PER_REQUEST >/dev/null
+
+    ddb_wait_table "$TABLE_NAME"
+
+    # Set a map attribute with a key
+    aws_cmd dynamodb update-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"user1"},"sk":{"S":"sort1"}}' \
+        --update-expression 'SET ratings = :ratings' \
+        --expression-attribute-values '{":ratings":{"M":{"foo":{"S":"5"},"bar":{"S":"3"}}}}' >/dev/null
+
+    # REMOVE ratings.foo
+    aws_cmd dynamodb update-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"user1"},"sk":{"S":"sort1"}}' \
+        --update-expression 'REMOVE ratings.foo' >/dev/null
+
+    # Verify foo is removed but bar remains
+    run aws_cmd dynamodb get-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"user1"},"sk":{"S":"sort1"}}'
+    assert_success
+    foo=$(echo "$output" | jq -r '.Item.ratings.M.foo // "null"')
+    bar=$(echo "$output" | jq -r '.Item.ratings.M.bar.S')
+    [ "$foo" = "null" ]
+    [ "$bar" = "3" ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1058,8 +1058,7 @@ public class DynamoDbService {
                 }
             }
 
-            String attrName = resolveAttributeName(attrPart, exprAttrNames);
-            item.remove(attrName);
+            removeValueAtPath(item, attrPart, exprAttrNames);
         }
         return clause;
     }
@@ -1363,6 +1362,45 @@ public class DynamoDbService {
      */
     private boolean hasValueAtPath(JsonNode item, String path, JsonNode exprAttrNames) {
         return getValueAtPath(item, path, exprAttrNames) != null;
+    }
+
+    /**
+     * Removes a value at a potentially nested attribute path.
+     * Supports paths like "attr", "parent.child", "#alias.nested" etc.
+     * For nested paths, navigates into the DynamoDB Map structure (M field)
+     * and removes the final key from its parent.
+     */
+    private void removeValueAtPath(ObjectNode item, String path, JsonNode exprAttrNames) {
+        String[] segments = path.split("\\.");
+        for (int i = 0; i < segments.length; i++) {
+            segments[i] = resolveAttributeName(segments[i].trim(), exprAttrNames);
+        }
+
+        if (segments.length == 1) {
+            item.remove(segments[0]);
+            return;
+        }
+
+        // Navigate to the parent of the target attribute
+        ObjectNode current = item;
+        for (int i = 0; i < segments.length - 1; i++) {
+            String segment = segments[i];
+            JsonNode child = current.get(segment);
+
+            if (child == null || !child.has("M")) {
+                // Path doesn't exist, nothing to remove
+                return;
+            }
+
+            JsonNode mapContent = child.get("M");
+            if (mapContent instanceof ObjectNode) {
+                current = (ObjectNode) mapContent;
+            } else {
+                return;
+            }
+        }
+
+        current.remove(segments[segments.length - 1]);
     }
 
     private int findNextComma(String s) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -924,4 +924,140 @@ class DynamoDbServiceTest {
                 "isActive should still be true after get");
     }
 
+    /**
+     * Test REMOVE with nested map paths (e.g. "ratings.foo").
+     * Reproduces GitHub issue #402: REMOVE on a map key succeeds but data is unchanged.
+     */
+    @Test
+    void testRemoveNestedMapKey() {
+        createUsersTable();
+
+        // Put item with a map attribute containing two keys
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "user-1"));
+        ObjectNode ratingsInner = mapper.createObjectNode();
+        ratingsInner.set("foo", attributeValue("S", "5"));
+        ratingsInner.set("bar", attributeValue("S", "3"));
+        ObjectNode ratingsMap = mapper.createObjectNode();
+        ratingsMap.set("M", ratingsInner);
+        initialItem.set("ratings", ratingsMap);
+        service.putItem("Users", initialItem);
+
+        ObjectNode key = mapper.createObjectNode();
+        key.set("userId", attributeValue("S", "user-1"));
+
+        // Verify both keys exist
+        JsonNode before = service.getItem("Users", key);
+        assertTrue(before.get("ratings").get("M").has("foo"));
+        assertTrue(before.get("ratings").get("M").has("bar"));
+
+        // REMOVE ratings.foo
+        DynamoDbService.UpdateResult result = service.updateItem("Users", key, null,
+                "REMOVE ratings.foo", null, null, "ALL_NEW");
+
+        JsonNode updated = result.newItem();
+        assertFalse(updated.get("ratings").get("M").has("foo"),
+                "foo should be removed from ratings map");
+        assertTrue(updated.get("ratings").get("M").has("bar"),
+                "bar should still exist in ratings map");
+        assertEquals("3", updated.get("ratings").get("M").get("bar").get("S").asText());
+    }
+
+    /**
+     * Test REMOVE with nested map paths using expression attribute names.
+     */
+    @Test
+    void testRemoveNestedMapKeyWithExpressionNames() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "user-2"));
+        ObjectNode metaInner = mapper.createObjectNode();
+        metaInner.set("temp", attributeValue("S", "value"));
+        metaInner.set("keep", attributeValue("S", "important"));
+        ObjectNode metaMap = mapper.createObjectNode();
+        metaMap.set("M", metaInner);
+        initialItem.set("metadata", metaMap);
+        service.putItem("Users", initialItem);
+
+        ObjectNode key = mapper.createObjectNode();
+        key.set("userId", attributeValue("S", "user-2"));
+
+        // REMOVE #meta.#tmp using expression attribute names
+        ObjectNode exprAttrNames = mapper.createObjectNode();
+        exprAttrNames.put("#meta", "metadata");
+        exprAttrNames.put("#tmp", "temp");
+
+        DynamoDbService.UpdateResult result = service.updateItem("Users", key, null,
+                "REMOVE #meta.#tmp", exprAttrNames, null, "ALL_NEW");
+
+        JsonNode updated = result.newItem();
+        assertFalse(updated.get("metadata").get("M").has("temp"),
+                "temp should be removed from metadata map");
+        assertTrue(updated.get("metadata").get("M").has("keep"),
+                "keep should still exist in metadata map");
+    }
+
+    /**
+     * Test REMOVE on a non-existent nested path does not fail.
+     */
+    @Test
+    void testRemoveNonExistentNestedPath() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "user-3"));
+        initialItem.set("name", attributeValue("S", "Alice"));
+        service.putItem("Users", initialItem);
+
+        ObjectNode key = mapper.createObjectNode();
+        key.set("userId", attributeValue("S", "user-3"));
+
+        // REMOVE on a path where the parent map doesn't exist - should not fail
+        DynamoDbService.UpdateResult result = service.updateItem("Users", key, null,
+                "REMOVE nonexistent.child", null, null, "ALL_NEW");
+
+        JsonNode updated = result.newItem();
+        assertEquals("Alice", updated.get("name").get("S").asText(),
+                "existing attributes should be unchanged");
+    }
+
+    /**
+     * Test REMOVE with deeply nested map paths (3 levels).
+     */
+    @Test
+    void testRemoveDeeplyNestedMapKey() {
+        createUsersTable();
+
+        // Build: settings.notifications.email = "on", settings.notifications.sms = "off"
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "user-4"));
+
+        ObjectNode notifInner = mapper.createObjectNode();
+        notifInner.set("email", attributeValue("S", "on"));
+        notifInner.set("sms", attributeValue("S", "off"));
+        ObjectNode notifMap = mapper.createObjectNode();
+        notifMap.set("M", notifInner);
+
+        ObjectNode settingsInner = mapper.createObjectNode();
+        settingsInner.set("notifications", notifMap);
+        ObjectNode settingsMap = mapper.createObjectNode();
+        settingsMap.set("M", settingsInner);
+
+        initialItem.set("settings", settingsMap);
+        service.putItem("Users", initialItem);
+
+        ObjectNode key = mapper.createObjectNode();
+        key.set("userId", attributeValue("S", "user-4"));
+
+        // REMOVE settings.notifications.sms
+        DynamoDbService.UpdateResult result = service.updateItem("Users", key, null,
+                "REMOVE settings.notifications.sms", null, null, "ALL_NEW");
+
+        JsonNode updated = result.newItem();
+        JsonNode notifs = updated.get("settings").get("M").get("notifications").get("M");
+        assertTrue(notifs.has("email"), "email should still exist");
+        assertFalse(notifs.has("sms"), "sms should be removed");
+    }
+
 }


### PR DESCRIPTION
## Summary
- `applyRemoveClause()` only removed top-level attributes, treating paths like `ratings.foo` as a literal key name instead of navigating into the DynamoDB Map structure
- Add `removeValueAtPath()` method that splits the document path into segments, resolves expression attribute name placeholders, and navigates through nested Map wrappers (`M` field) to remove the target key from its parent
- Follows the same path navigation pattern used by `setValueAtPath()` and `getValueAtPath()`

Fixes #402

## Changes
- `DynamoDbService.java`: Replace `item.remove(attrName)` with `removeValueAtPath()` call in `applyRemoveClause()`; add `removeValueAtPath()` method
- `DynamoDbServiceTest.java`: 4 unit tests covering nested map key removal, expression attribute names, non-existent paths, and 3-level deep nesting
- `dynamodb.bats`: AWS CLI compat test reproducing the exact scenario from #402

## Test plan
- [x] 4 new unit tests (DynamoDbServiceTest): nested paths, expression names, missing paths, deep nesting
- [x] 1 new AWS CLI compat test (dynamodb.bats): reproduces #402 scenario
- [x] Full test suite green (1991 passed, 0 failures)
- [x] Existing REMOVE tests still pass (testUpdateWithSetAndRemoveCombined)