### PR TITLE
fix(lambda): include LastUpdateStatus in function configuration responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -479,6 +479,7 @@ public class LambdaController {
         node.put("LastModified", String.valueOf(fn.getLastModified()));
         node.put("RevisionId", fn.getRevisionId());
         node.put("Version", fn.getVersion());
+        node.put("LastUpdateStatus", "Successful");
 
         if (fn.getEnvironment() != null && !fn.getEnvironment().isEmpty()) {
             ObjectNode envNode = node.putObject("Environment");

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -152,8 +152,21 @@ class LambdaIntegrationTest {
             .statusCode(400);
     }
 
+    // ── Issue #439: LastUpdateStatus in responses ─────────────────────
+
     @Test
     @Order(9)
+    void getFunctionIncludesLastUpdateStatus() {
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/hello-world")
+        .then()
+            .statusCode(200)
+            .body("Configuration.LastUpdateStatus", equalTo("Successful"));
+    }
+
+    @Test
+    @Order(10)
     void deleteFunction() {
         given()
         .when()
@@ -163,7 +176,7 @@ class LambdaIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void deletedFunctionNotFound() {
         given()
         .when()
@@ -173,7 +186,7 @@ class LambdaIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void createFunctionWithLargeInlineZip() throws Exception {
         // Build a valid zip with a handler file + 16 MB padding so the base64
         // encoding exceeds Jackson's former 20 MB maxStringLength default.


### PR DESCRIPTION
## Summary

Adds `LastUpdateStatus: "Successful"` to `buildFunctionConfiguration()`, which produces responses for CreateFunction, GetFunction, GetFunctionConfiguration, and UpdateFunctionCode. Closes #439

Per [AWS docs](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunctionConfiguration.html), LastUpdateStatus is first set to Successful after function creation completes. Since Floci is synchronous, Successful is always the correct value. LastUpdateStatusReason and LastUpdateStatusReasonCode are omitted because AWS only populates them on failure.

[Test failures seem unrelated to my PR.](https://github.com/floci-io/floci/pull/197#issuecomment-4253109783)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI v2 against a Docker container built from source. LastUpdateStatus Successful is present in responses for CreateFunction, GetFunction, GetFunctionConfiguration, and UpdateFunctionCode.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)