### PR TITLE
fix(kms): support ECC_SECG_P256K1 via BouncyCastle JCA

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.kms.model.KmsKey;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
@@ -91,8 +92,8 @@ public class KmsService {
                 generator = KeyPairGenerator.getInstance("RSA");
                 int size = Integer.parseInt(spec.substring(4));
                 generator.initialize(size);
-            } else if (spec.startsWith("ECC_")) {
-                generator = KeyPairGenerator.getInstance("EC");
+            } else if (isEcKeySpec(spec)) {
+                generator = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
                 String curveName = switch (spec) {
                     case "ECC_NIST_P256" -> "secp256r1";
                     case "ECC_NIST_P384" -> "secp384r1";
@@ -267,8 +268,10 @@ public class KmsService {
                 // If message is already a digest, we need a "NONEwith..." algorithm
                 jcaAlgo = "NONEwith" + (kmsKey.getCustomerMasterKeySpec().startsWith("RSA") ? "RSA" : "ECDSA");
             }
-            
-            Signature sig = Signature.getInstance(jcaAlgo);
+
+            Signature sig = isEcKeySpec(kmsKey.getCustomerMasterKeySpec())
+                ? Signature.getInstance(jcaAlgo, BouncyCastleProvider.PROVIDER_NAME)
+                : Signature.getInstance(jcaAlgo);
             sig.initSign(privateKey);
             sig.update(message);
             return sig.sign();
@@ -295,7 +298,9 @@ public class KmsService {
                 jcaAlgo = "NONEwith" + (kmsKey.getCustomerMasterKeySpec().startsWith("RSA") ? "RSA" : "ECDSA");
             }
 
-            Signature sig = Signature.getInstance(jcaAlgo);
+            Signature sig = isEcKeySpec(kmsKey.getCustomerMasterKeySpec())
+                ? Signature.getInstance(jcaAlgo, BouncyCastleProvider.PROVIDER_NAME)
+                : Signature.getInstance(jcaAlgo);
             sig.initVerify(publicKey);
             sig.update(message);
             return sig.verify(signature);
@@ -307,13 +312,13 @@ public class KmsService {
 
     private PrivateKey loadPrivateKey(String encoded, String spec) throws Exception {
         byte[] decoded = Base64.getDecoder().decode(encoded);
-        KeyFactory factory = KeyFactory.getInstance(spec.startsWith("RSA") ? "RSA" : "EC");
+        KeyFactory factory = buildKeyFactory(spec);
         return factory.generatePrivate(new PKCS8EncodedKeySpec(decoded));
     }
 
     private PublicKey loadPublicKey(String encoded, String spec) throws Exception {
         byte[] decoded = Base64.getDecoder().decode(encoded);
-        KeyFactory factory = KeyFactory.getInstance(spec.startsWith("RSA") ? "RSA" : "EC");
+        KeyFactory factory = buildKeyFactory(spec);
         return factory.generatePublic(new X509EncodedKeySpec(decoded));
     }
 
@@ -363,6 +368,16 @@ public class KmsService {
     }
 
     // ──────────────────────────── Helpers ────────────────────────────
+
+    private static boolean isEcKeySpec(String spec) {
+        return spec.startsWith("ECC_");
+    }
+
+    private static KeyFactory buildKeyFactory(String spec) throws Exception {
+      return spec.startsWith("RSA")
+          ? KeyFactory.getInstance("RSA")
+          : KeyFactory.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+    }
 
     private KmsKey resolveKey(String keyIdOrArn, String region) {
         String id = keyIdOrArn;

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -5,16 +5,21 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.kms.model.KmsAlias;
 import io.github.hectorvent.floci.services.kms.model.KmsKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.security.Security;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,6 +28,13 @@ class KmsServiceTest {
     private static final String REGION = "us-east-1";
 
     private KmsService kmsService;
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
 
     @BeforeEach
     void setUp() {
@@ -184,9 +196,10 @@ class KmsServiceTest {
                 kmsService.decrypt("not-valid-ciphertext".getBytes(StandardCharsets.UTF_8), REGION));
     }
 
-    @Test
-    void signAndVerify() {
-        KmsKey key = kmsService.createKey("ecdsa key", "SIGN_VERIFY", "ECC_NIST_P256", null, Map.of(), REGION);
+    @ParameterizedTest
+    @ValueSource(strings = {"ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521", "ECC_SECG_P256K1"})
+    void signAndVerify(String keySpec) {
+        KmsKey key = kmsService.createKey("ecdsa key", "SIGN_VERIFY", keySpec, null, Map.of(), REGION);
         byte[] message = "sign me".getBytes(StandardCharsets.UTF_8);
 
         byte[] sig = kmsService.sign(key.getKeyId(), message, "ECDSA_SHA_256", REGION);


### PR DESCRIPTION
## Summary

Fixes support of ECC_SECG_P256K1 key spec.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
