### PR TITLE
fix(lambda): accept name, partial ARN, and full ARN for {FunctionName}

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtils.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtils.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.regex.Pattern;
+
+/**
+ * Parses the many forms AWS Lambda accepts for a {@code FunctionName} path
+ * parameter: bare name, partial ARN ({@code ACCT:function:NAME}), or full ARN
+ * ({@code arn:aws:lambda:REGION:ACCT:function:NAME}), each optionally suffixed
+ * with {@code :qualifier} (version or alias).
+ */
+public final class LambdaArnUtils {
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_]+");
+    private static final Pattern ACCOUNT_PATTERN = Pattern.compile("\\d{12}");
+    private static final Pattern QUALIFIER_PATTERN = Pattern.compile("\\$LATEST|[a-zA-Z0-9-_]+");
+
+    private LambdaArnUtils() {}
+
+    /**
+     * Resolved components of a Lambda function reference.
+     *
+     * @param name      short function name (never null/blank)
+     * @param qualifier version or alias, or null if absent
+     * @param region    region extracted from a full ARN, or null for bare
+     *                  name / partial ARN inputs
+     */
+    public record ResolvedFunctionRef(String name, String qualifier, String region) {}
+
+    /**
+     * Parses a {@code FunctionName} path parameter. Throws
+     * {@link AwsException} ({@code InvalidParameterValueException}, HTTP 400)
+     * on any malformed input.
+     */
+    public static ResolvedFunctionRef resolve(String input) {
+        if (input == null || input.isBlank()) {
+            throw invalid("FunctionName must not be blank");
+        }
+
+        if (input.startsWith("arn:")) {
+            return parseFullArn(input);
+        }
+        if (input.contains(":function:")) {
+            return parsePartialArn(input);
+        }
+        return parseNameWithOptionalQualifier(input);
+    }
+
+    /**
+     * Resolves an input and reconciles any embedded qualifier with a
+     * {@code ?Qualifier=} query-string value. If both are supplied and differ,
+     * throws 400. Returns the effective qualifier (may be null).
+     */
+    public static ResolvedFunctionRef resolveWithQualifier(String input, String queryQualifier) {
+        ResolvedFunctionRef ref = resolve(input);
+        String embedded = ref.qualifier();
+        String normalizedQuery = (queryQualifier == null || queryQualifier.isBlank()) ? null : queryQualifier;
+
+        if (embedded != null && normalizedQuery != null && !embedded.equals(normalizedQuery)) {
+            throw invalid("The derived qualifier from the function name does not match the specified qualifier.");
+        }
+        String effective = embedded != null ? embedded : normalizedQuery;
+        if (effective != null && !QUALIFIER_PATTERN.matcher(effective).matches()) {
+            throw invalid("Invalid qualifier: " + effective);
+        }
+        return new ResolvedFunctionRef(ref.name(), effective, ref.region());
+    }
+
+    private static ResolvedFunctionRef parseFullArn(String input) {
+        // arn:aws:lambda:REGION:ACCT:function:NAME[:QUALIFIER]
+        String[] parts = input.split(":", -1);
+        if (parts.length < 7 || parts.length > 8) {
+            throw invalid("Invalid ARN: " + input);
+        }
+        if (!"arn".equals(parts[0]) || !"aws".equals(parts[1]) || !"lambda".equals(parts[2])) {
+            throw invalid("Invalid ARN: " + input);
+        }
+        String region = parts[3];
+        String account = parts[4];
+        if (region.isBlank()) {
+            throw invalid("ARN missing region: " + input);
+        }
+        if (!ACCOUNT_PATTERN.matcher(account).matches()) {
+            throw invalid("ARN has invalid account id: " + input);
+        }
+        if (!"function".equals(parts[5])) {
+            throw invalid("ARN resource type must be 'function': " + input);
+        }
+        String name = parts[6];
+        validateName(name);
+        String qualifier = parts.length == 8 ? parts[7] : null;
+        if (qualifier != null) {
+            validateQualifier(qualifier);
+        }
+        return new ResolvedFunctionRef(name, qualifier, region);
+    }
+
+    private static ResolvedFunctionRef parsePartialArn(String input) {
+        // ACCT:function:NAME[:QUALIFIER]
+        String[] parts = input.split(":", -1);
+        if (parts.length < 3 || parts.length > 4) {
+            throw invalid("Invalid partial ARN: " + input);
+        }
+        if (!"function".equals(parts[1])) {
+            throw invalid("Partial ARN resource type must be 'function': " + input);
+        }
+        String account = parts[0];
+        if (!ACCOUNT_PATTERN.matcher(account).matches()) {
+            throw invalid("Partial ARN has invalid account id: " + input);
+        }
+        String name = parts[2];
+        validateName(name);
+        String qualifier = parts.length == 4 ? parts[3] : null;
+        if (qualifier != null) {
+            validateQualifier(qualifier);
+        }
+        return new ResolvedFunctionRef(name, qualifier, null);
+    }
+
+    private static ResolvedFunctionRef parseNameWithOptionalQualifier(String input) {
+        // NAME[:QUALIFIER]
+        String[] parts = input.split(":", -1);
+        if (parts.length > 2) {
+            throw invalid("Invalid FunctionName: " + input);
+        }
+        String name = parts[0];
+        validateName(name);
+        String qualifier = parts.length == 2 ? parts[1] : null;
+        if (qualifier != null) {
+            validateQualifier(qualifier);
+        }
+        return new ResolvedFunctionRef(name, qualifier, null);
+    }
+
+    private static void validateName(String name) {
+        if (name == null || name.isEmpty()) {
+            throw invalid("FunctionName segment is empty");
+        }
+        if (!NAME_PATTERN.matcher(name).matches()) {
+            throw invalid("FunctionName contains invalid characters: " + name);
+        }
+    }
+
+    private static void validateQualifier(String qualifier) {
+        if (qualifier.isEmpty()) {
+            throw invalid("Qualifier segment is empty");
+        }
+        if (!QUALIFIER_PATTERN.matcher(qualifier).matches()) {
+            throw invalid("Invalid qualifier: " + qualifier);
+        }
+    }
+
+    private static AwsException invalid(String message) {
+        return new AwsException("InvalidParameterValueException", message, 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -182,6 +182,10 @@ public class LambdaService {
         if (functionName == null || functionName.isBlank()) {
             throw new AwsException("InvalidParameterValueException", "FunctionName is required", 400);
         }
+        // Accept bare name, partial ARN, or full ARN. Normalize to the short
+        // name so duplicate detection works regardless of which form the
+        // caller supplies across successive calls.
+        functionName = canonicalFunctionName(region, functionName);
         if (role == null || role.isBlank()) {
             throw new AwsException("InvalidParameterValueException", "Role is required", 400);
         }
@@ -250,9 +254,39 @@ public class LambdaService {
     }
 
     public LambdaFunction getFunction(String region, String functionName) {
-        return functionStore.get(region, functionName)
+        String canonical = canonicalFunctionName(region, functionName);
+        return functionStore.get(region, canonical)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Function not found: " + functionName, 404));
+    }
+
+    /**
+     * Resolves a {@code FunctionName} path parameter (bare name, partial ARN,
+     * or full ARN, with optional {@code :qualifier}) to its canonical short
+     * name, enforcing a region match when the input is a full ARN.
+     */
+    String canonicalFunctionName(String region, String functionName) {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(functionName);
+        enforceRegion(region, ref);
+        return ref.name();
+    }
+
+    /**
+     * Resolves a {@code FunctionName} path parameter and reconciles any
+     * embedded qualifier with an explicit {@code ?Qualifier=} query-string
+     * value, enforcing region match when the input is a full ARN.
+     */
+    LambdaArnUtils.ResolvedFunctionRef resolveWithRegion(String region, String functionName, String queryQualifier) {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolveWithQualifier(functionName, queryQualifier);
+        enforceRegion(region, ref);
+        return ref;
+    }
+
+    private void enforceRegion(String region, LambdaArnUtils.ResolvedFunctionRef ref) {
+        if (ref.region() != null && !ref.region().equals(region)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Region '" + ref.region() + "' in ARN does not match request region '" + region + "'", 400);
+        }
     }
 
     public List<LambdaFunction> listFunctions(String region) {
@@ -261,6 +295,7 @@ public class LambdaService {
 
     public LambdaFunction updateFunctionCode(String region, String functionName, Map<String, Object> request) {
         LambdaFunction fn = getFunction(region, functionName);
+        functionName = fn.getFunctionName();
 
         String zipFileBase64 = (String) request.get("ZipFile");
         String imageUri = (String) request.get("ImageUri");
@@ -290,6 +325,7 @@ public class LambdaService {
 
     public void deleteFunction(String region, String functionName) {
         LambdaFunction fn = getFunction(region, functionName); // throws 404 if not found
+        functionName = fn.getFunctionName();
         String arn = fn.getFunctionArn();
         warmPool.drainFunction(functionName);
         // Take the same per-function lock used by Put/DeleteFunctionConcurrency
@@ -332,9 +368,9 @@ public class LambdaService {
                     "Only SQS, Kinesis, and DynamoDB Streams event sources are supported.", 400);
         }
 
-        // Resolve function — supports both short name and ARN
-        String resolvedName = functionName.contains(":") ?
-                functionName.substring(functionName.lastIndexOf(':') + 1) : functionName;
+        // Resolve function — supports bare name, partial ARN, or full ARN
+        LambdaArnUtils.ResolvedFunctionRef fnRef = LambdaArnUtils.resolve(functionName);
+        String resolvedName = fnRef.name();
 
         // Extract region from the event source ARN (parts[3] for all supported ARN formats)
         String resolvedRegion;
@@ -344,6 +380,14 @@ public class LambdaService {
             // arn:aws:kinesis:region:... or arn:aws:dynamodb:region:...
             String[] parts = eventSourceArn.split(":");
             resolvedRegion = parts.length > 3 ? parts[3] : region;
+        }
+
+        // If the caller supplied a full function ARN, its region must agree
+        // with the region derived from the event source ARN. Otherwise we'd
+        // silently bind a different-region function of the same name.
+        if (fnRef.region() != null && !fnRef.region().equals(resolvedRegion)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Function ARN region '" + fnRef.region() + "' does not match event source region '" + resolvedRegion + "'", 400);
         }
 
         LambdaFunction fn = getFunction(resolvedRegion, resolvedName);
@@ -407,7 +451,10 @@ public class LambdaService {
 
     public List<EventSourceMapping> listEventSourceMappings(String functionArn) {
         if (functionArn != null && !functionArn.isBlank()) {
-            return esmStore.listByFunction(functionArn);
+            // Accept bare name, partial ARN, or full ARN. The store matches
+            // entries by their canonical short name, so normalize first.
+            String shortName = LambdaArnUtils.resolve(functionArn).name();
+            return esmStore.listByFunction(shortName);
         }
         return esmStore.list();
     }
@@ -451,6 +498,7 @@ public class LambdaService {
 
     public LambdaFunction publishVersion(String region, String functionName, String description) {
         LambdaFunction fn = getFunction(region, functionName);
+        functionName = fn.getFunctionName();
         int version = versionCounters.merge(region + "::" + functionName, 1, Integer::sum);
         LambdaFunction snapshot = new LambdaFunction();
         snapshot.setFunctionName(fn.getFunctionName());
@@ -475,8 +523,8 @@ public class LambdaService {
     }
 
     public List<LambdaFunction> listVersionsByFunction(String region, String functionName) {
-        getFunction(region, functionName); // verify function exists
-        return functionStore.listVersions(region, functionName);
+        LambdaFunction fn = getFunction(region, functionName); // verify function exists
+        return functionStore.listVersions(region, fn.getFunctionName());
     }
 
     // ──────────────────────────── Aliases ────────────────────────────
@@ -484,6 +532,7 @@ public class LambdaService {
     public LambdaAlias createAlias(String region, String functionName, String aliasName,
                                    String functionVersion, String description) {
         LambdaFunction fn = getFunction(region, functionName);
+        functionName = fn.getFunctionName();
         if (aliasStore != null && aliasStore.get(region, functionName, aliasName).isPresent()) {
             throw new AwsException("ResourceConflictException", "Alias already exists: " + aliasName, 409);
         }
@@ -506,15 +555,16 @@ public class LambdaService {
         if (aliasStore == null) {
             throw new AwsException("ResourceNotFoundException", "Alias not found: " + aliasName, 404);
         }
-        return aliasStore.get(region, functionName, aliasName)
+        String canonical = canonicalFunctionName(region, functionName);
+        return aliasStore.get(region, canonical, aliasName)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Alias not found: " + aliasName, 404));
     }
 
     public List<LambdaAlias> listAliases(String region, String functionName) {
-        getFunction(region, functionName); // verify function exists
+        LambdaFunction fn = getFunction(region, functionName); // verify function exists
         if (aliasStore == null) return List.of();
-        return aliasStore.list(region, functionName);
+        return aliasStore.list(region, fn.getFunctionName());
     }
 
     public LambdaAlias updateAlias(String region, String functionName, String aliasName,
@@ -529,14 +579,18 @@ public class LambdaService {
     }
 
     public void deleteAlias(String region, String functionName, String aliasName) {
-        getAlias(region, functionName, aliasName); // verify it exists
-        if (aliasStore != null) aliasStore.delete(region, functionName, aliasName);
-        LOG.infov("Deleted alias {0} for function {1}", aliasName, functionName);
+        String canonical = canonicalFunctionName(region, functionName);
+        getAlias(region, canonical, aliasName); // verify it exists
+        if (aliasStore != null) aliasStore.delete(region, canonical, aliasName);
+        LOG.infov("Deleted alias {0} for function {1}", aliasName, canonical);
     }
 
     // ──────────────────────────── Function URL Config ────────────────────────────
 
     public LambdaUrlConfig createFunctionUrlConfig(String region, String functionName, String qualifier, Map<String, Object> request) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        functionName = ref.name();
+        qualifier = ref.qualifier();
         LambdaUrlConfig urlConfig = new LambdaUrlConfig();
         urlConfig.setAuthType((String) request.getOrDefault("AuthType", "NONE"));
         if (request.containsKey("InvokeMode")) {
@@ -589,6 +643,9 @@ public class LambdaService {
     }
 
     public LambdaUrlConfig getFunctionUrlConfig(String region, String functionName, String qualifier) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        functionName = ref.name();
+        qualifier = ref.qualifier();
         LambdaUrlConfig urlConfig;
         if (qualifier != null && !qualifier.equals("$LATEST")) {
             urlConfig = getAlias(region, functionName, qualifier).getUrlConfig();
@@ -603,6 +660,9 @@ public class LambdaService {
     }
 
     public LambdaUrlConfig updateFunctionUrlConfig(String region, String functionName, String qualifier, Map<String, Object> request) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        functionName = ref.name();
+        qualifier = ref.qualifier();
         LambdaUrlConfig urlConfig = getFunctionUrlConfig(region, functionName, qualifier);
         
         if (request.containsKey("AuthType")) {
@@ -646,6 +706,9 @@ public class LambdaService {
     }
 
     public void deleteFunctionUrlConfig(String region, String functionName, String qualifier) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        functionName = ref.name();
+        qualifier = ref.qualifier();
         if (qualifier != null && !qualifier.equals("$LATEST")) {
             LambdaAlias alias = getAlias(region, functionName, qualifier);
             if (alias.getUrlConfig() == null) {
@@ -872,26 +935,49 @@ public class LambdaService {
     // ──────────────────────────── Tags ────────────────────────────
 
     public Map<String, String> listTags(String functionArn) {
-        String[] parts = functionArn.split(":");
-        LambdaFunction fn = getFunction(parts[3], parts[6]);
+        TagTarget target = resolveTagTarget(functionArn);
+        LambdaFunction fn = getFunction(target.region, target.name);
         return fn.getTags() != null ? fn.getTags() : Map.of();
     }
 
     public void tagResource(String functionArn, Map<String, String> tags) {
-        String[] parts = functionArn.split(":");
-        LambdaFunction fn = getFunction(parts[3], parts[6]);
+        TagTarget target = resolveTagTarget(functionArn);
+        LambdaFunction fn = getFunction(target.region, target.name);
         if (fn.getTags() == null) fn.setTags(new java.util.HashMap<>());
         fn.getTags().putAll(tags);
-        functionStore.save(parts[3], fn);
+        functionStore.save(target.region, fn);
     }
 
     public void untagResource(String functionArn, List<String> tagKeys) {
-        String[] parts = functionArn.split(":");
-        LambdaFunction fn = getFunction(parts[3], parts[6]);
+        TagTarget target = resolveTagTarget(functionArn);
+        LambdaFunction fn = getFunction(target.region, target.name);
         if (fn.getTags() != null) {
             tagKeys.forEach(fn.getTags()::remove);
         }
-        functionStore.save(parts[3], fn);
+        functionStore.save(target.region, fn);
+    }
+
+    private record TagTarget(String region, String name) {}
+
+    /**
+     * Resolves a tag-endpoint ARN to a (region, shortName) pair. The Lambda
+     * tag APIs only accept an unqualified full function ARN; reject partial
+     * ARNs, bare names, and qualified ARNs.
+     */
+    private TagTarget resolveTagTarget(String functionArn) {
+        if (functionArn == null || functionArn.isBlank()) {
+            throw new AwsException("InvalidParameterValueException", "Resource ARN is required", 400);
+        }
+        if (!functionArn.startsWith("arn:")) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Resource ARN must be a full Lambda function ARN: " + functionArn, 400);
+        }
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(functionArn);
+        if (ref.qualifier() != null) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Tag operations require an unqualified function ARN: " + functionArn, 400);
+        }
+        return new TagTarget(ref.region(), ref.name());
     }
 
     private int toInt(Object value, int defaultValue) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtilsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtilsTest.java
@@ -1,0 +1,98 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LambdaArnUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            // input, expectedName, expectedQualifier, expectedRegion
+            "my-fn, my-fn, , ",
+            "my-fn:prod, my-fn, prod, ",
+            "my-fn:$LATEST, my-fn, $LATEST, ",
+            "my-fn:42, my-fn, 42, ",
+            "000000000000:function:my-fn, my-fn, , ",
+            "000000000000:function:my-fn:prod, my-fn, prod, ",
+            "arn:aws:lambda:us-east-1:000000000000:function:my-fn, my-fn, , us-east-1",
+            "arn:aws:lambda:eu-west-1:123456789012:function:my-fn, my-fn, , eu-west-1",
+            "arn:aws:lambda:us-east-1:000000000000:function:my-fn:prod, my-fn, prod, us-east-1",
+            "arn:aws:lambda:us-east-1:000000000000:function:my-fn:$LATEST, my-fn, $LATEST, us-east-1",
+            "arn:aws:lambda:us-east-1:000000000000:function:my_fn-1, my_fn-1, , us-east-1",
+    })
+    void resolveAcceptsValidForms(String input, String expectedName, String expectedQualifier, String expectedRegion) {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(input);
+        assertEquals(expectedName, ref.name());
+        assertEquals(emptyToNull(expectedQualifier), ref.qualifier());
+        assertEquals(emptyToNull(expectedRegion), ref.region());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            " ",
+            "foo:function:",
+            ":function:foo",
+            "foo:function:name:q1:q2",
+            "arn:aws:lambda:us-east-1:000000000000:function:",
+            "arn:aws:lambda::000000000000:function:my-fn",
+            "arn:aws:lambda:us-east-1:abc:function:my-fn",
+            "arn:aws:lambda:us-east-1:000000000000:layer:my-layer",
+            "arn:aws:s3:us-east-1:000000000000:function:my-fn",
+            "arn:aws:lambda:us-east-1:000000000000:function:my-fn:q1:q2",
+            "my-fn:bad/qualifier",
+            "my:fn:extra:segments",
+            "name with spaces",
+            "name!bang",
+    })
+    void resolveRejectsMalformedInputs(String input) {
+        AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(input));
+        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void resolveRejectsNull() {
+        assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(null));
+    }
+
+    @Test
+    void resolveWithQualifierTakesEmbeddedWhenOnlyEmbedded() {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolveWithQualifier("my-fn:prod", null);
+        assertEquals("prod", ref.qualifier());
+    }
+
+    @Test
+    void resolveWithQualifierTakesQueryWhenOnlyQuery() {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolveWithQualifier("my-fn", "prod");
+        assertEquals("prod", ref.qualifier());
+    }
+
+    @Test
+    void resolveWithQualifierAcceptsMatching() {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolveWithQualifier("my-fn:prod", "prod");
+        assertEquals("prod", ref.qualifier());
+    }
+
+    @Test
+    void resolveWithQualifierRejectsConflict() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> LambdaArnUtils.resolveWithQualifier("my-fn:prod", "dev"));
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void resolveWithQualifierTreatsBlankQueryAsAbsent() {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolveWithQualifier("my-fn:prod", "");
+        assertEquals("prod", ref.qualifier());
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -102,6 +102,69 @@ class LambdaServiceTest {
     }
 
     @Test
+    void getFunctionAcceptsPartialArn() {
+        service.createFunction(REGION, baseRequest("arn-fn"));
+        LambdaFunction fn = service.getFunction(REGION, "000000000000:function:arn-fn");
+        assertEquals("arn-fn", fn.getFunctionName());
+    }
+
+    @Test
+    void getFunctionAcceptsFullArn() {
+        service.createFunction(REGION, baseRequest("arn-fn"));
+        LambdaFunction fn = service.getFunction(REGION,
+                "arn:aws:lambda:us-east-1:000000000000:function:arn-fn");
+        assertEquals("arn-fn", fn.getFunctionName());
+    }
+
+    @Test
+    void getFunctionAcceptsArnWithQualifier() {
+        service.createFunction(REGION, baseRequest("arn-fn"));
+        LambdaFunction fn = service.getFunction(REGION,
+                "arn:aws:lambda:us-east-1:000000000000:function:arn-fn:prod");
+        assertEquals("arn-fn", fn.getFunctionName());
+    }
+
+    @Test
+    void getFunctionRejectsRegionMismatch() {
+        service.createFunction(REGION, baseRequest("region-fn"));
+        AwsException ex = assertThrows(AwsException.class, () -> service.getFunction(REGION,
+                "arn:aws:lambda:eu-west-1:000000000000:function:region-fn"));
+        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void getFunctionRejectsMalformedArn() {
+        AwsException ex = assertThrows(AwsException.class, () -> service.getFunction(REGION,
+                "arn:aws:lambda:us-east-1:000000000000:layer:my-layer"));
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void createFunctionDeduplicatesAcrossNameAndArn() {
+        service.createFunction(REGION, baseRequest("dedup-fn"));
+        Map<String, Object> req = baseRequest("arn:aws:lambda:us-east-1:000000000000:function:dedup-fn");
+        AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
+        assertEquals("ResourceConflictException", ex.getErrorCode());
+    }
+
+    @Test
+    void deleteFunctionAcceptsFullArn() {
+        service.createFunction(REGION, baseRequest("delete-arn-fn"));
+        service.deleteFunction(REGION,
+                "arn:aws:lambda:us-east-1:000000000000:function:delete-arn-fn");
+        assertThrows(AwsException.class, () -> service.getFunction(REGION, "delete-arn-fn"));
+    }
+
+    @Test
+    void putFunctionConcurrencyAcceptsFullArn() {
+        service.createFunction(REGION, baseRequest("concurrency-arn-fn"));
+        service.putFunctionConcurrency(REGION,
+                "arn:aws:lambda:us-east-1:000000000000:function:concurrency-arn-fn", 5);
+        assertEquals(5, service.getFunctionConcurrency(REGION, "concurrency-arn-fn"));
+    }
+
+    @Test
     void listFunctionsReturnsAllInRegion() {
         service.createFunction(REGION, baseRequest("fn-1"));
         service.createFunction(REGION, baseRequest("fn-2"));


### PR DESCRIPTION
## Summary

Real AWS accepts bare name, partial ARN (`ACCT:function:NAME`), and full ARN (`arn:aws:lambda:REGION:ACCT:function:NAME`) for every endpoint that takes `{FunctionName}`, optionally suffixed with `:qualifier`. Floci only matched the stored short name, so every Lambda endpoint 404'd on ARN forms.

This change introduces `LambdaArnUtils.resolve()` as the single parse point and normalizes inputs in `LambdaService` at every user-facing method, so downstream store, warm-pool, code-store, and alias-store operations all use the canonical short name. `createFunction` now deduplicates across name/ARN forms.

## Behavior changes

- All existing Lambda endpoints now accept bare name, partial ARN, and full ARN (with or without `:qualifier`).
- Region mismatch between a full function ARN and the request region (or an event-source ARN region) returns `400 InvalidParameterValueException`.
- Tag endpoints (`ListTags`, `TagResource`, `UntagResource`) require an unqualified full function ARN; qualified ARNs and bare names are rejected with 400.
- URL config endpoints reconcile an ARN-embedded qualifier with the `?Qualifier=` query param and return 400 on conflict.
- `ListEventSourceMappings` normalizes its `FunctionName` filter so partial ARNs no longer miss stored mappings.
- Malformed inputs (blank, wrong service/partition, bad account segment, trailing junk, empty qualifier) now return 400 rather than best-effort parsing.

## Scope

Closes #434, split from #339. Credit to @okinaka for enumerating the affected endpoints.

Out of scope (follow-ups if wanted):
- Adding `?Qualifier=` support to endpoints that don't currently accept it (Invoke, GetFunction, AddPermission, etc.). This PR only fixes the 404; routing to a specific version/alias via qualifier is a separate feature.
- Region-aware `ListEventSourceMappings` filtering. Pre-existing behavior; unchanged here.
- Numeric-version qualifiers on Function URL config. Pre-existing limitation.

## Test plan

- [x] New `LambdaArnUtilsTest` with 31 parameterized cases covering every ARN form, qualifier placement, and malformed input class
- [x] New `LambdaServiceTest` cases covering `getFunction`/`deleteFunction`/`putFunctionConcurrency`/`createFunction` with bare name, partial ARN, full ARN, region mismatch, and ARN/name dedup
- [x] Full `./mvnw test` suite green: 2091 tests, 0 failures
- [x] External review by Codex and Gemini; all on-scope findings addressed

## Review

Reviewed with Codex (deep) and Gemini (deep). Codex flagged four issues across ESM region handling, tag endpoint qualifier acceptance, ESM listing normalization, and partial-ARN empty-account validation; all fixed. Gemini raised additional feature-expansion items (qualifier routing on Invoke/GetFunction, regional ESM filtering) that are pre-existing and out of scope for this PR.