### PR TITLE
feat(kinesis): implement UpdateStreamMode

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -61,6 +61,7 @@ public class KinesisJsonHandler {
             case "DecreaseStreamRetentionPeriod" -> handleDecreaseStreamRetentionPeriod(request, region);
             case "EnableEnhancedMonitoring" -> handleEnableEnhancedMonitoring(request, region);
             case "DisableEnhancedMonitoring" -> handleDisableEnhancedMonitoring(request, region);
+            case "UpdateStreamMode" -> handleUpdateStreamMode(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -75,14 +76,9 @@ public class KinesisJsonHandler {
 
         String streamArn = request.path("StreamARN").asText(null);
         if (streamArn != null) {
-            int streamIdx = streamArn.indexOf(":stream/");
-            if (streamIdx >= 0) {
-                String after = streamArn.substring(streamIdx + 8);
-                int slash = after.indexOf('/');
-                String name = slash >= 0 ? after.substring(0, slash) : after;
-                if (!name.isBlank()) {
-                    return name;
-                }
+            String name = parseStreamNameFromArn(streamArn);
+            if (name != null) {
+                return name;
             }
         }
 
@@ -90,11 +86,58 @@ public class KinesisJsonHandler {
                 "StreamName or valid StreamARN must be provided", 400);
     }
 
+    private String parseStreamNameFromArn(String streamArn) {
+        int streamIdx = streamArn.indexOf(":stream/");
+        if (streamIdx < 0) {
+            return null;
+        }
+        String after = streamArn.substring(streamIdx + 8);
+        int slash = after.indexOf('/');
+        String name = slash >= 0 ? after.substring(0, slash) : after;
+        return name.isBlank() ? null : name;
+    }
+
     private Response handleCreateStream(JsonNode request, String region) {
         String streamName = request.path("StreamName").asText();
         int shardCount = request.path("ShardCount").asInt(1);
-        service.createStream(streamName, shardCount, region);
+        String streamMode = null;
+        JsonNode modeDetails = request.path("StreamModeDetails");
+        if (modeDetails.isObject()) {
+            String mode = modeDetails.path("StreamMode").asText(null);
+            if (mode != null && !mode.isBlank()) {
+                streamMode = mode;
+            }
+        }
+        service.createStream(streamName, shardCount, streamMode, region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleUpdateStreamMode(JsonNode request, String region) {
+        // UpdateStreamMode accepts only StreamARN per the AWS API; StreamName is not valid.
+        String streamArn = request.path("StreamARN").asText(null);
+        if (streamArn == null || streamArn.isBlank()) {
+            throw new AwsException("InvalidArgumentException", "StreamARN is required", 400);
+        }
+        JsonNode modeDetails = request.path("StreamModeDetails");
+        if (!modeDetails.isObject()) {
+            throw new AwsException("InvalidArgumentException", "StreamModeDetails is required", 400);
+        }
+        String streamMode = modeDetails.path("StreamMode").asText(null);
+        if (streamMode == null || streamMode.isBlank()) {
+            throw new AwsException("InvalidArgumentException", "StreamModeDetails.StreamMode is required", 400);
+        }
+        String streamName = extractStreamNameFromArn(streamArn);
+        service.updateStreamMode(streamName, streamMode, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private String extractStreamNameFromArn(String streamArn) {
+        String name = parseStreamNameFromArn(streamArn);
+        if (name == null) {
+            throw new AwsException("InvalidArgumentException",
+                    "StreamARN does not contain a valid stream name: " + streamArn, 400);
+        }
+        return name;
     }
 
     private Response handleDeleteStream(JsonNode request, String region) {
@@ -128,6 +171,7 @@ public class KinesisJsonHandler {
         if (stream.getKeyId() != null) {
             desc.put("KeyId", stream.getKeyId());
         }
+        addStreamModeDetailsNode(desc, stream);
 
         addEnhancedMonitoringNode(desc, stream);
 
@@ -169,6 +213,7 @@ public class KinesisJsonHandler {
         if (stream.getKeyId() != null) {
             summary.put("KeyId", stream.getKeyId());
         }
+        addStreamModeDetailsNode(summary, stream);
 
         addEnhancedMonitoringNode(summary, stream);
 
@@ -178,6 +223,10 @@ public class KinesisJsonHandler {
     private void addEnhancedMonitoringNode(ObjectNode parent, KinesisStream stream) {
         ArrayNode shardLevelMetrics = parent.putArray("EnhancedMonitoring").addObject().putArray("ShardLevelMetrics");
         stream.getEnhancedMonitoringMetrics().stream().sorted().forEach(shardLevelMetrics::add);
+    }
+
+    private void addStreamModeDetailsNode(ObjectNode parent, KinesisStream stream) {
+        parent.putObject("StreamModeDetails").put("StreamMode", stream.getStreamMode());
     }
 
     private Response handleRegisterStreamConsumer(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -25,6 +25,8 @@ public class KinesisService {
             "IncomingBytes", "IncomingRecords", "OutgoingBytes", "OutgoingRecords",
             "WriteProvisionedThroughputExceeded", "ReadProvisionedThroughputExceeded",
             "IteratorAgeMilliseconds", "ALL");
+    private static final Set<String> VALID_STREAM_MODES = Set.of("PROVISIONED", "ON_DEMAND");
+    private static final String DEFAULT_STREAM_MODE = "PROVISIONED";
 
     private final StorageBackend<String, KinesisStream> store;
     private final StorageBackend<String, KinesisConsumer> consumerStore;
@@ -49,6 +51,16 @@ public class KinesisService {
     }
 
     public KinesisStream createStream(String streamName, int shardCount, String region) {
+        return createStream(streamName, shardCount, null, region);
+    }
+
+    public KinesisStream createStream(String streamName, int shardCount, String streamMode, String region) {
+        String resolvedMode = streamMode != null ? streamMode : DEFAULT_STREAM_MODE;
+        if (!VALID_STREAM_MODES.contains(resolvedMode)) {
+            throw new AwsException("InvalidArgumentException",
+                    "StreamMode must be PROVISIONED or ON_DEMAND, got: " + resolvedMode, 400);
+        }
+
         String storageKey = regionKey(region, streamName);
         if (store.get(storageKey).isPresent()) {
             throw new AwsException("ResourceInUseException", "Stream already exists: " + streamName, 400);
@@ -56,6 +68,7 @@ public class KinesisService {
 
         String arn = regionResolver.buildArn("kinesis", region, "stream/" + streamName);
         KinesisStream stream = new KinesisStream(streamName, arn);
+        stream.setStreamMode(resolvedMode);
 
         for (int i = 0; i < shardCount; i++) {
             String shardId = String.format("shardId-%012d", i);
@@ -63,8 +76,30 @@ public class KinesisService {
         }
 
         store.put(storageKey, stream);
-        LOG.infov("Created Kinesis stream: {0} in region {1} with {2} shards", streamName, region, shardCount);
+        LOG.infov("Created Kinesis stream: {0} in region {1} with {2} shards (mode: {3})",
+                streamName, region, shardCount, resolvedMode);
         return stream;
+    }
+
+    public void updateStreamMode(String streamName, String streamMode, String region) {
+        if (streamMode == null || !VALID_STREAM_MODES.contains(streamMode)) {
+            throw new AwsException("InvalidArgumentException",
+                    "StreamMode must be PROVISIONED or ON_DEMAND, got: " + streamMode, 400);
+        }
+        KinesisStream stream = resolveStream(streamName, region);
+        if (!"ACTIVE".equals(stream.getStreamStatus())) {
+            throw new AwsException("ResourceInUseException",
+                    "Stream " + streamName + " is not ACTIVE (current state: " + stream.getStreamStatus() + ")", 400);
+        }
+        // Same-mode is a no-op. Mirrors the same-value behaviour in
+        // increase/decreaseStreamRetentionPeriod (see #342). Avoids breaking
+        // terraform-provider-aws which calls UpdateStreamMode on every refresh.
+        if (streamMode.equals(stream.getStreamMode())) {
+            return;
+        }
+        stream.setStreamMode(streamMode);
+        store.put(regionKey(region, streamName), stream);
+        LOG.infov("Updated stream mode for {0} to {1}", streamName, streamMode);
     }
 
     public List<String> listStreams(String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -468,4 +468,137 @@ class KinesisIntegrationTest {
         .then()
             .statusCode(400);
     }
+
+    @Test
+    @Order(30)
+    void updateStreamModeRoundTrip() {
+        // Create a dedicated stream so other ordered tests aren't affected by the mode flip.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "stream-mode-test", "ShardCount": 1}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Default mode is PROVISIONED.
+        String streamArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "stream-mode-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescriptionSummary.StreamModeDetails.StreamMode", equalTo("PROVISIONED"))
+            .extract().jsonPath().getString("StreamDescriptionSummary.StreamARN");
+
+        // Switch to ON_DEMAND.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.UpdateStreamMode")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\", \"StreamModeDetails\": {\"StreamMode\": \"ON_DEMAND\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // DescribeStream now reports ON_DEMAND.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "stream-mode-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.StreamModeDetails.StreamMode", equalTo("ON_DEMAND"));
+
+        // Calling UpdateStreamMode again with the same mode is a no-op (mirrors retention semantics)
+        // and is what terraform-provider-aws does on every refresh. See #440.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.UpdateStreamMode")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\", \"StreamModeDetails\": {\"StreamMode\": \"ON_DEMAND\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(31)
+    void createStreamWithOnDemandMode() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "on-demand-create-test", "ShardCount": 1, "StreamModeDetails": {"StreamMode": "ON_DEMAND"}}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "on-demand-create-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("StreamDescription.StreamModeDetails.StreamMode", equalTo("ON_DEMAND"));
+    }
+
+    @Test
+    @Order(32)
+    void updateStreamModeRequiresStreamArn() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.UpdateStreamMode")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "stream-mode-test", "StreamModeDetails": {"StreamMode": "ON_DEMAND"}}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidArgumentException"));
+    }
+
+    @Test
+    @Order(33)
+    void updateStreamModeRejectsInvalidMode() {
+        String streamArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "stream-mode-test"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("StreamDescriptionSummary.StreamARN");
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.UpdateStreamMode")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\", \"StreamModeDetails\": {\"StreamMode\": \"BOGUS\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidArgumentException"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -233,4 +233,113 @@ class KinesisJsonHandlerTest {
         assertEquals("by-name",
                 responseEntity(resp).get("StreamDescription").get("StreamName").asText());
     }
+
+    @Test
+    void describeStreamReturnsDefaultStreamMode() {
+        createStream("test-stream");
+
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStream", req, REGION);
+        ObjectNode desc = (ObjectNode) responseEntity(resp).get("StreamDescription");
+        assertEquals("PROVISIONED", desc.get("StreamModeDetails").get("StreamMode").asText());
+    }
+
+    @Test
+    void describeStreamSummaryReturnsDefaultStreamMode() {
+        createStream("test-stream");
+
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStreamSummary", req, REGION);
+        ObjectNode summary = (ObjectNode) responseEntity(resp).get("StreamDescriptionSummary");
+        assertEquals("PROVISIONED", summary.get("StreamModeDetails").get("StreamMode").asText());
+    }
+
+    @Test
+    void createStreamHonorsOnDemandStreamMode() {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("StreamName", "test-stream");
+        req.put("ShardCount", 1);
+        req.putObject("StreamModeDetails").put("StreamMode", "ON_DEMAND");
+        assertThat(handler.handle("CreateStream", req, REGION).getStatus(), is(200));
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStream", descReq, REGION);
+        ObjectNode desc = (ObjectNode) responseEntity(resp).get("StreamDescription");
+        assertEquals("ON_DEMAND", desc.get("StreamModeDetails").get("StreamMode").asText());
+    }
+
+    @Test
+    void updateStreamModeSwitchesProvisionedToOnDemand() {
+        createStream("test-stream");
+
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamARN", STREAM_ARN);
+        updateReq.putObject("StreamModeDetails").put("StreamMode", "ON_DEMAND");
+        assertThat(handler.handle("UpdateStreamMode", updateReq, REGION).getStatus(), is(200));
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        Response resp = handler.handle("DescribeStream", descReq, REGION);
+        ObjectNode desc = (ObjectNode) responseEntity(resp).get("StreamDescription");
+        assertEquals("ON_DEMAND", desc.get("StreamModeDetails").get("StreamMode").asText());
+    }
+
+    @Test
+    void updateStreamModeSameModeIsNoOp() {
+        // Terraform refresh calls UpdateStreamMode unconditionally; same-mode must succeed.
+        createStream("test-stream");
+
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamARN", STREAM_ARN);
+        updateReq.putObject("StreamModeDetails").put("StreamMode", "PROVISIONED");
+        assertThat(handler.handle("UpdateStreamMode", updateReq, REGION).getStatus(), is(200));
+    }
+
+    @Test
+    void updateStreamModeRejectsInvalidMode() {
+        createStream("test-stream");
+
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamARN", STREAM_ARN);
+        updateReq.putObject("StreamModeDetails").put("StreamMode", "BOGUS");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("UpdateStreamMode", updateReq, REGION));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateStreamModeRequiresStreamArn() {
+        createStream("test-stream");
+
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamName", "test-stream");
+        updateReq.putObject("StreamModeDetails").put("StreamMode", "ON_DEMAND");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("UpdateStreamMode", updateReq, REGION));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateStreamModeRequiresStreamModeDetails() {
+        createStream("test-stream");
+
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamARN", STREAM_ARN);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("UpdateStreamMode", updateReq, REGION));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateStreamModeRejectsUnknownStream() {
+        ObjectNode updateReq = MAPPER.createObjectNode();
+        updateReq.put("StreamARN", STREAM_ARN);
+        updateReq.putObject("StreamModeDetails").put("StreamMode", "ON_DEMAND");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("UpdateStreamMode", updateReq, REGION));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
 }


### PR DESCRIPTION
## Summary

Implements `UpdateStreamMode` (currently returns 400 `UnsupportedOperation`) and rounds out the surrounding StreamMode wiring so `terraform-provider-aws` stops failing on stream refresh.

`terraform-provider-aws` calls `UpdateStreamMode` unconditionally on every refresh of an `aws_kinesis_stream` resource. Without it, the second `terraform apply` errors even though the stream is functional.

## Changes

- **New `UpdateStreamMode` handler.** Resolves the stream by `StreamARN` (the AWS API does not accept `StreamName` for this op), validates `StreamMode` is `PROVISIONED` or `ON_DEMAND`, requires the stream to be `ACTIVE`, and treats same-mode requests as a no-op so terraform refresh succeeds. The same-mode no-op mirrors the `IncreaseStreamRetentionPeriod` behaviour added in #342 for the same terraform-driven reason.
- **`CreateStream` honours `StreamModeDetails.StreamMode`** when supplied; defaults to `PROVISIONED`.
- **`DescribeStream` / `DescribeStreamSummary` now emit `StreamModeDetails`** so terraform refresh observes the actual mode and stops re-planning the resource.

## Out of scope

- `UPDATING` state transition during a mode switch (real AWS sets the stream to `UPDATING` then back to `ACTIVE`); not needed for the terraform-refresh fix.
- 2-switches-per-24h rate limit; not needed for local emulation.
- `ListStreams` `StreamSummaries[].StreamModeDetails` (newer AWS response field); not used by terraform refresh.

Closes #440

## Test plan

- [x] 9 new unit tests in `KinesisJsonHandlerTest` (default mode in describe responses, create with `ON_DEMAND`, update round-trip, same-mode no-op, invalid-mode rejection, missing `StreamARN`, missing `StreamModeDetails`, unknown stream rejection)
- [x] 4 new integration tests in `KinesisIntegrationTest` covering the end-to-end terraform flow (create default → update → describe; create with `ON_DEMAND`; reject `StreamName`-only update; reject invalid mode)
- [x] Full `./mvnw test` suite green (2285 tests)