### PR TITLE
feat(eventbridge): implement TagResource and UntagResource

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -59,6 +59,8 @@ public class EventBridgeHandler {
                 case "ListTargetsByRule" -> handleListTargetsByRule(request, region);
                 case "PutEvents" -> handlePutEvents(request, region);
                 case "ListTagsForResource" -> handleListTagsForResource(request, region);
+                case "TagResource" -> handleTagResource(request, region);
+                case "UntagResource" -> handleUntagResource(request, region);
                 default -> Response.status(400)
                         .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                         .build();
@@ -299,6 +301,27 @@ public class EventBridgeHandler {
             tagsArray.add(tagNode);
         });
         return Response.ok(response).build();
+    }
+
+    private Response handleTagResource(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceARN").asText(null);
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ResourceARN is required.", 400);
+        }
+        Map<String, String> tags = parseTagsArray(request.path("Tags"));
+        eventBridgeService.tagResource(resourceArn, tags, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleUntagResource(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceARN").asText(null);
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ResourceARN is required.", 400);
+        }
+        List<String> tagKeys = new ArrayList<>();
+        request.path("TagKeys").forEach(k -> tagKeys.add(k.asText()));
+        eventBridgeService.untagResource(resourceArn, tagKeys, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     // ──────────────────────────── Helpers ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -339,6 +339,74 @@ public class EventBridgeService {
         return Map.of();
     }
 
+    public void tagResource(String resourceArn, Map<String, String> tags, String region) {
+        if (resourceArn.contains("event-bus/")) {
+            String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
+            String key = busKey(region, busName);
+            EventBus bus = busStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Resource not found: " + resourceArn, 404));
+            bus.getTags().putAll(tags);
+            busStore.put(key, bus);
+            return;
+        }
+        if (resourceArn.contains("rule/")) {
+            String afterRule = resourceArn.substring(resourceArn.lastIndexOf("rule/") + "rule/".length());
+            String busName;
+            String ruleName;
+            if (afterRule.contains("/")) {
+                int slashIdx = afterRule.indexOf('/');
+                busName = afterRule.substring(0, slashIdx);
+                ruleName = afterRule.substring(slashIdx + 1);
+            } else {
+                busName = "default";
+                ruleName = afterRule;
+            }
+            String key = ruleKey(region, busName, ruleName);
+            Rule rule = ruleStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Resource not found: " + resourceArn, 404));
+            rule.getTags().putAll(tags);
+            ruleStore.put(key, rule);
+            return;
+        }
+        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 404);
+    }
+
+    public void untagResource(String resourceArn, List<String> tagKeys, String region) {
+        if (resourceArn.contains("event-bus/")) {
+            String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
+            String key = busKey(region, busName);
+            EventBus bus = busStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Resource not found: " + resourceArn, 404));
+            tagKeys.forEach(bus.getTags()::remove);
+            busStore.put(key, bus);
+            return;
+        }
+        if (resourceArn.contains("rule/")) {
+            String afterRule = resourceArn.substring(resourceArn.lastIndexOf("rule/") + "rule/".length());
+            String busName;
+            String ruleName;
+            if (afterRule.contains("/")) {
+                int slashIdx = afterRule.indexOf('/');
+                busName = afterRule.substring(0, slashIdx);
+                ruleName = afterRule.substring(slashIdx + 1);
+            } else {
+                busName = "default";
+                ruleName = afterRule;
+            }
+            String key = ruleKey(region, busName, ruleName);
+            Rule rule = ruleStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Resource not found: " + resourceArn, 404));
+            tagKeys.forEach(rule.getTags()::remove);
+            ruleStore.put(key, rule);
+            return;
+        }
+        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 404);
+    }
+
     // ──────────────────────────── PutEvents ────────────────────────────
 
     public record PutEventsResult(int failedCount, List<Map<String, String>> entries) {}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
@@ -1,0 +1,259 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeTagResourceIntegrationTest {
+
+    private static final String EVENT_BRIDGE_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void tagResourceOnEventBus() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+            .body("{\"Name\":\"tag-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String busArn = given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"tag-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Arn");
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.TagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "Tags": [
+                        {"Key": "env", "Value": "prod"},
+                        {"Key": "team", "Value": "infra"}
+                    ]
+                }
+                """.formatted(busArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + busArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("prod"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("infra"));
+    }
+
+    @Test
+    @Order(2)
+    void tagResourceOnRule() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutRule")
+            .body("{\"Name\":\"tag-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String ruleArn = given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"tag-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Arn");
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.TagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "Tags": [
+                        {"Key": "service", "Value": "payments"},
+                        {"Key": "priority", "Value": "high"}
+                    ]
+                }
+                """.formatted(ruleArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + ruleArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'service' }.Value", equalTo("payments"))
+            .body("Tags.find { it.Key == 'priority' }.Value", equalTo("high"));
+    }
+
+    @Test
+    @Order(3)
+    void untagResourceOnEventBus() {
+        String busArn = given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"tag-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Arn");
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.UntagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "TagKeys": ["env"]
+                }
+                """.formatted(busArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + busArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("infra"));
+    }
+
+    @Test
+    @Order(4)
+    void untagResourceOnRule() {
+        String ruleArn = given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"tag-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Arn");
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.UntagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "TagKeys": ["service", "priority"]
+                }
+                """.formatted(ruleArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + ruleArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(0));
+    }
+
+    @Test
+    @Order(5)
+    void tagResourceNotFound() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.TagResource")
+            .body("""
+                {
+                    "ResourceARN": "arn:aws:events:us-east-1:000000000000:event-bus/nonexistent",
+                    "Tags": [{"Key": "k", "Value": "v"}]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(6)
+    void untagResourceNotFound() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.UntagResource")
+            .body("""
+                {
+                    "ResourceARN": "arn:aws:events:us-east-1:000000000000:rule/nonexistent-rule",
+                    "TagKeys": ["k"]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(7)
+    void cleanup() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DeleteRule")
+            .body("{\"Name\":\"tag-test-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+            .body("{\"Name\":\"tag-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

Implements `TagResource` and `UntagResource` for EventBridge event buses and rules. Closes #445

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI v2 against a Docker container built from source. Tested TagResource, UntagResource, and ListTagsForResource on both event buses and rules, including error cases for nonexistent resources (returns 400 ResourceNotFoundException).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)