### PR TITLE
security: fix S3 path traversal vulnerability

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -254,6 +254,7 @@ public class S3Controller {
                                 @QueryParam("encoding-type") String encodingType,
                                 @QueryParam("key-marker") String keyMarker,
                                 @Context UriInfo uriInfo) {
+        validateRawUri();
         try {
             if (hasQueryParam(uriInfo, "uploads")) {
                 return handleListMultipartUploads(bucket);
@@ -1681,6 +1682,7 @@ public class S3Controller {
             throw new AwsException("InvalidArgument",
                     "Bucket POST must contain a field named 'key'.", 400);
         }
+        validateKeyNoTraversal(key);
 
         if (fileData == null) {
             throw new AwsException("InvalidArgument",
@@ -1955,6 +1957,34 @@ public class S3Controller {
             return uriInfo.getPathParameters().getFirst("key");
         }
         String rawKey = rawPath.substring(prefixIndex + bucketPrefix.length());
-        return URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+        String key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+        validateKeyNoTraversal(key);
+        return key;
+    }
+
+    private void validateKeyNoTraversal(String key) {
+        if (key == null) return;
+        try {
+            // Use a dummy root to mirror the service pattern, allowing leading slashes but keeping them in sandbox
+            java.nio.file.Path dummyRoot = java.nio.file.Path.of("/s3-sandbox");
+            String safeKey = key;
+            while (safeKey.startsWith("/")) {
+                safeKey = safeKey.substring(1);
+            }
+            java.nio.file.Path resolved = dummyRoot.resolve(safeKey).normalize();
+            if (!resolved.startsWith(dummyRoot)) {
+                throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+            }
+        } catch (java.nio.file.InvalidPathException e) {
+            throw new AwsException("InvalidKey", "The specified key contains invalid characters.", 400);
+        }
+    }
+
+    private void validateRawUri() {
+        String rawUri = currentVertxRequest.getCurrent().request().uri();
+        String lower = rawUri.toLowerCase();
+        if (lower.contains("/..") || lower.contains("../") || lower.contains("%2e%2e") || lower.contains("%2e.") || lower.contains(".%2e")) {
+            throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1775,11 +1775,33 @@ public class S3Service {
     private static final String DATA_SUFFIX = ".s3data";
 
     private Path resolveObjectPath(String bucketName, String key) {
-        return dataRoot.resolve(bucketName).resolve(key + DATA_SUFFIX);
+        Path bucketDir = dataRoot.resolve(bucketName).normalize();
+        
+        String safeKey = key;
+        while (safeKey.startsWith("/")) {
+            safeKey = safeKey.substring(1);
+        }
+        
+        Path resolved = bucketDir.resolve(safeKey + DATA_SUFFIX).normalize();
+        if (!resolved.startsWith(bucketDir)) {
+            throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+        }
+        return resolved;
     }
 
     private Path resolveVersionedPath(String bucketName, String key, String versionId) {
-        return dataRoot.resolve(".versions").resolve(bucketName).resolve(key).resolve(versionId + DATA_SUFFIX);
+        Path baseDir = dataRoot.resolve(".versions").resolve(bucketName).normalize();
+        
+        String safeKey = key;
+        while (safeKey.startsWith("/")) {
+            safeKey = safeKey.substring(1);
+        }
+        
+        Path resolved = baseDir.resolve(safeKey).resolve(versionId + DATA_SUFFIX).normalize();
+        if (!resolved.startsWith(baseDir)) {
+            throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+        }
+        return resolved;
     }
 
     private void writeVersionedFile(String bucketName, String key, String versionId, byte[] data) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -147,6 +147,26 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(10)
+    void pathTraversalInUrlIsNormalizedByFramework() {
+        // Vertx normalizes raw `..` in URL paths before the application layer,
+        // so /test-bucket/../../secret.txt becomes /secret.txt at the framework level
+        // and routes to a bucket-level handler (not S3Service.putObject for test-bucket).
+        //
+        // The actual service-layer traversal guard (resolveObjectPath) is tested
+        // in S3ServiceTest.resolvePathWithTraversalThrows.
+        //
+        // Verify that the normalized path does NOT result in a 500 error.
+        given()
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/../../secret.txt")
+        .then()
+            .statusCode(not(equalTo(500)));
+    }
+
+    @Test
     @Order(11)
     void listObjectsWithPrefix() {
         given()
@@ -1417,5 +1437,40 @@ class S3IntegrationTest {
             .body(containsString("eu-central-1"));
 
         given().when().delete("/" + bucket);
+    }
+    @Test
+    void pathTraversalAttemptsReturn400() {
+        // 1. URL-encoded dots survival through Vertx but decoded by our extractObjectKey
+        given()
+                .urlEncodingEnabled(false)
+                .pathParam("bucket", "test-bucket")
+        .when()
+                .get("/{bucket}/%2e%2e/%2e%2e/secret.txt")
+        .then()
+                .statusCode(400)
+                .body(containsString("InvalidKey"));
+
+        // 2. Null byte (survives URL-decoding but fails java.nio.file.Path validation)
+        given()
+                .urlEncodingEnabled(false)
+                .pathParam("bucket", "test-bucket")
+        .when()
+                .get("/{bucket}/%00.txt")
+        .then()
+                .statusCode(400)
+                .body(containsString("InvalidKey"));
+
+        // 3. Mixed-case percent-encoded traversal (%2E instead of %2e)
+        //    Absolute paths like //etc/passwd are normalized by the HTTP server
+        //    before reaching the controller, so they can't be tested via HTTP.
+        //    They are caught at the service layer by the startsWith(bucketDir) guard.
+        given()
+                .urlEncodingEnabled(false)
+                .pathParam("bucket", "test-bucket")
+        .when()
+                .get("/{bucket}/%2E%2E/%2E%2E/secret.txt")
+        .then()
+                .statusCode(400)
+                .body(containsString("InvalidKey"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -478,4 +478,32 @@ class S3ServiceTest {
         assertFalse(page2.isTruncated());
         assertEquals("c.txt", page2.objects().get(0).getKey());
     }
+
+    @Test
+    void resolvePathWithTraversalThrows() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        
+        // Blocked: going above the bucket root
+        AwsException ex = assertThrows(AwsException.class, () -> 
+                s3Service.putObject("test-bucket", "../outside.txt", "data".getBytes(), null, null));
+        assertEquals("InvalidKey", ex.getErrorCode());
+        
+        // Blocked: deeper traversal
+        assertThrows(AwsException.class, () -> 
+                s3Service.getObject("test-bucket", "dir/../../../etc/passwd"));
+    }
+
+    @Test
+    void putObjectWithInternalTraversalStaysWithinBucket() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        byte[] data = "safe-content".getBytes();
+
+        // Allowed: traversal that normalizes to a path still inside the bucket
+        assertDoesNotThrow(() ->
+                s3Service.putObject("test-bucket", "docs/../file.txt", data, null, null));
+
+        // Retrieve using the same literal key (S3 keys are opaque strings)
+        S3Object got = s3Service.getObject("test-bucket", "docs/../file.txt");
+        assertArrayEquals(data, got.getData());
+    }
 }


### PR DESCRIPTION
## Summary
This PR patches a **critical Path Traversal vulnerability** in the S3 storage service. 
By normalizing and validating user-provided object keys, it ensures that all S3 operations remain strictly jailed within the intended bucket directories. This prevents malicious actors from using keys like `../../` to access or overwrite sensitive files on the host system where Floci is running.
## Type of change
- [x] Bug fix (`fix:`) / Security Patch
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore
## AWS Compatibility
- **Logic**: This fix is internal to the storage layer and does not alter the external S3 wire protocol.
- **Error Handling**: When a traversal attempt is detected, the service now returns a standard `400 Bad Request` with an `InvalidKey` error code, ensuring clients receive a clear security-related rejection.
- **Verification**: Verified using custom integration tests that attempt to PUT and GET objects using traversal-style keys.
## Checklist
- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (Added security test case to `S3IntegrationTest.java`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)