### PR TITLE
fix(logging): include stack trace in AwsJson11Controller catch-all

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -144,7 +144,7 @@ public class AwsJson11Controller {
         } catch (AwsException e) {
             return JsonErrorResponseUtils.createErrorResponse(e);
         } catch (Exception e) {
-            LOG.errorf("Error processing %s request", serviceKey, e);
+            LOG.errorf(e, "Error processing %s request", serviceKey);
             return JsonErrorResponseUtils.createErrorResponse(e);
         }
     }


### PR DESCRIPTION
## Summary

`AwsJson11Controller`'s catch-all exception handler used `LOG.errorf(String, Object...)` with the throwable as a trailing format arg:

\`\`\`java
LOG.errorf("Error processing %s request", serviceKey, e);
\`\`\`

JBoss Logger's varargs `errorf` doesn't recognize a trailing `Throwable`, `serviceKey` fills the `%s`, `e` is silently dropped, and the stack trace never reaches the log. Operators see only `ERROR ... Error processing logs request` with no cause.

The fix uses the `errorf(Throwable, String, Object...)` overload so the cause is attached:

\`\`\`java
LOG.errorf(e, "Error processing %s request", serviceKey);
\`\`\`

This matches what `AwsJsonController` and `AwsJsonCborController` already do (both use `LOG.error(msg, throwable)`).

## Why this matters

Surfaced by floci-io/floci#482, a user reported `DescribeLogGroups` returning `500 InternalFailure` with `message:null`, but couldn't diagnose further because the controller log line had no stack trace. `DescribeLogGroups` itself is implemented and passes the curl repro from that issue, so the underlying failure is something else; without this fix it's invisible.

Refs #482

## Test plan

- [x] `./mvnw -q compile` clean
- [x] Codex `focused` review: no findings
- [x] Gemini `pro` review: confirmed correct overload, no other instances of the anti-pattern in sibling controllers