### PR TITLE
fix(dynamodb): accept newline as UpdateExpression clause separator

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1066,20 +1066,22 @@ public class DynamoDbService {
                 break;
             }
 
+            // Split on the earlier of the next clause keyword or the next comma.
+            // Prefer the keyword when it comes first so intra-clause commas in a
+            // following clause (e.g. "REMOVE a SET b = :b, c = :c") don't bleed
+            // into this helper's attribute parsing.
             int commaIdx = findNextComma(clause);
+            int nextClause = findNextClauseKeyword(clause);
             String attrPart;
-            if (commaIdx >= 0) {
+            if (nextClause >= 0 && (commaIdx < 0 || nextClause < commaIdx)) {
+                attrPart = clause.substring(0, nextClause).trim();
+                clause = clause.substring(nextClause).trim();
+            } else if (commaIdx >= 0) {
                 attrPart = clause.substring(0, commaIdx).trim();
                 clause = clause.substring(commaIdx + 1).trim();
             } else {
-                int nextClause = findNextClauseKeyword(clause);
-                if (nextClause >= 0) {
-                    attrPart = clause.substring(0, nextClause).trim();
-                    clause = clause.substring(nextClause).trim();
-                } else {
-                    attrPart = clause.trim();
-                    clause = "";
-                }
+                attrPart = clause.trim();
+                clause = "";
             }
 
             removeValueAtPath(item, attrPart, exprAttrNames);
@@ -1111,13 +1113,17 @@ public class DynamoDbService {
                 }
             }
 
-            // Advance past this assignment
+            // Advance past this assignment. Prefer the next clause keyword when
+            // it precedes the next comma so intra-clause commas in a following
+            // SET (e.g. "ADD a :v SET b = :b, c = :c") don't swallow the keyword.
             int commaIdx = findNextComma(clause);
-            if (commaIdx >= 0) {
+            int nextClause = findNextClauseKeyword(clause);
+            if (nextClause >= 0 && (commaIdx < 0 || nextClause < commaIdx)) {
+                clause = clause.substring(nextClause).trim();
+            } else if (commaIdx >= 0) {
                 clause = clause.substring(commaIdx + 1).trim();
             } else {
-                int nextClause = findNextClauseKeyword(clause);
-                clause = nextClause >= 0 ? clause.substring(nextClause).trim() : "";
+                clause = "";
             }
         }
         return clause;
@@ -1224,13 +1230,17 @@ public class DynamoDbService {
                 }
             }
 
-            // Advance past this assignment
+            // Advance past this assignment. Prefer the next clause keyword when
+            // it precedes the next comma so intra-clause commas in a following
+            // SET (e.g. "DELETE s :v SET b = :b, c = :c") don't swallow the keyword.
             int commaIdx = findNextComma(clause);
-            if (commaIdx >= 0) {
+            int nextClause = findNextClauseKeyword(clause);
+            if (nextClause >= 0 && (commaIdx < 0 || nextClause < commaIdx)) {
+                clause = clause.substring(nextClause).trim();
+            } else if (commaIdx >= 0) {
                 clause = clause.substring(commaIdx + 1).trim();
             } else {
-                int nextClause = findNextClauseKeyword(clause);
-                clause = nextClause >= 0 ? clause.substring(nextClause).trim() : "";
+                clause = "";
             }
         }
         return clause;
@@ -1458,10 +1468,22 @@ public class DynamoDbService {
     }
 
     private int indexOfKeyword(String upper, String keyword) {
-        int idx = upper.indexOf(keyword);
-        // Ensure it's at word boundary (start of string or preceded by space)
-        if (idx > 0 && upper.charAt(idx - 1) != ' ') return -1;
-        return idx;
+        // Find the next occurrence of keyword at a word boundary (start of string
+        // or preceded by whitespace). Loop past non-boundary hits so attribute
+        // names that contain a keyword as a substring (e.g. "oldSET" before a
+        // real "SET " clause) don't shadow a later valid match.
+        //
+        // Go AWS SDK v2 expression.Builder emits newline-separated clauses, so
+        // the boundary check accepts any whitespace (space, tab, CR, LF), not
+        // just literal space.
+        int from = 0;
+        while (from <= upper.length()) {
+            int idx = upper.indexOf(keyword, from);
+            if (idx < 0) return -1;
+            if (idx == 0 || Character.isWhitespace(upper.charAt(idx - 1))) return idx;
+            from = idx + 1;
+        }
+        return -1;
     }
 
     // --- Filter expression evaluation ---

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -1060,4 +1060,336 @@ class DynamoDbServiceTest {
         assertFalse(notifs.has("sms"), "sms should be removed");
     }
 
+    // --- UpdateExpression clause separator tests ---
+    //
+    // The Go AWS SDK v2 expression.Builder joins top-level clauses with '\n',
+    // emitting expressions like "SET #a = :a\nADD #b :b". Each of the cases
+    // below hits a different edge of the clause-boundary / clause-advancement
+    // logic. See GitHub issue #430 for the full repro.
+
+    private void seedCounterItem(String id, long counterValue, String nameValue) {
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", id));
+        initialItem.set("counter", attributeValue("N", Long.toString(counterValue)));
+        initialItem.set("name", attributeValue("S", nameValue));
+        service.putItem("Users", initialItem);
+    }
+
+    private ObjectNode userIdKey(String id) {
+        ObjectNode key = mapper.createObjectNode();
+        key.set("userId", attributeValue("S", id));
+        return key;
+    }
+
+    @Test
+    void updateExpressionAcceptsNewlineBetweenSetAndAdd() {
+        // "SET ... \n ADD ..." — previously both clauses were silently dropped:
+        // applySetClause greedily consumed ":newName\nADD counter :inc" as the
+        // value and failed the lookup, so neither SET nor ADD ran.
+        createUsersTable();
+        seedCounterItem("u1", 1L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#n", "name");
+        names.put("#c", "counter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":inc", attributeValue("N", "5"));
+
+        service.updateItem("Users", userIdKey("u1"), null,
+                "SET #n = :newName\nADD #c :inc", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u1"));
+        assertEquals("new", stored.get("name").get("S").asText(),
+                "SET clause must apply across a newline boundary");
+        assertEquals("6", stored.get("counter").get("N").asText(),
+                "ADD clause must apply across a newline boundary");
+    }
+
+    @Test
+    void updateExpressionAcceptsNewlineBetweenAddAndSet() {
+        createUsersTable();
+        seedCounterItem("u2", 10L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#n", "name");
+        names.put("#c", "counter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":inc", attributeValue("N", "3"));
+
+        service.updateItem("Users", userIdKey("u2"), null,
+                "ADD #c :inc\nSET #n = :newName", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u2"));
+        assertEquals("new", stored.get("name").get("S").asText());
+        assertEquals("13", stored.get("counter").get("N").asText());
+    }
+
+    @Test
+    void updateExpressionAcceptsTabBetweenClauses() {
+        createUsersTable();
+        seedCounterItem("u3", 0L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#n", "name");
+        names.put("#c", "counter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":inc", attributeValue("N", "1"));
+
+        service.updateItem("Users", userIdKey("u3"), null,
+                "SET #n = :newName\tADD #c :inc", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u3"));
+        assertEquals("new", stored.get("name").get("S").asText());
+        assertEquals("1", stored.get("counter").get("N").asText());
+    }
+
+    @Test
+    void updateExpressionAcceptsCrlfBetweenClauses() {
+        createUsersTable();
+        seedCounterItem("u4", 100L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#n", "name");
+        names.put("#c", "counter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":inc", attributeValue("N", "7"));
+
+        service.updateItem("Users", userIdKey("u4"), null,
+                "SET #n = :newName\r\nADD #c :inc", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u4"));
+        assertEquals("new", stored.get("name").get("S").asText());
+        assertEquals("107", stored.get("counter").get("N").asText());
+    }
+
+    @Test
+    void updateExpressionAcceptsThreeNewlineSeparatedClauses() {
+        // Canonical Go SDK shape: SET + ADD + DELETE joined by '\n'.
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u5"));
+        initialItem.set("counter", attributeValue("N", "2"));
+        ObjectNode ss = mapper.createObjectNode();
+        ss.putArray("SS").add("keep").add("drop");
+        initialItem.set("tagsToClear", ss);
+        service.putItem("Users", initialItem);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#a", "alpha");
+        names.put("#b", "beta");
+        names.put("#c", "counter");
+        names.put("#d", "tagsToClear");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":a", attributeValue("S", "A"));
+        values.set(":b", attributeValue("S", "B"));
+        values.set(":inc", attributeValue("N", "4"));
+        ObjectNode dropSet = mapper.createObjectNode();
+        dropSet.putArray("SS").add("drop");
+        values.set(":d", dropSet);
+
+        service.updateItem("Users", userIdKey("u5"), null,
+                "SET #a = :a, #b = :b\nADD #c :inc\nDELETE #d :d",
+                names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u5"));
+        assertEquals("A", stored.get("alpha").get("S").asText());
+        assertEquals("B", stored.get("beta").get("S").asText());
+        assertEquals("6", stored.get("counter").get("N").asText());
+        assertTrue(stored.has("tagsToClear"), "tagsToClear should still exist");
+        JsonNode remaining = stored.get("tagsToClear").get("SS");
+        assertEquals(1, remaining.size());
+        assertEquals("keep", remaining.get(0).asText());
+    }
+
+    @Test
+    void updateExpressionAcceptsNewlineBetweenRemoveAndSet() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u6"));
+        initialItem.set("tempField", attributeValue("S", "bye"));
+        initialItem.set("name", attributeValue("S", "old"));
+        service.putItem("Users", initialItem);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#t", "tempField");
+        names.put("#n", "name");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+
+        service.updateItem("Users", userIdKey("u6"), null,
+                "REMOVE #t\nSET #n = :newName", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u6"));
+        assertFalse(stored.has("tempField"), "tempField should be removed");
+        assertEquals("new", stored.get("name").get("S").asText());
+    }
+
+    @Test
+    void updateExpressionAcceptsNewlineBetweenDeleteAndAdd() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u7"));
+        initialItem.set("counter", attributeValue("N", "10"));
+        ObjectNode ss = mapper.createObjectNode();
+        ss.putArray("SS").add("keep").add("drop");
+        initialItem.set("tags", ss);
+        service.putItem("Users", initialItem);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#c", "counter");
+        names.put("#tag", "tags");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":inc", attributeValue("N", "2"));
+        ObjectNode dropSet = mapper.createObjectNode();
+        dropSet.putArray("SS").add("drop");
+        values.set(":d", dropSet);
+
+        service.updateItem("Users", userIdKey("u7"), null,
+                "DELETE #tag :d\nADD #c :inc", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u7"));
+        assertEquals("12", stored.get("counter").get("N").asText());
+        JsonNode remaining = stored.get("tags").get("SS");
+        assertEquals(1, remaining.size());
+        assertEquals("keep", remaining.get(0).asText());
+    }
+
+    @Test
+    void updateExpressionAddBeforeSetDoesNotSwallowSetKeywordAtIntraSetComma() {
+        // Regression for Bug 2: before the advancement alignment fix,
+        // applyAddClause preferred the next comma (inside the SET clause's
+        // "b = :b, c = :c") over the SET keyword, consuming the keyword and
+        // dropping the SET entirely.
+        createUsersTable();
+        seedCounterItem("u8", 0L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#c", "counter");
+        names.put("#n", "name");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":inc", attributeValue("N", "1"));
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":other", attributeValue("S", "x"));
+
+        service.updateItem("Users", userIdKey("u8"), null,
+                "ADD #c :inc SET #n = :newName, extra = :other", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u8"));
+        assertEquals("1", stored.get("counter").get("N").asText(), "ADD must apply");
+        assertEquals("new", stored.get("name").get("S").asText(), "SET must apply");
+        assertEquals("x", stored.get("extra").get("S").asText(), "second SET assignment must apply");
+    }
+
+    @Test
+    void updateExpressionRemoveBeforeSetDoesNotSwallowSetKeywordAtIntraSetComma() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u9"));
+        initialItem.set("tempField", attributeValue("S", "bye"));
+        initialItem.set("name", attributeValue("S", "old"));
+        service.putItem("Users", initialItem);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#t", "tempField");
+        names.put("#n", "name");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":other", attributeValue("S", "x"));
+
+        service.updateItem("Users", userIdKey("u9"), null,
+                "REMOVE #t SET #n = :newName, extra = :other", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u9"));
+        assertFalse(stored.has("tempField"), "REMOVE must apply");
+        assertEquals("new", stored.get("name").get("S").asText(), "SET must apply");
+        assertEquals("x", stored.get("extra").get("S").asText(), "second SET assignment must apply");
+    }
+
+    @Test
+    void updateExpressionDeleteBeforeSetDoesNotSwallowSetKeywordAtIntraSetComma() {
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u10"));
+        initialItem.set("name", attributeValue("S", "old"));
+        ObjectNode ss = mapper.createObjectNode();
+        ss.putArray("SS").add("keep").add("drop");
+        initialItem.set("tags", ss);
+        service.putItem("Users", initialItem);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#tag", "tags");
+        names.put("#n", "name");
+        ObjectNode values = mapper.createObjectNode();
+        ObjectNode dropSet = mapper.createObjectNode();
+        dropSet.putArray("SS").add("drop");
+        values.set(":d", dropSet);
+        values.set(":newName", attributeValue("S", "new"));
+        values.set(":other", attributeValue("S", "x"));
+
+        service.updateItem("Users", userIdKey("u10"), null,
+                "DELETE #tag :d SET #n = :newName, extra = :other", names, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u10"));
+        JsonNode remaining = stored.get("tags").get("SS");
+        assertEquals(1, remaining.size());
+        assertEquals("keep", remaining.get(0).asText());
+        assertEquals("new", stored.get("name").get("S").asText());
+        assertEquals("x", stored.get("extra").get("S").asText());
+    }
+
+    @Test
+    void updateExpressionFindsValidKeywordAfterAttributeNameSuffix() {
+        // Regression for the indexOfKeyword loop: an attribute name ending in
+        // a keyword substring ("oldSET") must not mask a following real clause.
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u12"));
+        initialItem.set("oldSET", attributeValue("S", "bye"));
+        service.putItem("Users", initialItem);
+
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":v", attributeValue("S", "hi"));
+
+        service.updateItem("Users", userIdKey("u12"), null,
+                "REMOVE oldSET SET newAttr = :v", null, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u12"));
+        assertFalse(stored.has("oldSET"), "oldSET should be removed");
+        assertEquals("hi", stored.get("newAttr").get("S").asText(),
+                "SET must still be recognised past the oldSET attribute name");
+    }
+
+    @Test
+    void updateExpressionDoesNotMatchKeywordInsideAttributeName() {
+        // False-positive guard for the indexOfKeyword boundary relaxation.
+        // An attribute literally named "prefixSET" must not be treated as a
+        // clause keyword, and a following comma must still split the SET clause.
+        createUsersTable();
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", "u11"));
+        service.putItem("Users", initialItem);
+
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":v1", attributeValue("S", "one"));
+        values.set(":v2", attributeValue("S", "two"));
+
+        service.updateItem("Users", userIdKey("u11"), null,
+                "SET prefixSET = :v1, other = :v2", null, values, "ALL_NEW");
+
+        JsonNode stored = service.getItem("Users", userIdKey("u11"));
+        assertEquals("one", stored.get("prefixSET").get("S").asText());
+        assertEquals("two", stored.get("other").get("S").asText());
+    }
+
 }


### PR DESCRIPTION
## Summary

Go AWS SDK v2 `expression.Builder` joins top-level `UpdateExpression` clauses with `\n` (e.g. `"SET #a = :a\nADD #b :b"`). Floci silently dropped clauses on these inputs because the clause-boundary parser only accepted a literal space as a word boundary. Fixes #430.

Three related fixes in `DynamoDbService`:

1. **`indexOfKeyword` word-boundary relaxation.** Accept any whitespace (space, tab, CR, LF) before a clause keyword via `Character.isWhitespace`, not just `' '`. Before the fix, `SET x = :a\nADD y :b` lost **both** clauses: `applySetClause` greedily consumed `":a\nADD y :b"` as the SET value, failed the placeholder lookup, and neither SET nor ADD ran.
2. **`indexOfKeyword` loops past non-boundary hits.** `String.indexOf` on the first non-boundary occurrence used to return `-1` even when a later valid occurrence existed. An attribute named `oldSET` in `"REMOVE oldSET SET newAttr = :v"` masked the real `SET`. Loop until a boundary match is found or the string ends.
3. **`applyAddClause` / `applyDeleteClause` / `applyRemoveClause` clause advancement alignment.** Before this PR they advanced on the next comma before checking for a clause keyword, so an intra-clause comma in a following SET (e.g. `"ADD a :v SET b = :b, c = :c"`) consumed the `SET` keyword. Aligned with `applySetClause`'s existing "earlier of next clause keyword or next comma wins" rule.

## Test cases added

All in `DynamoDbServiceTest.java`:

| Case | Expression shape | What it exercises |
|---|---|---|
| 1 | `SET #n = :n\nADD #c :inc` | Newline between SET and ADD (primary repro) |
| 2 | `ADD #c :inc\nSET #n = :n` | Newline between ADD and SET |
| 3 | `SET #n = :n\tADD #c :inc` | Tab separator |
| 4 | `SET #n = :n\r\nADD #c :inc` | CRLF separator |
| 5 | `SET #a = :a, #b = :b\nADD #c :inc\nDELETE #d :d` | Canonical Go SDK three-clause shape |
| 6 | `REMOVE #t\nSET #n = :n` | REMOVE then SET across newline |
| 7 | `DELETE #tag :d\nADD #c :inc` | DELETE then ADD across newline |
| 8 | `ADD #c :inc SET #n = :n, extra = :o` | Intra-SET comma must not swallow SET keyword |
| 9 | `REMOVE #t SET #n = :n, extra = :o` | Same guard for REMOVE->SET |
| 10 | `DELETE #tag :d SET #n = :n, extra = :o` | Same guard for DELETE->SET |
| 11 | `REMOVE oldSET SET newAttr = :v` | `indexOfKeyword` loops past `oldSET` suffix |
| 12 | `SET prefixSET = :v1, other = :v2` | Attribute name containing `SET` not mis-parsed |

## Test plan

- [x] `./mvnw test -Dtest=DynamoDbServiceTest` (57 tests pass, 12 new)
- [x] `./mvnw test` full suite (2062 tests pass)
- [x] Codex + Gemini agentic reviews on the diff (findings addressed or deliberately out of scope)

## Out of scope

- The leading-keyword match in `applyUpdateExpression` (lines 892-904) still hardcodes a trailing literal space, so `SET\t#a = :a` at the start of an expression is still unsupported. No known SDK emits that shape and Go SDK only emits `\n` between clauses, not leading.
- The keyword constants passed to `indexOfKeyword` (`"SET "`, `"REMOVE "`, etc.) keep the trailing literal space. Switching to regex-based whitespace matching is a larger refactor and not needed to fix #430.
- Rewriting the hand-rolled parser with a formal grammar is a separate discussion.

## Backwards compatibility

- Previously rejected inputs (newline/tab/CR-separated clauses) now apply correctly. No behaviour change for inputs the parser already accepted; all 45 pre-existing `DynamoDbServiceTest` cases still pass unchanged.