### PR TITLE
fix(kinesis): return time-based MillisBehindLatest

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -393,8 +393,24 @@ public class KinesisService {
         Map<String, Object> response = new HashMap<>();
         response.put("Records", result);
         response.put("NextShardIterator", nextIterator);
-        response.put("MillisBehindLatest", Math.max(0, allRecords.size() - nextIndex));
+        response.put("MillisBehindLatest", computeMillisBehindLatest(allRecords, nextIndex));
         return response;
+    }
+
+    /**
+     * Time delta in ms between the last record returned and the shard tip.
+     * Zero when caught up, the shard is empty, or no records were returned.
+     */
+    private long computeMillisBehindLatest(List<KinesisRecord> allRecords, int nextIndex) {
+        if (nextIndex <= 0 || nextIndex >= allRecords.size()) {
+            return 0L;
+        }
+        Instant lastReturned = allRecords.get(nextIndex - 1).getApproximateArrivalTimestamp();
+        Instant tip = allRecords.get(allRecords.size() - 1).getApproximateArrivalTimestamp();
+        if (lastReturned == null || tip == null) {
+            return 0L;
+        }
+        return Math.max(0L, tip.toEpochMilli() - lastReturned.toEpochMilli());
     }
 
     private KinesisStream resolveStream(String streamName, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
@@ -4,11 +4,14 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisConsumer;
+import io.github.hectorvent.floci.services.kinesis.model.KinesisRecord;
+import io.github.hectorvent.floci.services.kinesis.model.KinesisShard;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -104,6 +107,78 @@ class KinesisServiceTest {
         @SuppressWarnings("unchecked")
         var records = (List<?>) result.get("Records");
         assertTrue(records.isEmpty());
+        assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
+    }
+
+    @Test
+    void millisBehindLatestIsZeroOnEmptyShard() {
+        kinesisService.createStream("empty", 1, REGION);
+        String shardId = kinesisService.describeStream("empty", REGION).getShards().getFirst().getShardId();
+        String iterator = kinesisService.getShardIterator("empty", shardId, "TRIM_HORIZON", null, REGION);
+
+        Map<String, Object> result = kinesisService.getRecords(iterator, 10, REGION);
+
+        assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
+    }
+
+    @Test
+    void millisBehindLatestIsZeroWhenCaughtUp() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.putRecord("my-stream", "a".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+        kinesisService.putRecord("my-stream", "b".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+
+        String shardId = kinesisService.describeStream("my-stream", REGION).getShards().getFirst().getShardId();
+        String iterator = kinesisService.getShardIterator("my-stream", shardId, "TRIM_HORIZON", null, REGION);
+
+        Map<String, Object> result = kinesisService.getRecords(iterator, 10, REGION);
+
+        @SuppressWarnings("unchecked")
+        var records = (List<?>) result.get("Records");
+        assertEquals(2, records.size());
+        assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
+    }
+
+    @Test
+    void millisBehindLatestIsTimeDeltaWhenBatchLimitHit() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.putRecord("my-stream", "a".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+        kinesisService.putRecord("my-stream", "b".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+        kinesisService.putRecord("my-stream", "c".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+
+        // Overwrite timestamps so we can assert a deterministic delta.
+        KinesisShard shard = kinesisService.describeStream("my-stream", REGION).getShards().getFirst();
+        List<KinesisRecord> records = shard.getRecords();
+        Instant base = Instant.parse("2026-01-01T00:00:00Z");
+        records.get(0).setApproximateArrivalTimestamp(base);
+        records.get(1).setApproximateArrivalTimestamp(base.plusMillis(1500));
+        records.get(2).setApproximateArrivalTimestamp(base.plusMillis(4000));
+
+        String iterator = kinesisService.getShardIterator("my-stream", shard.getShardId(), "TRIM_HORIZON", null, REGION);
+
+        Map<String, Object> result = kinesisService.getRecords(iterator, 2, REGION);
+
+        @SuppressWarnings("unchecked")
+        var returned = (List<?>) result.get("Records");
+        assertEquals(2, returned.size());
+        // Last returned = records[1] at +1500ms, tip = records[2] at +4000ms, delta = 2500ms
+        assertEquals(2500L, ((Number) result.get("MillisBehindLatest")).longValue());
+    }
+
+    @Test
+    void millisBehindLatestIsZeroWhenTimestampsMissing() {
+        kinesisService.createStream("my-stream", 1, REGION);
+        kinesisService.putRecord("my-stream", "a".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+        kinesisService.putRecord("my-stream", "b".getBytes(StandardCharsets.UTF_8), "pk", REGION);
+
+        KinesisShard shard = kinesisService.describeStream("my-stream", REGION).getShards().getFirst();
+        // Simulate a record with no arrival timestamp (e.g. legacy data or a partial put).
+        shard.getRecords().getFirst().setApproximateArrivalTimestamp(null);
+
+        String iterator = kinesisService.getShardIterator("my-stream", shard.getShardId(), "TRIM_HORIZON", null, REGION);
+        Map<String, Object> result = kinesisService.getRecords(iterator, 1, REGION);
+
+        // First record returned, second still ahead; null timestamp must not NPE.
+        assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`GetRecords` was returning the **count of records remaining in the shard** for `MillisBehindLatest`, mislabeled as milliseconds. AWS documents this field as the time delta between the consumer position and the shard tip, and downstream consumers (e.g. KCL, async-kinesis, custom iterator-age gauges) treat it as ms, so lag-based alerting against floci was wildly wrong (e.g. 10 records ahead surfaced as 10 ms lag).

This change computes `MillisBehindLatest` as `tipArrivalTimestamp - lastReturnedArrivalTimestamp` in ms, using the `ApproximateArrivalTimestamp` already stamped at `PutRecord` time. Returns `0` when the consumer is at the shard tip, the shard is empty, no records were returned, or timestamps are missing (defensive).

Reference: [AWS GetRecords API](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html):
> MillisBehindLatest: The number of milliseconds the GetRecords response is from the tip of the stream... A value of zero indicates that record processing is caught up.

## Backwards compatibility

Consumers that were (accidentally) relying on the count semantics will see different values. Since the field is documented as ms and the old value was nonsensical in that unit, any code treating it correctly is unaffected.

## Test plan
- [x] 4 new unit tests in `KinesisServiceTest` covering: empty shard, caught-up, batch-limit-hit (with deterministic 2500 ms delta), null-timestamp defensive path
- [x] Added `MillisBehindLatest == 0` assertion to the existing `LATEST` iterator test
- [x] Full suite green: `./mvnw test`, 2046 passed, 0 failed, 0 errors, 0 skipped