### PR TITLE
fix(dynamoDB): support arithmetic in DynamoDB SET expressions

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
@@ -315,8 +315,74 @@ class DynamoDbExpressionTests {
         assertThat(resp.count()).isEqualTo(3);
     }
 
+    // ---- SET arithmetic ----
+
     @Test
     @Order(14)
+    @DisplayName("UpdateExpression: SET with if_not_exists + arithmetic increment")
+    void updateSetIfNotExistsPlusIncrement() {
+        String table = "expr-arith-test";
+        ddb.createTable(CreateTableRequest.builder()
+                .tableName(table)
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .build());
+
+        try {
+            // First increment on non-existent item: if_not_exists(counter, 0) + 1 = 1
+            ddb.updateItem(UpdateItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .updateExpression("SET counter = if_not_exists(counter, :start) + :inc")
+                    .expressionAttributeValues(Map.of(
+                            ":start", AttributeValue.builder().n("0").build(),
+                            ":inc", AttributeValue.builder().n("1").build()))
+                    .build());
+
+            GetItemResponse r1 = ddb.getItem(GetItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .build());
+            assertThat(r1.item().get("counter").n()).isEqualTo("1");
+
+            // Second increment: existing (1) + 1 = 2
+            ddb.updateItem(UpdateItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .updateExpression("SET counter = if_not_exists(counter, :start) + :inc")
+                    .expressionAttributeValues(Map.of(
+                            ":start", AttributeValue.builder().n("0").build(),
+                            ":inc", AttributeValue.builder().n("1").build()))
+                    .build());
+
+            GetItemResponse r2 = ddb.getItem(GetItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .build());
+            assertThat(r2.item().get("counter").n()).isEqualTo("2");
+
+            // Subtraction: existing (2) - 1 = 1
+            ddb.updateItem(UpdateItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .updateExpression("SET counter = counter - :dec")
+                    .expressionAttributeValues(Map.of(
+                            ":dec", AttributeValue.builder().n("1").build()))
+                    .build());
+
+            GetItemResponse r3 = ddb.getItem(GetItemRequest.builder()
+                    .tableName(table)
+                    .key(Map.of("pk", AttributeValue.fromS("k1")))
+                    .build());
+            assertThat(r3.item().get("counter").n()).isEqualTo("1");
+        } finally {
+            ddb.deleteTable(DeleteTableRequest.builder().tableName(table).build());
+        }
+    }
+
+    @Test
+    @Order(15)
     @DisplayName("Query: compact format BETWEEN — no spaces around AND")
     void queryCompactBetween() {
         QueryResponse resp = ddb.query(QueryRequest.builder()

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -995,13 +995,20 @@ public class DynamoDbService {
                 String rightExpr = valuePart.substring(arithmeticIdx + 1).trim();
                 JsonNode leftVal = evaluateSetExpr(item, leftExpr, exprAttrNames, exprAttrValues);
                 JsonNode rightVal = evaluateSetExpr(item, rightExpr, exprAttrNames, exprAttrValues);
-                if (leftVal != null && rightVal != null && leftVal.has("N") && rightVal.has("N")) {
+                if (leftVal == null || rightVal == null || !leftVal.has("N") || !rightVal.has("N")) {
+                    throw new AwsException("ValidationException",
+                            "Invalid UpdateExpression: Incorrect operand type for operator or function", 400);
+                }
+                try {
                     java.math.BigDecimal left = new java.math.BigDecimal(leftVal.get("N").asText());
                     java.math.BigDecimal right = new java.math.BigDecimal(rightVal.get("N").asText());
                     java.math.BigDecimal result = (operator == '+') ? left.add(right) : left.subtract(right);
                     ObjectNode numNode = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
                     numNode.put("N", result.toPlainString());
                     setValueAtPath(item, attrPath, numNode, exprAttrNames);
+                } catch (NumberFormatException e) {
+                    throw new AwsException("ValidationException",
+                            "The parameter cannot be converted to a numeric value", 400);
                 }
             } else if (valuePart.startsWith("if_not_exists(")) {
                 // if_not_exists(attrRef, fallbackExpr) evaluates to:
@@ -1080,19 +1087,19 @@ public class DynamoDbService {
             if (args.length == 2) {
                 String checkAttr = resolveAttributeName(args[0].trim(), exprAttrNames);
                 String fallbackExpr = args[1].trim();
-                if (item.has(checkAttr)) {
-                    return item.get(checkAttr);
+                if (hasValueAtPath(item, checkAttr, exprAttrNames)) {
+                    return getValueAtPath(item, checkAttr, exprAttrNames);
                 } else if (fallbackExpr.startsWith(":") && exprAttrValues != null) {
                     return exprAttrValues.get(fallbackExpr);
                 } else {
-                    return item.get(resolveAttributeName(fallbackExpr, exprAttrNames));
+                    return getValueAtPath(item, resolveAttributeName(fallbackExpr, exprAttrNames), exprAttrNames);
                 }
             }
             return null;
         } else if (expr.startsWith(":") && exprAttrValues != null) {
             return exprAttrValues.get(expr);
         } else {
-            return item.get(resolveAttributeName(expr, exprAttrNames));
+            return getValueAtPath(item, resolveAttributeName(expr, exprAttrNames), exprAttrNames);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -985,7 +985,25 @@ public class DynamoDbService {
 
 
             // Resolve the value
-            if (valuePart.startsWith("if_not_exists(")) {
+            // Check for arithmetic expressions (operand + operand, operand - operand)
+            // before handling individual expression types, since the left operand can be
+            // a function like if_not_exists(...).
+            int arithmeticIdx = findArithmeticOperator(valuePart);
+            if (arithmeticIdx >= 0) {
+                String leftExpr = valuePart.substring(0, arithmeticIdx).trim();
+                char operator = valuePart.charAt(arithmeticIdx);
+                String rightExpr = valuePart.substring(arithmeticIdx + 1).trim();
+                JsonNode leftVal = evaluateSetExpr(item, leftExpr, exprAttrNames, exprAttrValues);
+                JsonNode rightVal = evaluateSetExpr(item, rightExpr, exprAttrNames, exprAttrValues);
+                if (leftVal != null && rightVal != null && leftVal.has("N") && rightVal.has("N")) {
+                    java.math.BigDecimal left = new java.math.BigDecimal(leftVal.get("N").asText());
+                    java.math.BigDecimal right = new java.math.BigDecimal(rightVal.get("N").asText());
+                    java.math.BigDecimal result = (operator == '+') ? left.add(right) : left.subtract(right);
+                    ObjectNode numNode = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                    numNode.put("N", result.toPlainString());
+                    setValueAtPath(item, attrPath, numNode, exprAttrNames);
+                }
+            } else if (valuePart.startsWith("if_not_exists(")) {
                 // if_not_exists(attrRef, fallbackExpr) evaluates to:
                 //   attrRef's current value  — when attrRef exists in the item
                 //   fallbackExpr             — otherwise
@@ -1532,6 +1550,28 @@ public class DynamoDbService {
         } catch (NumberFormatException e) {
             return a.compareTo(b);
         }
+    }
+
+    /**
+     * Finds the index of an arithmetic operator (+ or -) that is outside
+     * function parentheses. Returns -1 if none found.
+     */
+    private int findArithmeticOperator(String expr) {
+        int depth = 0;
+        for (int i = 0; i < expr.length(); i++) {
+            char c = expr.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+            } else if (depth == 0 && (c == '+' || c == '-')) {
+                // Ensure this is a binary operator, not a sign at the start or after '('
+                if (i > 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
     }
 
     private String[] extractFunctionArgs(String funcCall) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1324,6 +1324,111 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    @Order(31)
+    void updateItemSetArithmeticIncrement() {
+        // Create table
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ArithmeticTable",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // First call: if_not_exists(counter, :start) + :inc → 60000001
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ArithmeticTable",
+                    "Key": {"PK": {"S": "LastId"}},
+                    "UpdateExpression": "SET customerId = if_not_exists(customerId, :start) + :inc",
+                    "ExpressionAttributeValues": {
+                        ":start": {"N": "60000000"},
+                        ":inc": {"N": "1"}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify first increment
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ArithmeticTable",
+                    "Key": {"PK": {"S": "LastId"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.customerId.N", equalTo("60000001"));
+
+        // Second call: existing (60000001) + 1 → 60000002
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ArithmeticTable",
+                    "Key": {"PK": {"S": "LastId"}},
+                    "UpdateExpression": "SET customerId = if_not_exists(customerId, :start) + :inc",
+                    "ExpressionAttributeValues": {
+                        ":start": {"N": "60000000"},
+                        ":inc": {"N": "1"}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify second increment
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "ArithmeticTable",
+                    "Key": {"PK": {"S": "LastId"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.customerId.N", equalTo("60000002"));
+
+        // Cleanup
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "ArithmeticTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedOperation() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateGlobalTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -558,6 +558,140 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void updateItemSetArithmeticIncrement() {
+        createUsersTable();
+
+        // Put an item with counter = 100
+        ObjectNode existing = mapper.createObjectNode();
+        existing.set("userId", attributeValue("S", "u1"));
+        ObjectNode counterVal = mapper.createObjectNode();
+        counterVal.put("N", "100");
+        existing.set("counter", counterVal);
+        service.putItem("Users", existing);
+
+        ObjectNode key = item("userId", "u1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode incVal = mapper.createObjectNode();
+        incVal.put("N", "1");
+        exprValues.set(":inc", incVal);
+
+        service.updateItem("Users", key, null,
+                "SET counter = counter + :inc",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals("101", stored.get("counter").get("N").asText(),
+                "counter should be incremented from 100 to 101");
+    }
+
+    @Test
+    void updateItemSetArithmeticDecrement() {
+        createUsersTable();
+
+        ObjectNode existing = mapper.createObjectNode();
+        existing.set("userId", attributeValue("S", "u1"));
+        ObjectNode counterVal = mapper.createObjectNode();
+        counterVal.put("N", "50");
+        existing.set("counter", counterVal);
+        service.putItem("Users", existing);
+
+        ObjectNode key = item("userId", "u1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode decVal = mapper.createObjectNode();
+        decVal.put("N", "3");
+        exprValues.set(":dec", decVal);
+
+        service.updateItem("Users", key, null,
+                "SET counter = counter - :dec",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals("47", stored.get("counter").get("N").asText(),
+                "counter should be decremented from 50 to 47");
+    }
+
+    @Test
+    void updateItemSetIfNotExistsWithArithmeticOnNewItem() {
+        createUsersTable();
+
+        ObjectNode key = item("userId", "u1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode startVal = mapper.createObjectNode();
+        startVal.put("N", "60000000");
+        ObjectNode incVal = mapper.createObjectNode();
+        incVal.put("N", "1");
+        exprValues.set(":start", startVal);
+        exprValues.set(":inc", incVal);
+
+        service.updateItem("Users", key, null,
+                "SET counter = if_not_exists(counter, :start) + :inc",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals("60000001", stored.get("counter").get("N").asText(),
+                "counter should be if_not_exists default (60000000) + 1 = 60000001");
+    }
+
+    @Test
+    void updateItemSetIfNotExistsWithArithmeticOnExistingItem() {
+        createUsersTable();
+
+        ObjectNode existing = mapper.createObjectNode();
+        existing.set("userId", attributeValue("S", "u1"));
+        ObjectNode counterVal = mapper.createObjectNode();
+        counterVal.put("N", "60000005");
+        existing.set("counter", counterVal);
+        service.putItem("Users", existing);
+
+        ObjectNode key = item("userId", "u1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode startVal = mapper.createObjectNode();
+        startVal.put("N", "60000000");
+        ObjectNode incVal = mapper.createObjectNode();
+        incVal.put("N", "1");
+        exprValues.set(":start", startVal);
+        exprValues.set(":inc", incVal);
+
+        service.updateItem("Users", key, null,
+                "SET counter = if_not_exists(counter, :start) + :inc",
+                null, exprValues, null);
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals("60000006", stored.get("counter").get("N").asText(),
+                "counter should be existing (60000005) + 1 = 60000006");
+    }
+
+    @Test
+    void updateItemSetArithmeticConsecutiveIncrements() {
+        createUsersTable();
+
+        ObjectNode key = item("userId", "u1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode startVal = mapper.createObjectNode();
+        startVal.put("N", "0");
+        ObjectNode incVal = mapper.createObjectNode();
+        incVal.put("N", "1");
+        exprValues.set(":start", startVal);
+        exprValues.set(":inc", incVal);
+
+        // Three consecutive increments
+        for (int i = 0; i < 3; i++) {
+            service.updateItem("Users", key, null,
+                    "SET counter = if_not_exists(counter, :start) + :inc",
+                    null, exprValues, null);
+        }
+
+        JsonNode stored = service.getItem("Users", key);
+        assertNotNull(stored);
+        assertEquals("3", stored.get("counter").get("N").asText(),
+                "counter should be 3 after three increments starting from 0");
+    }
+
+    @Test
     void scanWithBoolFilterExpression() {
         createUsersTable();
         ObjectNode u1 = item("userId", "u1");


### PR DESCRIPTION
## Summary

- DynamoDB `SET` expressions with `+` / `-` (`SET cnt = cnt + :inc`, `SET x = if_not_exists(x, :start) + :inc`) silently dropped the arithmetic — only the left operand was assigned
- Add `findArithmeticOperator()` to locate `+`/`-` outside function parens
- Evaluate both operands via `evaluateSetExpr`, perform BigDecimal math
- 5 new unit tests: plain increment, decrement, `if_not_exists` + arithmetic (new/existing item), consecutive increments

Closes #479

## Test plan

- [x] `DynamoDbServiceTest` — 66 tests pass (5 new)
- [x] `DynamoDbIntegrationTest` — 39 tests pass (no regressions)