### PR TITLE
fix: implement S3 bucket ownership controls

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -167,6 +167,10 @@ public class S3Controller {
                 s3Service.putPublicAccessBlock(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
             }
+            if (hasQueryParam(uriInfo, "ownershipControls")) {
+                s3Service.putBucketOwnershipControls(bucket, new String(body, StandardCharsets.UTF_8));
+                return Response.ok().build();
+            }
 
             String locationConstraint = null;
             if (body != null && body.length > 0) {
@@ -224,6 +228,10 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "publicAccessBlock")) {
                 s3Service.deletePublicAccessBlock(bucket);
+                return Response.noContent().build();
+            }
+            if (hasQueryParam(uriInfo, "ownershipControls")) {
+                s3Service.deleteBucketOwnershipControls(bucket);
                 return Response.noContent().build();
             }
             s3Service.deleteBucket(bucket);
@@ -285,6 +293,9 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "publicAccessBlock")) {
                 return Response.ok(s3Service.getPublicAccessBlock(bucket)).build();
+            }
+            if (hasQueryParam(uriInfo, "ownershipControls")) {
+                return Response.ok(s3Service.getBucketOwnershipControls(bucket)).build();
             }
 
             int max = (maxKeys != null && maxKeys > 0) ? maxKeys : 1000;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1343,6 +1343,30 @@ public class S3Service {
         bucketStore.put(bucketName, bucket);
     }
 
+    public String getBucketOwnershipControls(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        if (bucket.getOwnershipControlsConfiguration() == null) {
+            throw new AwsException("OwnershipControlsNotFoundError",
+                    "The bucket ownership controls were not found.", 404);
+        }
+        return bucket.getOwnershipControlsConfiguration();
+    }
+
+    public void putBucketOwnershipControls(String bucketName, String ownershipControlsXml) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        bucket.setOwnershipControlsConfiguration(ownershipControlsXml);
+        bucketStore.put(bucketName, bucket);
+    }
+
+    public void deleteBucketOwnershipControls(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        bucket.setOwnershipControlsConfiguration(null);
+        bucketStore.put(bucketName, bucket);
+    }
+
     public void restoreObject(String bucketName, String key, String versionId, String restoreXml) {
         // Validation only - stub implementation
         getObject(bucketName, key, versionId);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -24,6 +24,7 @@ public class Bucket {
     private String acl; // XML representation or JSON stub
     private String encryptionConfiguration; // XML string
     private String publicAccessBlockConfiguration; // XML string
+    private String ownershipControlsConfiguration; // XML string
     private String region;
 
     public Bucket() {
@@ -80,6 +81,11 @@ public class Bucket {
     public String getPublicAccessBlockConfiguration() { return publicAccessBlockConfiguration; }
     public void setPublicAccessBlockConfiguration(String publicAccessBlockConfiguration) {
         this.publicAccessBlockConfiguration = publicAccessBlockConfiguration;
+    }
+
+    public String getOwnershipControlsConfiguration() { return ownershipControlsConfiguration; }
+    public void setOwnershipControlsConfiguration(String ownershipControlsConfiguration) {
+        this.ownershipControlsConfiguration = ownershipControlsConfiguration;
     }
 
     public String getRegion() { return region; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3OwnershipControlsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3OwnershipControlsIntegrationTest.java
@@ -1,0 +1,89 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3OwnershipControlsIntegrationTest {
+
+    private static final String BUCKET = "ownership-controls-int-test";
+    private static final String OWNERSHIP_CONTROLS_XML = """
+            <OwnershipControls xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Rule>
+                    <ObjectOwnership>BucketOwnerPreferred</ObjectOwnership>
+                </Rule>
+            </OwnershipControls>
+            """;
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getOwnershipControlsBeforePutReturns404() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?ownershipControls")
+        .then()
+            .statusCode(404)
+            .body(containsString("OwnershipControlsNotFoundError"));
+    }
+
+    @Test
+    @Order(3)
+    void putOwnershipControlsReturns200() {
+        given()
+            .body(OWNERSHIP_CONTROLS_XML)
+        .when()
+            .put("/" + BUCKET + "?ownershipControls")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void getOwnershipControlsReturnsStoredConfiguration() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?ownershipControls")
+        .then()
+            .statusCode(200)
+            .body(containsString("<OwnershipControls"))
+            .body(containsString("<ObjectOwnership>BucketOwnerPreferred</ObjectOwnership>"));
+    }
+
+    @Test
+    @Order(5)
+    void deleteOwnershipControlsReturns204() {
+        given()
+        .when()
+            .delete("/" + BUCKET + "?ownershipControls")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(6)
+    void getOwnershipControlsAfterDeleteReturns404() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?ownershipControls")
+        .then()
+            .statusCode(404)
+            .body(containsString("OwnershipControlsNotFoundError"));
+    }
+}


### PR DESCRIPTION
## Summary
- route `?ownershipControls` as a bucket subresource instead of falling through to `CreateBucket`
- persist bucket ownership controls in the S3 bucket model and expose get/put/delete service methods
- add focused integration coverage for put/get/delete ownership controls and missing-config behavior

## Root cause
`PUT /{bucket}?ownershipControls` was not handled in `S3Controller`, so requests fell through to `createBucket(...)`. For an existing bucket that produced the incorrect `BucketAlreadyOwnedByYou` 409 reported in #438.

## Testing
- `./mvnw test -Dtest=S3OwnershipControlsIntegrationTest`
- `./mvnw test -Dtest=S3IntegrationTest,S3VersioningIntegrationTest,S3AclIntegrationTest,S3CorsIntegrationTest,S3OwnershipControlsIntegrationTest`
