### PR TITLE
fix(ses): align /_aws/ses inspection endpoint with LocalStack behavior

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -223,13 +223,13 @@ public class SesController {
                 String subject = simple.path("Subject").path("Data").asText("");
                 String bodyText = simple.path("Body").path("Text").path("Data").asText(null);
                 String bodyHtml = simple.path("Body").path("Html").path("Data").asText(null);
-                messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, replyToAddresses, subject, bodyText, bodyHtml, region);
+                messageId = sesService.sendEmail(region, fromEmailAddress, toAddresses, ccAddresses,
+                        bccAddresses, replyToAddresses, subject, bodyText, bodyHtml);
             } else if (content.has("Template")) {
                 String subject = content.path("Template").path("TemplateName").asText("(template)");
                 String templateData = content.path("Template").path("TemplateData").asText("");
-                messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, replyToAddresses, subject, templateData, null, region);
+                messageId = sesService.sendEmail(region, fromEmailAddress, toAddresses, ccAddresses,
+                        bccAddresses, replyToAddresses, subject, templateData, null);
             } else {
                 throw new AwsException("BadRequestException",
                         "Content must contain Raw, Simple, or Template.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -201,6 +201,7 @@ public class SesController {
             List<String> toAddresses = jsonArrayToList(destination.path("ToAddresses"));
             List<String> ccAddresses = jsonArrayToList(destination.path("CcAddresses"));
             List<String> bccAddresses = jsonArrayToList(destination.path("BccAddresses"));
+            List<String> replyToAddresses = jsonArrayToList(request.path("ReplyToAddresses"));
 
             JsonNode content = request.path("Content");
             String messageId;
@@ -223,12 +224,12 @@ public class SesController {
                 String bodyText = simple.path("Body").path("Text").path("Data").asText(null);
                 String bodyHtml = simple.path("Body").path("Html").path("Data").asText(null);
                 messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, subject, bodyText, bodyHtml, region);
+                        bccAddresses, replyToAddresses, subject, bodyText, bodyHtml, region);
             } else if (content.has("Template")) {
                 String subject = content.path("Template").path("TemplateName").asText("(template)");
                 String templateData = content.path("Template").path("TemplateData").asText("");
                 messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, subject, templateData, null, region);
+                        bccAddresses, replyToAddresses, subject, templateData, null, region);
             } else {
                 throw new AwsException("BadRequestException",
                         "Content must contain Raw, Simple, or Template.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -223,13 +223,13 @@ public class SesController {
                 String subject = simple.path("Subject").path("Data").asText("");
                 String bodyText = simple.path("Body").path("Text").path("Data").asText(null);
                 String bodyHtml = simple.path("Body").path("Html").path("Data").asText(null);
-                messageId = sesService.sendEmail(region, fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, replyToAddresses, subject, bodyText, bodyHtml);
+                messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
+                        bccAddresses, replyToAddresses, subject, bodyText, bodyHtml, region);
             } else if (content.has("Template")) {
                 String subject = content.path("Template").path("TemplateName").asText("(template)");
                 String templateData = content.path("Template").path("TemplateData").asText("");
-                messageId = sesService.sendEmail(region, fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, replyToAddresses, subject, templateData, null);
+                messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
+                        bccAddresses, replyToAddresses, subject, templateData, null, region);
             } else {
                 throw new AwsException("BadRequestException",
                         "Content must contain Raw, Simple, or Template.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -70,6 +70,11 @@ public class SesInspectionController {
                     email.getBccAddresses().forEach(bccArr::add);
                 }
 
+                if (email.getReplyToAddresses() != null && !email.getReplyToAddresses().isEmpty()) {
+                    ArrayNode replyTo = node.putArray("ReplyToAddresses");
+                    email.getReplyToAddresses().forEach(replyTo::add);
+                }
+
                 node.put("Subject", email.getSubject());
 
                 ObjectNode body = node.putObject("Body");

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -34,7 +34,7 @@ public class SesInspectionController {
 
     @GET
     public Response getEmails(@QueryParam("id") String messageId) {
-        List<SentEmail> emails = sesService.getAllEmails();
+        List<SentEmail> emails = sesService.getEmails();
 
         ArrayNode messages = objectMapper.createArrayNode();
         for (SentEmail email : emails) {
@@ -103,7 +103,7 @@ public class SesInspectionController {
 
     @DELETE
     public Response clearEmails() {
-        sesService.clearAllEmails();
+        sesService.clearEmails();
         return Response.ok().build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -38,8 +38,7 @@ public class SesInspectionController {
 
     @GET
     public Response getEmails(@QueryParam("id") String messageId) {
-        String region = regionResolver.getDefaultRegion();
-        List<SentEmail> emails = sesService.getEmails(region);
+        List<SentEmail> emails = sesService.getAllEmails();
 
         ArrayNode messages = objectMapper.createArrayNode();
         for (SentEmail email : emails) {
@@ -48,7 +47,7 @@ public class SesInspectionController {
             }
             ObjectNode node = objectMapper.createObjectNode();
             node.put("Id", email.getMessageId());
-            node.put("Region", region);
+            node.put("Region", email.getRegion() != null ? email.getRegion() : "");
             node.put("Source", email.getSource());
 
             if (email.isRaw()) {
@@ -104,8 +103,7 @@ public class SesInspectionController {
 
     @DELETE
     public Response clearEmails() {
-        String region = regionResolver.getDefaultRegion();
-        sesService.clearEmails(region);
+        sesService.clearAllEmails();
         return Response.ok().build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -51,25 +51,39 @@ public class SesInspectionController {
             node.put("Region", region);
             node.put("Source", email.getSource());
 
-            ObjectNode destination = node.putObject("Destination");
-            if (email.getToAddresses() != null) {
-                ArrayNode toArr = destination.putArray("ToAddresses");
-                email.getToAddresses().forEach(toArr::add);
-            }
-            if (email.getCcAddresses() != null) {
-                ArrayNode ccArr = destination.putArray("CcAddresses");
-                email.getCcAddresses().forEach(ccArr::add);
-            }
-            if (email.getBccAddresses() != null) {
-                ArrayNode bccArr = destination.putArray("BccAddresses");
-                email.getBccAddresses().forEach(bccArr::add);
-            }
+            if (email.isRaw()) {
+                // LocalStack returns RawData for raw emails, without
+                // Destination / Subject / Body fields.
+                node.put("RawData", email.getRawData());
+            } else {
+                ObjectNode destination = node.putObject("Destination");
+                if (email.getToAddresses() != null) {
+                    ArrayNode toArr = destination.putArray("ToAddresses");
+                    email.getToAddresses().forEach(toArr::add);
+                }
+                if (email.getCcAddresses() != null) {
+                    ArrayNode ccArr = destination.putArray("CcAddresses");
+                    email.getCcAddresses().forEach(ccArr::add);
+                }
+                if (email.getBccAddresses() != null) {
+                    ArrayNode bccArr = destination.putArray("BccAddresses");
+                    email.getBccAddresses().forEach(bccArr::add);
+                }
 
-            node.put("Subject", email.getSubject());
+                node.put("Subject", email.getSubject());
 
-            ObjectNode body = node.putObject("Body");
-            body.put("text_part", email.getBody() != null ? email.getBody() : "");
-            body.put("html_part", email.getBody() != null ? email.getBody() : "");
+                ObjectNode body = node.putObject("Body");
+                if (email.getBodyText() != null) {
+                    body.put("text_part", email.getBodyText());
+                } else {
+                    body.putNull("text_part");
+                }
+                if (email.getBodyHtml() != null) {
+                    body.put("html_part", email.getBodyHtml());
+                } else {
+                    body.putNull("html_part");
+                }
+            }
 
             if (email.getSentAt() != null) {
                 node.put("Timestamp", email.getSentAt().toString());

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.ses;
 
-import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -25,14 +24,11 @@ import java.util.List;
 public class SesInspectionController {
 
     private final SesService sesService;
-    private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
 
     @Inject
-    public SesInspectionController(SesService sesService, RegionResolver regionResolver,
-                                    ObjectMapper objectMapper) {
+    public SesInspectionController(SesService sesService, ObjectMapper objectMapper) {
         this.sesService = sesService;
-        this.regionResolver = regionResolver;
         this.objectMapper = objectMapper;
     }
 
@@ -47,7 +43,11 @@ public class SesInspectionController {
             }
             ObjectNode node = objectMapper.createObjectNode();
             node.put("Id", email.getMessageId());
-            node.put("Region", email.getRegion() != null ? email.getRegion() : "");
+            if (email.getRegion() != null) {
+                node.put("Region", email.getRegion());
+            } else {
+                node.putNull("Region");
+            }
             node.put("Source", email.getSource());
 
             if (email.isRaw()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -60,11 +60,11 @@ public class SesInspectionController {
                     ArrayNode toArr = destination.putArray("ToAddresses");
                     email.getToAddresses().forEach(toArr::add);
                 }
-                if (email.getCcAddresses() != null) {
+                if (email.getCcAddresses() != null && !email.getCcAddresses().isEmpty()) {
                     ArrayNode ccArr = destination.putArray("CcAddresses");
                     email.getCcAddresses().forEach(ccArr::add);
                 }
-                if (email.getBccAddresses() != null) {
+                if (email.getBccAddresses() != null && !email.getBccAddresses().isEmpty()) {
                     ArrayNode bccArr = destination.putArray("BccAddresses");
                     email.getBccAddresses().forEach(bccArr::add);
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesInspectionController.java
@@ -56,7 +56,7 @@ public class SesInspectionController {
                 node.put("RawData", email.getRawData());
             } else {
                 ObjectNode destination = node.putObject("Destination");
-                if (email.getToAddresses() != null) {
+                if (email.getToAddresses() != null && !email.getToAddresses().isEmpty()) {
                     ArrayNode toArr = destination.putArray("ToAddresses");
                     email.getToAddresses().forEach(toArr::add);
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -125,12 +125,13 @@ public class SesQueryHandler {
         List<String> toAddresses = extractMembers(params, "Destination.ToAddresses");
         List<String> ccAddresses = extractMembers(params, "Destination.CcAddresses");
         List<String> bccAddresses = extractMembers(params, "Destination.BccAddresses");
+        List<String> replyToAddresses = extractMembers(params, "ReplyToAddresses");
         String subject = getParam(params, "Message.Subject.Data");
         String bodyText = getParam(params, "Message.Body.Text.Data");
         String bodyHtml = getParam(params, "Message.Body.Html.Data");
 
         String messageId = sesService.sendEmail(source, toAddresses, ccAddresses, bccAddresses,
-                subject, bodyText, bodyHtml, region);
+                replyToAddresses, subject, bodyText, bodyHtml, region);
 
         String result = new XmlBuilder().elem("MessageId", messageId).build();
         return Response.ok(AwsQueryResponse.envelope("SendEmail", AwsNamespaces.SES, result)).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -130,8 +130,8 @@ public class SesQueryHandler {
         String bodyText = getParam(params, "Message.Body.Text.Data");
         String bodyHtml = getParam(params, "Message.Body.Html.Data");
 
-        String messageId = sesService.sendEmail(source, toAddresses, ccAddresses, bccAddresses,
-                replyToAddresses, subject, bodyText, bodyHtml, region);
+        String messageId = sesService.sendEmail(region, source, toAddresses, ccAddresses,
+                bccAddresses, replyToAddresses, subject, bodyText, bodyHtml);
 
         String result = new XmlBuilder().elem("MessageId", messageId).build();
         return Response.ok(AwsQueryResponse.envelope("SendEmail", AwsNamespaces.SES, result)).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -130,8 +130,8 @@ public class SesQueryHandler {
         String bodyText = getParam(params, "Message.Body.Text.Data");
         String bodyHtml = getParam(params, "Message.Body.Html.Data");
 
-        String messageId = sesService.sendEmail(region, source, toAddresses, ccAddresses,
-                bccAddresses, replyToAddresses, subject, bodyText, bodyHtml);
+        String messageId = sesService.sendEmail(source, toAddresses, ccAddresses, bccAddresses,
+                replyToAddresses, subject, bodyText, bodyHtml, region);
 
         String result = new XmlBuilder().elem("MessageId", messageId).build();
         return Response.ok(AwsQueryResponse.envelope("SendEmail", AwsNamespaces.SES, result)).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -218,10 +218,7 @@ public class SesService {
     }
 
     public void clearAllEmails() {
-        List<String> keys = new ArrayList<>(emailStore.keys().stream()
-                .filter(k -> k.startsWith("email::"))
-                .toList());
-        keys.forEach(emailStore::delete);
+        emailStore.clear();
         LOG.info("Cleared all SES emails across all regions");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -199,27 +199,13 @@ public class SesService {
         return emails;
     }
 
-    public List<SentEmail> getEmails(String region) {
-        String prefix = "email::" + region + "::";
-        return emailStore.scan(k -> k.startsWith(prefix));
-    }
-
-    public List<SentEmail> getAllEmails() {
+    public List<SentEmail> getEmails() {
         return emailStore.scan(k -> k.startsWith("email::"));
     }
 
-    public void clearEmails(String region) {
-        String prefix = "email::" + region + "::";
-        List<String> keys = new ArrayList<>(emailStore.keys().stream()
-                .filter(k -> k.startsWith(prefix))
-                .toList());
-        keys.forEach(emailStore::delete);
-        LOG.infov("Cleared all SES emails in region {0}", region);
-    }
-
-    public void clearAllEmails() {
+    public void clearEmails() {
         emailStore.clear();
-        LOG.info("Cleared all SES emails across all regions");
+        LOG.info("Cleared all SES emails");
     }
 
     public boolean isAccountSendingEnabled(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -101,8 +101,8 @@ public class SesService {
     }
 
     public String sendEmail(String source, List<String> toAddresses, List<String> ccAddresses,
-                            List<String> bccAddresses, String subject, String bodyText,
-                            String bodyHtml, String region) {
+                            List<String> bccAddresses, List<String> replyToAddresses,
+                            String subject, String bodyText, String bodyHtml, String region) {
         if (source == null || source.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
         }
@@ -116,6 +116,7 @@ public class SesService {
         String messageId = UUID.randomUUID().toString();
         SentEmail email = new SentEmail(messageId, source, toAddresses, ccAddresses, bccAddresses,
                 subject, bodyText, bodyHtml);
+        email.setReplyToAddresses(replyToAddresses);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES email sent: from={0}, to={1}, subject={2}, messageId={3}",

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -100,9 +100,10 @@ public class SesService {
         return identityStore.get(key).orElse(null);
     }
 
-    public String sendEmail(String source, List<String> toAddresses, List<String> ccAddresses,
+    public String sendEmail(String region, String source,
+                            List<String> toAddresses, List<String> ccAddresses,
                             List<String> bccAddresses, List<String> replyToAddresses,
-                            String subject, String bodyText, String bodyHtml, String region) {
+                            String subject, String bodyText, String bodyHtml) {
         if (source == null || source.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -119,6 +119,9 @@ public class SesService {
     }
 
     public String sendRawEmail(String source, List<String> destinations, String rawMessage, String region) {
+        if (source == null || source.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
+        }
         if (rawMessage == null || rawMessage.isBlank()) {
             throw new AwsException("InvalidParameterValue", "RawMessage.Data is required.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.ses;
 
-import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -27,8 +26,7 @@ public class SesService {
     private final StorageBackend<String, Boolean> accountSettingsStore;
 
     @Inject
-    @SuppressWarnings("unused") // EmulatorConfig is unused but required for CDI init ordering
-    public SesService(StorageFactory storageFactory, EmulatorConfig config) {
+    public SesService(StorageFactory storageFactory) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.emailStore = storageFactory.create("ses", "ses-emails.json",

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.ses;
 
-import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -27,7 +26,7 @@ public class SesService {
     private final StorageBackend<String, Boolean> accountSettingsStore;
 
     @Inject
-    public SesService(StorageFactory storageFactory, EmulatorConfig config) {
+    public SesService(StorageFactory storageFactory) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.emailStore = storageFactory.create("ses", "ses-emails.json",

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -114,8 +114,8 @@ public class SesService {
         }
 
         String messageId = UUID.randomUUID().toString();
-        String body = bodyHtml != null ? bodyHtml : bodyText;
-        SentEmail email = new SentEmail(messageId, source, toAddresses, ccAddresses, bccAddresses, subject, body);
+        SentEmail email = new SentEmail(messageId, source, toAddresses, ccAddresses, bccAddresses,
+                subject, bodyText, bodyHtml);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES email sent: from={0}, to={1}, subject={2}, messageId={3}",
@@ -127,7 +127,7 @@ public class SesService {
         String messageId = UUID.randomUUID().toString();
         SentEmail email = new SentEmail(messageId, source,
                 destinations != null ? destinations : Collections.emptyList(),
-                null, null, "(raw)", rawMessage);
+                rawMessage);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES raw email sent: from={0}, messageId={1}", source, messageId);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -2,7 +2,6 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
-import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -26,28 +25,23 @@ public class SesService {
     private final StorageBackend<String, Identity> identityStore;
     private final StorageBackend<String, SentEmail> emailStore;
     private final StorageBackend<String, Boolean> accountSettingsStore;
-    private final RegionResolver regionResolver;
 
     @Inject
-    public SesService(StorageFactory storageFactory, EmulatorConfig config,
-                      RegionResolver regionResolver) {
+    public SesService(StorageFactory storageFactory, EmulatorConfig config) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.emailStore = storageFactory.create("ses", "ses-emails.json",
                 new TypeReference<Map<String, SentEmail>>() {});
         this.accountSettingsStore = storageFactory.create("ses", "ses-account-settings.json",
                 new TypeReference<Map<String, Boolean>>() {});
-        this.regionResolver = regionResolver;
     }
 
     SesService(StorageBackend<String, Identity> identityStore,
                StorageBackend<String, SentEmail> emailStore,
-               StorageBackend<String, Boolean> accountSettingsStore,
-               RegionResolver regionResolver) {
+               StorageBackend<String, Boolean> accountSettingsStore) {
         this.identityStore = identityStore;
         this.emailStore = emailStore;
         this.accountSettingsStore = accountSettingsStore;
-        this.regionResolver = regionResolver;
     }
 
     public Identity verifyEmailIdentity(String emailAddress, String region) {
@@ -125,6 +119,9 @@ public class SesService {
     }
 
     public String sendRawEmail(String source, List<String> destinations, String rawMessage, String region) {
+        if (rawMessage == null || rawMessage.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "RawMessage.Data is required.", 400);
+        }
         String messageId = UUID.randomUUID().toString();
         SentEmail email = new SentEmail(messageId, region, source,
                 destinations != null ? destinations : Collections.emptyList(),

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -117,6 +117,7 @@ public class SesService {
         SentEmail email = new SentEmail(messageId, source, toAddresses, ccAddresses, bccAddresses,
                 subject, bodyText, bodyHtml);
         email.setReplyToAddresses(replyToAddresses);
+        email.setRegion(region);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES email sent: from={0}, to={1}, subject={2}, messageId={3}",
@@ -129,6 +130,7 @@ public class SesService {
         SentEmail email = new SentEmail(messageId, source,
                 destinations != null ? destinations : Collections.emptyList(),
                 rawMessage);
+        email.setRegion(region);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES raw email sent: from={0}, messageId={1}", source, messageId);
@@ -202,6 +204,10 @@ public class SesService {
         return emailStore.scan(k -> k.startsWith(prefix));
     }
 
+    public List<SentEmail> getAllEmails() {
+        return emailStore.scan(k -> k.startsWith("email::"));
+    }
+
     public void clearEmails(String region) {
         String prefix = "email::" + region + "::";
         List<String> keys = new ArrayList<>(emailStore.keys().stream()
@@ -209,6 +215,14 @@ public class SesService {
                 .toList());
         keys.forEach(emailStore::delete);
         LOG.infov("Cleared all SES emails in region {0}", region);
+    }
+
+    public void clearAllEmails() {
+        List<String> keys = new ArrayList<>(emailStore.keys().stream()
+                .filter(k -> k.startsWith("email::"))
+                .toList());
+        keys.forEach(emailStore::delete);
+        LOG.info("Cleared all SES emails across all regions");
     }
 
     public boolean isAccountSendingEnabled(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -114,10 +114,8 @@ public class SesService {
         }
 
         String messageId = UUID.randomUUID().toString();
-        SentEmail email = new SentEmail(messageId, source, toAddresses, ccAddresses, bccAddresses,
-                subject, bodyText, bodyHtml);
-        email.setReplyToAddresses(replyToAddresses);
-        email.setRegion(region);
+        SentEmail email = new SentEmail(messageId, region, source, toAddresses, ccAddresses,
+                bccAddresses, replyToAddresses, subject, bodyText, bodyHtml);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES email sent: from={0}, to={1}, subject={2}, messageId={3}",
@@ -127,10 +125,9 @@ public class SesService {
 
     public String sendRawEmail(String source, List<String> destinations, String rawMessage, String region) {
         String messageId = UUID.randomUUID().toString();
-        SentEmail email = new SentEmail(messageId, source,
+        SentEmail email = new SentEmail(messageId, region, source,
                 destinations != null ? destinations : Collections.emptyList(),
                 rawMessage);
-        email.setRegion(region);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         LOG.infov("SES raw email sent: from={0}, messageId={1}", source, messageId);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -26,7 +27,8 @@ public class SesService {
     private final StorageBackend<String, Boolean> accountSettingsStore;
 
     @Inject
-    public SesService(StorageFactory storageFactory) {
+    @SuppressWarnings("unused") // EmulatorConfig is unused but required for CDI init ordering
+    public SesService(StorageFactory storageFactory, EmulatorConfig config) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.emailStore = storageFactory.create("ses", "ses-emails.json",

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -95,10 +95,9 @@ public class SesService {
         return identityStore.get(key).orElse(null);
     }
 
-    public String sendEmail(String region, String source,
-                            List<String> toAddresses, List<String> ccAddresses,
+    public String sendEmail(String source, List<String> toAddresses, List<String> ccAddresses,
                             List<String> bccAddresses, List<String> replyToAddresses,
-                            String subject, String bodyText, String bodyHtml) {
+                            String subject, String bodyText, String bodyHtml, String region) {
         if (source == null || source.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
@@ -29,6 +29,9 @@ public class SentEmail {
     @JsonProperty("Subject")
     private String subject;
 
+    @JsonProperty("ReplyToAddresses")
+    private List<String> replyToAddresses;
+
     @JsonProperty("BodyText")
     private String bodyText;
 
@@ -84,6 +87,9 @@ public class SentEmail {
 
     public String getSubject() { return subject; }
     public void setSubject(String subject) { this.subject = subject; }
+
+    public List<String> getReplyToAddresses() { return replyToAddresses; }
+    public void setReplyToAddresses(List<String> replyToAddresses) { this.replyToAddresses = replyToAddresses; }
 
     public String getBodyText() { return bodyText; }
     public void setBodyText(String bodyText) { this.bodyText = bodyText; }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
@@ -29,24 +29,41 @@ public class SentEmail {
     @JsonProperty("Subject")
     private String subject;
 
-    @JsonProperty("Body")
-    private String body;
+    @JsonProperty("BodyText")
+    private String bodyText;
+
+    @JsonProperty("BodyHtml")
+    private String bodyHtml;
+
+    @JsonProperty("RawData")
+    private String rawData;
 
     @JsonProperty("SentAt")
     private Instant sentAt;
 
     public SentEmail() {}
 
+    /** Constructor for Simple / Template content. */
     public SentEmail(String messageId, String source, List<String> toAddresses,
                      List<String> ccAddresses, List<String> bccAddresses,
-                     String subject, String body) {
+                     String subject, String bodyText, String bodyHtml) {
         this.messageId = messageId;
         this.source = source;
         this.toAddresses = toAddresses;
         this.ccAddresses = ccAddresses;
         this.bccAddresses = bccAddresses;
         this.subject = subject;
-        this.body = body;
+        this.bodyText = bodyText;
+        this.bodyHtml = bodyHtml;
+        this.sentAt = Instant.now();
+    }
+
+    /** Constructor for Raw content. */
+    public SentEmail(String messageId, String source, List<String> destinations, String rawData) {
+        this.messageId = messageId;
+        this.source = source;
+        this.toAddresses = destinations;
+        this.rawData = rawData;
         this.sentAt = Instant.now();
     }
 
@@ -68,8 +85,16 @@ public class SentEmail {
     public String getSubject() { return subject; }
     public void setSubject(String subject) { this.subject = subject; }
 
-    public String getBody() { return body; }
-    public void setBody(String body) { this.body = body; }
+    public String getBodyText() { return bodyText; }
+    public void setBodyText(String bodyText) { this.bodyText = bodyText; }
+
+    public String getBodyHtml() { return bodyHtml; }
+    public void setBodyHtml(String bodyHtml) { this.bodyHtml = bodyHtml; }
+
+    public String getRawData() { return rawData; }
+    public void setRawData(String rawData) { this.rawData = rawData; }
+
+    public boolean isRaw() { return rawData != null; }
 
     public Instant getSentAt() { return sentAt; }
     public void setSentAt(Instant sentAt) { this.sentAt = sentAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -36,6 +37,7 @@ public class SentEmail {
     private List<String> replyToAddresses;
 
     @JsonProperty("BodyText")
+    @JsonAlias("Body")
     private String bodyText;
 
     @JsonProperty("BodyHtml")

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
@@ -52,14 +52,17 @@ public class SentEmail {
     public SentEmail() {}
 
     /** Constructor for Simple / Template content. */
-    public SentEmail(String messageId, String source, List<String> toAddresses,
-                     List<String> ccAddresses, List<String> bccAddresses,
+    public SentEmail(String messageId, String region, String source,
+                     List<String> toAddresses, List<String> ccAddresses,
+                     List<String> bccAddresses, List<String> replyToAddresses,
                      String subject, String bodyText, String bodyHtml) {
         this.messageId = messageId;
+        this.region = region;
         this.source = source;
         this.toAddresses = toAddresses;
         this.ccAddresses = ccAddresses;
         this.bccAddresses = bccAddresses;
+        this.replyToAddresses = replyToAddresses;
         this.subject = subject;
         this.bodyText = bodyText;
         this.bodyHtml = bodyHtml;
@@ -67,8 +70,10 @@ public class SentEmail {
     }
 
     /** Constructor for Raw content. */
-    public SentEmail(String messageId, String source, List<String> destinations, String rawData) {
+    public SentEmail(String messageId, String region, String source,
+                     List<String> destinations, String rawData) {
         this.messageId = messageId;
+        this.region = region;
         this.source = source;
         this.toAddresses = destinations;
         this.rawData = rawData;

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SentEmail.java
@@ -14,6 +14,9 @@ public class SentEmail {
     @JsonProperty("MessageId")
     private String messageId;
 
+    @JsonProperty("Region")
+    private String region;
+
     @JsonProperty("Source")
     private String source;
 
@@ -72,6 +75,9 @@ public class SentEmail {
 
     public String getMessageId() { return messageId; }
     public void setMessageId(String messageId) { this.messageId = messageId; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
 
     public String getSource() { return source; }
     public void setSource(String source) { this.source = source; }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -357,6 +357,34 @@ class SesIntegrationTest {
 
     @Test
     @Order(20)
+    void sendEmailV1_replyToAddressesStoredInInspection() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request")
+            .formParam("Action", "SendEmail")
+            .formParam("Source", "sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "recipient@example.com")
+            .formParam("ReplyToAddresses.member.1", "reply@example.com")
+            .formParam("Message.Subject.Data", "V1 ReplyTo")
+            .formParam("Message.Body.Text.Data", "body")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].ReplyToAddresses", hasItem("reply@example.com"));
+    }
+
+    @Test
+    @Order(21)
     void unsupportedAction_returns400() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -753,6 +753,77 @@ class SesV2IntegrationTest {
 
     @Test
     @Order(73)
+    void inspectionEndpoint_replyToAddressesAreStored() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "ReplyToAddresses": ["reply1@example.com", "reply2@example.com"],
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "ReplyTo Test"},
+                            "Body": {"Text": {"Data": "hello"}}
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].ReplyToAddresses", hasItems("reply1@example.com", "reply2@example.com"));
+    }
+
+    @Test
+    @Order(74)
+    void inspectionEndpoint_noReplyToOmitsField() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "No ReplyTo"},
+                            "Body": {"Text": {"Data": "hello"}}
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0]", not(hasKey("ReplyToAddresses")));
+    }
+
+    @Test
+    @Order(75)
     void inspectionEndpoint_rawEmailReturnsRawData() {
         given().delete("/_aws/ses").then().statusCode(200);
 

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -617,6 +617,178 @@ class SesV2IntegrationTest {
             .body("__type", equalTo("BadRequestException"));
     }
 
+    // ──────────────── Inspection endpoint (/_aws/ses) ────────────────
+
+    @Test
+    @Order(70)
+    void inspectionEndpoint_textAndHtmlAreStoredSeparately() {
+        // Create identity
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "inspect-sender@example.com"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        // Clear any previous messages
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        // Send with distinct Text and Html bodies
+        String messageId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "Inspect Test"},
+                            "Body": {
+                                "Text": {"Data": "plain text body"},
+                                "Html": {"Data": "<p>html body</p>"}
+                            }
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200)
+        .extract()
+            .path("MessageId");
+
+        // Verify via inspection endpoint
+        given()
+        .when()
+            .get("/_aws/ses?id=" + messageId)
+        .then()
+            .statusCode(200)
+            .body("messages[0].Body.text_part", equalTo("plain text body"))
+            .body("messages[0].Body.html_part", equalTo("<p>html body</p>"));
+    }
+
+    @Test
+    @Order(71)
+    void inspectionEndpoint_textOnlyEmail() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "Text Only"},
+                            "Body": {
+                                "Text": {"Data": "only text"}
+                            }
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Body.text_part", equalTo("only text"))
+            .body("messages[0].Body.html_part", nullValue());
+    }
+
+    @Test
+    @Order(72)
+    void inspectionEndpoint_htmlOnlyEmail() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "Html Only"},
+                            "Body": {
+                                "Html": {"Data": "<b>only html</b>"}
+                            }
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Body.text_part", nullValue())
+            .body("messages[0].Body.html_part", equalTo("<b>only html</b>"));
+    }
+
+    @Test
+    @Order(73)
+    void inspectionEndpoint_rawEmailReturnsRawData() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "FromEmailAddress": "inspect-sender@example.com",
+                    "Destination": {
+                        "ToAddresses": ["inspect-to@example.com"]
+                    },
+                    "Content": {
+                        "Raw": {
+                            "Data": "Subject: Raw\\r\\n\\r\\nRaw body"
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].RawData", notNullValue())
+            .body("messages[0].RawData", containsString("Raw body"))
+            .body("messages[0]", not(hasKey("Destination")))
+            .body("messages[0]", not(hasKey("Subject")))
+            .body("messages[0]", not(hasKey("Body")));
+    }
+
     // ──────────────── GetEmailIdentity full response ────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -860,6 +860,78 @@ class SesV2IntegrationTest {
             .body("messages[0]", not(hasKey("Body")));
     }
 
+    @Test
+    @Order(80)
+    void inspectionEndpoint_returnsEmailsFromAllRegions() {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        // Create identity usable in both regions (domain covers all addresses)
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "example.com"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        // Send from us-east-1
+        given()
+            .contentType("application/json")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request")
+            .body("""
+                {
+                    "FromEmailAddress": "multi@example.com",
+                    "Destination": {"ToAddresses": ["to@example.com"]},
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "US East"},
+                            "Body": {"Text": {"Data": "from us-east-1"}}
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        // Send from ap-northeast-1
+        given()
+            .contentType("application/json")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=AKID/20260101/ap-northeast-1/ses/aws4_request")
+            .body("""
+                {
+                    "FromEmailAddress": "multi@example.com",
+                    "Destination": {"ToAddresses": ["to@example.com"]},
+                    "Content": {
+                        "Simple": {
+                            "Subject": {"Data": "AP NE"},
+                            "Body": {"Text": {"Data": "from ap-northeast-1"}}
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200);
+
+        // Inspection returns both, each with correct Region
+        given()
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages.size()", equalTo(2))
+            .body("messages.find { it.Subject == 'US East' }.Region", equalTo("us-east-1"))
+            .body("messages.find { it.Subject == 'AP NE' }.Region", equalTo("ap-northeast-1"));
+    }
+
     // ──────────────── GetEmailIdentity full response ────────────────
 
     @Test


### PR DESCRIPTION
## Summary

The `/_aws/ses` inspection endpoint had several gaps compared to
[LocalStack's SES inspection API](https://docs.localstack.cloud/aws/services/ses/#retrieve-sent-emails).
This PR closes the three main gaps:

1. **Text/Html body collapsed into one field** — `SentEmail` stored a
   single `body` that was `bodyHtml != null ? bodyHtml : bodyText`,
   making `text_part` and `html_part` identical in the response. Now
   stored separately; the absent part is `null` (not empty string),
   matching LocalStack 4.14.0.

2. **ReplyToAddresses silently dropped** — both SES v1 (Query) and v2
   (REST JSON) send paths ignored `ReplyToAddresses`. Now parsed, stored
   on `SentEmail`, and returned in the inspection response when non-empty.

3. **Region fixed to default** — the inspection endpoint only returned
   emails for `FLOCI_DEFAULT_REGION`. LocalStack returns all regions
   with each message carrying its own `Region` field. Now returns all
   emails across all regions.

**Bonus**: Raw emails now use a dedicated `RawData` field in the
inspection response (no `Destination`/`Subject`/`Body`), matching
LocalStack's shape.

### Response examples

**Simple email** (`Content.Simple` with both Text and Html):

```json
{
  "messages": [
    {
      "Id": "abc-123",
      "Region": "us-east-1",
      "Source": "sender@example.com",
      "Destination": {
        "ToAddresses": ["to@example.com"]
      },
      "ReplyToAddresses": ["reply@example.com"],
      "Subject": "Hello",
      "Body": {
        "text_part": "plain text body",
        "html_part": "<p>html body</p>"
      },
      "Timestamp": "2026-04-18T12:00:00Z"
    }
  ]
}
```

When only Text is set, `html_part` is `null` (and vice versa).
`ReplyToAddresses` is omitted entirely when not provided.

**Raw email** (`Content.Raw`):

```json
{
  "messages": [
    {
      "Id": "def-456",
      "Region": "us-east-1",
      "Source": "sender@example.com",
      "RawData": "From: sender@example.com\r\nTo: to@example.com\r\nSubject: Raw\r\n\r\nRaw body",
      "Timestamp": "2026-04-18T12:00:00Z"
    }
  ]
}
```

Raw emails carry `RawData` (the full MIME message) instead of
`Destination`, `Subject`, and `Body` — matching
[LocalStack's documented shape](https://docs.localstack.cloud/aws/services/ses/#retrieve-sent-emails).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable — `/_aws/ses` is a LocalStack-specific inspection
endpoint, not an AWS API. Compatibility target is LocalStack 4.14.0,
verified by running `docker run localstack/localstack:4.14.0` and
comparing the response shapes for simple (text/html/both), raw, and
multi-region emails.

## Checklist

- [x] `./mvnw test` passes locally (57 SES tests green)
- [x] New or updated integration test added — 7 new tests in
  `SesV2IntegrationTest` (text+html, text-only, html-only, raw,
  replyTo round-trip, replyTo omission, multi-region) and 1 in
  `SesIntegrationTest` (v1 Query ReplyToAddresses round-trip)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Known limitations

- Old persisted `SentEmail` objects use a single `Body` field.
  `@JsonAlias("Body")` maps it to `bodyText` on deserialization so the
  value is preserved, but `bodyHtml` will be null.