### PR TITLE
fix(sqs): honor queue-level DelaySeconds on FIFO queues

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -317,6 +317,21 @@ public class SqsService {
                     "Message body must be shorter than " + maxMessageSize + " bytes.", 400);
         }
 
+        int queueDelaySeconds = parseDelaySecondsAttribute(queue.getAttributes().get("DelaySeconds"));
+
+        // Resolve the effective delay:
+        //   - FIFO queues only support queue-level DelaySeconds per AWS SQS,
+        //     so any per-message value is ignored and we always use the
+        //     queue attribute. Without this, FIFO silently dropped the
+        //     queue-level default (issue #475).
+        //   - Standard queues honor per-message DelaySeconds when provided
+        //     (> 0). Applying the queue-level default on the standard path
+        //     requires distinguishing "omitted" from "explicit 0" in the
+        //     handlers, which the current int-parameter API cannot express;
+        //     that's left as follow-up work -- this patch only addresses
+        //     the FIFO regression called out in the issue.
+        int effectiveDelaySeconds = queue.isFifo() ? queueDelaySeconds : delaySeconds;
+
         // FIFO queue validation
         if (queue.isFifo()) {
             if (messageGroupId == null || messageGroupId.isEmpty()) {
@@ -353,6 +368,9 @@ public class SqsService {
             message.setMessageGroupId(messageGroupId);
             message.setMessageDeduplicationId(dedupId);
             message.setSequenceNumber(sequenceCounter.incrementAndGet());
+            if (effectiveDelaySeconds > 0) {
+                message.setVisibleAt(Instant.now().plusSeconds(effectiveDelaySeconds));
+            }
             if (messageAttributes != null && !messageAttributes.isEmpty()) {
                 message.getMessageAttributes().putAll(messageAttributes);
                 message.updateMd5OfMessageAttributes();
@@ -367,8 +385,8 @@ public class SqsService {
 
         // Standard queue
         Message message = new Message(body);
-        if (delaySeconds > 0) {
-            message.setVisibleAt(Instant.now().plusSeconds(delaySeconds));
+        if (effectiveDelaySeconds > 0) {
+            message.setVisibleAt(Instant.now().plusSeconds(effectiveDelaySeconds));
         }
         if (messageAttributes != null && !messageAttributes.isEmpty()) {
             message.getMessageAttributes().putAll(messageAttributes);
@@ -379,6 +397,23 @@ public class SqsService {
         notifyReceivers(storageKey);
         LOG.debugv("Sent message {0} to queue {1}", message.getMessageId(), queueUrl);
         return message;
+    }
+
+    /**
+     * Parse the queue-level DelaySeconds attribute. Returns 0 when the
+     * attribute is null, empty, non-numeric, or negative -- the queue falls
+     * back to "no default delay" rather than failing the SendMessage call.
+     */
+    private int parseDelaySecondsAttribute(String value) {
+        if (value == null || value.isEmpty()) {
+            return 0;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed > 0 ? parsed : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     private void notifyReceivers(String storageKey) {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -311,4 +311,38 @@ class SqsServiceTest {
         List<Message> third = sqsService.receiveMessage(queue.getQueueUrl(), 1, -1, 0);
         assertEquals(1, third.size(), "Message should become visible after queue's VisibilityTimeout (1s), not global default (30s)");
     }
+
+    // --- Queue-level DelaySeconds for FIFO queues (issue #475) ---
+
+    @Test
+    void queueLevelDelaySecondsAppliesToFifoQueue() {
+        Queue queue = sqsService.createQueue("delay-fifo.fifo",
+                Map.of("ContentBasedDeduplication", "true", "DelaySeconds", "1"));
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", 0, "group1", null);
+
+        List<Message> immediate = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0);
+        assertTrue(immediate.isEmpty(),
+                "FIFO queue should honor queue-level DelaySeconds (issue #475)");
+
+        try { Thread.sleep(1100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        List<Message> later = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0);
+        assertEquals(1, later.size(),
+                "Message should become visible once DelaySeconds elapses");
+    }
+
+    @Test
+    void fifoQueueIgnoresPerMessageDelaySeconds() {
+        // AWS SQS FIFO queues only support queue-level DelaySeconds; any
+        // per-message value is ignored. Here the queue default is 0 and the
+        // caller passes a positive per-message delay -- the message must be
+        // immediately visible.
+        Queue queue = sqsService.createQueue("fifo-ignores-per-msg.fifo",
+                Map.of("ContentBasedDeduplication", "true"));
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", 60, "group1", null);
+
+        List<Message> immediate = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0);
+        assertEquals(1, immediate.size(),
+                "FIFO queues must ignore per-message DelaySeconds");
+    }
 }


### PR DESCRIPTION
## Summary

FIFO `sendMessage` silently dropped the queue-level `DelaySeconds` attribute: messages were stored and became immediately receivable regardless of the queue's configured default. Also reproduces via `SendMessageBatch` on FIFO queues.

Resolve the effective delay from the `DelaySeconds` queue attribute before the FIFO/standard split, then apply it via `Message.setVisibleAt` in both branches. FIFO always uses the queue-level value -- AWS SQS doesn't accept per-message `DelaySeconds` on FIFO queues -- while the standard path keeps its existing per-message behavior.

## What changed

- `SqsService.sendMessage` now computes `effectiveDelaySeconds` once before the FIFO validation block and applies it to FIFO messages via `setVisibleAt`. Added `parseDelaySecondsAttribute` helper that tolerates null/empty/non-numeric/negative attribute values.
- `SqsServiceTest`: added `queueLevelDelaySecondsAppliesToFifoQueue` (regression test for the reported bug) and `fifoQueueIgnoresPerMessageDelaySeconds` (AWS-compatibility guard).

## Scope notes

A few things I intentionally left out of this patch because they require wider changes than the reported bug:

- **Queue-level default on standard queues.** Currently the handler can't distinguish "caller omitted `DelaySeconds`" from "caller sent `DelaySeconds=0`" -- both arrive as `int 0`. Applying the queue-level default on the standard path needs a sentinel (or `Integer`) through the handler layer, and touches `SnsService`, `S3Service`, and `EventBridgeInvoker` which also pass `0` verbatim. Happy to pick that up in a follow-up if you want the full AWS parity; flagging so the maintainer can confirm the direction before a bigger refactor lands.
- **Persistence across restarts.** `Message.visibleAt` is `@JsonIgnore`, so delayed visibility doesn't survive restart. This is pre-existing for standard queues and this patch just inherits it for FIFO. Noted for a separate PR.

## Test plan

```
./mvnw test -Dtest=SqsServiceTest
```

Reproduction from the issue confirms the queue-level default now applies on FIFO.

Fixes #475
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
