### PR TITLE
feat(lambda): support ScalingConfig.MaximumConcurrency on SQS event source mappings

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaEsmScalingConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaEsmScalingConfigTest.java
@@ -1,0 +1,172 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Lambda - ESM ScalingConfig")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaEsmScalingConfigTest {
+
+    private static final String FUNCTION_NAME = "sdk-test-esm-scaling-fn";
+    private static final String SQS_QUEUE_NAME = "sdk-test-esm-scaling-queue";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static LambdaClient lambda;
+    private static SqsClient sqs;
+    private static String queueArn;
+    private static String queueUrl;
+    private static final Set<String> createdEsmUuids = new HashSet<>();
+
+    @BeforeAll
+    static void setup() {
+        lambda = TestFixtures.lambdaClient();
+        sqs = TestFixtures.sqsClient();
+
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.minimalZip()))
+                        .build())
+                .build());
+
+        queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(SQS_QUEUE_NAME)
+                .build())
+                .queueUrl();
+        queueArn = sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
+                .queueUrl(queueUrl)
+                .attributeNames(QueueAttributeName.QUEUE_ARN)
+                .build())
+                .attributes()
+                .get(QueueAttributeName.QUEUE_ARN);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda != null) {
+            for (String uuid : createdEsmUuids) {
+                try {
+                    lambda.deleteEventSourceMapping(DeleteEventSourceMappingRequest.builder()
+                            .uuid(uuid).build());
+                } catch (Exception ignored) {}
+            }
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            lambda.close();
+        }
+        if (sqs != null) {
+            try {
+                sqs.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build());
+            } catch (Exception ignored) {}
+            sqs.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createEsm_withScalingConfig_roundTrips() {
+        CreateEventSourceMappingResponse created = lambda.createEventSourceMapping(
+                CreateEventSourceMappingRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .eventSourceArn(queueArn)
+                        .batchSize(5)
+                        .scalingConfig(ScalingConfig.builder().maximumConcurrency(7).build())
+                        .build());
+        createdEsmUuids.add(created.uuid());
+
+        assertThat(created.scalingConfig()).isNotNull();
+        assertThat(created.scalingConfig().maximumConcurrency()).isEqualTo(7);
+
+        GetEventSourceMappingResponse fetched = lambda.getEventSourceMapping(
+                GetEventSourceMappingRequest.builder().uuid(created.uuid()).build());
+        assertThat(fetched.scalingConfig()).isNotNull();
+        assertThat(fetched.scalingConfig().maximumConcurrency()).isEqualTo(7);
+    }
+
+    @Test
+    @Order(2)
+    void createEsm_withoutScalingConfig_doesNotExposeIt() {
+        CreateEventSourceMappingResponse created = lambda.createEventSourceMapping(
+                CreateEventSourceMappingRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .eventSourceArn(queueArn)
+                        .batchSize(2)
+                        .build());
+        createdEsmUuids.add(created.uuid());
+
+        // SDK models an omitted object as null (or an unset builder); both are acceptable
+        assertThat(created.scalingConfig() == null
+                || created.scalingConfig().maximumConcurrency() == null).isTrue();
+    }
+
+    @Test
+    @Order(3)
+    void createEsm_withMaximumConcurrencyBelowTwo_throwsInvalidParameter() {
+        assertThatThrownBy(() -> lambda.createEventSourceMapping(
+                CreateEventSourceMappingRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .eventSourceArn(queueArn)
+                        .scalingConfig(ScalingConfig.builder().maximumConcurrency(1).build())
+                        .build()))
+                .isInstanceOf(InvalidParameterValueException.class);
+    }
+
+    @Test
+    @Order(4)
+    void createEsm_withMaximumConcurrencyAboveThousand_throwsInvalidParameter() {
+        assertThatThrownBy(() -> lambda.createEventSourceMapping(
+                CreateEventSourceMappingRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .eventSourceArn(queueArn)
+                        .scalingConfig(ScalingConfig.builder().maximumConcurrency(1001).build())
+                        .build()))
+                .isInstanceOf(InvalidParameterValueException.class);
+    }
+
+    @Test
+    @Order(5)
+    void updateEsm_addsThenClearsScalingConfig() {
+        CreateEventSourceMappingResponse created = lambda.createEventSourceMapping(
+                CreateEventSourceMappingRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .eventSourceArn(queueArn)
+                        .batchSize(4)
+                        .build());
+        createdEsmUuids.add(created.uuid());
+
+        UpdateEventSourceMappingResponse added = lambda.updateEventSourceMapping(
+                UpdateEventSourceMappingRequest.builder()
+                        .uuid(created.uuid())
+                        .scalingConfig(ScalingConfig.builder().maximumConcurrency(3).build())
+                        .build());
+        assertThat(added.scalingConfig()).isNotNull();
+        assertThat(added.scalingConfig().maximumConcurrency()).isEqualTo(3);
+
+        // Clear by sending an empty ScalingConfig — AWS treats this as "reset".
+        UpdateEventSourceMappingResponse cleared = lambda.updateEventSourceMapping(
+                UpdateEventSourceMappingRequest.builder()
+                        .uuid(created.uuid())
+                        .scalingConfig(ScalingConfig.builder().build())
+                        .build());
+        assertThat(cleared.scalingConfig() == null
+                || cleared.scalingConfig().maximumConcurrency() == null).isTrue();
+    }
+}

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -178,6 +178,34 @@ aws lambda create-event-source-mapping \
   --endpoint-url $AWS_ENDPOINT_URL
 ```
 
+### ScalingConfig (SQS only)
+
+`CreateEventSourceMapping` and `UpdateEventSourceMapping` accept a
+`ScalingConfig.MaximumConcurrency` integer between 2 and 1000 on SQS
+event sources, matching the AWS wire format. `GetEventSourceMapping` and
+`ListEventSourceMappings` echo the value back when set; responses omit
+the `ScalingConfig` field entirely when no cap is configured.
+
+```bash
+aws lambda create-event-source-mapping \
+  --function-name my-function \
+  --event-source-arn $QUEUE_ARN \
+  --scaling-config MaximumConcurrency=5 \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
+Validation mirrors AWS: values outside 2–1000 are rejected with
+`InvalidParameterValueException`, and `ScalingConfig` on a non-SQS event
+source (Kinesis / DynamoDB Streams) is also rejected — those services
+use `ParallelizationFactor` instead, which is a separate field.
+
+!!! note "Enforcement status"
+    The configured `MaximumConcurrency` is persisted and returned on the
+    wire, but the SQS poller does not yet cap concurrent invocations at
+    this value (the poller today serializes invocations per ESM to one
+    at a time regardless). Real parallel dispatch capped by
+    `MaximumConcurrency` is tracked as a follow-up.
+
 ## Supported Runtimes
 
 Any runtime that has an official AWS Lambda container image works with Floci (e.g. `nodejs22.x`, `python3.13`, `java21`, `go1.x`, `provided.al2023`).

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -295,6 +295,14 @@ public class LambdaController {
         if (esm.getFunctionResponseTypes() != null) {
             esm.getFunctionResponseTypes().forEach(responseTypes::add);
         }
+        // Only emit ScalingConfig when a cap is actually set — AWS omits the
+        // field entirely on mappings with no MaximumConcurrency rather than
+        // returning an empty object.
+        Integer maxConcurrency = esm.getMaximumConcurrency();
+        if (maxConcurrency != null) {
+            ObjectNode scaling = node.putObject("ScalingConfig");
+            scaling.put("MaximumConcurrency", maxConcurrency.intValue());
+        }
         @SuppressWarnings("unchecked")
         Map<String, Object> result = objectMapper.convertValue(node, Map.class);
         return result;

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -481,13 +481,25 @@ public class LambdaService {
         if (!(raw instanceof Map<?, ?>)) {
             return null;
         }
+        boolean isSqs = eventSourceArn != null && eventSourceArn.contains(":sqs:");
         Map<?, ?> map = (Map<?, ?>) raw;
         Object mc = map.get("MaximumConcurrency");
         if (mc == null) {
+            // Empty ScalingConfig ({}) on SQS means "clear the cap".
+            // On non-SQS sources ScalingConfig is not valid at all.
+            if (!isSqs) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ScalingConfig is only supported for Amazon SQS event source mappings", 400);
+            }
             return null;
         }
         int value;
         if (mc instanceof Number) {
+            double d = ((Number) mc).doubleValue();
+            if (d != Math.floor(d)) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ScalingConfig.MaximumConcurrency must be an integer", 400);
+            }
             value = ((Number) mc).intValue();
         } else {
             try {
@@ -501,9 +513,9 @@ public class LambdaService {
             throw new AwsException("InvalidParameterValueException",
                     "ScalingConfig.MaximumConcurrency must be between 2 and 1000 (got " + value + ")", 400);
         }
-        if (eventSourceArn == null || !eventSourceArn.contains(":sqs:")) {
+        if (!isSqs) {
             throw new AwsException("InvalidParameterValueException",
-                    "ScalingConfig.MaximumConcurrency is only supported for Amazon SQS event source mappings", 400);
+                    "ScalingConfig is only supported for Amazon SQS event source mappings", 400);
         }
         return new ScalingConfig(value);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -500,7 +500,7 @@ public class LambdaService {
                     "ScalingConfig.MaximumConcurrency must be a numeric value", 400);
         }
         double d = ((Number) mc).doubleValue();
-        if (d != Math.floor(d)) {
+        if (Double.isNaN(d) || Double.isInfinite(d) || d != Math.floor(d)) {
             throw new AwsException("InvalidParameterValueException",
                     "ScalingConfig.MaximumConcurrency must be an integer", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -5,11 +5,12 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.lambda.model.EventSourceMapping;
-import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaAlias;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.lambda.model.LambdaUrlConfig;
+import io.github.hectorvent.floci.services.lambda.model.ScalingConfig;
 import io.github.hectorvent.floci.services.lambda.zip.CodeStore;
 import io.github.hectorvent.floci.services.lambda.zip.ZipExtractor;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -442,6 +443,8 @@ public class LambdaService {
                 ? (List<String>) request.get("FunctionResponseTypes")
                 : new ArrayList<>();
 
+        ScalingConfig scalingConfig = parseScalingConfig(request, eventSourceArn);
+
         String queueUrl = eventSourceArn.contains(":sqs:") ? AwsArnUtils.arnToQueueUrl(eventSourceArn, config.effectiveBaseUrl()) : null;
 
         EventSourceMapping esm = new EventSourceMapping();
@@ -454,6 +457,7 @@ public class LambdaService {
         esm.setBatchSize(batchSize);
         esm.setEnabled(enabled);
         esm.setState(enabled ? "Enabled" : "Disabled");
+        esm.setScalingConfig(scalingConfig);
         esm.setFunctionResponseTypes(functionResponseTypes);
         esm.setLastModified(System.currentTimeMillis());
 
@@ -463,6 +467,45 @@ public class LambdaService {
         }
         LOG.infov("Created ESM {0}: {1} → {2}", esm.getUuid(), eventSourceArn, resolvedName);
         return esm;
+    }
+
+    /**
+     * Parses {@code ScalingConfig} out of a create/update request and applies
+     * AWS-level validation: {@code MaximumConcurrency} must be in [2, 1000]
+     * and is only valid on SQS event sources. Returns {@code null} when no
+     * config was supplied or when the supplied config has no cap (AWS treats
+     * an empty ScalingConfig as "clear the cap").
+     */
+    private ScalingConfig parseScalingConfig(Map<String, Object> request, String eventSourceArn) {
+        Object raw = request.get("ScalingConfig");
+        if (!(raw instanceof Map<?, ?>)) {
+            return null;
+        }
+        Map<?, ?> map = (Map<?, ?>) raw;
+        Object mc = map.get("MaximumConcurrency");
+        if (mc == null) {
+            return null;
+        }
+        int value;
+        if (mc instanceof Number) {
+            value = ((Number) mc).intValue();
+        } else {
+            try {
+                value = Integer.parseInt(mc.toString());
+            } catch (NumberFormatException e) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ScalingConfig.MaximumConcurrency must be an integer", 400);
+            }
+        }
+        if (value < 2 || value > 1000) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ScalingConfig.MaximumConcurrency must be between 2 and 1000 (got " + value + ")", 400);
+        }
+        if (eventSourceArn == null || !eventSourceArn.contains(":sqs:")) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ScalingConfig.MaximumConcurrency is only supported for Amazon SQS event source mappings", 400);
+        }
+        return new ScalingConfig(value);
     }
 
     private void startPollingHelper(EventSourceMapping esm) {
@@ -513,6 +556,11 @@ public class LambdaService {
             boolean nowEnabled = !Boolean.FALSE.equals(request.get("Enabled"));
             esm.setEnabled(nowEnabled);
             esm.setState(nowEnabled ? "Enabled" : "Disabled");
+        }
+        if (request.containsKey("ScalingConfig")) {
+            // AWS: passing ScalingConfig resets it. An empty object or one
+            // with MaximumConcurrency=null clears the cap.
+            esm.setScalingConfig(parseScalingConfig(request, esm.getEventSourceArn()));
         }
 
         esm.setLastModified(System.currentTimeMillis());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -478,46 +478,42 @@ public class LambdaService {
      */
     private ScalingConfig parseScalingConfig(Map<String, Object> request, String eventSourceArn) {
         Object raw = request.get("ScalingConfig");
-        if (!(raw instanceof Map<?, ?>)) {
+        if (raw == null) {
             return null;
+        }
+        if (!(raw instanceof Map<?, ?>)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ScalingConfig must be a JSON object", 400);
         }
         boolean isSqs = eventSourceArn != null && eventSourceArn.contains(":sqs:");
         Map<?, ?> map = (Map<?, ?>) raw;
         Object mc = map.get("MaximumConcurrency");
         if (mc == null) {
-            // Empty ScalingConfig ({}) on SQS means "clear the cap".
-            // On non-SQS sources ScalingConfig is not valid at all.
             if (!isSqs) {
                 throw new AwsException("InvalidParameterValueException",
                         "ScalingConfig is only supported for Amazon SQS event source mappings", 400);
             }
             return null;
         }
-        int value;
-        if (mc instanceof Number) {
-            double d = ((Number) mc).doubleValue();
-            if (d != Math.floor(d)) {
-                throw new AwsException("InvalidParameterValueException",
-                        "ScalingConfig.MaximumConcurrency must be an integer", 400);
-            }
-            value = ((Number) mc).intValue();
-        } else {
-            try {
-                value = Integer.parseInt(mc.toString());
-            } catch (NumberFormatException e) {
-                throw new AwsException("InvalidParameterValueException",
-                        "ScalingConfig.MaximumConcurrency must be an integer", 400);
-            }
-        }
-        if (value < 2 || value > 1000) {
+        if (!(mc instanceof Number)) {
             throw new AwsException("InvalidParameterValueException",
-                    "ScalingConfig.MaximumConcurrency must be between 2 and 1000 (got " + value + ")", 400);
+                    "ScalingConfig.MaximumConcurrency must be a numeric value", 400);
+        }
+        double d = ((Number) mc).doubleValue();
+        if (d != Math.floor(d)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ScalingConfig.MaximumConcurrency must be an integer", 400);
+        }
+        long longValue = ((Number) mc).longValue();
+        if (longValue < 2 || longValue > 1000) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ScalingConfig.MaximumConcurrency must be between 2 and 1000 (got " + longValue + ")", 400);
         }
         if (!isSqs) {
             throw new AwsException("InvalidParameterValueException",
                     "ScalingConfig is only supported for Amazon SQS event source mappings", 400);
         }
-        return new ScalingConfig(value);
+        return new ScalingConfig((int) longValue);
     }
 
     private void startPollingHelper(EventSourceMapping esm) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -24,6 +24,7 @@ public class EventSourceMapping {
     private long lastModified;
     private List<String> functionResponseTypes = new ArrayList<>();
     private Map<String, String> shardSequenceNumbers = new HashMap<>();
+    private ScalingConfig scalingConfig;
 
     public EventSourceMapping() {
     }
@@ -70,5 +71,13 @@ public class EventSourceMapping {
     public Map<String, String> getShardSequenceNumbers() { return shardSequenceNumbers; }
     public void setShardSequenceNumbers(Map<String, String> shardSequenceNumbers) {
         this.shardSequenceNumbers = shardSequenceNumbers != null ? shardSequenceNumbers : new java.util.HashMap<>();
+    }
+
+    public ScalingConfig getScalingConfig() { return scalingConfig; }
+    public void setScalingConfig(ScalingConfig scalingConfig) { this.scalingConfig = scalingConfig; }
+
+    /** Convenience accessor: returns {@code null} when no cap is configured. */
+    public Integer getMaximumConcurrency() {
+        return scalingConfig != null ? scalingConfig.getMaximumConcurrency() : null;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/ScalingConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/ScalingConfig.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.lambda.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * AWS Lambda Event Source Mapping scaling configuration.
+ *
+ * <p>Currently carries only {@code MaximumConcurrency}, the SQS-only cap on
+ * how many Lambda invocations an ESM may run in parallel. The rest of the
+ * AWS schema (none today) can extend this class as needed.
+ *
+ * <p>Wire shape:
+ * <pre>{@code
+ * "ScalingConfig": { "MaximumConcurrency": 5 }
+ * }</pre>
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScalingConfig {
+
+    private Integer maximumConcurrency;
+
+    public ScalingConfig() {
+    }
+
+    public ScalingConfig(Integer maximumConcurrency) {
+        this.maximumConcurrency = maximumConcurrency;
+    }
+
+    public Integer getMaximumConcurrency() {
+        return maximumConcurrency;
+    }
+
+    public void setMaximumConcurrency(Integer maximumConcurrency) {
+        this.maximumConcurrency = maximumConcurrency;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -349,6 +349,45 @@ class EsmIntegrationTest {
 
     @Test
     @Order(44)
+    void createEventSourceMappingRejectsEmptyScalingConfigOnNonSqsSource() {
+        String kinesisArn = "arn:aws:kinesis:" + REGION + ":" + ACCOUNT_ID + ":stream/irrelevant";
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": {}
+                }
+                """.formatted(FUNCTION_NAME, kinesisArn))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("only supported for Amazon SQS"));
+    }
+
+    @Test
+    @Order(45)
+    void createEventSourceMappingRejectsNonIntegerMaximumConcurrency() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": { "MaximumConcurrency": 2.5 }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("must be an integer"));
+    }
+
+    @Test
+    @Order(46)
     void responseOmitsScalingConfigWhenUnset() {
         // A mapping created without ScalingConfig should not expose the key
         // in subsequent responses — AWS omits the field rather than returning
@@ -374,7 +413,7 @@ class EsmIntegrationTest {
     }
 
     @Test
-    @Order(45)
+    @Order(47)
     void updateEventSourceMappingAddsAndClearsScalingConfig() {
         String uuid = given()
             .contentType("application/json")

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -452,6 +452,100 @@ class EsmIntegrationTest {
 
     @Test
     @Order(49)
+    void updateEventSourceMappingRejectsInvalidScalingConfig() {
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 2
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+        .extract()
+            .path("UUID");
+
+        // Below minimum
+        given()
+            .contentType("application/json")
+            .body("{ \"ScalingConfig\": { \"MaximumConcurrency\": 1 } }")
+        .when()
+            .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(400)
+            .body("message", containsString("between 2 and 1000"));
+
+        // Above maximum
+        given()
+            .contentType("application/json")
+            .body("{ \"ScalingConfig\": { \"MaximumConcurrency\": 1001 } }")
+        .when()
+            .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(400)
+            .body("message", containsString("between 2 and 1000"));
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(50)
+    void listEventSourceMappingsWithMixedScalingConfig() {
+        // Create one ESM with ScalingConfig and one without.
+        String uuidWith = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 3,
+                    "ScalingConfig": { "MaximumConcurrency": 10 }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+        .extract()
+            .path("UUID");
+
+        String uuidWithout = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 4
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+        .extract()
+            .path("UUID");
+
+        // List should return both; one with ScalingConfig and one without.
+        given()
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings?FunctionName=" + FUNCTION_ARN)
+        .then()
+            .statusCode(200)
+            .body("EventSourceMappings.find { it.UUID == '" + uuidWith + "' }.ScalingConfig.MaximumConcurrency",
+                    equalTo(10))
+            .body("EventSourceMappings.find { it.UUID == '" + uuidWithout + "' }.ScalingConfig",
+                    nullValue());
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuidWith).then().statusCode(202);
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuidWithout).then().statusCode(202);
+    }
+
+    @Test
+    @Order(51)
     void updateEventSourceMappingAddsAndClearsScalingConfig() {
         String uuid = given()
             .contentType("application/json")

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -388,6 +388,44 @@ class EsmIntegrationTest {
 
     @Test
     @Order(46)
+    void createEventSourceMappingRejectsStringMaximumConcurrency() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": { "MaximumConcurrency": "7" }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("numeric"));
+    }
+
+    @Test
+    @Order(47)
+    void createEventSourceMappingRejectsNonObjectScalingConfig() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": "not-an-object"
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("JSON object"));
+    }
+
+    @Test
+    @Order(48)
     void responseOmitsScalingConfigWhenUnset() {
         // A mapping created without ScalingConfig should not expose the key
         // in subsequent responses — AWS omits the field rather than returning
@@ -413,7 +451,7 @@ class EsmIntegrationTest {
     }
 
     @Test
-    @Order(47)
+    @Order(49)
     void updateEventSourceMappingAddsAndClearsScalingConfig() {
         String uuid = given()
             .contentType("application/json")

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -254,4 +254,165 @@ class EsmIntegrationTest {
         .then()
             .statusCode(404);
     }
+
+    // ──────────────────────────── ScalingConfig ────────────────────────────
+
+    @Test
+    @Order(40)
+    void createEventSourceMappingWithScalingConfigRoundTrips() {
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 5,
+                    "ScalingConfig": { "MaximumConcurrency": 7 }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("ScalingConfig.MaximumConcurrency", equalTo(7))
+        .extract()
+            .path("UUID");
+
+        given()
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(200)
+            .body("ScalingConfig.MaximumConcurrency", equalTo(7));
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(41)
+    void createEventSourceMappingRejectsMaximumConcurrencyBelowMinimum() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": { "MaximumConcurrency": 1 }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("between 2 and 1000"));
+    }
+
+    @Test
+    @Order(42)
+    void createEventSourceMappingRejectsMaximumConcurrencyAboveMaximum() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": { "MaximumConcurrency": 1001 }
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("between 2 and 1000"));
+    }
+
+    @Test
+    @Order(43)
+    void createEventSourceMappingRejectsScalingConfigOnNonSqsSource() {
+        // MaximumConcurrency is SQS-only in AWS. Kinesis uses ParallelizationFactor.
+        String kinesisArn = "arn:aws:kinesis:" + REGION + ":" + ACCOUNT_ID + ":stream/irrelevant";
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "ScalingConfig": { "MaximumConcurrency": 5 }
+                }
+                """.formatted(FUNCTION_NAME, kinesisArn))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("only supported for Amazon SQS"));
+    }
+
+    @Test
+    @Order(44)
+    void responseOmitsScalingConfigWhenUnset() {
+        // A mapping created without ScalingConfig should not expose the key
+        // in subsequent responses — AWS omits the field rather than returning
+        // an empty object.
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 2
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("$", not(hasKey("ScalingConfig")))
+        .extract()
+            .path("UUID");
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(45)
+    void updateEventSourceMappingAddsAndClearsScalingConfig() {
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 4
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("$", not(hasKey("ScalingConfig")))
+        .extract()
+            .path("UUID");
+
+        // Add
+        given()
+            .contentType("application/json")
+            .body("{ \"ScalingConfig\": { \"MaximumConcurrency\": 3 } }")
+        .when()
+            .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(202)
+            .body("ScalingConfig.MaximumConcurrency", equalTo(3));
+
+        // Clear by sending an empty ScalingConfig (AWS semantics)
+        given()
+            .contentType("application/json")
+            .body("{ \"ScalingConfig\": {} }")
+        .when()
+            .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(202)
+            .body("$", not(hasKey("ScalingConfig")));
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
 }


### PR DESCRIPTION
## Summary

Wire-level support for `ScalingConfig.MaximumConcurrency` on Lambda SQS
event source mappings. `CreateEventSourceMapping` and
`UpdateEventSourceMapping` accept, validate, and persist the value;
`GetEventSourceMapping` and `ListEventSourceMappings` echo it back.
Responses omit `ScalingConfig` when no cap is configured, matching AWS
behavior.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- `MaximumConcurrency` accepted in range 2–1000, validated with
  `InvalidParameterValueException` on: out-of-range, non-integer
  (including fractional, NaN, Infinity), non-numeric type (string),
  non-object `ScalingConfig`, and non-SQS event sources. Matches the
  [AWS `ScalingConfig` type](https://docs.aws.amazon.com/lambda/latest/api/API_ScalingConfig.html).
- Response shape: `"ScalingConfig": {"MaximumConcurrency": N}` when set,
  omitted entirely when null — verified against AWS SDK v2 typed
  `ScalingConfig` round-trip in the compatibility test.
- `UpdateEventSourceMapping` with an empty `ScalingConfig` (`{}`) clears
  the cap (AWS reset semantics). Omitting `ScalingConfig` from the
  update request preserves the existing value.
- `ScalingConfig` on non-SQS event sources (Kinesis / DynamoDB Streams)
  is rejected even when empty, since those services use
  `ParallelizationFactor` instead.

The configured value is persisted but **not yet enforced** at invocation
time — the SQS poller today serializes invocations per ESM to one at a
time (`activePolls` guard). Real parallel dispatch capped by
`MaximumConcurrency` is a follow-up.

## Checklist

- [x] `./mvnw test` passes locally (`EsmIntegrationTest`: 26 tests
  green, including 12 new ScalingConfig cases)
- [x] New or updated integration test added — 12 integration tests in
  `EsmIntegrationTest` and 5 SDK compatibility tests in
  `LambdaEsmScalingConfigTest`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Known limitations

- Enforcement is not wired yet — the poller still caps at 1 concurrent
  invocation per ESM via `activePolls.putIfAbsent`. This is a
  pre-existing limitation unrelated to this PR.
- `ParallelizationFactor` for Kinesis / DynamoDB Streams is not
  implemented (separate AWS field, out of scope).