### PR TITLE
test: decouple CloudFormation vhost test from DNS setup

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationVirtualHostTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationVirtualHostTests.java
@@ -4,36 +4,40 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.ListStacksResponse;
-
-import java.net.URI;
 
 import static org.assertj.core.api.Assertions.*;
 
 /**
  * Ensures that requests to non-S3 service hostnames (e.g. cloudformation.amazonaws.com)
  * are not incorrectly hijacked by the S3 virtual host filter.
+ *
+ * <p>The TCP connection lands on the configured Floci endpoint; an execution
+ * interceptor overrides the Host header so Floci sees the request as though it
+ * came from {@code cloudformation.us-east-1.amazonaws.com}. This decouples the
+ * test from DNS setup so it works equally against localhost, a docker service
+ * name (e.g. {@code http://floci:4566}), or a remote Floci deployment.
  */
 @DisplayName("CloudFormation Virtual Host")
 class CloudFormationVirtualHostTests {
+
+    private static final String VIRTUAL_HOST = "cloudformation.us-east-1.amazonaws.com";
 
     private static CloudFormationClient cfn;
 
     @BeforeAll
     static void setup() {
-        // We override the endpoint to simulate a virtual host style request for CloudFormation
-        URI endpoint = TestFixtures.endpoint();
-        URI cfnEndpoint = URI.create("http://cloudformation.us-east-1.amazonaws.com:" + endpoint.getPort());
-        if (endpoint.getHost().equals("localhost")) {
-            cfnEndpoint = URI.create("http://cloudformation.localhost:" + endpoint.getPort());
-        }
-
         cfn = CloudFormationClient.builder()
-                .endpointOverride(cfnEndpoint)
+                .endpointOverride(TestFixtures.endpoint())
                 .region(software.amazon.awssdk.regions.Region.US_EAST_1)
                 .credentialsProvider(software.amazon.awssdk.auth.credentials.StaticCredentialsProvider.create(
                         software.amazon.awssdk.auth.credentials.AwsBasicCredentials.create("test", "test")))
+                .overrideConfiguration(c -> c.addExecutionInterceptor(new HostHeaderSpoofInterceptor(VIRTUAL_HOST)))
                 .build();
     }
 
@@ -49,5 +53,27 @@ class CloudFormationVirtualHostTests {
     void listStacksVirtualHost() {
         ListStacksResponse resp = cfn.listStacks();
         assertThat(resp.sdkHttpResponse().isSuccessful()).isTrue();
+    }
+
+    /**
+     * Rewrites the Host header on outbound requests so Floci sees the incoming
+     * request as virtual-hosted under {@code hostHeader}, while the underlying
+     * TCP connection still goes to the endpoint configured via
+     * {@code endpointOverride}.
+     */
+    private static final class HostHeaderSpoofInterceptor implements ExecutionInterceptor {
+        private final String hostHeader;
+
+        HostHeaderSpoofInterceptor(String hostHeader) {
+            this.hostHeader = hostHeader;
+        }
+
+        @Override
+        public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+                                                ExecutionAttributes executionAttributes) {
+            return context.httpRequest().toBuilder()
+                    .putHeader("Host", hostHeader)
+                    .build();
+        }
     }
 }


### PR DESCRIPTION
## Summary

The test's purpose is to verify that S3VirtualHostFilter does not hijack
non-S3 requests whose Host header matches an AWS service hostname pattern.

Previous implementation routed the TCP connection itself to
cloudformation.us-east-1.amazonaws.com, relying on DNS:
  - localhost case: worked because .localhost resolves to 127.0.0.1
  - non-localhost (e.g. FLOCI_ENDPOINT=http://floci:4566 in CI): DNS
    resolves to real AWS, port 4566 is closed, test times out

The test was silently skipped by surefire (pattern **/*Test.java matched
singular only) until #197 added **/*Tests.java, exposing the latent bug.

Fix: connect to the configured Floci endpoint and spoof the Host header
via an ExecutionInterceptor. The filter sees the virtual-hosted hostname
exactly as intended, without any DNS or /etc/hosts coupling. Works
identically against localhost, a docker service name, or a remote Floci.
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
