### PR TITLE
fix(cloudformation): forward Lambda environment variables during stack provisioning

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -356,6 +356,16 @@ public class CloudFormationResourceProvisioner {
             req.put("Description", description);
         }
 
+        if (props != null && props.has("Environment")) {
+            JsonNode envNode = engine.resolveNode(props.get("Environment"));
+            if (envNode != null && envNode.has("Variables")) {
+                JsonNode varsNode = envNode.get("Variables");
+                Map<String, String> vars = new HashMap<>();
+                varsNode.fields().forEachRemaining(e -> vars.put(e.getKey(), e.getValue().asText()));
+                req.put("Environment", Map.of("Variables", vars));
+            }
+        }
+
         io.github.hectorvent.floci.services.lambda.model.LambdaFunction func;
         try {
             func = lambdaService.createFunction(region, req);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -245,6 +245,61 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_lambdaWithEnvironmentVariables() {
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "cfn-env-func",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/cfn-test-lambda-role",
+                    "Environment": {
+                      "Variables": {
+                        "MY_VAR": "hello",
+                        "STAGE": "local"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-env-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-env-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/cfn-env-func")
+        .then()
+            .statusCode(200)
+            .body("Configuration.FunctionName", equalTo("cfn-env-func"))
+            .body("Configuration.Environment.Variables.MY_VAR", equalTo("hello"))
+            .body("Configuration.Environment.Variables.STAGE", equalTo("local"));
+    }
+
+    @Test
     void createStack_lambdaWithImageUri() {
         String template = """
             {


### PR DESCRIPTION
## Summary

`CloudFormationResourceProvisioner.provisionLambda()` never read the `Environment` property from the CloudFormation template, so Lambda functions created via CloudFormation/CDK had empty environment variables. The downstream code (`LambdaService.createFunction()`, `ContainerLauncher`) already handles environment variables correctly. The only missing link was the provisioner not forwarding them.

Closes #484

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was that `Environment.Variables` declared in a CloudFormation `AWS::Lambda::Function` resource were silently discarded during stack provisioning. After this fix, environment variables are resolved (including intrinsic function references) and forwarded to `LambdaService.createFunction()`, matching real AWS CloudFormation behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)