### PR TITLE
fix(dynamodb): support UpdateContinuousBackups and DescribeContinuousBackups (#437)

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
+++ b/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
@@ -170,6 +170,34 @@ teardown() {
     assert_success
 }
 
+@test "DynamoDB: update and describe continuous backups" {
+    aws_cmd dynamodb create-table \
+        --table-name "$TABLE_NAME" \
+        --attribute-definitions AttributeName=pk,AttributeType=S \
+        --key-schema AttributeName=pk,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST >/dev/null
+
+    ddb_wait_table "$TABLE_NAME"
+
+    run aws_cmd dynamodb describe-continuous-backups --table-name "$TABLE_NAME"
+    assert_success
+    status=$(json_get "$output" '.ContinuousBackupsDescription.ContinuousBackupsStatus')
+    [ "$status" = "ENABLED" ]
+    pitr_status=$(json_get "$output" '.ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus')
+    [ "$pitr_status" = "DISABLED" ]
+    missing_period=$(echo "$output" | jq '.ContinuousBackupsDescription.PointInTimeRecoveryDescription | has("RecoveryPeriodInDays")')
+    [ "$missing_period" = "false" ]
+
+    run aws_cmd dynamodb update-continuous-backups \
+        --table-name "$TABLE_NAME" \
+        --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true
+    assert_success
+    updated_status=$(json_get "$output" '.ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus')
+    [ "$updated_status" = "ENABLED" ]
+    recovery_period=$(json_get "$output" '.ContinuousBackupsDescription.PointInTimeRecoveryDescription.RecoveryPeriodInDays')
+    [ "$recovery_period" = "35" ]
+}
+
 # --- DynamoDB GSI/LSI Tests ---
 
 @test "DynamoDB: create table with GSI and LSI" {

--- a/compatibility-tests/sdk-test-python/tests/test_dynamodb.py
+++ b/compatibility-tests/sdk-test-python/tests/test_dynamodb.py
@@ -65,6 +65,55 @@ class TestDynamoDBTable:
         response = dynamodb_client.describe_time_to_live(TableName=test_table)
         assert response["TimeToLiveDescription"]["TimeToLiveStatus"] == "DISABLED"
 
+    def test_update_and_describe_continuous_backups(self, dynamodb_client, unique_name):
+        """Test PITR can be enabled and described through the SDK."""
+        table_name = f"pytest-ddb-{unique_name}"
+
+        dynamodb_client.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        try:
+            response = dynamodb_client.describe_continuous_backups(TableName=table_name)
+            assert (
+                response["ContinuousBackupsDescription"]["ContinuousBackupsStatus"]
+                == "ENABLED"
+            )
+            assert (
+                response["ContinuousBackupsDescription"][
+                    "PointInTimeRecoveryDescription"
+                ]["PointInTimeRecoveryStatus"]
+                == "DISABLED"
+            )
+            assert (
+                "RecoveryPeriodInDays"
+                not in response["ContinuousBackupsDescription"][
+                    "PointInTimeRecoveryDescription"
+                ]
+            )
+
+            response = dynamodb_client.update_continuous_backups(
+                TableName=table_name,
+                PointInTimeRecoverySpecification={"PointInTimeRecoveryEnabled": True},
+            )
+            assert (
+                response["ContinuousBackupsDescription"][
+                    "PointInTimeRecoveryDescription"
+                ]["PointInTimeRecoveryStatus"]
+                == "ENABLED"
+            )
+            assert (
+                response["ContinuousBackupsDescription"][
+                    "PointInTimeRecoveryDescription"
+                ]["RecoveryPeriodInDays"]
+                == 35
+            )
+        finally:
+            dynamodb_client.delete_table(TableName=table_name)
+
     def test_delete_table(self, dynamodb_client, unique_name):
         """Test DeleteTable removes table."""
         table_name = f"pytest-ddb-{unique_name}"

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -53,6 +53,8 @@ public class DynamoDbJsonHandler {
             case "UpdateTable" -> handleUpdateTable(request, region);
             case "DescribeTimeToLive" -> handleDescribeTimeToLive(request, region);
             case "UpdateTimeToLive" -> handleUpdateTimeToLive(request, region);
+            case "DescribeContinuousBackups" -> handleDescribeContinuousBackups(request, region);
+            case "UpdateContinuousBackups" -> handleUpdateContinuousBackups(request, region);
             case "TransactWriteItems" -> handleTransactWriteItems(request, region);
             case "TransactGetItems" -> handleTransactGetItems(request, region);
             case "TagResource" -> handleTagResource(request, region);
@@ -528,6 +530,35 @@ public class DynamoDbJsonHandler {
         return Response.ok(response).build();
     }
 
+    private Response handleDescribeContinuousBackups(JsonNode request, String region) {
+        String tableName = request.path("TableName").asText();
+        TableDefinition table = dynamoDbService.describeTable(tableName, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("ContinuousBackupsDescription", continuousBackupsDescriptionNode(table));
+        return Response.ok(response).build();
+    }
+
+    private Response handleUpdateContinuousBackups(JsonNode request, String region) {
+        String tableName = request.path("TableName").asText();
+        JsonNode spec = request.path("PointInTimeRecoverySpecification");
+        boolean enabled = spec.path("PointInTimeRecoveryEnabled").asBoolean(false);
+        Integer recoveryPeriodInDays = spec.has("RecoveryPeriodInDays")
+                ? spec.path("RecoveryPeriodInDays").asInt()
+                : null;
+        if (recoveryPeriodInDays != null && (recoveryPeriodInDays < 1 || recoveryPeriodInDays > 35)) {
+            throw new AwsException("ValidationException",
+                    "RecoveryPeriodInDays must be between 1 and 35", 400);
+        }
+
+        TableDefinition table = dynamoDbService.updateContinuousBackups(
+                tableName, enabled, recoveryPeriodInDays, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("ContinuousBackupsDescription", continuousBackupsDescriptionNode(table));
+        return Response.ok(response).build();
+    }
+
     private Response handleTransactWriteItems(JsonNode request, String region) {
         JsonNode transactItemsNode = request.path("TransactItems");
         List<JsonNode> transactItems = new ArrayList<>();
@@ -845,6 +876,20 @@ public class DynamoDbJsonHandler {
             node.put("LatestStreamLabel", label);
         }
 
+        return node;
+    }
+
+    private ObjectNode continuousBackupsDescriptionNode(TableDefinition table) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ContinuousBackupsStatus", "ENABLED");
+
+        ObjectNode pitrNode = objectMapper.createObjectNode();
+        pitrNode.put("PointInTimeRecoveryStatus",
+                table.isPointInTimeRecoveryEnabled() ? "ENABLED" : "DISABLED");
+        if (table.isPointInTimeRecoveryEnabled()) {
+            pitrNode.put("RecoveryPeriodInDays", table.getPointInTimeRecoveryRecoveryPeriodInDays());
+        }
+        node.set("PointInTimeRecoveryDescription", pitrNode);
         return node;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -799,6 +799,20 @@ public class DynamoDbService {
         LOG.infov("Updated TTL for table {0}: enabled={1}, attr={2}", tableName, enabled, ttlAttributeName);
     }
 
+    public TableDefinition updateContinuousBackups(String tableName, boolean enabled,
+                                                   Integer recoveryPeriodInDays, String region) {
+        String storageKey = regionKey(region, tableName);
+        TableDefinition table = tableStore.get(storageKey)
+                .orElseThrow(() -> resourceNotFoundException(tableName));
+        table.setPointInTimeRecoveryEnabled(enabled);
+        table.setPointInTimeRecoveryRecoveryPeriodInDays(
+                recoveryPeriodInDays != null ? recoveryPeriodInDays : table.getPointInTimeRecoveryRecoveryPeriodInDays());
+        tableStore.put(storageKey, table);
+        LOG.infov("Updated PITR for table {0}: enabled={1}, recoveryPeriodInDays={2}",
+                tableName, enabled, table.getPointInTimeRecoveryRecoveryPeriodInDays());
+        return table;
+    }
+
     static boolean isExpired(JsonNode item, TableDefinition table) {
         if (!table.isTtlEnabled() || table.getTtlAttributeName() == null) return false;
         JsonNode attr = item.get(table.getTtlAttributeName());

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -32,6 +32,8 @@ public class TableDefinition {
     private String billingMode; // "PROVISIONED" or "PAY_PER_REQUEST"
     private String ttlAttributeName;
     private boolean ttlEnabled;
+    private boolean pointInTimeRecoveryEnabled;
+    private int pointInTimeRecoveryRecoveryPeriodInDays;
     private boolean streamEnabled;
     private String streamArn;
     private String streamViewType;
@@ -43,6 +45,7 @@ public class TableDefinition {
         this.tags = new HashMap<>();
         this.globalSecondaryIndexes = new ArrayList<>();
         this.localSecondaryIndexes = new ArrayList<>();
+        this.pointInTimeRecoveryRecoveryPeriodInDays = 35;
         this.kinesisStreamingDestinations = new ArrayList<>();
     }
 
@@ -68,6 +71,7 @@ public class TableDefinition {
         this.tags = new HashMap<>();
         this.globalSecondaryIndexes = new ArrayList<>();
         this.localSecondaryIndexes = new ArrayList<>();
+        this.pointInTimeRecoveryRecoveryPeriodInDays = 35;
         this.kinesisStreamingDestinations = new ArrayList<>();
     }
 
@@ -119,6 +123,16 @@ public class TableDefinition {
 
     public boolean isTtlEnabled() { return ttlEnabled; }
     public void setTtlEnabled(boolean ttlEnabled) { this.ttlEnabled = ttlEnabled; }
+
+    public boolean isPointInTimeRecoveryEnabled() { return pointInTimeRecoveryEnabled; }
+    public void setPointInTimeRecoveryEnabled(boolean pointInTimeRecoveryEnabled) {
+        this.pointInTimeRecoveryEnabled = pointInTimeRecoveryEnabled;
+    }
+
+    public int getPointInTimeRecoveryRecoveryPeriodInDays() { return pointInTimeRecoveryRecoveryPeriodInDays; }
+    public void setPointInTimeRecoveryRecoveryPeriodInDays(int pointInTimeRecoveryRecoveryPeriodInDays) {
+        this.pointInTimeRecoveryRecoveryPeriodInDays = pointInTimeRecoveryRecoveryPeriodInDays;
+    }
 
     public boolean isStreamEnabled() { return streamEnabled; }
     public void setStreamEnabled(boolean streamEnabled) { this.streamEnabled = streamEnabled; }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1088,6 +1088,134 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    void updateAndDescribeContinuousBackups() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ContinuousBackupsTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ContinuousBackupsTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ContinuousBackupsDescription.ContinuousBackupsStatus", equalTo("ENABLED"))
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
+                    equalTo("DISABLED"))
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.RecoveryPeriodInDays",
+                    nullValue());
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ContinuousBackupsTable",
+                    "PointInTimeRecoverySpecification": {
+                        "PointInTimeRecoveryEnabled": true
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ContinuousBackupsDescription.ContinuousBackupsStatus", equalTo("ENABLED"))
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
+                    equalTo("ENABLED"))
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.RecoveryPeriodInDays",
+                    equalTo(35));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ContinuousBackupsTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
+                    equalTo("ENABLED"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ContinuousBackupsTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void updateContinuousBackupsRejectsOutOfRangeRecoveryPeriod() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ContinuousBackupsValidationTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ContinuousBackupsValidationTable",
+                    "PointInTimeRecoverySpecification": {
+                        "PointInTimeRecoveryEnabled": true,
+                        "RecoveryPeriodInDays": 36
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ContinuousBackupsValidationTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedOperation() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateGlobalTable")


### PR DESCRIPTION
## Summary
Add DynamoDB PITR support for `UpdateContinuousBackups` and `DescribeContinuousBackups`.

This fixes Terraform flows that enable `point_in_time_recovery` on `aws_dynamodb_table`, which previously failed with `UnknownOperationException` after the table was created.

## Changes
- route `UpdateContinuousBackups` and `DescribeContinuousBackups` in the DynamoDB JSON handler
- persist PITR state on table metadata
- return `ContinuousBackupsDescription` with Terraform-compatible PITR status
- validate `RecoveryPeriodInDays` range (`1..35`)
- add integration and compatibility regression coverage

## Verification
- `./mvnw -q test -Dtest=DynamoDbIntegrationTest`
- live AWS CLI flow against local Floci:
  - `create-table`
  - `describe-continuous-backups`
  - `update-continuous-backups`
  - `delete-table`
- `python3 -m pytest compatibility-tests/sdk-test-python/tests/test_dynamodb.py -k continuous_backups -q`

## Notes
- `terraform` was not installed in the local environment, so I verified the client behavior through live AWS CLI and boto3 compatibility paths instead.
- this implements PITR state and response handling, not full restore-window timestamp emulation

Fixes #437
