### PR TITLE
feat(cloudwatch): implement GetMetricData

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
@@ -47,7 +47,7 @@ public class CloudWatchMetricsJsonHandler {
             case "ListTagsForResource" -> handleListTagsForResource(request, region);
             case "TagResource" -> handleTagResource(request, region);
             case "UntagResource" -> handleUntagResource(request, region);
-            case "GetMetricData" -> Response.ok(objectMapper.createObjectNode().putArray("MetricDataResults")).build();
+            case "GetMetricData" -> handleGetMetricData(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported by CloudWatch JSON."))
                     .build();
@@ -241,6 +241,63 @@ public class CloudWatchMetricsJsonHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    private Response handleGetMetricData(JsonNode request, String region) {
+        Instant startTime = parseInstantNode(request.path("StartTime"));
+        Instant endTime = parseInstantNode(request.path("EndTime"));
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = new ArrayList<>();
+        JsonNode queriesNode = request.path("MetricDataQueries");
+        if (queriesNode.isArray()) {
+            for (JsonNode qNode : queriesNode) {
+                String id = qNode.path("Id").asText();
+                String expression = qNode.has("Expression") ? qNode.path("Expression").asText() : null;
+                String label = qNode.has("Label") ? qNode.path("Label").asText() : null;
+                boolean returnData = qNode.path("ReturnData").asBoolean(true);
+
+                CloudWatchMetricsService.MetricStat metricStat = null;
+                JsonNode msNode = qNode.path("MetricStat");
+                if (!msNode.isMissingNode()) {
+                    JsonNode metricNode = msNode.path("Metric");
+                    String namespace = metricNode.path("Namespace").asText();
+                    String metricName = metricNode.path("MetricName").asText();
+                    int period = msNode.path("Period").asInt(60);
+                    String stat = msNode.path("Stat").asText();
+                    String unit = msNode.has("Unit") ? msNode.path("Unit").asText() : null;
+                    List<Dimension> dims = parseDimensionsJson(metricNode.path("Dimensions"));
+
+                    metricStat = new CloudWatchMetricsService.MetricStat(
+                            namespace, metricName, dims, period, stat, unit);
+                }
+
+                queries.add(new CloudWatchMetricsService.MetricDataQuery(
+                        id, metricStat, expression, label, returnData));
+            }
+        }
+
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                metricsService.getMetricData(queries, startTime, endTime, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode resultsArray = response.putArray("MetricDataResults");
+        for (var r : results) {
+            ObjectNode rNode = resultsArray.addObject();
+            rNode.put("Id", r.id());
+            rNode.put("Label", r.label());
+            rNode.put("StatusCode", r.statusCode());
+
+            ArrayNode tsArray = rNode.putArray("Timestamps");
+            for (Instant ts : r.timestamps()) {
+                tsArray.add(ts.getEpochSecond());
+            }
+
+            ArrayNode valArray = rNode.putArray("Values");
+            for (Double v : r.values()) {
+                valArray.add(v);
+            }
+        }
+        return Response.ok(response).build();
+    }
+
     private List<MetricDatum> parseMetricDataJson(JsonNode node) {
         List<MetricDatum> datums = new ArrayList<>();
         if (!node.isArray()) return datums;
@@ -276,6 +333,15 @@ public class CloudWatchMetricsJsonHandler {
             dims.add(new Dimension(d.path("Name").asText(), d.path("Value").asText()));
         }
         return dims;
+    }
+
+    /** Parse a JsonNode that may be a numeric epoch (long/double) or an ISO-8601 string. */
+    private Instant parseInstantNode(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) return null;
+        if (node.isNumber()) {
+            return Instant.ofEpochSecond(node.asLong());
+        }
+        return parseInstant(node.asText(null));
     }
 
     private Instant parseInstant(String value) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
@@ -37,7 +37,7 @@ public class CloudWatchMetricsQueryHandler {
             case "PutMetricData" -> handlePutMetricData(params, region);
             case "ListMetrics" -> handleListMetrics(params, region);
             case "GetMetricStatistics" -> handleGetMetricStatistics(params, region);
-            case "GetMetricData" -> handleGetMetricDataStub(params);
+            case "GetMetricData" -> handleGetMetricData(params, region);
             case "PutMetricAlarm" -> handlePutMetricAlarm(params, region);
             case "DescribeAlarms" -> handleDescribeAlarms(params, region);
             case "DeleteAlarms" -> handleDeleteAlarms(params, region);
@@ -133,9 +133,79 @@ public class CloudWatchMetricsQueryHandler {
         return Response.ok(AwsQueryResponse.envelope("GetMetricStatistics", null, xml.build())).build();
     }
 
-    private Response handleGetMetricDataStub(MultivaluedMap<String, String> params) {
-        String result = new XmlBuilder().start("MetricDataResults").end("MetricDataResults").build();
-        return Response.ok(AwsQueryResponse.envelope("GetMetricData", null, result)).build();
+    private Response handleGetMetricData(MultivaluedMap<String, String> params, String region) {
+        Instant startTime = parseInstant(params.getFirst("StartTime"));
+        Instant endTime = parseInstant(params.getFirst("EndTime"));
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = parseMetricDataQueries(params);
+
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                metricsService.getMetricData(queries, startTime, endTime, region);
+
+        DateTimeFormatter fmt = DateTimeFormatter.ISO_INSTANT;
+        var xml = new XmlBuilder().start("MetricDataResults");
+        for (var r : results) {
+            xml.start("member")
+                    .elem("Id", r.id())
+                    .elem("Label", r.label())
+                    .elem("StatusCode", r.statusCode());
+
+            xml.start("Timestamps");
+            for (Instant ts : r.timestamps()) {
+                xml.elem("member", fmt.format(ts));
+            }
+            xml.end("Timestamps");
+
+            xml.start("Values");
+            for (Double v : r.values()) {
+                xml.elem("member", String.valueOf(v));
+            }
+            xml.end("Values");
+
+            xml.end("member");
+        }
+        xml.end("MetricDataResults");
+        return Response.ok(AwsQueryResponse.envelope("GetMetricData", null, xml.build())).build();
+    }
+
+    private List<CloudWatchMetricsService.MetricDataQuery> parseMetricDataQueries(
+            MultivaluedMap<String, String> params) {
+        List<CloudWatchMetricsService.MetricDataQuery> queries = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String prefix = "MetricDataQueries.member." + i;
+            String id = params.getFirst(prefix + ".Id");
+            if (id == null) break;
+
+            String expression = params.getFirst(prefix + ".Expression");
+            String label = params.getFirst(prefix + ".Label");
+            boolean returnData = !"false".equals(params.getFirst(prefix + ".ReturnData"));
+
+            CloudWatchMetricsService.MetricStat metricStat = null;
+            String msNamespace = params.getFirst(prefix + ".MetricStat.Metric.Namespace");
+            if (msNamespace != null) {
+                String msMetricName = params.getFirst(prefix + ".MetricStat.Metric.MetricName");
+                int msPeriod = parseIntParam(params, prefix + ".MetricStat.Period", 60);
+                String msStat = params.getFirst(prefix + ".MetricStat.Stat");
+                String msUnit = params.getFirst(prefix + ".MetricStat.Unit");
+
+                List<Dimension> dims = new ArrayList<>();
+                for (int j = 1; ; j++) {
+                    String dimName = params.getFirst(
+                            prefix + ".MetricStat.Metric.Dimensions.member." + j + ".Name");
+                    if (dimName == null) break;
+                    String dimValue = params.getFirst(
+                            prefix + ".MetricStat.Metric.Dimensions.member." + j + ".Value");
+                    dims.add(new Dimension(dimName, dimValue));
+                }
+
+                metricStat = new CloudWatchMetricsService.MetricStat(
+                        msNamespace, msMetricName, dims, msPeriod, msStat, msUnit);
+            }
+
+            queries.add(new CloudWatchMetricsService.MetricDataQuery(
+                    id, metricStat, expression, label, returnData));
+        }
+        return queries;
     }
 
     private Response handlePutMetricAlarm(MultivaluedMap<String, String> params, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
@@ -100,6 +100,31 @@ public class CloudWatchMetricsService {
     public record Datapoint(Instant timestamp, double sampleCount, double sum,
                              double average, double minimum, double maximum, String unit) {}
 
+    public record MetricStat(
+            String namespace,
+            String metricName,
+            List<Dimension> dimensions,
+            int period,
+            String stat,
+            String unit
+    ) {}
+
+    public record MetricDataQuery(
+            String id,
+            MetricStat metricStat,
+            String expression,
+            String label,
+            boolean returnData
+    ) {}
+
+    public record MetricDataResult(
+            String id,
+            String label,
+            List<Instant> timestamps,
+            List<Double> values,
+            String statusCode
+    ) {}
+
     public List<Datapoint> getMetricStatistics(String namespace, String metricName,
                                                 List<Dimension> dimensions,
                                                 Instant startTime, Instant endTime,
@@ -157,6 +182,56 @@ public class CloudWatchMetricsService {
         }
         result.sort(Comparator.comparing(Datapoint::timestamp));
         return result;
+    }
+
+    public List<MetricDataResult> getMetricData(
+            List<MetricDataQuery> queries,
+            Instant startTime,
+            Instant endTime,
+            String region) {
+
+        List<MetricDataResult> results = new ArrayList<>();
+
+        for (MetricDataQuery query : queries) {
+            if (!query.returnData()) {
+                continue;
+            }
+            if (query.metricStat() != null) {
+                MetricStat stat = query.metricStat();
+                int period = stat.period() > 0 ? stat.period() : 60;
+
+                List<Datapoint> datapoints = getMetricStatistics(
+                        stat.namespace(), stat.metricName(), stat.dimensions(),
+                        startTime, endTime, period,
+                        List.of(stat.stat()), stat.unit(), region);
+
+                List<Instant> timestamps = new ArrayList<>();
+                List<Double> values = new ArrayList<>();
+                for (Datapoint dp : datapoints) {
+                    timestamps.add(dp.timestamp());
+                    values.add(resolveStatValue(dp, stat.stat()));
+                }
+
+                String label = query.label() != null ? query.label() : stat.metricName();
+                results.add(new MetricDataResult(query.id(), label, timestamps, values, "Complete"));
+            }
+            // Expression-based queries are out of scope for this implementation
+        }
+        return results;
+    }
+
+    private double resolveStatValue(Datapoint dp, String stat) {
+        return switch (stat) {
+            case "Average" -> dp.average();
+            case "Sum" -> dp.sum();
+            case "Minimum" -> dp.minimum();
+            case "Maximum" -> dp.maximum();
+            case "SampleCount" -> dp.sampleCount();
+            default -> {
+                if (stat.startsWith("p")) yield dp.maximum();
+                else yield dp.average();
+            }
+        };
     }
 
     public void putMetricAlarm(MetricAlarm alarm, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsGetMetricDataTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsGetMetricDataTest.java
@@ -1,0 +1,257 @@
+package io.github.hectorvent.floci.services.cloudwatch.metrics;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.cloudwatch.metrics.model.Dimension;
+import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricDatum;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CloudWatchMetricsGetMetricDataTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String NAMESPACE = "AWS/EC2";
+
+    private CloudWatchMetricsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CloudWatchMetricsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new RegionResolver("us-east-1", "000000000000")
+        );
+    }
+
+    private MetricDatum datumAt(String name, double value, long epochSecond) {
+        MetricDatum d = new MetricDatum();
+        d.setMetricName(name);
+        d.setValue(value);
+        d.setTimestamp(epochSecond);
+        return d;
+    }
+
+    private MetricDatum datumWithDimAt(String name, double value, long epochSecond,
+                                        String dimName, String dimValue) {
+        MetricDatum d = datumAt(name, value, epochSecond);
+        d.setDimensions(List.of(new Dimension(dimName, dimValue)));
+        return d;
+    }
+
+    private CloudWatchMetricsService.MetricDataQuery metricStatQuery(
+            String id, String namespace, String metricName,
+            List<Dimension> dims, int period, String stat) {
+        CloudWatchMetricsService.MetricStat ms = new CloudWatchMetricsService.MetricStat(
+                namespace, metricName, dims, period, stat, null);
+        return new CloudWatchMetricsService.MetricDataQuery(id, ms, null, null, true);
+    }
+
+    // ──────────────────────────── Basic correctness ────────────────────────────
+
+    @Test
+    void getMetricDataReturnsSeededDataPoint() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(
+                datumWithDimAt("CPUUtilization", 75.5, ts, "InstanceId", "i-1234")
+        ), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "CPUUtilization",
+                        List.of(new Dimension("InstanceId", "i-1234")), 60, "Average")
+        );
+
+        Instant start = Instant.ofEpochSecond(ts - 60);
+        Instant end = Instant.ofEpochSecond(ts + 60);
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(1, results.size());
+        CloudWatchMetricsService.MetricDataResult r = results.getFirst();
+        assertEquals("m0", r.id());
+        assertEquals("CPUUtilization", r.label());
+        assertEquals("Complete", r.statusCode());
+        assertEquals(1, r.values().size());
+        assertEquals(75.5, r.values().getFirst(), 0.001);
+    }
+
+    // ──────────────────────────── Multiple queries ────────────────────────────
+
+    @Test
+    void getMetricDataHandlesMultipleQueries() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(
+                datumWithDimAt("CPUUtilization", 50.0, ts, "InstanceId", "i-1234"),
+                datumWithDimAt("NetworkIn", 1024.0, ts, "InstanceId", "i-1234")
+        ), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("cpu", NAMESPACE, "CPUUtilization",
+                        List.of(new Dimension("InstanceId", "i-1234")), 60, "Average"),
+                metricStatQuery("net", NAMESPACE, "NetworkIn",
+                        List.of(new Dimension("InstanceId", "i-1234")), 60, "Sum")
+        );
+
+        Instant start = Instant.ofEpochSecond(ts - 60);
+        Instant end = Instant.ofEpochSecond(ts + 60);
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(2, results.size());
+        assertEquals("cpu", results.get(0).id());
+        assertEquals("net", results.get(1).id());
+        assertEquals(50.0, results.get(0).values().getFirst(), 0.001);
+        assertEquals(1024.0, results.get(1).values().getFirst(), 0.001);
+    }
+
+    // ──────────────────────────── Time range filtering ────────────────────────────
+
+    @Test
+    void getMetricDataFiltersOutsideTimeRange() {
+        long oldTs = Instant.now().minusSeconds(7200).getEpochSecond();
+        long newTs = Instant.now().getEpochSecond();
+
+        service.putMetricData(NAMESPACE, List.of(
+                datumAt("CPUUtilization", 90.0, oldTs),
+                datumAt("CPUUtilization", 30.0, newTs)
+        ), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "CPUUtilization", List.of(), 60, "Average")
+        );
+
+        // Only include the recent point
+        Instant start = Instant.ofEpochSecond(newTs - 60);
+        Instant end = Instant.ofEpochSecond(newTs + 60);
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(1, results.size());
+        assertEquals(1, results.getFirst().values().size());
+        assertEquals(30.0, results.getFirst().values().getFirst(), 0.001);
+    }
+
+    // ──────────────────────────── Empty results ────────────────────────────
+
+    @Test
+    void getMetricDataReturnsEmptyWhenNoMatchingData() {
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "CPUUtilization", List.of(), 60, "Average")
+        );
+
+        Instant start = Instant.now().minusSeconds(300);
+        Instant end = Instant.now();
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(1, results.size());
+        assertTrue(results.getFirst().timestamps().isEmpty());
+        assertTrue(results.getFirst().values().isEmpty());
+        assertEquals("Complete", results.getFirst().statusCode());
+    }
+
+    // ──────────────────────────── ReturnData=false ────────────────────────────
+
+    @Test
+    void getMetricDataSkipsQueriesWithReturnDataFalse() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(
+                datumAt("CPUUtilization", 55.0, ts)
+        ), REGION);
+
+        CloudWatchMetricsService.MetricStat ms = new CloudWatchMetricsService.MetricStat(
+                NAMESPACE, "CPUUtilization", List.of(), 60, "Average", null);
+        CloudWatchMetricsService.MetricDataQuery query =
+                new CloudWatchMetricsService.MetricDataQuery("m0", ms, null, null, false);
+
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(List.of(query),
+                        Instant.ofEpochSecond(ts - 60), Instant.ofEpochSecond(ts + 60), REGION);
+
+        assertTrue(results.isEmpty());
+    }
+
+    // ──────────────────────────── Stat variants ────────────────────────────
+
+    @Test
+    void getMetricDataResolvesSumStat() {
+        long ts = Instant.now().getEpochSecond();
+        // Put two datums in the same period bucket — their sum should aggregate
+        service.putMetricData(NAMESPACE, List.of(
+                datumAt("RequestCount", 10.0, ts),
+                datumAt("RequestCount", 20.0, ts)
+        ), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "RequestCount", List.of(), 60, "Sum")
+        );
+
+        Instant start = Instant.ofEpochSecond(ts - 60);
+        Instant end = Instant.ofEpochSecond(ts + 60);
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(1, results.size());
+        assertEquals(1, results.getFirst().values().size());
+        assertEquals(30.0, results.getFirst().values().getFirst(), 0.001);
+    }
+
+    @Test
+    void getMetricDataResolvesMaximumStat() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(
+                datumAt("Latency", 5.0, ts),
+                datumAt("Latency", 99.0, ts)
+        ), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "Latency", List.of(), 60, "Maximum")
+        );
+
+        Instant start = Instant.ofEpochSecond(ts - 60);
+        Instant end = Instant.ofEpochSecond(ts + 60);
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries, start, end, REGION);
+
+        assertEquals(99.0, results.getFirst().values().getFirst(), 0.001);
+    }
+
+    // ──────────────────────────── Label ────────────────────────────
+
+    @Test
+    void getMetricDataUsesMetricNameAsDefaultLabel() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(datumAt("CPUUtilization", 50.0, ts)), REGION);
+
+        List<CloudWatchMetricsService.MetricDataQuery> queries = List.of(
+                metricStatQuery("m0", NAMESPACE, "CPUUtilization", List.of(), 60, "Average")
+        );
+
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(queries,
+                        Instant.ofEpochSecond(ts - 60), Instant.ofEpochSecond(ts + 60), REGION);
+
+        assertEquals("CPUUtilization", results.getFirst().label());
+    }
+
+    @Test
+    void getMetricDataUsesCustomLabel() {
+        long ts = Instant.now().getEpochSecond();
+        service.putMetricData(NAMESPACE, List.of(datumAt("CPUUtilization", 50.0, ts)), REGION);
+
+        CloudWatchMetricsService.MetricStat ms = new CloudWatchMetricsService.MetricStat(
+                NAMESPACE, "CPUUtilization", List.of(), 60, "Average", null);
+        CloudWatchMetricsService.MetricDataQuery query =
+                new CloudWatchMetricsService.MetricDataQuery("m0", ms, null, "My CPU", true);
+
+        List<CloudWatchMetricsService.MetricDataResult> results =
+                service.getMetricData(List.of(query),
+                        Instant.ofEpochSecond(ts - 60), Instant.ofEpochSecond(ts + 60), REGION);
+
+        assertEquals("My CPU", results.getFirst().label());
+    }
+}


### PR DESCRIPTION
## Summary

Implement `CloudWatch:GetMetricData`, which was previously a stub returning empty results.

Closes — (no issue tracked)

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against **AWS SDK for Java v2 (2.42.24)**.

`GetMetricData` is dispatched via the JSON 1.0 protocol (`BaseAwsJsonProtocolFactory`) — not the Query protocol used by other CloudWatch operations. Timestamps arrive as numeric epoch seconds; the handler uses `parseInstantNode()` to read them from the `JsonNode` directly rather than via `asText()`, which would produce scientific notation for large longs and silently break time-range filtering.

The Query protocol handler is also implemented for completeness (CLI / non-SDK callers).

Wire format confirmed manually with:
```bash
aws cloudwatch get-metric-data \
  --metric-data-queries '[{"Id":"m0","MetricStat":{"Metric":{"Namespace":"AWS/EC2","MetricName":"CPUUtilization"},"Period":60,"Stat":"Average"}}]' \
  --start-time 2026-04-14T17:00:00Z --end-time 2026-04-14T18:00:00Z \
  --endpoint-url http://localhost:4566
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudWatchMetricsGetMetricDataTest` — 9 unit tests covering basic round-trip, multiple queries, time-range filtering, empty results, `ReturnData=false`, Sum/Maximum aggregation, default and custom label)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
