### PR TITLE
feat(bedrock-runtime): stub Converse and InvokeModel for #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [Unreleased]
 
 
+### Features
+
+* **bedrock-runtime:** add stub for Converse and InvokeModel ([#87](https://github.com/floci-io/floci/issues/87))
+
+
 ### Bug Fixes
 
 * unify service metadata behind a descriptor-backed catalog for enablement, routing, and storage lookups

--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ flowchart LR
 | **OpenSearch** | In-process | Domain CRUD, tags, versions, instance types, upgrade stubs |
 | **AppConfig** | In-process | Applications, environments, profiles, hosted configuration versions, deployments |
 | **AppConfigData** | In-process | Configuration sessions, dynamic configuration retrieval |
+| **Bedrock Runtime** | In-process (stub) | Dummy Converse and InvokeModel responses for local development; streaming returns 501 |
 
 > **Lambda, ElastiCache, RDS, MSK, and ECS** spin up real Docker containers and support IAM authentication and SigV4 request signing — the same auth flow as production AWS. **ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane.
 >
 > For per-service operation counts and endpoint protocols, see the [Services Overview](https://floci.io/floci/services/) in the documentation site.
 
-**33 AWS services supported.**
+**34 AWS services supported.**
 
 ## Quick Start
 

--- a/docs/services/bedrock-runtime.md
+++ b/docs/services/bedrock-runtime.md
@@ -1,0 +1,72 @@
+# Bedrock Runtime
+
+**Protocol:** REST JSON
+**Endpoint:** `POST http://localhost:4566/model/{modelId}/...`
+
+Floci emulates the AWS Bedrock Runtime data-plane API with a dummy response stub. The response shape matches the real AWS Converse and InvokeModel contracts so AWS SDK and CLI clients accept the reply without error. No real model inference is performed: every call returns a fixed assistant turn plus synthetic token usage metadata.
+
+The Bedrock management plane (`aws bedrock ...`: `ListFoundationModels`, `GetFoundationModel`, customization) is not yet emulated.
+
+## Supported Operations
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| `Converse` | `POST /model/{modelId}/converse` | Returns static assistant message |
+| `InvokeModel` | `POST /model/{modelId}/invoke` | Returns Anthropic-shaped body for `anthropic.*` and `*.anthropic.*` model ids; generic `{"outputs": [...]}` shape otherwise |
+| `ConverseStream` | `POST /model/{modelId}/converse-stream` | Returns 501 `UnsupportedOperationException` |
+| `InvokeModelWithResponseStream` | `POST /model/{modelId}/invoke-with-response-stream` | Returns 501 `UnsupportedOperationException` |
+
+`modelId` is URL-decoded by JAX-RS and echoed verbatim. Plain model ids (e.g. `anthropic.claude-3-haiku-20240307-v1:0`), inference-profile ids (e.g. `us.anthropic.claude-3-5-sonnet-20241022-v2:0`), and full ARNs containing slashes (e.g. `arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20241022-v2:0`) are all accepted.
+
+Converse accepts `messages`, `system`, `inferenceConfig`, and `toolConfig` fields. Only `messages` is validated (non-empty array). Other fields are accepted and ignored. Tool-use round-tripping is not implemented.
+
+InvokeModel bodies are passed through as opaque bytes; the stub does not parse request payloads.
+
+## Configuration
+
+```yaml
+floci:
+  services:
+    bedrock-runtime:
+      enabled: true
+```
+
+## Examples
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+
+# Converse
+aws bedrock-runtime converse \
+  --model-id anthropic.claude-3-haiku-20240307-v1:0 \
+  --messages '[{"role":"user","content":[{"text":"hi"}]}]'
+
+# InvokeModel (Anthropic Claude)
+aws bedrock-runtime invoke-model \
+  --model-id anthropic.claude-3-haiku-20240307-v1:0 \
+  --body '{"anthropic_version":"bedrock-2023-05-31","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/response.json
+cat /tmp/response.json
+```
+
+```python
+import boto3
+client = boto3.client("bedrock-runtime", endpoint_url="http://localhost:4566")
+resp = client.converse(
+    modelId="anthropic.claude-3-haiku-20240307-v1:0",
+    messages=[{"role": "user", "content": [{"text": "hi"}]}],
+)
+print(resp["output"]["message"]["content"][0]["text"])
+```
+
+## Out of Scope
+
+- Real model inference (always returns a fixed string).
+- Streaming (`ConverseStream`, `InvokeModelWithResponseStream`) return 501.
+- Bedrock management plane (`ListFoundationModels`, `GetFoundationModel`, model customisation).
+- Bedrock Agents, Knowledge Bases, Guardrails, provisioned throughput.
+- Tool-use round-tripping in Converse.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 32 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 33 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service counts and operation counts. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -42,6 +42,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [OpenSearch](opensearch.md) | `/2021-01-01/opensearch/...` | REST JSON | 24 |
 | [AppConfig](appconfig.md) | `/applications/...`, `/deploymentstrategies/...` | REST JSON | 16 |
 | [AppConfigData](appconfig.md#data-plane) | `/configurationsessions`, `/configuration` | REST JSON | 2 |
+| [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 
 **Lambda, ElastiCache, RDS, and ECS** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,4 +98,5 @@ nav:
     - OpenSearch: services/opensearch.md
     - EC2: services/ec2.md
     - AppConfig: services/appconfig.md
+    - Bedrock Runtime: services/bedrock-runtime.md
   - Contributing: contributing.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -234,6 +234,7 @@ public interface EmulatorConfig {
         AppConfigDataServiceConfig appconfigdata();
         EcrServiceConfig ecr();
         ResourceGroupsTaggingServiceConfig tagging();
+        BedrockRuntimeServiceConfig bedrockRuntime();
     }
 
     interface SsmServiceConfig {
@@ -464,6 +465,11 @@ public interface EmulatorConfig {
     }
 
     interface ResourceGroupsTaggingServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface BedrockRuntimeServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.core.common;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.appconfig.AppConfigController;
 import io.github.hectorvent.floci.services.appconfig.AppConfigDataController;
+import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeController;
 import io.github.hectorvent.floci.services.cognito.CognitoOAuthController;
 import io.github.hectorvent.floci.services.cognito.CognitoWellKnownController;
 import io.github.hectorvent.floci.services.lambda.LambdaController;
@@ -181,7 +182,18 @@ public class ResolvedServiceCatalog {
                 descriptor("tagging", "tagging", config.services().tagging().enabled(), true,
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
-                        Set.of("ResourceGroupsTaggingAPI_20170126."), Set.of("tagging"), Set.of(), Set.of())
+                        Set.of("ResourceGroupsTaggingAPI_20170126."), Set.of("tagging"), Set.of(), Set.of()),
+                descriptor("bedrock-runtime", "bedrock-runtime",
+                        config.services().bedrockRuntime().enabled(), true,
+                        null, null, 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(),
+                        // Register both signing names. boto3's service model declares
+                        // signingName=bedrock for bedrock-runtime; register the endpoint
+                        // id too as a safety net (catalog lookup is exact-match).
+                        Set.of("bedrock", "bedrock-runtime"),
+                        Set.of(),
+                        Set.of(BedrockRuntimeController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeController.java
@@ -1,0 +1,101 @@
+package io.github.hectorvent.floci.services.bedrockruntime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+/**
+ * AWS Bedrock Runtime REST JSON endpoints.
+ *
+ * Real Bedrock Runtime uses {@code POST /model/{modelId}/converse} and
+ * {@code POST /model/{modelId}/invoke} against the
+ * {@code bedrock-runtime.<region>.amazonaws.com} host. Floci routes all
+ * hostnames to port 4566, so path-based dispatch is sufficient.
+ *
+ * Returns dummy responses only: no real model inference.
+ */
+@Path("/model")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class BedrockRuntimeController {
+
+    private static final Logger LOG = Logger.getLogger(BedrockRuntimeController.class);
+
+    private final BedrockRuntimeService service;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public BedrockRuntimeController(BedrockRuntimeService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/{modelId:.+}/converse")
+    public Response converse(@PathParam("modelId") String modelId, String body) {
+        if (modelId == null || modelId.isBlank()) {
+            throw new AwsException("ValidationException", "modelId is required.", 400);
+        }
+        JsonNode request;
+        try {
+            request = body == null || body.isBlank()
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+        } catch (Exception e) {
+            throw new AwsException("ValidationException",
+                    "Malformed request body: " + e.getMessage(), 400);
+        }
+
+        JsonNode messages = request.path("messages");
+        if (!messages.isArray() || messages.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "messages is required and must be a non-empty array.", 400);
+        }
+
+        ObjectNode response = service.buildConverseResponse(modelId);
+        LOG.debugv("Bedrock Converse: modelId={0}, messages={1}", modelId, messages.size());
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/{modelId:.+}/invoke")
+    @Consumes(MediaType.WILDCARD)
+    public Response invokeModel(@PathParam("modelId") String modelId, byte[] body) {
+        if (modelId == null || modelId.isBlank()) {
+            throw new AwsException("ValidationException", "modelId is required.", 400);
+        }
+        // Bedrock InvokeModel bodies are model-specific opaque blobs; do not parse.
+        byte[] response = service.buildInvokeModelResponse(modelId);
+        LOG.debugv("Bedrock InvokeModel: modelId={0}, bodyBytes={1}",
+                modelId, body == null ? 0 : body.length);
+        return Response.ok(response, MediaType.APPLICATION_JSON).build();
+    }
+
+    @POST
+    @Path("/{modelId:.+}/invoke-with-response-stream")
+    @Consumes(MediaType.WILDCARD)
+    public Response invokeModelWithResponseStream(@PathParam("modelId") String modelId) {
+        throw new AwsException("UnsupportedOperationException",
+                "InvokeModelWithResponseStream is not supported by the Floci stub. "
+                        + "Use InvokeModel or Converse instead.", 501);
+    }
+
+    @POST
+    @Path("/{modelId:.+}/converse-stream")
+    @Consumes(MediaType.WILDCARD)
+    public Response converseStream(@PathParam("modelId") String modelId) {
+        throw new AwsException("UnsupportedOperationException",
+                "ConverseStream is not supported by the Floci stub. "
+                        + "Use Converse instead.", 501);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeService.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.services.bedrockruntime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Dummy response builder for Bedrock Runtime. Stateless.
+ * No real model inference: returns a fixed assistant turn plus token usage metadata.
+ */
+@ApplicationScoped
+public class BedrockRuntimeService {
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public BedrockRuntimeService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ObjectNode buildConverseResponse(String modelId) {
+        ObjectNode root = objectMapper.createObjectNode();
+
+        ObjectNode output = root.putObject("output");
+        ObjectNode message = output.putObject("message");
+        message.put("role", "assistant");
+        ArrayNode content = message.putArray("content");
+        ObjectNode textBlock = content.addObject();
+        textBlock.put("text", "Floci stub response for model=" + modelId);
+
+        root.put("stopReason", "end_turn");
+
+        ObjectNode usage = root.putObject("usage");
+        usage.put("inputTokens", 10);
+        usage.put("outputTokens", 12);
+        usage.put("totalTokens", 22);
+
+        ObjectNode metrics = root.putObject("metrics");
+        metrics.put("latencyMs", 1);
+
+        return root;
+    }
+
+    public byte[] buildInvokeModelResponse(String modelId) {
+        ObjectNode root = objectMapper.createObjectNode();
+        String lower = modelId == null ? "" : modelId.toLowerCase();
+        if (lower.startsWith("anthropic.") || lower.contains(".anthropic.")) {
+            root.put("id", "msg_stub");
+            root.put("type", "message");
+            root.put("role", "assistant");
+            ArrayNode content = root.putArray("content");
+            ObjectNode block = content.addObject();
+            block.put("type", "text");
+            block.put("text", "Floci stub response");
+            root.put("model", modelId);
+            root.put("stop_reason", "end_turn");
+            ObjectNode usage = root.putObject("usage");
+            usage.put("input_tokens", 10);
+            usage.put("output_tokens", 12);
+        } else {
+            // Generic minimal shape for Meta, Mistral, Titan and others.
+            // Bedrock returns provider-specific bodies; callers parse by model family.
+            ArrayNode outputs = root.putArray("outputs");
+            ObjectNode item = outputs.addObject();
+            item.put("text", "Floci stub response");
+        }
+        try {
+            return objectMapper.writeValueAsBytes(root);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize InvokeModel response", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -167,3 +167,5 @@ floci:
       tls-enabled: false
       keep-running-on-shutdown: true
       uri-style: hostname
+    bedrock-runtime:
+      enabled: true

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
@@ -48,7 +48,8 @@ class HealthControllerIntegrationTest {
                 "appconfig": "running",
                 "appconfigdata": "running",
                 "ecr": "running",
-                "tagging": "running"
+                "tagging": "running",
+                "bedrock-runtime": "running"
               },
               "edition": "floci-always-free",
               "version": "dev"

--- a/src/test/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockRuntimeIntegrationTest.java
@@ -1,0 +1,253 @@
+package io.github.hectorvent.floci.services.bedrockruntime;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for the Bedrock Runtime stub (Converse + InvokeModel).
+ * Uses RestAssured directly against the REST JSON wire format.
+ */
+@QuarkusTest
+class BedrockRuntimeIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock/aws4_request";
+
+    @Test
+    void converse_happyPath() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "messages": [
+                    {"role": "user", "content": [{"text": "hi"}]}
+                  ]
+                }
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+        .then()
+            .statusCode(200)
+            .body("output.message.role", equalTo("assistant"))
+            .body("output.message.content[0].text",
+                    containsString("anthropic.claude-3-haiku-20240307-v1:0"))
+            .body("stopReason", equalTo("end_turn"))
+            .body("usage.inputTokens", greaterThan(0))
+            .body("usage.outputTokens", greaterThan(0))
+            .body("usage.totalTokens", greaterThan(0))
+            .body("metrics.latencyMs", notNullValue());
+    }
+
+    @Test
+    void converse_acceptsSystemAndInferenceConfig() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "messages": [
+                    {"role": "user", "content": [{"text": "hi"}]}
+                  ],
+                  "system": [{"text": "You are a helpful assistant."}],
+                  "inferenceConfig": {"maxTokens": 100, "temperature": 0.7},
+                  "toolConfig": {"tools": []}
+                }
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+        .then()
+            .statusCode(200)
+            .body("output.message.role", equalTo("assistant"));
+    }
+
+    @Test
+    void converse_inferenceProfileArn() {
+        // Real AWS SDKs send full ARNs with slashes for inference profiles and
+        // provisioned throughput. Path must match via {modelId:.+}.
+        String arn = "arn:aws:bedrock:us-east-1:123456789012:inference-profile/"
+                + "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": [{"role": "user", "content": [{"text": "hi"}]}]}
+                """)
+        .when()
+            .post("/model/" + arn + "/converse")
+        .then()
+            .statusCode(200)
+            .body("output.message.content[0].text", containsString("inference-profile/"));
+    }
+
+    @Test
+    void invokeModel_inferenceProfileArn() {
+        String arn = "arn:aws:bedrock:us-east-1:123456789012:inference-profile/"
+                + "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": [{"role": "user", "content": "hi"}]}
+                """)
+        .when()
+            .post("/model/" + arn + "/invoke")
+        .then()
+            .statusCode(200)
+            .body("type", equalTo("message"))
+            .body("model", containsString("inference-profile/"));
+    }
+
+    @Test
+    void converse_inferenceProfileModelId() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": [{"role": "user", "content": [{"text": "hi"}]}]}
+                """)
+        .when()
+            .post("/model/us.anthropic.claude-3-5-sonnet-20241022-v2:0/converse")
+        .then()
+            .statusCode(200)
+            .body("output.message.content[0].text",
+                    containsString("us.anthropic.claude-3-5-sonnet-20241022-v2:0"));
+    }
+
+    @Test
+    void converse_missingMessages_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void converse_emptyMessages_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": []}
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void invokeModel_anthropicShape() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "anthropic_version": "bedrock-2023-05-31",
+                  "max_tokens": 100,
+                  "messages": [{"role": "user", "content": "hi"}]
+                }
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/invoke")
+        .then()
+            .statusCode(200)
+            .body("id", equalTo("msg_stub"))
+            .body("type", equalTo("message"))
+            .body("role", equalTo("assistant"))
+            .body("content[0].type", equalTo("text"))
+            .body("content[0].text", notNullValue())
+            .body("model", equalTo("anthropic.claude-3-haiku-20240307-v1:0"))
+            .body("stop_reason", equalTo("end_turn"))
+            .body("usage.input_tokens", greaterThan(0))
+            .body("usage.output_tokens", greaterThan(0));
+    }
+
+    @Test
+    void invokeModel_inferenceProfileAnthropicShape() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": [{"role": "user", "content": "hi"}]}
+                """)
+        .when()
+            .post("/model/us.anthropic.claude-3-5-sonnet-20241022-v2:0/invoke")
+        .then()
+            .statusCode(200)
+            .body("type", equalTo("message"))
+            .body("model", equalTo("us.anthropic.claude-3-5-sonnet-20241022-v2:0"));
+    }
+
+    @Test
+    void invokeModel_otherModelFamilyGetsGenericShape() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"prompt": "hi", "max_gen_len": 100}
+                """)
+        .when()
+            .post("/model/meta.llama3-8b-instruct-v1:0/invoke")
+        .then()
+            .statusCode(200)
+            .body("outputs[0].text", notNullValue());
+    }
+
+    @Test
+    void invokeModelWithResponseStream_returns501() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/invoke-with-response-stream")
+        .then()
+            .statusCode(501)
+            .body("__type", equalTo("UnsupportedOperationException"));
+    }
+
+    @Test
+    void converseStream_returns501() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"messages": [{"role": "user", "content": [{"text": "hi"}]}]}
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse-stream")
+        .then()
+            .statusCode(501)
+            .body("__type", equalTo("UnsupportedOperationException"));
+    }
+
+    @Test
+    void disabled_whenServiceDisabled_returns400() {
+        // The bedrock-runtime service is enabled in test config. Confirm it is
+        // reachable via the default signing name in the Authorization header.
+        given()
+            .contentType("application/json")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock-runtime/aws4_request")
+            .body("""
+                {"messages": [{"role": "user", "content": [{"text": "hi"}]}]}
+                """)
+        .when()
+            .post("/model/anthropic.claude-3-haiku-20240307-v1:0/converse")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -137,3 +137,5 @@ floci:
       enabled: true
     ecr:
       enabled: true
+    bedrock-runtime:
+      enabled: true


### PR DESCRIPTION
Closes #87.

## Summary

Adds a Bedrock Runtime service stub so AWS SDK and CLI clients can target Floci for local development of Bedrock Runtime callers. Dummy responses only, no real model inference.

- `POST /model/{modelId}/converse`: returns a fixed assistant message with synthetic `usage` and `metrics`, matching the AWS Converse response shape.
- `POST /model/{modelId}/invoke`: returns an Anthropic-shaped body for `anthropic.*` and `*.anthropic.*` model ids; a generic `{"outputs": [...]}` shape otherwise. Request body is passed through as opaque bytes, no parsing.
- `converse-stream` and `invoke-with-response-stream` return `501 UnsupportedOperationException` so SDKs receive a clear error instead of a 404.
- `{modelId:.+}` path regex accepts full ARNs (inference profiles, provisioned throughput) in addition to plain ids and inference-profile ids.

## Descriptor wiring

Registered in `ResolvedServiceCatalog` with both `bedrock` and `bedrock-runtime` credential scopes. boto3's service model declares `signingName: "bedrock"` for `bedrock-runtime`; registering both names avoids the STS-style mismatch (STS is `Set.of("sts")` despite informally sharing scope with IAM). Response building uses `JsonNode` rather than typed POJOs, so no `@RegisterForReflection` is needed.

## Out of scope

- Real model inference (issue explicitly allows dummy).
- `bedrock` management plane (`ListFoundationModels`, `GetFoundationModel`, model customisation). The SDK endpoint id and CLI command are different (`aws bedrock ...` vs `aws bedrock-runtime ...`). Separate follow-up.
- Streaming (`ConverseStream`, `InvokeModelWithResponseStream`). Returns 501 rather than being silently absent.
- Bedrock Agents, Knowledge Bases, Guardrails, provisioned throughput control plane.
- Tool-use round-tripping in Converse (`toolConfig` is accepted and ignored).

## Test plan

- [x] 13 new integration tests under `BedrockRuntimeIntegrationTest` (Converse happy path + validation + system/inferenceConfig/toolConfig acceptance + inference-profile id + inference-profile ARN; InvokeModel Anthropic + non-Anthropic + inference-profile ARN; 2x 501 streaming; reachable via alternate signing name).
- [x] `HealthControllerIntegrationTest` snapshot updated to include `bedrock-runtime: running`.
- [x] Full suite: `./mvnw test` → **2263 passed, 0 failures**.
- [x] `aws bedrock-runtime converse --model-id anthropic.claude-3-haiku-20240307-v1:0 --messages '[{"role":"user","content":[{"text":"hi"}]}]' --endpoint-url http://localhost:4566` returns a well-formed response (covered by integration test at the wire level).

## Docs

- New `docs/services/bedrock-runtime.md` with supported operations, config, and CLI/boto3 examples.
- Added to `mkdocs.yml` nav and `docs/services/index.md` table.
- `README.md` service table row added; service count 33 → 34.
- `CHANGELOG.md` entry under Unreleased / Features.