### PR TITLE
fix(s3): honor canned object ACLs on write paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * include `ec2` and `ecs` in enabled-service reporting and enforce disabled gating for ACM and ECS targeted requests
 * return protocol-correct JSON disabled responses for auth-only REST GETs instead of falling back to XML
 * honor `floci.storage.services.acm.*` overrides in `StorageFactory`
+* **s3:** honor canned object ACLs on PutObject, CopyObject, and multipart uploads
 
 ## [1.5.2](https://github.com/floci-io/floci/compare/1.5.1...1.5.2) (2026-04-10)
 

--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -138,8 +138,12 @@ Floci now persists and returns the following object attribute state on S3 object
 - storage class from `x-amz-storage-class`
 - checksum metadata for object reads and `GetObjectAttributes`
 - multipart part manifests for `GetObjectAttributes(ObjectParts)`
+- canned object ACLs from `x-amz-acl` on `PutObject`, `CopyObject`, and multipart initiation
 
 Current limitations:
 
 - checksum responses focus on SHA-1 and SHA-256
 - copy-based metadata updates support `x-amz-metadata-directive: REPLACE` for user metadata and content type, but do not yet cover every AWS copy header
+- explicit ACL grant headers such as `x-amz-grant-read` and `x-amz-grant-full-control` are not modeled yet
+- cross-account canned ACL variants collapse to the emulator's single synthetic owner where Floci does not model a distinct second principal
+- `aws-exec-read` is accepted for compatibility, but Floci does not yet model a distinct EC2 bundle-reader grantee in `GetObjectAcl`

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -399,12 +399,14 @@ public class S3Controller {
             String persistedEncoding = toPersistedContentEncoding(contentEncoding);
             String contentDisposition = httpHeaders.getHeaderString("Content-Disposition");
             String cacheControl = httpHeaders.getHeaderString("Cache-Control");
+            String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     httpHeaders.getHeaderString("x-amz-storage-class"),
                     persistedEncoding,
                     lockMode, retainUntil, legalHold,
                     contentDisposition,
-                    cacheControl);
+                    cacheControl,
+                    cannedAcl);
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
@@ -731,7 +733,8 @@ public class S3Controller {
                 MultipartUpload upload = s3Service.initiateMultipartUpload(bucket, key, contentType,
                         extractUserMetadata(httpHeaders),
                         httpHeaders.getHeaderString("x-amz-storage-class"),
-                        httpHeaders.getHeaderString("Content-Disposition"));
+                        httpHeaders.getHeaderString("Content-Disposition"),
+                        httpHeaders.getHeaderString("x-amz-acl"));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("InitiateMultipartUploadResult", AwsNamespaces.S3)
@@ -1359,6 +1362,7 @@ public class S3Controller {
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
         String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
+        String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
         S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
                 httpHeaders.getHeaderString("x-amz-metadata-directive"),
                 extractUserMetadata(httpHeaders),
@@ -1366,7 +1370,8 @@ public class S3Controller {
                 contentType,
                 copyContentEncoding,
                 copyContentDisposition,
-                copyCacheControl);
+                copyCacheControl,
+                cannedAcl);
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyObjectResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -930,6 +930,9 @@ public class S3Service {
                                                    Map<String, String> metadata, String storageClass,
                                                    String contentDisposition, String acl) {
         ensureBucketExists(bucket);
+        if (acl != null && !acl.isBlank()) {
+            cannedObjectAclXml(acl);
+        }
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
         if (metadata != null) {
             upload.getMetadata().putAll(metadata);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -37,6 +37,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class S3Service {
+    private static final String DEFAULT_OWNER_ID = "000000000000";
+    private static final String DEFAULT_OWNER_DISPLAY_NAME = "floci";
+    private static final String ALL_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AllUsers";
+    private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
 
     @FunctionalInterface
     interface LambdaInvoker {
@@ -184,30 +188,30 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, storageClass, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String contentEncoding,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                              String contentDisposition, String cacheControl) {
+                              String contentDisposition, String cacheControl, String acl) {
         S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl);
+                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl, acl);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
     }
@@ -218,7 +222,7 @@ public class S3Service {
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
         return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
-                null, null, null, null, null, null);
+                null, null, null, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
@@ -226,14 +230,14 @@ public class S3Service {
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return storeObject(bucketName, key, data, contentType, metadata, storageClass, checksum, parts,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata, String storageClass,
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                                 String contentEncoding, String contentDisposition, String cacheControl) {
+                                 String contentEncoding, String contentDisposition, String cacheControl, String acl) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
@@ -248,6 +252,7 @@ public class S3Service {
         object.setContentEncoding(contentEncoding);
         object.setContentDisposition(contentDisposition);
         object.setCacheControl(cacheControl);
+        object.setAcl(cannedObjectAclXml(acl));
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();
@@ -600,14 +605,14 @@ public class S3Service {
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType) {
         return copyObject(sourceBucket, sourceKey, destBucket, destKey, metadataDirective,
-                replacementMetadata, storageClass, contentType, null, null, null);
+                replacementMetadata, storageClass, contentType, null, null, null, null);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey,
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType, String contentEncoding,
-                               String contentDisposition, String cacheControl) {
+                               String contentDisposition, String cacheControl, String acl) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
 
@@ -624,7 +629,7 @@ public class S3Service {
         String effectiveCacheControl = replaceMetadata && cacheControl != null ? cacheControl : source.getCacheControl();
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
                 effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null,
-                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl);
+                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl, acl);
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
@@ -913,17 +918,17 @@ public class S3Service {
     // --- Multipart Upload Operations ---
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType) {
-        return initiateMultipartUpload(bucket, key, contentType, null, null, null);
+        return initiateMultipartUpload(bucket, key, contentType, null, null, null, null);
     }
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass) {
-        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, null);
+        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, null, null);
     }
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass,
-                                                   String contentDisposition) {
+                                                   String contentDisposition, String acl) {
         ensureBucketExists(bucket);
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
         if (metadata != null) {
@@ -931,6 +936,7 @@ public class S3Service {
         }
         upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
         upload.setContentDisposition(contentDisposition);
+        upload.setAcl(acl);
 
         if (inMemory) {
             memoryMultipartStore.put(upload.getUploadId(), new ConcurrentHashMap<>());
@@ -1037,7 +1043,7 @@ public class S3Service {
             S3Checksum checksum = buildChecksum(allData, completedParts, true);
             S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
                     upload.getStorageClass(), checksum, completedParts, null, null, null,
-                    null, upload.getContentDisposition(), null);
+                    null, upload.getContentDisposition(), null, upload.getAcl());
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);
@@ -1264,7 +1270,7 @@ public class S3Service {
     public String getBucketAcl(String bucketName) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
-        return bucket.getAcl() != null ? bucket.getAcl() : defaultAclXml("000000000000", "floci");
+        return bucket.getAcl() != null ? bucket.getAcl() : defaultAclXml(DEFAULT_OWNER_ID, DEFAULT_OWNER_DISPLAY_NAME);
     }
 
     public void putBucketAcl(String bucketName, String acl) {
@@ -1276,7 +1282,7 @@ public class S3Service {
 
     public String getObjectAcl(String bucketName, String key, String versionId) {
         S3Object obj = getObject(bucketName, key, versionId);
-        return obj.getAcl() != null ? obj.getAcl() : defaultAclXml("000000000000", "floci");
+        return obj.getAcl() != null ? obj.getAcl() : defaultAclXml(DEFAULT_OWNER_ID, DEFAULT_OWNER_DISPLAY_NAME);
     }
 
     public void putObjectAcl(String bucketName, String key, String versionId, String acl) {
@@ -1340,7 +1346,7 @@ public class S3Service {
         LOG.infov("Restored object: {0}/{1} (stub)", bucketName, key);
     }
 
-    private String defaultAclXml(String id, String displayName) {
+    private static String defaultAclXml(String id, String displayName) {
         return new XmlBuilder()
                 .start("AccessControlPolicy")
                   .start("Owner")
@@ -1356,6 +1362,74 @@ public class S3Service {
                       .elem("Permission", "FULL_CONTROL")
                     .end("Grant")
                   .end("AccessControlList")
+                .end("AccessControlPolicy")
+                .build();
+    }
+
+    static String cannedObjectAclXml(String cannedAcl) {
+        if (cannedAcl == null || cannedAcl.isBlank()) {
+            return null;
+        }
+        return switch (cannedAcl) {
+            case "private", "bucket-owner-read", "bucket-owner-full-control" ->
+                    defaultAclXml(DEFAULT_OWNER_ID, DEFAULT_OWNER_DISPLAY_NAME);
+            // Floci currently runs as a single synthetic account, so there is no distinct EC2 bundle-reader
+            // principal to represent in GetObjectAcl responses yet.
+            case "aws-exec-read" -> defaultAclXml(DEFAULT_OWNER_ID, DEFAULT_OWNER_DISPLAY_NAME);
+            case "public-read" -> objectAclXml(
+                    ownerFullControlGrant(),
+                    groupGrant(ALL_USERS_GROUP_URI, "READ"));
+            case "public-read-write" -> objectAclXml(
+                    ownerFullControlGrant(),
+                    groupGrant(ALL_USERS_GROUP_URI, "READ"),
+                    groupGrant(ALL_USERS_GROUP_URI, "WRITE"));
+            case "authenticated-read" -> objectAclXml(
+                    ownerFullControlGrant(),
+                    groupGrant(AUTHENTICATED_USERS_GROUP_URI, "READ"));
+            default -> throw new AwsException("InvalidArgument",
+                    "Unsupported x-amz-acl value: " + cannedAcl, 400);
+        };
+    }
+
+    private static String ownerFullControlGrant() {
+        return canonicalUserGrant(DEFAULT_OWNER_ID, DEFAULT_OWNER_DISPLAY_NAME, "FULL_CONTROL");
+    }
+
+    private static String canonicalUserGrant(String id, String displayName, String permission) {
+        return new XmlBuilder()
+                .start("Grant")
+                .raw("<Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\">")
+                .elem("ID", id)
+                .elem("DisplayName", displayName)
+                .raw("</Grantee>")
+                .elem("Permission", permission)
+                .end("Grant")
+                .build();
+    }
+
+    private static String groupGrant(String uri, String permission) {
+        return new XmlBuilder()
+                .start("Grant")
+                .raw("<Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Group\">")
+                .elem("URI", uri)
+                .raw("</Grantee>")
+                .elem("Permission", permission)
+                .end("Grant")
+                .build();
+    }
+
+    private static String objectAclXml(String... grants) {
+        XmlBuilder xml = new XmlBuilder()
+                .start("AccessControlPolicy")
+                .start("Owner")
+                .elem("ID", DEFAULT_OWNER_ID)
+                .elem("DisplayName", DEFAULT_OWNER_DISPLAY_NAME)
+                .end("Owner")
+                .start("AccessControlList");
+        for (String grant : grants) {
+            xml.raw(grant);
+        }
+        return xml.end("AccessControlList")
                 .end("AccessControlPolicy")
                 .build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -17,6 +17,7 @@ public class MultipartUpload {
     private String contentType;
     private String storageClass;
     private String contentDisposition;
+    private String acl;
     private Map<String, String> metadata;
     private Instant initiated;
     private final Map<Integer, Part> parts = new ConcurrentHashMap<>();
@@ -53,6 +54,9 @@ public class MultipartUpload {
 
     public String getContentDisposition() { return contentDisposition; }
     public void setContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; }
+
+    public String getAcl() { return acl; }
+    public void setAcl(String acl) { this.acl = acl; }
 
     public Map<String, String> getMetadata() { return metadata; }
     public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
@@ -61,7 +61,7 @@ class S3AclIntegrationTest {
             .statusCode(200);
 
         given()
-            .header("x-amz-copy-source", "/" + BUCKET + "/public.txt")
+            .header("x-amz-copy-source", "/" + BUCKET + "/copy-source.txt")
         .when()
             .put("/" + BUCKET + "/copy-default-private.txt")
         .then()
@@ -145,6 +145,19 @@ class S3AclIntegrationTest {
             .body("bad acl")
         .when()
             .put("/" + BUCKET + "/invalid-acl.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("Unsupported x-amz-acl value"));
+    }
+
+    @Test
+    @Order(7)
+    void initiateMultipartUploadRejectsUnsupportedCannedAcl() {
+        given()
+            .header("x-amz-acl", "totally-unsupported")
+        .when()
+            .post("/" + BUCKET + "/invalid-multipart.txt?uploads")
         .then()
             .statusCode(400)
             .body(containsString("InvalidArgument"))

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
@@ -1,0 +1,153 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3AclIntegrationTest {
+
+    private static final String BUCKET = "acl-test-bucket";
+    private static final String ALL_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AllUsers";
+    private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+    private static String multipartUploadId;
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void putObjectAppliesPublicReadAcl() {
+        given()
+            .header("x-amz-acl", "public-read")
+            .body("public body")
+        .when()
+            .put("/" + BUCKET + "/public.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/public.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(3)
+    void copyObjectWithoutAclDefaultsToPrivateAcl() {
+        given()
+            .body("copy me")
+        .when()
+            .put("/" + BUCKET + "/copy-source.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/public.txt")
+        .when()
+            .put("/" + BUCKET + "/copy-default-private.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/copy-default-private.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(ALL_USERS_GROUP_URI)))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(4)
+    void copyObjectAppliesRequestedAuthenticatedReadAcl() {
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/copy-source.txt")
+            .header("x-amz-acl", "authenticated-read")
+        .when()
+            .put("/" + BUCKET + "/copy-authenticated.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/copy-authenticated.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(AUTHENTICATED_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"))
+            .body(not(containsString(ALL_USERS_GROUP_URI)));
+    }
+
+    @Test
+    @Order(5)
+    void initiateMultipartUploadAppliesRequestedAclOnComplete() {
+        multipartUploadId = given()
+            .header("x-amz-acl", "public-read")
+        .when()
+            .post("/" + BUCKET + "/multipart-public.txt?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body("part-one")
+        .when()
+            .put("/" + BUCKET + "/multipart-public.txt?uploadId=" + multipartUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+
+        given()
+            .contentType("application/xml")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/multipart-public.txt?uploadId=" + multipartUploadId)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/multipart-public.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"));
+    }
+
+    @Test
+    @Order(6)
+    void putObjectRejectsUnsupportedCannedAcl() {
+        given()
+            .header("x-amz-acl", "totally-unsupported")
+            .body("bad acl")
+        .when()
+            .put("/" + BUCKET + "/invalid-acl.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("Unsupported x-amz-acl value"));
+    }
+}


### PR DESCRIPTION
## What changed

This PR adds canned object ACL support on S3 object creation paths.

- honors `x-amz-acl` on `PutObject`
- honors `x-amz-acl` on `CopyObject`
- carries `x-amz-acl` through multipart initiation/completion
- exposes the stored ACL via `GetObjectAcl`
- rejects invalid canned ACL values at multipart initiation time instead of deferring the error until completion

## Why

Floci already supported `PutObjectAcl` and `GetObjectAcl`, but objects created through normal write paths ignored canned ACL headers. That made `GetObjectAcl` diverge from AWS behavior for newly written objects and blocked consumers that rely on `ACL=public-read` / `private` during upload.

## Notes

This PR stays scoped to canned ACLs on object write paths. It does not add support for explicit `x-amz-grant-*` headers or presigned POST ACL handling.

Because Floci currently models a single synthetic owner, cross-account canned ACL variants are intentionally collapsed to that owner, and `aws-exec-read` is accepted without modeling a distinct EC2 bundle-reader grantee yet.

## Validation

- `./mvnw -q -Dtest=S3AclIntegrationTest test`
- `./mvnw -q -Dtest=S3AclIntegrationTest,S3MultipartIntegrationTest,S3IntegrationTest,S3ServiceTest test`
