### PR TITLE
fix(sqs): include MD5OfMessageAttributes in SendMessageBatch JSON response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -307,6 +307,9 @@ public class SqsJsonHandler {
                     success.put("Id", id);
                     success.put("MessageId", msg.getMessageId());
                     success.put("MD5OfMessageBody", msg.getMd5OfBody());
+                    if (msg.getMd5OfMessageAttributes() != null) {
+                        success.put("MD5OfMessageAttributes", msg.getMd5OfMessageAttributes());
+                    }
                     if (msg.getSequenceNumber() > 0) {
                         success.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
                     }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -145,6 +145,31 @@ class SqsJsonProtocolTest {
     }
 
     @Test
+    @Order(6)
+    void sendMessageBatchReturnsMd5OfMessageAttributes() {
+        String body = "{\"QueueUrl\":\"" + queueUrl + "\","
+                + "\"Entries\":[{"
+                + "\"Id\":\"m1\","
+                + "\"MessageBody\":\"batch body\","
+                + "\"MessageAttributes\":{"
+                + "\"trace-id\":{\"DataType\":\"String\",\"StringValue\":\"abc-123\"}"
+                + "}}]}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessageBatch")
+            .body(body)
+        .when()
+            .post("/" + ACCOUNT_ID + "/" + QUEUE_NAME)
+        .then()
+            .statusCode(200)
+            .body("Successful", hasSize(1))
+            .body("Successful[0].Id", equalTo("m1"))
+            .body("Successful[0].MD5OfMessageBody", notNullValue())
+            .body("Successful[0].MD5OfMessageAttributes", notNullValue());
+    }
+
+    @Test
     @Order(7)
     void deleteQueueViaQueueUrlPath() {
         String body = "{\"QueueUrl\":\"" + queueUrl + "\"}";


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                              
   
  Fixes the SQS `SendMessageBatch` action under the JSON 1.0 protocol: successful batch entries now include `MD5OfMessageAttributes` when the request carried `MessageAttributes`, matching real AWS and aligning with the single `SendMessage` and Query-protocol batch paths.                                           
                  
  Closes #495                                                                                                                                                                                                                                                                                                             
                  
  ## Type of change

  - [x] Bug fix (`fix:`)
  - [ ] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)                                                                                                                                                                                                                                                                             
  - [ ] Docs / chore
                                                                                                                                                                                                                                                                                                                          
  ## AWS Compatibility

  The `SqsJsonHandler#handleSendMessageBatch` response previously emitted only `Id`, `MessageId`, `MD5OfMessageBody`, and (for FIFO) `SequenceNumber`. The `MD5OfMessageAttributes` field — present on real AWS and required for client-side attribute-integrity validation — was dropped even though the service layer   
  already computed it via `Message#updateMd5OfMessageAttributes`.
                                                                                                                                                                                                                                                                                                                          
  Verified with AWS CLI v2 against a local Floci instance: the field is now returned when `MessageAttributes` are supplied. Single `SendMessage` (JSON) and `SendMessageBatch` (Query) were already correct and are untouched.                                                                                            
   
  ## Checklist                                                                                                                                                                                                                                                                                                            
                  
  - [x] `./mvnw test` passes locally (62/62 SQS tests, including the new regression test)                                                                                                                                                                                                                                 
  - [x] New or updated integration test added — `SqsJsonProtocolTest#sendMessageBatchReturnsMd5OfMessageAttributes`
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — single commit `fix(sqs): include MD5OfMessageAttributes in SendMessageBatch JSON response`  