### PR TITLE
fix(s3-control): accept URL-encoded ARNs and return XML errors (#435)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
@@ -17,10 +17,12 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * S3 Control API endpoints used by Terraform AWS provider v6.x and other tools.
@@ -53,17 +55,21 @@ public class S3ControlController {
             @PathParam("resourceArn") String resourceArn,
             @HeaderParam("x-amz-account-id") String accountId) {
 
-        String bucketName = extractBucketName(resourceArn);
-        Map<String, String> tags = s3Service.getBucketTagging(bucketName);
+        try {
+            String bucketName = extractBucketName(resourceArn);
+            Map<String, String> tags = s3Service.getBucketTagging(bucketName);
 
-        XmlBuilder xml = new XmlBuilder()
-                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
-                .start("ListTagsForResourceResult", AwsNamespaces.S3_CONTROL)
-                .start("Tags");
-        tags.forEach((k, v) ->
-                xml.start("Tag").elem("Key", k).elem("Value", v).end("Tag"));
-        xml.end("Tags").end("ListTagsForResourceResult");
-        return Response.ok(xml.build()).build();
+            XmlBuilder xml = new XmlBuilder()
+                    .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                    .start("ListTagsForResourceResult", AwsNamespaces.S3_CONTROL)
+                    .start("Tags");
+            tags.forEach((k, v) ->
+                    xml.start("Tag").elem("Key", k).elem("Value", v).end("Tag"));
+            xml.end("Tags").end("ListTagsForResourceResult");
+            return Response.ok(xml.build()).build();
+        } catch (AwsException e) {
+            return xmlErrorResponse(e);
+        }
     }
 
     /**
@@ -81,11 +87,15 @@ public class S3ControlController {
             @HeaderParam("x-amz-account-id") String accountId,
             byte[] body) {
 
-        String bucketName = extractBucketName(resourceArn);
-        String xml = new String(body, StandardCharsets.UTF_8);
-        Map<String, String> tags = XmlParser.extractPairs(xml, "Tag", "Key", "Value");
-        s3Service.putBucketTagging(bucketName, tags);
-        return Response.noContent().build();
+        try {
+            String bucketName = extractBucketName(resourceArn);
+            String xml = new String(body, StandardCharsets.UTF_8);
+            Map<String, String> tags = XmlParser.extractPairs(xml, "Tag", "Key", "Value");
+            s3Service.putBucketTagging(bucketName, tags);
+            return Response.noContent().build();
+        } catch (AwsException e) {
+            return xmlErrorResponse(e);
+        }
     }
 
     /**
@@ -101,20 +111,60 @@ public class S3ControlController {
             @HeaderParam("x-amz-account-id") String accountId,
             @QueryParam("tagKeys") List<String> tagKeys) {
 
-        String bucketName = extractBucketName(resourceArn);
-        Map<String, String> existing = new HashMap<>(s3Service.getBucketTagging(bucketName));
-        tagKeys.forEach(existing::remove);
-        s3Service.putBucketTagging(bucketName, existing);
-        return Response.noContent().build();
+        try {
+            String bucketName = extractBucketName(resourceArn);
+            Map<String, String> existing = new HashMap<>(s3Service.getBucketTagging(bucketName));
+            tagKeys.forEach(existing::remove);
+            s3Service.putBucketTagging(bucketName, existing);
+            return Response.noContent().build();
+        } catch (AwsException e) {
+            return xmlErrorResponse(e);
+        }
     }
 
+    /**
+     * Parse the bucket name out of an S3 bucket ARN path parameter.
+     *
+     * <p>The AWS Go SDK v2 (used by Terraform) percent-encodes the ARN's
+     * colons and slashes in the request path, while the Java SDK sends them
+     * literally. We decode defensively so both forms work, and so routing
+     * frameworks that leave {@code %2F} encoded in path segments don't break
+     * us.
+     */
     private String extractBucketName(String resourceArn) {
-        int idx = resourceArn.lastIndexOf(":bucket/");
+        String decoded;
+        try {
+            decoded = URLDecoder.decode(resourceArn, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("InvalidRequest",
+                    "Malformed percent-encoding in resource ARN: " + e.getMessage(), 400);
+        }
+        int idx = decoded.lastIndexOf(":bucket/");
         if (idx < 0) {
             throw new AwsException("InvalidRequest",
                     "Unsupported resource type. Only S3 bucket ARNs are supported " +
                     "(arn:aws:s3:<region>:<account>:bucket/<name>).", 400);
         }
-        return resourceArn.substring(idx + ":bucket/".length());
+        return decoded.substring(idx + ":bucket/".length());
+    }
+
+    /**
+     * S3 Control is a REST-XML protocol, so error responses must also be XML.
+     * The global {@code AwsExceptionMapper} emits JSON, which trips up the
+     * Go SDK's XML error deserializer with "unexpected EOF".
+     */
+    private Response xmlErrorResponse(AwsException e) {
+        String xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("Error")
+                .elem("Code", e.getErrorCode())
+                .elem("Message", e.getMessage())
+                .elem("RequestId", UUID.randomUUID().toString())
+                .end("Error")
+                .build();
+        return Response.status(e.getHttpStatus())
+                .type(MediaType.APPLICATION_XML)
+                .entity(xml)
+                .build();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
@@ -1,0 +1,163 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Integration tests for S3 Control API handling of URL-encoded ARN path
+ * parameters, which is what the Go AWS SDK v2 (and thus the Terraform AWS
+ * provider v6.x) sends.
+ *
+ * <p>Tracked by upstream issue #435 (regression of fix #363).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ControlUrlEncodedArnIntegrationTest {
+
+    private static final String BUCKET = "go-sdk-control-bucket";
+    private static final String ACCOUNT = "000000000000";
+    private static final String REGION = "us-east-1";
+
+    private static final String DECODED_ARN =
+            "arn:aws:s3:" + REGION + ":" + ACCOUNT + ":bucket/" + BUCKET;
+
+    // What the Go SDK actually puts on the wire: colons AND slashes URL-encoded.
+    private static final String ENCODED_ARN =
+            "arn%3Aaws%3As3%3A" + REGION + "%3A" + ACCOUNT + "%3Abucket%2F" + BUCKET;
+
+    @Test
+    @Order(1)
+    @DisplayName("setup: create bucket and tag it via the standard S3 tagging API")
+    void setupBucketWithTags() {
+        given().when().put("/" + BUCKET).then().statusCode(200);
+
+        String tagBody = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Tagging><TagSet>" +
+                "<Tag><Key>Env</Key><Value>dev</Value></Tag>" +
+                "</TagSet></Tagging>";
+
+        given().contentType("application/xml").body(tagBody)
+                .when().put("/" + BUCKET + "?tagging")
+                .then().statusCode(204);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("ListTagsForResource accepts URL-encoded ARN from Go AWS SDK v2 (#435)")
+    void listTagsForResourceWithUrlEncodedArn() {
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + ENCODED_ARN)
+        .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<ListTagsForResourceResult"))
+            .body(containsString("<Key>Env</Key>"))
+            .body(containsString("<Value>dev</Value>"));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("ListTagsForResource still accepts non-encoded ARN (from Java SDK)")
+    void listTagsForResourceWithPlainArn() {
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + DECODED_ARN)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>Env</Key>"));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("TagResource accepts URL-encoded ARN from Go AWS SDK v2 (#435)")
+    void tagResourceWithUrlEncodedArn() {
+        String body = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "<Tagging xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">" +
+                "<Tags>" +
+                "<Tag><Key>Owner</Key><Value>team-a</Value></Tag>" +
+                "<Tag><Key>CostCenter</Key><Value>cc-42</Value></Tag>" +
+                "</Tags></Tagging>";
+
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+            .contentType("application/xml")
+            .body(body)
+        .when()
+            .post("/v20180820/tags/" + ENCODED_ARN)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + ENCODED_ARN)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>Owner</Key>"))
+            .body(containsString("<Key>CostCenter</Key>"));
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("UntagResource accepts URL-encoded ARN from Go AWS SDK v2 (#435)")
+    void untagResourceWithUrlEncodedArn() {
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .delete("/v20180820/tags/" + ENCODED_ARN + "?tagKeys=CostCenter")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + ENCODED_ARN)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>Owner</Key>"))
+            .body(not(containsString("<Key>CostCenter</Key>")));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Malformed ARN returns valid S3-style XML error body (#435)")
+    void malformedArnReturnsXmlError() {
+        // Path param must not contain a literal ':bucket/' segment after decoding.
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/arn%3Aaws%3As3%3A%3A%3Abogus%2F" + BUCKET)
+        .then()
+            .statusCode(400)
+            .contentType(containsString("xml"))
+            .body(containsString("<Error>"))
+            .body(containsString("<Code>InvalidRequest</Code>"));
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("Malformed percent-encoding returns XML error, not JSON 500 (#435)")
+    void malformedPercentEncodingReturnsXmlError() {
+        // %ZZ is not a valid percent-encoding sequence; URLDecoder throws IAE.
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/arn%3Aaws%ZZbucket%2F" + BUCKET)
+        .then()
+            .statusCode(400)
+            .contentType(containsString("xml"))
+            .body(containsString("<Error>"))
+            .body(containsString("<Code>InvalidRequest</Code>"));
+    }
+}


### PR DESCRIPTION
Fixes #435 (regression of #341 / #363).

## Why

Terraform AWS provider v6.x, via Go AWS SDK v2, percent-encodes the colons and slashes of the resource ARN in the request path:

```
GET /v20180820/tags/arn%3Aaws%3As3%3Aus-east-1%3A000000000000%3Abucket%2Fmy-bucket
```

Two things went wrong:

1. `S3ControlController.extractBucketName()` searched for the literal `:bucket/`, which doesn't match `%3Abucket%2F`. Every Terraform tag read/write returned 400 `InvalidRequest`.
2. S3 Control is a REST-XML protocol, but `AwsException` falls through to the global `AwsExceptionMapper`, which emits JSON. The Go SDK's XML deserializer then fails with `XML syntax error on line 1: unexpected EOF`, masking the real cause.

The Java SDK compat test added in #363 doesn't URL-encode path parameters, so neither issue surfaced there.

## What

- `extractBucketName()` now `URLDecoder.decode`s the ARN before parsing. Malformed percent-encoding (e.g. `%ZZ`) is converted to a 400 `InvalidRequest` rather than propagating `IllegalArgumentException` to the JSON mapper.
- All three S3 Control handlers (`listTagsForResource`, `tagResource`, `untagResource`) catch `AwsException` and serialize it as an S3-style `<Error>` XML body. This mirrors the pattern already used by `S3Controller.xmlErrorResponse`.

## Test plan

New `S3ControlUrlEncodedArnIntegrationTest` covers:

- [x] `ListTagsForResource` with URL-encoded ARN (Go SDK shape) returns 200 + XML
- [x] `ListTagsForResource` with plain ARN (Java SDK shape) still returns 200
- [x] `TagResource` with URL-encoded ARN returns 204, tags round-trip
- [x] `UntagResource` with URL-encoded ARN returns 204, correct tag removed
- [x] Invalid ARN shape returns 400 with XML `<Error><Code>InvalidRequest</Code>` body
- [x] Malformed percent-encoding returns 400 with XML body (not JSON 500)

Verification:

```bash
./mvnw test -Dtest=S3ControlUrlEncodedArnIntegrationTest
# Tests run: 7, Failures: 0, Errors: 0
```

Existing `S3ControlTest` Java SDK compat path still passes. Full `./mvnw clean test` suite otherwise green (ElastiCache failures are pre-existing, require Docker).

## Manual reproduction

```bash
docker run -d -p 4566:4566 hectorvent/floci:1.5.3   # before
docker build -t floci-fix . && docker run -d -p 4566:4566 floci-fix   # after

curl -s -o /dev/null -w "%{http_code}\n" \
  -H "x-amz-account-id: 000000000000" \
  "http://localhost:4566/v20180820/tags/arn%3Aaws%3As3%3Aus-east-1%3A000000000000%3Abucket%2Ftest-tags"
# before: 400 (with JSON body)
# after:  200 (with XML body) once the bucket exists
```