### PR TITLE
Feat/s3 static website hosting

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -19,6 +19,7 @@ import io.github.hectorvent.floci.services.s3.model.Part;
 import io.github.hectorvent.floci.services.s3.model.S3Checksum;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import io.github.hectorvent.floci.services.s3.model.TopicNotification;
+import io.github.hectorvent.floci.services.s3.model.WebsiteConfiguration;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
@@ -143,6 +144,9 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "object-lock")) {
                 return handlePutObjectLockConfiguration(bucket, body);
             }
+            if (hasQueryParam(uriInfo, "website")) {
+                return handlePutBucketWebsite(bucket, body);
+            }
             if (hasQueryParam(uriInfo, "policy")) {
                 s3Service.putBucketPolicy(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
@@ -208,6 +212,10 @@ public class S3Controller {
         try {
             if (hasQueryParam(uriInfo, "tagging")) {
                 s3Service.deleteBucketTagging(bucket);
+                return Response.noContent().build();
+            }
+            if (hasQueryParam(uriInfo, "website")) {
+                s3Service.deleteBucketWebsite(bucket);
                 return Response.noContent().build();
             }
             if (hasQueryParam(uriInfo, "policy")) {
@@ -276,6 +284,9 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "object-lock")) {
                 return handleGetObjectLockConfiguration(bucket);
             }
+            if (hasQueryParam(uriInfo, "website")) {
+                return handleGetBucketWebsite(bucket);
+            }
             if (hasQueryParam(uriInfo, "policy")) {
                 return Response.ok(s3Service.getBucketPolicy(bucket)).build();
             }
@@ -296,6 +307,28 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "ownershipControls")) {
                 return Response.ok(s3Service.getBucketOwnershipControls(bucket)).build();
+            }
+
+            // --- Website Hosting Redirection Logic ---
+            if (uriInfo.getQueryParameters().isEmpty() || (uriInfo.getQueryParameters().size() == 1 && hasQueryParam(uriInfo, "list-type"))) {
+                try {
+                    WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
+                    if (webConfig.getIndexDocument() != null) {
+                        try {
+                            S3Object indexObj = s3Service.getObject(bucket, webConfig.getIndexDocument());
+                            return Response.ok(indexObj.getData())
+                                    .type(indexObj.getContentType())
+                                    .header("Content-Length", indexObj.getSize())
+                                    .header("ETag", indexObj.getETag())
+                                    .header("x-amz-website-redirect-location", "index")
+                                    .build();
+                        } catch (AwsException e) {
+                            // If index.html is missing, we could serve ErrorDocument, but for now we fall back to listObjects
+                        }
+                    }
+                } catch (AwsException e) {
+                    // Bucket is not a website, continue to listObjects
+                }
             }
 
             int max = (maxKeys != null && maxKeys > 0) ? maxKeys : 1000;
@@ -1956,5 +1989,33 @@ public class S3Controller {
         }
         String rawKey = rawPath.substring(prefixIndex + bucketPrefix.length());
         return URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+    }
+
+    private Response handleGetBucketWebsite(String bucket) {
+        WebsiteConfiguration config = s3Service.getBucketWebsite(bucket);
+        XmlBuilder xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("WebsiteConfiguration", AwsNamespaces.S3)
+                .start("IndexDocument")
+                .elem("Suffix", config.getIndexDocument())
+                .end("IndexDocument");
+        if (config.getErrorDocument() != null) {
+            xml.start("ErrorDocument")
+               .elem("Key", config.getErrorDocument())
+               .end("ErrorDocument");
+        }
+        xml.end("WebsiteConfiguration");
+        return Response.ok(xml.build()).build();
+    }
+
+    private Response handlePutBucketWebsite(String bucket, byte[] body) {
+        String xml = new String(body, StandardCharsets.UTF_8);
+        String indexDoc = XmlParser.extractFirst(xml, "Suffix", null);
+        String errorDoc = XmlParser.extractFirst(xml, "Key", null);
+        if (indexDoc == null) {
+            throw new AwsException("MalformedXML", "IndexDocument.Suffix is required.", 400);
+        }
+        s3Service.putBucketWebsite(bucket, new WebsiteConfiguration(indexDoc, errorDoc));
+        return Response.ok().build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -804,6 +804,34 @@ public class S3Service {
         return bucket.getTags() != null ? bucket.getTags() : Map.of();
     }
 
+    public void putBucketWebsite(String bucketName, WebsiteConfiguration config) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket",
+                        "The specified bucket does not exist.", 404));
+        bucket.setWebsiteConfiguration(config);
+        bucketStore.put(bucketName, bucket);
+        LOG.infov("Set website configuration for bucket: {0}", bucketName);
+    }
+
+    public WebsiteConfiguration getBucketWebsite(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket",
+                        "The specified bucket does not exist.", 404));
+        if (bucket.getWebsiteConfiguration() == null) {
+            throw new AwsException("NoSuchWebsiteConfiguration", "The specified bucket does not have a website configuration.", 404);
+        }
+        return bucket.getWebsiteConfiguration();
+    }
+
+    public void deleteBucketWebsite(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket",
+                        "The specified bucket does not exist.", 404));
+        bucket.setWebsiteConfiguration(null);
+        bucketStore.put(bucketName, bucket);
+        LOG.infov("Deleted website configuration for bucket: {0}", bucketName);
+    }
+
     public void deleteBucketTagging(String bucketName) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -26,6 +26,7 @@ public class Bucket {
     private String publicAccessBlockConfiguration; // XML string
     private String ownershipControlsConfiguration; // XML string
     private String region;
+    private WebsiteConfiguration websiteConfiguration;
 
     public Bucket() {
         this.tags = new HashMap<>();
@@ -90,4 +91,7 @@ public class Bucket {
 
     public String getRegion() { return region; }
     public void setRegion(String region) { this.region = region; }
+
+    public WebsiteConfiguration getWebsiteConfiguration() { return websiteConfiguration; }
+    public void setWebsiteConfiguration(WebsiteConfiguration websiteConfiguration) { this.websiteConfiguration = websiteConfiguration; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/WebsiteConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/WebsiteConfiguration.java
@@ -1,0 +1,22 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class WebsiteConfiguration {
+    private String indexDocument;
+    private String errorDocument;
+
+    public WebsiteConfiguration() {}
+
+    public WebsiteConfiguration(String indexDocument, String errorDocument) {
+        this.indexDocument = indexDocument;
+        this.errorDocument = errorDocument;
+    }
+
+    public String getIndexDocument() { return indexDocument; }
+    public void setIndexDocument(String indexDocument) { this.indexDocument = indexDocument; }
+
+    public String getErrorDocument() { return errorDocument; }
+    public void setErrorDocument(String errorDocument) { this.errorDocument = errorDocument; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
@@ -1,0 +1,138 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3WebsiteIntegrationTest {
+
+    private static final String BUCKET = "website-test-bucket";
+
+    @Test
+    @Order(1)
+    void setupBucket() {
+        given()
+            .put("/" + BUCKET)
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getWebsiteConfigurationMissingReturns404() {
+        given()
+            .queryParam("website", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchWebsiteConfiguration"));
+    }
+
+    @Test
+    @Order(3)
+    void putWebsiteConfiguration() {
+        String xml = """
+                <WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <IndexDocument>
+                        <Suffix>index.html</Suffix>
+                    </IndexDocument>
+                    <ErrorDocument>
+                        <Key>error.html</Key>
+                    </ErrorDocument>
+                </WebsiteConfiguration>
+                """;
+        given()
+            .queryParam("website", "")
+            .contentType("application/xml")
+            .body(xml)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void getWebsiteConfiguration() {
+        given()
+            .queryParam("website", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<IndexDocument><Suffix>index.html</Suffix></IndexDocument>"))
+            .body(containsString("<ErrorDocument><Key>error.html</Key></ErrorDocument>"));
+    }
+
+    @Test
+    @Order(5)
+    void indexRedirectionNotWorkingYetWithoutIndexFile() {
+        // Access root - should return XML list because index.html is missing
+        given()
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(containsString("<ListBucketResult"));
+    }
+
+    @Test
+    @Order(6)
+    void uploadIndexFile() {
+        given()
+            .contentType("text/html")
+            .body("<html><body>Hello Website</body></html>")
+        .when()
+            .put("/" + BUCKET + "/index.html")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(7)
+    void indexRedirectionWorks() {
+        // Access root - should now return index.html content
+        given()
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .contentType("text/html")
+            .body(equalTo("<html><body>Hello Website</body></html>"));
+    }
+
+    @Test
+    @Order(8)
+    void deleteWebsiteConfiguration() {
+        given()
+            .queryParam("website", "")
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+
+        // Verify it's gone
+        given()
+            .queryParam("website", "")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void cleanup() {
+        given().delete("/" + BUCKET + "/index.html");
+        given().delete("/" + BUCKET);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds initial support for **S3 Static Website Hosting**. 
- Adds the `WebsiteConfiguration` model to handle index and error document settings.
- Implements `GET ?website`, `PUT ?website`, and `DELETE ?website` REST handlers in the S3 service.
- **Redirection Logic**: Implemented an active handler that serves the `index.html` file when a user accesses the root of a bucket configured for website hosting.
This enables developers to test S3-hosted Single Page Applications (SPAs) locally alongside their backends without the overhead of heavier emulators.
## Type of change
- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore
## AWS Compatibility
- **Protocol**: Verified against the S3 `2006-03-01` XML schema.
- **Client Verification**: Tested with **AWS SDK for Java v2** (`putBucketWebsite`) and **AWS CLI** (`aws s3 website`).
- **Behavior**: Wire-compatible with standard S3 responses for `NoSuchWebsiteConfiguration` (404) and index document serving (200).
## Checklist
- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`S3WebsiteIntegrationTest.java`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)