### PR TITLE
fix(cognito): add aud claim to ID tokens

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -835,8 +835,8 @@ public class CognitoService {
         }
         // Fallback for legacy tokens: emit minimal tokens using clientId from request
         Map<String, Object> auth = new HashMap<>();
-        auth.put("AccessToken", generateTokenString("access", "unknown", pool));
-        auth.put("IdToken", generateTokenString("id", "unknown", pool));
+        auth.put("AccessToken", generateTokenString("access", "unknown", pool, clientId));
+        auth.put("IdToken", generateTokenString("id", "unknown", pool, clientId));
         auth.put("ExpiresIn", 3600);
         auth.put("TokenType", "Bearer");
         Map<String, Object> result = new HashMap<>();
@@ -901,30 +901,36 @@ public class CognitoService {
         String clientIdFragment = (clientId != null && !clientId.isBlank() && "access".equals(type))
                 ? ",\"client_id\":\"" + escapeJson(clientId) + "\""
                 : "";
+        String audFragment = (clientId != null && !clientId.isBlank() && "id".equals(type))
+                ? ",\"aud\":\"" + escapeJson(clientId) + "\""
+                : "";
         String payloadJson = String.format(
                 "{\"sub\":\"%s\",\"event_id\":\"%s\",\"token_use\":\"%s\",\"auth_time\":%d," +
                 "\"iss\":\"%s\",\"exp\":%d,\"iat\":%d," +
-                "\"username\":\"%s\",\"email\":\"%s\",\"cognito:username\":\"%s\"%s%s}",
+                "\"username\":\"%s\",\"email\":\"%s\",\"cognito:username\":\"%s\"%s%s%s}",
                 escapeJson(sub), UUID.randomUUID(), type, now,
                 escapeJson(getIssuer(pool.getId())), now + 3600, now,
-                user.getUsername(), email, user.getUsername(), clientIdFragment, groupsFragment
+                user.getUsername(), email, user.getUsername(), clientIdFragment, audFragment, groupsFragment
         );
         String payload = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
         return signJwt(header, payload, getSigningPrivateKey(pool));
     }
 
-    private String generateTokenString(String type, String username, UserPool pool) {
+    private String generateTokenString(String type, String username, UserPool pool, String clientId) {
         long now = System.currentTimeMillis() / 1000L;
         String headerJson = String.format(
                 "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"kid\":\"%s\"}",
                 escapeJson(getSigningKeyId(pool)));
         String header = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(headerJson.getBytes(StandardCharsets.UTF_8));
+        String audFragment = (clientId != null && !clientId.isBlank() && "id".equals(type))
+                ? ",\"aud\":\"" + escapeJson(clientId) + "\""
+                : "";
         String payloadJson = String.format(
                 "{\"sub\":\"%s\",\"token_use\":\"%s\",\"iss\":\"%s\"," +
-                "\"exp\":%d,\"iat\":%d,\"username\":\"%s\"}",
-                UUID.randomUUID(), type, escapeJson(getIssuer(pool.getId())), now + 3600, now, username
+                "\"exp\":%d,\"iat\":%d,\"username\":\"%s\"%s}",
+                UUID.randomUUID(), type, escapeJson(getIssuer(pool.getId())), now + 3600, now, username, audFragment
         );
         String payload = Base64.getUrlEncoder().withoutPadding()
                 .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -358,6 +358,58 @@ class CognitoIntegrationTest {
                 "IdToken should not contain client_id");
     }
 
+    // ── Issue #452: IdToken contains aud claim ─────────────────────────
+
+    @Test
+    @Order(32)
+    void idTokenContainsAudClaimMatchingClientId() throws Exception {
+        JsonNode auth = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": { "USERNAME": "%s", "PASSWORD": "%s" }
+                }
+                """.formatted(clientId, username, password));
+        String idToken = auth.path("AuthenticationResult").path("IdToken").asText();
+        JsonNode payload = decodeJwtPayload(idToken);
+        assertEquals(clientId, payload.path("aud").asText(),
+                "IdToken must contain aud claim set to the requesting client ID");
+    }
+
+    @Test
+    @Order(33)
+    void accessTokenDoesNotContainAudClaim() throws Exception {
+        String accessToken = initiateAuthAndGetAccessToken();
+        JsonNode payload = decodeJwtPayload(accessToken);
+        assertTrue(payload.path("aud").isMissingNode(),
+                "AccessToken should not contain aud claim");
+    }
+
+    @Test
+    @Order(34)
+    void idTokenFromRefreshTokenContainsAudClaim() throws Exception {
+        JsonNode authResp = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": { "USERNAME": "%s", "PASSWORD": "%s" }
+                }
+                """.formatted(clientId, username, password));
+        String refreshToken = authResp.path("AuthenticationResult").path("RefreshToken").asText();
+
+        JsonNode refreshed = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "REFRESH_TOKEN_AUTH",
+                  "AuthParameters": { "REFRESH_TOKEN": "%s" }
+                }
+                """.formatted(clientId, refreshToken));
+        String idToken = refreshed.path("AuthenticationResult").path("IdToken").asText();
+        JsonNode payload = decodeJwtPayload(idToken);
+        assertEquals(clientId, payload.path("aud").asText(),
+                "IdToken from refresh flow must contain aud claim set to the requesting client ID");
+    }
+
     // ── Issue #416: ListUserPoolClients response matches spec ──────────
 
     @Test


### PR DESCRIPTION
## Summary

Adds the missing `aud` (audience) claim to Cognito ID tokens, set to the app client ID per the [OIDC spec](https://openid.net/specs/openid-connect-core-1_0.html#IDToken). Closes #452

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI v2 against a Docker container built from source:
- ID token from `InitiateAuth` (USER_PASSWORD_AUTH) contains `aud` = client ID
- Access token does not contain `aud` (unchanged, correct per spec)
- ID token from refresh token flow contains `aud` = client ID

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)