### PR TITLE
fix(dynamodb): validate sort key in buildItemKey to prevent item collisions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1566,9 +1566,11 @@ public class DynamoDbService {
         String skName = table.getSortKeyName();
         if (skName != null) {
             JsonNode skAttr = item.get(skName);
-            if (skAttr != null) {
-                return pk + "#" + extractScalarValue(skAttr);
+            if (skAttr == null) {
+                throw new AwsException("ValidationException",
+                        "One of the required keys was not given a value", 400);
             }
+            return pk + "#" + extractScalarValue(skAttr);
         }
         return pk;
     }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1367,6 +1367,83 @@ class DynamoDbIntegrationTest {
         assertEquals(Long.toString(crc32Of(errorResponse.asByteArray())), errorCrc);
     }
 
+    @Test
+    void updateItemWithSamePartitionKeyButDifferentSortKeyCreatesSeparateItems() {
+        // Reproduces GitHub issue #498: UpdateItem on a table with a sort key
+        // overwrites the existing row instead of creating a new one when the
+        // partition key matches but the sort key differs.
+        String tableName = "CoordinationTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [
+                        {"AttributeName": "GroupKey", "KeyType": "HASH"},
+                        {"AttributeName": "Id", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "GroupKey", "AttributeType": "S"},
+                        {"AttributeName": "Id", "AttributeType": "S"}
+                    ],
+                    "ProvisionedThroughput": {"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"GroupKey": {"S": "leader"}, "Id": {"S": "app1"}},
+                    "UpdateExpression": "SET Owner = :1",
+                    "ExpressionAttributeValues": {":1": {"S": "owner-app1"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"GroupKey": {"S": "leader"}, "Id": {"S": "app2"}},
+                    "UpdateExpression": "SET Owner = :1",
+                    "ExpressionAttributeValues": {":1": {"S": "owner-app2"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(2))
+            .body("ScannedCount", equalTo(2));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
     private static long crc32Of(byte[] bytes) {
         CRC32 crc = new CRC32();
         crc.update(bytes);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -1081,6 +1081,83 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void updateItemWithDifferentSortKeysCreatesSeparateItems() {
+        createOrdersTable();
+
+        ObjectNode key1 = item("customerId", "c1", "orderId", "app1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":owner", attributeValue("S", "owner-1"));
+
+        service.updateItem("Orders", key1, null,
+                "SET owner = :owner", null, exprValues, null);
+
+        ObjectNode key2 = item("customerId", "c1", "orderId", "app2");
+        exprValues = mapper.createObjectNode();
+        exprValues.set(":owner", attributeValue("S", "owner-2"));
+
+        service.updateItem("Orders", key2, null,
+                "SET owner = :owner", null, exprValues, null);
+
+        DynamoDbService.ScanResult scanResult = service.scan("Orders", null, null, null, null, null, null);
+        assertEquals(2, scanResult.items().size(),
+                "two items with same partition key but different sort keys must be stored separately");
+
+        JsonNode item1 = service.getItem("Orders", key1);
+        assertNotNull(item1);
+        assertEquals("owner-1", item1.get("owner").get("S").asText());
+
+        JsonNode item2 = service.getItem("Orders", key2);
+        assertNotNull(item2);
+        assertEquals("owner-2", item2.get("owner").get("S").asText());
+    }
+
+    @Test
+    void updateItemMissingSortKeyThrowsValidationException() {
+        createOrdersTable();
+
+        ObjectNode keyMissingSk = item("customerId", "c1");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":val", attributeValue("S", "test"));
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.updateItem("Orders", keyMissingSk, null,
+                        "SET name = :val", null, exprValues, null));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void getItemMissingSortKeyThrowsValidationException() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o1", "total", "100"));
+
+        ObjectNode keyMissingSk = item("customerId", "c1");
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.getItem("Orders", keyMissingSk));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void deleteItemMissingSortKeyThrowsValidationException() {
+        createOrdersTable();
+        service.putItem("Orders", item("customerId", "c1", "orderId", "o1", "total", "100"));
+
+        ObjectNode keyMissingSk = item("customerId", "c1");
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.deleteItem("Orders", keyMissingSk));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void putItemMissingSortKeyThrowsValidationException() {
+        createOrdersTable();
+
+        ObjectNode itemMissingSk = item("customerId", "c1", "total", "100");
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.putItem("Orders", itemMissingSk));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
     void updateExpressionAcceptsNewlineBetweenSetAndAdd() {
         // "SET ... \n ADD ..." — previously both clauses were silently dropped:
         // applySetClause greedily consumed ":newName\nADD counter :inc" as the


### PR DESCRIPTION
## Summary

`buildItemKey()` silently fell back to partition-key-only lookup when the sort key was missing from the input, even if the table schema defines one. This caused items with the same partition key but different sort keys to collide on UpdateItem, GetItem, PutItem, and DeleteItem. The fix throws a `ValidationException` when the table defines a sort key but the input omits it, matching real AWS DynamoDB behavior.

Closes #498

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was that `UpdateItem` on a table with a composite key (HASH + RANGE) would overwrite an existing item when the partition key matched but the sort key differed, instead of creating a separate item. Real AWS DynamoDB rejects requests with a missing required key attribute with `ValidationException: One of the required keys was not given a value`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)