### PR TITLE
feat(ec2): implement CreateVolume, DescribeVolumes, DeleteVolume

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -107,6 +107,10 @@ public class Ec2QueryHandler {
                 case "DescribeAccountAttributes" -> handleDescribeAccountAttributes(params, region);
                 // Instance Types
                 case "DescribeInstanceTypes" -> handleDescribeInstanceTypes(params, region);
+                // Volumes
+                case "CreateVolume" -> handleCreateVolume(params, region);
+                case "DescribeVolumes" -> handleDescribeVolumes(params, region);
+                case "DeleteVolume" -> handleDeleteVolume(params, region);
                 default -> ec2Error("UnsupportedOperation",
                         "Operation " + action + " is not supported.", 400);
             };
@@ -1265,6 +1269,100 @@ public class Ec2QueryHandler {
                     .end("item");
         }
         xml.end("tagSet");
+        return xml.build();
+    }
+
+    // ─── Volume handlers ──────────────────────────────────────────────────────
+
+    private Response handleCreateVolume(MultivaluedMap<String, String> p, String region) {
+        String availabilityZone = p.getFirst("AvailabilityZone");
+        String volumeType = p.getFirst("VolumeType");
+        String sizeStr = p.getFirst("Size");
+        int size = sizeStr != null ? Integer.parseInt(sizeStr) : 8;
+        String encryptedStr = p.getFirst("Encrypted");
+        boolean encrypted = "true".equalsIgnoreCase(encryptedStr);
+        String iopsStr = p.getFirst("Iops");
+        int iops = iopsStr != null ? Integer.parseInt(iopsStr) : 0;
+        String snapshotId = p.getFirst("SnapshotId");
+
+        List<Tag> volumeTags = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String resType = p.getFirst("TagSpecification." + i + ".ResourceType");
+            if (resType == null) break;
+            if ("volume".equals(resType)) {
+                for (int j = 1; ; j++) {
+                    String k = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Key");
+                    if (k == null) break;
+                    String v = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Value");
+                    volumeTags.add(new Tag(k, v));
+                }
+            }
+        }
+
+        Volume vol = service.createVolume(region, availabilityZone, volumeType, size,
+                encrypted, iops, snapshotId, volumeTags);
+        XmlBuilder xml = new XmlBuilder()
+                .start("CreateVolumeResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .raw(volumeXml(vol))
+                .end("CreateVolumeResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeVolumes(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "VolumeId");
+        Map<String, List<String>> filters = getFilters(p);
+        List<Volume> volList = service.describeVolumes(region, ids, filters);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeVolumesResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("volumeSet");
+        for (Volume vol : volList) {
+            xml.start("item").raw(volumeXml(vol)).end("item");
+        }
+        xml.end("volumeSet")
+                .elem("nextToken", "")
+                .end("DescribeVolumesResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDeleteVolume(MultivaluedMap<String, String> p, String region) {
+        service.deleteVolume(region, p.getFirst("VolumeId"));
+        return booleanResponse("DeleteVolume");
+    }
+
+    private String volumeXml(Volume vol) {
+        XmlBuilder xml = new XmlBuilder()
+                .elem("volumeId", vol.getVolumeId())
+                .elem("size", String.valueOf(vol.getSize()))
+                .elem("volumeType", vol.getVolumeType())
+                .elem("status", vol.getState())
+                .elem("availabilityZone", vol.getAvailabilityZone())
+                .elem("encrypted", String.valueOf(vol.isEncrypted()));
+        if (vol.getIops() > 0) {
+            xml.elem("iops", String.valueOf(vol.getIops()));
+        }
+        if (vol.getSnapshotId() != null) {
+            xml.elem("snapshotId", vol.getSnapshotId());
+        }
+        if (vol.getCreateTime() != null) {
+            xml.elem("createTime", ISO_FMT.format(vol.getCreateTime()));
+        }
+        xml.start("attachmentSet");
+        for (VolumeAttachment att : vol.getAttachments()) {
+            xml.start("item")
+                    .elem("volumeId", att.getVolumeId())
+                    .elem("instanceId", att.getInstanceId())
+                    .elem("device", att.getDevice())
+                    .elem("status", att.getState())
+                    .elem("deleteOnTermination", String.valueOf(att.isDeleteOnTermination()));
+            if (att.getAttachTime() != null) {
+                xml.elem("attachTime", ISO_FMT.format(att.getAttachTime()));
+            }
+            xml.end("item");
+        }
+        xml.end("attachmentSet")
+                .raw(tagSetXml(vol.getTags()));
         return xml.build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -30,6 +30,7 @@ public class Ec2Service {
     private final Map<String, KeyPair> keyPairs = new ConcurrentHashMap<>();
     private final Map<String, Address> addresses = new ConcurrentHashMap<>();
     private final Map<String, Instance> instances = new ConcurrentHashMap<>();
+    private final Map<String, Volume> volumes = new ConcurrentHashMap<>();
     // resourceId → List<Tag>
     private final Map<String, List<Tag>> tags = new ConcurrentHashMap<>();
     private final Set<String> seededRegions = ConcurrentHashMap.newKeySet();
@@ -1196,6 +1197,16 @@ public class Ec2Service {
                 default -> true;
             };
         }
+        if (resource instanceof Volume vol) {
+            return switch (filterName) {
+                case "volume-id" -> values.contains(vol.getVolumeId());
+                case "status" -> values.contains(vol.getState());
+                case "volume-type" -> values.contains(vol.getVolumeType());
+                case "availability-zone" -> values.contains(vol.getAvailabilityZone());
+                case "encrypted" -> values.contains(String.valueOf(vol.isEncrypted()));
+                default -> true;
+            };
+        }
         return true;
     }
 
@@ -1209,6 +1220,54 @@ public class Ec2Service {
         if (resource instanceof RouteTable rt) return rt.getTags();
         if (resource instanceof KeyPair kp) return kp.getTags();
         if (resource instanceof Address addr) return addr.getTags();
+        if (resource instanceof Volume vol) return vol.getTags();
         return Collections.emptyList();
+    }
+
+    // ─── Volumes ───────────────────────────────────────────────────────────────
+
+    public Volume createVolume(String region, String availabilityZone, String volumeType,
+                               int size, boolean encrypted, int iops, String snapshotId,
+                               List<Tag> volumeTags) {
+        ensureDefaultResources(region);
+        String volumeId = "vol-" + randomHex(17);
+        Volume vol = new Volume();
+        vol.setVolumeId(volumeId);
+        vol.setAvailabilityZone(availabilityZone != null ? availabilityZone : region + "a");
+        vol.setVolumeType(volumeType != null ? volumeType : "gp2");
+        vol.setSize(size > 0 ? size : 8);
+        vol.setEncrypted(encrypted);
+        vol.setIops(iops > 0 ? iops : (volumeType != null && volumeType.startsWith("io") ? iops : 0));
+        vol.setSnapshotId(snapshotId);
+        vol.setCreateTime(Instant.now());
+        vol.setState("available");
+        vol.setRegion(region);
+        if (volumeTags != null) vol.setTags(new ArrayList<>(volumeTags));
+        volumes.put(key(region, volumeId), vol);
+        return vol;
+    }
+
+    public List<Volume> describeVolumes(String region, List<String> volumeIds,
+                                        Map<String, List<String>> filters) {
+        if (volumeIds != null && !volumeIds.isEmpty()) {
+            for (String id : volumeIds) {
+                if (volumes.get(key(region, id)) == null) {
+                    throw new AwsException("InvalidVolume.NotFound",
+                            "The volume '" + id + "' does not exist.", 400);
+                }
+            }
+        }
+        return volumes.values().stream()
+                .filter(v -> v.getRegion().equals(region))
+                .filter(v -> volumeIds == null || volumeIds.isEmpty() || volumeIds.contains(v.getVolumeId()))
+                .filter(v -> matchesFilters(v, filters, region))
+                .collect(Collectors.toList());
+    }
+
+    public void deleteVolume(String region, String volumeId) {
+        if (volumes.remove(key(region, volumeId)) == null) {
+            throw new AwsException("InvalidVolume.NotFound",
+                    "The volume '" + volumeId + "' does not exist.", 400);
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Volume.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Volume.java
@@ -1,0 +1,64 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Volume {
+
+    private String volumeId;
+    private String volumeType;        // gp2, gp3, io1, io2, st1, sc1, standard
+    private int size;                  // GiB
+    private String state;             // creating, available, in-use, deleting, deleted, error
+    private String availabilityZone;
+    private boolean encrypted;
+    private int iops;
+    private String snapshotId;
+    private Instant createTime;
+    private String region;
+    private List<Tag> tags = new ArrayList<>();
+    private List<VolumeAttachment> attachments = new ArrayList<>();
+
+    public Volume() {}
+
+    public String getVolumeId() { return volumeId; }
+    public void setVolumeId(String volumeId) { this.volumeId = volumeId; }
+
+    public String getVolumeType() { return volumeType; }
+    public void setVolumeType(String volumeType) { this.volumeType = volumeType; }
+
+    public int getSize() { return size; }
+    public void setSize(int size) { this.size = size; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getAvailabilityZone() { return availabilityZone; }
+    public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+
+    public boolean isEncrypted() { return encrypted; }
+    public void setEncrypted(boolean encrypted) { this.encrypted = encrypted; }
+
+    public int getIops() { return iops; }
+    public void setIops(int iops) { this.iops = iops; }
+
+    public String getSnapshotId() { return snapshotId; }
+    public void setSnapshotId(String snapshotId) { this.snapshotId = snapshotId; }
+
+    public Instant getCreateTime() { return createTime; }
+    public void setCreateTime(Instant createTime) { this.createTime = createTime; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags; }
+
+    public List<VolumeAttachment> getAttachments() { return attachments; }
+    public void setAttachments(List<VolumeAttachment> attachments) { this.attachments = attachments; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VolumeAttachment.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VolumeAttachment.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VolumeAttachment {
+
+    private String instanceId;
+    private String device;
+    private String state;   // attaching, attached, detaching, detached
+    private Instant attachTime;
+    private boolean deleteOnTermination;
+    private String volumeId;
+
+    public VolumeAttachment() {}
+
+    public String getInstanceId() { return instanceId; }
+    public void setInstanceId(String instanceId) { this.instanceId = instanceId; }
+
+    public String getDevice() { return device; }
+    public void setDevice(String device) { this.device = device; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public Instant getAttachTime() { return attachTime; }
+    public void setAttachTime(Instant attachTime) { this.attachTime = attachTime; }
+
+    public boolean isDeleteOnTermination() { return deleteOnTermination; }
+    public void setDeleteOnTermination(boolean deleteOnTermination) { this.deleteOnTermination = deleteOnTermination; }
+
+    public String getVolumeId() { return volumeId; }
+    public void setVolumeId(String volumeId) { this.volumeId = volumeId; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -29,6 +29,7 @@ class Ec2IntegrationTest {
     private static String rtbAssocId;
     private static String allocationId;
     private static String associationId;
+    private static String volumeId;
 
     // =========================================================================
     // Default resources
@@ -716,6 +717,110 @@ class Ec2IntegrationTest {
     }
 
     // =========================================================================
+    // Volumes
+    // =========================================================================
+
+    @Test
+    @Order(93)
+    void createVolume() {
+        volumeId = given()
+            .formParam("Action", "CreateVolume")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .formParam("VolumeType", "gp2")
+            .formParam("Size", "20")
+            .formParam("TagSpecification.1.ResourceType", "volume")
+            .formParam("TagSpecification.1.Tag.1.Key", "Name")
+            .formParam("TagSpecification.1.Tag.1.Value", "test-volume")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateVolumeResponse.volumeId", startsWith("vol-"))
+            .body("CreateVolumeResponse.volumeType", equalTo("gp2"))
+            .body("CreateVolumeResponse.size", equalTo("20"))
+            .body("CreateVolumeResponse.status", equalTo("available"))
+            .body("CreateVolumeResponse.availabilityZone", equalTo("us-east-1a"))
+            .body("CreateVolumeResponse.encrypted", equalTo("false"))
+        .extract().path("CreateVolumeResponse.volumeId");
+    }
+
+    @Test
+    @Order(94)
+    void describeVolumes() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("VolumeId.1", volumeId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.volumeId", equalTo(volumeId))
+            .body("DescribeVolumesResponse.volumeSet.item.volumeType", equalTo("gp2"))
+            .body("DescribeVolumesResponse.volumeSet.item.size", equalTo("20"))
+            .body("DescribeVolumesResponse.volumeSet.item.status", equalTo("available"));
+    }
+
+    @Test
+    @Order(95)
+    void describeVolumesByStatusFilter() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("Filter.1.Name", "status")
+            .formParam("Filter.1.Value.1", "available")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.status", equalTo("available"));
+    }
+
+    @Test
+    @Order(96)
+    void describeVolumesByVolumeTypeFilter() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("Filter.1.Name", "volume-type")
+            .formParam("Filter.1.Value.1", "gp2")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.volumeType", equalTo("gp2"));
+    }
+
+    @Test
+    @Order(97)
+    void deleteVolume() {
+        given()
+            .formParam("Action", "DeleteVolume")
+            .formParam("VolumeId", volumeId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeleteVolumeResponse.return", equalTo("true"));
+    }
+
+    @Test
+    @Order(98)
+    void describeDeletedVolumeReturnsNotFound() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("VolumeId.1", volumeId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidVolume.NotFound"));
+    }
+
+    // =========================================================================
     // Teardown / cleanup
     // =========================================================================
 
@@ -895,6 +1000,20 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(202)
+    void describeNonExistentVolume() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("VolumeId.1", "vol-0000000000000dead")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidVolume.NotFound"));
+    }
+
+    @Test
+    @Order(203)
     void unsupportedAction() {
         given()
             .formParam("Action", "SomeUnknownAction")


### PR DESCRIPTION
## Summary

Implements EC2 EBS volume support — `CreateVolume`, `DescribeVolumes`, and `DeleteVolume` — in the existing EC2 service.

Previously the EC2 service had no `Volume` model and no volume-related actions. This PR adds the minimum viable volume API so that callers can create volumes, query them with filters, and delete them.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against **AWS CLI v2** (`aws ec2 create-volume`, `aws ec2 describe-volumes`, `aws ec2 delete-volumes`) and **AWS SDK for Java v2** EC2 client.

**Wire protocol notes:**

- Uses EC2 Query Protocol (form-encoded POST, XML response)
- `CreateVolume` response is the volume object at the top level (not wrapped in a set), matching the AWS wire format
- `DescribeVolumes` response wraps results in `<volumeSet><item>…</item></volumeSet>` with a trailing `<nextToken/>` element
- `DeleteVolume` returns the standard boolean envelope `<DeleteVolumeResponse><return>true</return></DeleteVolumeResponse>`
- `CreateVolume` accepts `TagSpecification.N.ResourceType=volume` for tagging at creation time
- Error code for a missing volume is `InvalidVolume.NotFound` (HTTP 400)

**Supported filters for `DescribeVolumes`:**

| Filter name        | Description                          |
|--------------------|--------------------------------------|
| `volume-id`        | Match by volume ID                   |
| `status`           | `available`, `in-use`, etc.          |
| `volume-type`      | `gp2`, `gp3`, `io1`, `io2`, etc.     |
| `availability-zone`| AZ name                              |
| `encrypted`        | `true` / `false`                     |
| `tag:<key>`        | Match by tag key/value               |
| `tag-key`          | Match by tag key presence            |
| `tag-value`        | Match by tag value presence          |

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
