### PR TITLE
feat: add EventBridge PutPermission and RemovePermission support

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -61,6 +61,8 @@ public class EventBridgeHandler {
                 case "ListTagsForResource" -> handleListTagsForResource(request, region);
                 case "TagResource" -> handleTagResource(request, region);
                 case "UntagResource" -> handleUntagResource(request, region);
+                case "PutPermission" -> handlePutPermission(request, region);
+                case "RemovePermission" -> handleRemovePermission(request, region);
                 default -> Response.status(400)
                         .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                         .build();
@@ -324,6 +326,28 @@ public class EventBridgeHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    private Response handlePutPermission(JsonNode request, String region) {
+        String busName = request.path("EventBusName").asText(null);
+        String action = request.path("Action").asText(null);
+        String principal = request.path("Principal").asText(null);
+        String statementId = request.path("StatementId").asText(null);
+        String policy = request.path("Policy").asText(null);
+        JsonNode conditionNode = request.path("Condition");
+        String conditionJson = conditionNode.isMissingNode() || conditionNode.isNull()
+                ? null : conditionNode.toString();
+        eventBridgeService.putPermission(busName, action, principal, statementId,
+                conditionJson, policy, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleRemovePermission(JsonNode request, String region) {
+        String busName = request.path("EventBusName").asText(null);
+        String statementId = request.path("StatementId").asText(null);
+        boolean removeAll = request.path("RemoveAllPermissions").asBoolean(false);
+        eventBridgeService.removePermission(busName, statementId, removeAll, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private ObjectNode buildBusNode(EventBus bus) {
@@ -335,6 +359,9 @@ public class EventBridgeHandler {
         }
         if (bus.getCreatedTime() != null) {
             node.put("CreationTime", bus.getCreatedTime().getEpochSecond());
+        }
+        if (bus.getPolicy() != null) {
+            node.put("Policy", bus.getPolicy());
         }
         return node;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -407,6 +407,115 @@ public class EventBridgeService {
         throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 404);
     }
 
+    // ──────────────────────────── Permissions ────────────────────────────
+
+    public void putPermission(String busName, String action, String principal,
+                              String statementId, String conditionJson, String policyJson, String region) {
+        String effectiveBus = resolvedBusName(busName);
+        if ("default".equals(effectiveBus)) {
+            getOrCreateDefaultBus(region);
+        }
+        String key = busKey(region, effectiveBus);
+        EventBus bus = busStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "EventBus not found: " + effectiveBus, 404));
+
+        try {
+            if (policyJson != null && !policyJson.isBlank()) {
+                bus.setPolicy(policyJson);
+            } else {
+                String currentPolicy = bus.getPolicy();
+                ObjectNode policy;
+                if (currentPolicy != null && !currentPolicy.isBlank()) {
+                    policy = (ObjectNode) objectMapper.readTree(currentPolicy);
+                } else {
+                    policy = objectMapper.createObjectNode();
+                    policy.put("Version", "2012-10-17");
+                    policy.putArray("Statement");
+                }
+
+                ArrayNode statements = (ArrayNode) policy.get("Statement");
+                for (int i = 0; i < statements.size(); i++) {
+                    if (statementId.equals(statements.get(i).path("Sid").asText(null))) {
+                        statements.remove(i);
+                        break;
+                    }
+                }
+
+                ObjectNode statement = objectMapper.createObjectNode();
+                statement.put("Sid", statementId);
+                statement.put("Effect", "Allow");
+                statement.put("Principal", principal != null ? principal : "*");
+                statement.put("Action", action != null ? action : "events:PutEvents");
+                statement.put("Resource", bus.getArn());
+                if (conditionJson != null && !conditionJson.isBlank()) {
+                    statement.set("Condition", objectMapper.readTree(conditionJson));
+                }
+                statements.add(statement);
+                bus.setPolicy(objectMapper.writeValueAsString(policy));
+            }
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("InternalException", "Failed to process permission policy: " + e.getMessage(), 500);
+        }
+
+        busStore.put(key, bus);
+        LOG.infov("Put permission on bus {0}, statement {1}", effectiveBus, statementId);
+    }
+
+    public void removePermission(String busName, String statementId, boolean removeAll, String region) {
+        String effectiveBus = resolvedBusName(busName);
+        if ("default".equals(effectiveBus)) {
+            getOrCreateDefaultBus(region);
+        }
+        String key = busKey(region, effectiveBus);
+        EventBus bus = busStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "EventBus not found: " + effectiveBus, 404));
+
+        if (removeAll) {
+            bus.setPolicy(null);
+        } else {
+            if (statementId == null || statementId.isBlank()) {
+                throw new AwsException("ValidationException", "StatementId is required.", 400);
+            }
+            try {
+                String currentPolicy = bus.getPolicy();
+                if (currentPolicy == null || currentPolicy.isBlank()) {
+                    throw new AwsException("ResourceNotFoundException",
+                            "Statement not found: " + statementId, 400);
+                }
+                ObjectNode policy = (ObjectNode) objectMapper.readTree(currentPolicy);
+                ArrayNode statements = (ArrayNode) policy.get("Statement");
+                boolean found = false;
+                for (int i = 0; i < statements.size(); i++) {
+                    if (statementId.equals(statements.get(i).path("Sid").asText(null))) {
+                        statements.remove(i);
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    throw new AwsException("ResourceNotFoundException",
+                            "Statement not found: " + statementId, 400);
+                }
+                if (statements.isEmpty()) {
+                    bus.setPolicy(null);
+                } else {
+                    bus.setPolicy(objectMapper.writeValueAsString(policy));
+                }
+            } catch (AwsException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new AwsException("InternalException", "Failed to process permission policy: " + e.getMessage(), 500);
+            }
+        }
+
+        busStore.put(key, bus);
+        LOG.infov("Removed permission from bus {0}, statement {1}, removeAll {2}", effectiveBus, statementId, removeAll);
+    }
+
     // ──────────────────────────── PutEvents ────────────────────────────
 
     public record PutEventsResult(int failedCount, List<Map<String, String>> entries) {}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/EventBus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/EventBus.java
@@ -14,6 +14,7 @@ public class EventBus {
     private String description;
     private Map<String, String> tags = new HashMap<>();
     private Instant createdTime;
+    private String policy;
 
     public EventBus() {}
 
@@ -38,4 +39,7 @@ public class EventBus {
 
     public Instant getCreatedTime() { return createdTime; }
     public void setCreatedTime(Instant createdTime) { this.createdTime = createdTime; }
+
+    public String getPolicy() { return policy; }
+    public void setPolicy(String policy) { this.policy = policy; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgePermissionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgePermissionIntegrationTest.java
@@ -1,0 +1,233 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgePermissionIntegrationTest {
+
+    private static final String EVENT_BRIDGE_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createBusForPermissionTests() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+            .body("{\"Name\":\"perm-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void putPermissionStoresPolicy() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "Action": "events:PutEvents",
+                    "Principal": "*",
+                    "StatementId": "test-stmt"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"perm-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Policy", notNullValue())
+            .body("Policy", containsString("test-stmt"))
+            .body("Policy", containsString("events:PutEvents"));
+    }
+
+    @Test
+    @Order(3)
+    void putPermissionReplacesExistingStatement() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "Action": "events:PutEvents",
+                    "Principal": "123456789012",
+                    "StatementId": "test-stmt"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"perm-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Policy", containsString("123456789012"))
+            .body("Policy", not(containsString("\"*\"")));
+    }
+
+    @Test
+    @Order(4)
+    void removePermissionDeletesStatement() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.RemovePermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "StatementId": "test-stmt"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"perm-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Policy", nullValue());
+    }
+
+    @Test
+    @Order(5)
+    void removePermissionWithRemoveAllClearsPolicy() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "Action": "events:PutEvents",
+                    "Principal": "*",
+                    "StatementId": "stmt-a"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "Action": "events:PutEvents",
+                    "Principal": "111122223333",
+                    "StatementId": "stmt-b"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.RemovePermission")
+            .body("""
+                {
+                    "EventBusName": "perm-test-bus",
+                    "RemoveAllPermissions": true
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"perm-test-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Policy", nullValue());
+    }
+
+    @Test
+    @Order(6)
+    void putPermissionOnNonExistentBusReturns404() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "EventBusName": "nonexistent-bus",
+                    "Action": "events:PutEvents",
+                    "Principal": "*",
+                    "StatementId": "test"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(7)
+    void putPermissionOnDefaultBus() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutPermission")
+            .body("""
+                {
+                    "Action": "events:PutEvents",
+                    "Principal": "*",
+                    "StatementId": "default-stmt"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Policy", containsString("default-stmt"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for EventBridge `PutPermission` and `RemovePermission` operations. These APIs manage resource-based policies on event buses, allowing cross-account event delivery. The policy is stored on the bus and returned via `DescribeEventBus`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- `PutPermission` accepts both individual parameters (`Action`, `Principal`, `StatementId`, `Condition`) and full `Policy` JSON, matching the [AWS PutPermission API](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html).
- `RemovePermission` supports both `StatementId`-based removal and `RemoveAllPermissions: true`, matching the [AWS RemovePermission API](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemovePermission.html).
- `DescribeEventBus` now returns the `Policy` field as a JSON string when a policy exists, omitted when null.
- Policy is built as an IAM-style resource-based policy with `Version`, `Statement` array, and per-statement `Sid`, `Effect`, `Principal`, `Action`, `Resource`, and optional `Condition`.
- Calling `PutPermission` with an existing `StatementId` replaces the statement (upsert semantics).
- Removing the last statement clears the policy entirely (policy field becomes null).
- `ResourceNotFoundException` on non-existent bus, consistent with existing EventBridge error handling.

The policy is stored but **not enforced**. Floci does not perform IAM authorization checks. This is consistent with how other Floci services handle permissions.

## Checklist

- [x] `./mvnw test` passes locally (`EventBridgePermissionIntegrationTest`: 7 tests green)
- [x] New integration test added (7 tests covering put, replace, remove by statement, remove all, non-existent bus error, and default bus)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)