### PR TITLE
fix(ecr): fixing port and network issues on ecr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "4566:4566"
-      - "5100-5199:5100-5199"
       - "6379-6399:6379-6399"
       - "7001-7099:7001-7099"
     volumes:
@@ -17,6 +16,8 @@ services:
       FLOCI_SERVICES_DOCKER_NETWORK: floci_default
       FLOCI_SERVICES_RDS_PROXY_BASE_PORT: "7001"
       FLOCI_STORAGE_HOST_PERSISTENT_PATH: ${PWD}/data
+      FLOCI_HOSTNAME: floci
+      FLOCI_BASE_URL: http://floci:4566
     networks:
       floci_default:
         aliases:

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -40,6 +40,9 @@ services:
 !!! warning "Docker socket"
     Lambda, ElastiCache, and RDS require access to the Docker socket (`/var/run/docker.sock`) to spawn and manage containers. If you don't use these services, you can omit that volume.
 
+!!! note "ECR ports are not listed here intentionally"
+    ECR is backed by a separate `registry:2` sidecar container (`floci-ecr-registry`) that Floci starts and manages. That container binds its own host port (default `5100`) directly — adding `5100-5199` to the floci service's `ports` would conflict with the sidecar and break `docker push`/`docker pull`. See [Ports Reference → ECR](./ports.md#ports-51005199--ecr-registry) for details.
+
 ## Multi-container networking
 
 By default, Floci embeds `localhost` in response URLs — for example, SQS queue

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -5,7 +5,7 @@
 | Port / Range | Protocol | Purpose |
 |---|---|---|
 | `4566` | HTTP | All AWS API calls (every service) |
-| `5100–5199` | HTTP | ECR Registry port, for `docker push` / `docker pull` |
+| `5100–5199` | HTTP | ECR Registry sidecar (`floci-ecr-registry`) — bound directly by that container, not the floci container |
 | `6379–6399` | TCP | ElastiCache Redis proxy, one port per replication group |
 | `7001–7099` | TCP | RDS proxy, one port per DB instance |
 | `9200–9299` | HTTP | Lambda Runtime API (internal: consumed by spawned Lambda containers, not host-mapped) |
@@ -75,19 +75,35 @@ This range is reserved for OpenSearch `mode: real`, which will spin up an OpenSe
 !!! note
  When real mode lands, configure the range with `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` and `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT`.
 
+## Ports 5100–5199 — ECR Registry
+
+ECR is backed by a separate `registry:2` sidecar container (`floci-ecr-registry`) that Floci starts lazily on the first ECR API call. That container binds its own host port directly — **do not** add `5100-5199` to the floci service's `ports` in Docker Compose. Doing so pre-allocates those ports on the floci container and prevents the sidecar from binding them, causing the ECR registry to fail to start.
+
+```
+host:5100  ←──  floci-ecr-registry (registry:2 container, started by Floci)
+                       ↑
+                 EcrRegistryManager manages this container's lifecycle
+```
+
+`docker login localhost:5100` works because the sidecar has a direct host port binding. No docker-compose port mapping is needed.
+
+!!! warning "Do not expose ECR port range on the floci service"
+    Adding `- "5100-5199:5100-5199"` to the floci service ports will conflict with the ECR sidecar container and break `docker push` / `docker pull`.
+
 ## Exposing Ports in Docker Compose
 
-When running Floci inside Docker, you must expose these ranges to the host so your application (or Redis/psql CLI) can connect:
+When running Floci inside Docker, expose these ranges to the host so your application (or Redis/psql CLI) can connect. **ECR ports are excluded** — they are handled by the registry sidecar:
 
 ```yaml
 services:
   floci:
     image: hectorvent/floci:latest
     ports:
-      - "4566:4566"
-      - "5100-5199:5100-5199"
-      - "6379-6399:6379-6399"
-      - "7001-7099:7001-7099"
+      - "4566:4566"           # All AWS API calls
+      - "6379-6399:6379-6399" # ElastiCache / Redis proxy ports
+      - "7001-7099:7001-7099" # RDS / PostgreSQL + MySQL proxy ports
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 If your application runs inside the same Docker Compose network, it can reach Floci directly on container port `4566` — the host port mapping is only needed for tools running on the host (CLI, IDE plugins, etc.).

--- a/docs/services/ecr.md
+++ b/docs/services/ecr.md
@@ -67,6 +67,25 @@ floci:
 | `uri-style` | `hostname` | `hostname` returns `*.dkr.ecr.<region>.localhost`; `path` returns `localhost:<port>/<account>/<region>/<repo>` |
 | `tls-enabled` | `false` | Reserved for the future ACM-backed TLS phase |
 
+### Docker Compose port mapping
+
+The ECR registry sidecar container binds its host port directly — do **not** add `5100-5199` to the floci service's `ports` in `docker-compose.yml`. Adding that range pre-allocates those ports on the floci container and prevents the sidecar from binding them:
+
+```yaml
+# Correct — no ECR port range on the floci service
+services:
+  floci:
+    image: hectorvent/floci:latest
+    ports:
+      - "4566:4566"
+      - "6379-6399:6379-6399"   # ElastiCache
+      - "7001-7099:7001-7099"   # RDS
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+`docker login localhost:5100` works automatically once Floci starts the registry sidecar — no additional port mapping is needed.
+
 ## Examples
 
 ```bash

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -95,10 +95,10 @@ public class ContainerLifecycleManager {
         dockerClient.startContainerCmd(containerId).exec();
         LOG.infov("Started container {0}", containerId);
 
-        // Connect to the Docker network after starting so that host port bindings
-        // are established first. Setting withNetworkMode during create suppresses
-        // port publishing on macOS Docker Desktop.
-        if (spec.networkMode() != null && !spec.networkMode().isBlank()) {
+        // For containers with port bindings, withNetworkMode was skipped during creation
+        // (it suppresses port publishing on macOS Docker Desktop). Connect to the
+        // configured network now, after the host port bindings are established.
+        if (spec.networkMode() != null && !spec.networkMode().isBlank() && spec.hasPortBindings()) {
             try {
                 dockerClient.connectToNetworkCmd()
                         .withContainerId(containerId)
@@ -282,10 +282,13 @@ public class ContainerLifecycleManager {
             hostConfig.withPortBindings(ports);
         }
 
-        // Network mode is intentionally NOT set here.
-        // withNetworkMode() during container creation suppresses host port bindings
-        // on macOS Docker Desktop. Network attachment is done after start via
-        // connectToNetworkCmd() in createAndStart().
+        // Network mode: only set during creation when there are no host port bindings.
+        // withNetworkMode() + port bindings suppresses port publishing on macOS Docker Desktop,
+        // so containers with port bindings (e.g. ECR registry) connect to the network
+        // after start via connectToNetworkCmd() instead.
+        if (spec.networkMode() != null && !spec.networkMode().isBlank() && !spec.hasPortBindings()) {
+            hostConfig.withNetworkMode(spec.networkMode());
+        }
 
         // Mounts (named volumes, bind mounts)
         if (spec.mounts() != null && !spec.mounts().isEmpty()) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -319,13 +319,17 @@ public class ContainerLifecycleManager {
         Map<Integer, EndpointInfo> endpoints = new HashMap<>();
 
         for (int containerPort : spec.exposedPorts()) {
-            endpoints.put(containerPort, resolveEndpoint(inspect, containerPort));
+            endpoints.put(containerPort, resolveEndpoint(inspect, containerPort, spec.networkMode()));
         }
 
         return endpoints;
     }
 
     private EndpointInfo resolveEndpoint(InspectContainerResponse inspect, int containerPort) {
+        return resolveEndpoint(inspect, containerPort, null);
+    }
+
+    private EndpointInfo resolveEndpoint(InspectContainerResponse inspect, int containerPort, String preferredNetwork) {
         if (!containerDetector.isRunningInContainer()) {
             // Native mode: use localhost and the bound host port
             var bindings = inspect.getNetworkSettings().getPorts().getBindings();
@@ -338,15 +342,27 @@ public class ContainerLifecycleManager {
             // Fallback to container port
             return new EndpointInfo("localhost", containerPort);
         } else {
-            // Container mode: use container IP on the docker network
-            String containerIp = resolveContainerIp(inspect);
+            // Container mode: use container IP on the docker network.
+            // Prefer the configured network's IP — the container may be on multiple
+            // networks (bridge + the configured network) when connectToNetworkCmd()
+            // is used instead of withNetworkMode() during creation.
+            String containerIp = resolveContainerIp(inspect, preferredNetwork);
             return new EndpointInfo(containerIp, containerPort);
         }
     }
 
-    private String resolveContainerIp(InspectContainerResponse inspect) {
+    private String resolveContainerIp(InspectContainerResponse inspect, String preferredNetwork) {
         var networks = inspect.getNetworkSettings().getNetworks();
         if (networks != null) {
+            // Prefer the configured network so that when the container is on both
+            // bridge (default) and the service network, we return the right IP.
+            if (preferredNetwork != null && networks.containsKey(preferredNetwork)) {
+                String ip = networks.get(preferredNetwork).getIpAddress();
+                if (ip != null && !ip.isBlank()) {
+                    return ip;
+                }
+            }
+            // Fall back to any network
             for (Map.Entry<String, ContainerNetwork> entry : networks.entrySet()) {
                 String ip = entry.getValue().getIpAddress();
                 if (ip != null && !ip.isBlank()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -179,19 +179,17 @@ public class EcrRegistryManager {
             // persistentPath so the replace is a no-op and we bind the absolute
             // container data path. In a container with an absolute host path set,
             // replace rewrites the container-internal path to the host-side path.
+            // normalize() eliminates any "./" segments so the replace() matches reliably.
             String dataPath = Paths.get(config.services().ecr().dataPath(), "registry")
-                    .toAbsolutePath().toString();
-            String hostDataPath = dataPath.replace(config.storage().persistentPath(), hostPersistentPath);
+                    .toAbsolutePath().normalize().toString();
+            String persistentPath = Paths.get(config.storage().persistentPath())
+                    .toAbsolutePath().normalize().toString();
+            String hostDataPath = dataPath.replace(persistentPath, hostPersistentPath);
             if (!inContainer) {
                 ensureDataDir();
             }
             hostConfig.withBinds(new Bind(hostDataPath, new Volume("/var/lib/registry")));
         }
-
-        config.services().ecr().dockerNetwork()
-                .or(() -> config.services().dockerNetwork())
-                .filter(n -> !n.isBlank())
-                .ifPresent(hostConfig::withNetworkMode);
 
         try {
             CreateContainerResponse created = dockerClient.createContainerCmd(image)
@@ -208,6 +206,24 @@ public class EcrRegistryManager {
         } catch (Exception e) {
             throw new RuntimeException("Failed to start ECR backing registry container: " + e.getMessage(), e);
         }
+
+        // Connect to the configured Docker network after starting so that host port
+        // bindings are established first (withNetworkMode during create suppresses
+        // port publishing on some Docker runtimes, e.g. Docker Desktop on macOS).
+        config.services().ecr().dockerNetwork()
+                .or(() -> config.services().dockerNetwork())
+                .filter(n -> !n.isBlank())
+                .ifPresent(network -> {
+                    try {
+                        dockerClient.connectToNetworkCmd()
+                                .withContainerId(containerId)
+                                .withNetworkId(network)
+                                .exec();
+                        LOG.infov("Connected ECR registry {0} to network {1}", name, network);
+                    } catch (Exception e) {
+                        LOG.warnv("Could not connect ECR registry to network {0}: {1}", network, e.getMessage());
+                    }
+                });
         runReconcileOnce();
     }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

This PR fixes three bugs that caused ECR and other tests to fail locally (macOS Docker Desktop) while passing in CI (Linux), and updates documentation to prevent the same confusion.                                                                                                                                                                    
   
**1. Missing FLOCI_HOSTNAME in docker-compose.yml**                                                                                                                               
                                                            
CI starts Floci with -e FLOCI_HOSTNAME=floci; the local docker-compose.yml did not set it. Without it, Floci embeds localhost in generated URLs (ElastiCache endpoints, Cognito OIDC discovery). Test containers on the same Docker network cannot reach localhost of the Floci container, so those URLs were unreachable.
                                                                                                                                                                                
  Added FLOCI_HOSTNAME: floci, FLOCI_BASE_URL: http://floci:4566, and the localhost.floci.cloud network alias.                                                                  
   
**2. docker-compose.yml — removed 5100-5199:5100-5199 port mapping**                                                                                                              
                                                            
  ECR is backed by a separate registry:2 sidecar container (floci-ecr-registry) that Floci starts and manages. That container needs to bind host ports in the 5100–5199 range   
  itself. Publishing that same range on the floci service pre-allocated those ports, causing address already in use when the sidecar tried to start.
                                                                                                                                                                                
**3. EcrRegistryManager — path normalization (toAbsolutePath without normalize)**                                                                                                 
   
  Paths.get("./data/ecr").toAbsolutePath() produces /app/./data/ecr (with a literal ./). The subsequent replace("/app/data", hostPath) never matched, so the container was      
  passed the internal path /app/./data/ecr/registry as a bind-mount source. Docker Desktop rejected it with "path is not shared from the host."
                                                                                                                                                                                
  Fixed by chaining .normalize() on both dataPath and persistentPath before the replace.                                                                                        
   
**4. EcrRegistryManager — withNetworkMode broken on macOS Docker Desktop**                                                                                                        
                                                            
On Linux (CI), setting NetworkMode during container creation attaches the container to the named network and preserves host port bindings. On macOS Docker Desktop, the same call silently fails: the container ends up on no network with no port bindings — completely isolated.
                                                                                                                                                                                
Fixed by removing withNetworkMode from the HostConfig and instead calling connectToNetworkCmd() explicitly after the container starts. This ensures the host port binding (0.0.0.0:5100 → 5000/tcp) is established first, then the container is joined to the Floci Docker network.
                                                                                                                                                                                
**Documentation**                                             

Updated docs/configuration/ports.md, docs/services/ecr.md, and docs/configuration/docker-compose.md to clarify that ECR ports must not be listed on the floci service in ocker-compose.yml, and to explain the sidecar container model.


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
