### PR TITLE
[FEAT] CloudFormation: gracefully skip unsupported custom resource types

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -131,7 +131,13 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::ApiGatewayV2::Stage" -> provisionApiGatewayV2Stage(resource, properties, engine, region);
                 case "AWS::ApiGatewayV2::Deployment" -> provisionApiGatewayV2Deployment(resource, properties, engine, region);
                 default -> {
-                    LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
+                    if (resourceType.startsWith("AWS::")) {
+                        LOG.warnv("Unsupported AWS resource type: {0} ({1}) — stubbing with placeholder",
+                                resourceType, logicalId);
+                    } else {
+                        LOG.warnv("Skipping custom resource type: {0} ({1}) — not supported in local emulation",
+                                resourceType, logicalId);
+                    }
                     resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
                     resource.getAttributes().put("Arn", "arn:aws:stub:::" + logicalId);
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisionerTest.java
@@ -1,0 +1,58 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CloudFormationResourceProvisionerTest {
+
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        // Services are null — unsupported types never invoke them
+        provisioner = new CloudFormationResourceProvisioner(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null);
+    }
+
+    @Test
+    void customResourceType_stubbedWithCreateComplete() {
+        StackResource resource = provisioner.provision(
+                "MyService", "Acorns::ECS::ServiceV2", null,
+                null, "us-east-1", "000000000000", "test-stack");
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertNull(resource.getStatusReason());
+        assertTrue(resource.getPhysicalId().startsWith("MyService-"));
+        assertEquals("arn:aws:stub:::MyService", resource.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void unsupportedAwsResourceType_stubbedWithCreateComplete() {
+        StackResource resource = provisioner.provision(
+                "MyBus", "AWS::Events::EventBus", null,
+                null, "us-east-1", "000000000000", "test-stack");
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertNull(resource.getStatusReason());
+        assertTrue(resource.getPhysicalId().startsWith("MyBus-"));
+        assertEquals("arn:aws:stub:::MyBus", resource.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void multipleCustomTypes_eachGetUniquePhysicalId() {
+        StackResource r1 = provisioner.provision(
+                "ResourceA", "Custom::MyThing", null,
+                null, "us-east-1", "000000000000", "test-stack");
+        StackResource r2 = provisioner.provision(
+                "ResourceB", "Custom::MyThing", null,
+                null, "us-east-1", "000000000000", "test-stack");
+
+        assertNotEquals(r1.getPhysicalId(), r2.getPhysicalId());
+        assertEquals("CREATE_COMPLETE", r1.getStatus());
+        assertEquals("CREATE_COMPLETE", r2.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #423

Unsupported resource types in CloudFormation templates (e.g., `Acorns::ECS::ServiceV2`, `Custom::MyResource`, `AWS::Events::EventBus`) were logged at `DEBUG` level, making them invisible during normal operation. Developers had no indication that a resource was stubbed instead of provisioned.

This PR upgrades the log level to `WARN` and differentiates the message between unimplemented AWS types and non-AWS custom/third-party types, so developers can immediately see what was skipped.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable. This changes Floci's internal logging behavior for resource types it does not implement. No wire protocol changes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)