### PR TITLE
feat(cognito): implement AdminEnableUser and AdminDisableUser actions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -55,6 +55,8 @@ public class CognitoJsonHandler {
             case "AdminSetUserPassword" -> handleAdminSetUserPassword(request);
             case "AdminUpdateUserAttributes" -> handleAdminUpdateUserAttributes(request);
             case "AdminUserGlobalSignOut" -> handleAdminUserGlobalSignOut(request);
+            case "AdminEnableUser" -> handleAdminEnableUser(request);
+            case "AdminDisableUser" -> handleAdminDisableUser(request);
             case "ListUsers" -> handleListUsers(request);
             case "InitiateAuth" -> handleInitiateAuth(request);
             case "AdminInitiateAuth" -> handleAdminInitiateAuth(request);
@@ -286,6 +288,16 @@ public class CognitoJsonHandler {
                 request.path("UserPoolId").asText(),
                 request.path("Username").asText()
         );
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleAdminEnableUser(JsonNode request) {
+        service.adminEnableUser(request.path("UserPoolId").asText(), request.path("Username").asText());
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleAdminDisableUser(JsonNode request) {
+        service.adminDisableUser(request.path("UserPoolId").asText(), request.path("Username").asText());
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -411,6 +411,22 @@ public class CognitoService {
         userStore.put(userKey(userPoolId, user.getUsername()), user);
     }
 
+    public void adminEnableUser(String userPoolId, String username) {
+        CognitoUser user = adminGetUser(userPoolId, username);
+        user.setEnabled(true);
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        userStore.put(userKey(userPoolId, user.getUsername()), user);
+        LOG.infov("Enabled user {0} in pool {1}", user.getUsername(), userPoolId);
+    }
+
+    public void adminDisableUser(String userPoolId, String username) {
+        CognitoUser user = adminGetUser(userPoolId, username);
+        user.setEnabled(false);
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        userStore.put(userKey(userPoolId, user.getUsername()), user);
+        LOG.infov("Disabled user {0} in pool {1}", user.getUsername(), userPoolId);
+    }
+
     public List<CognitoUser> listUsers(String userPoolId, String filter) {
         String prefix = userPoolId + "::";
         List<CognitoUser> all = userStore.scan(k -> k.startsWith(prefix));
@@ -635,6 +651,9 @@ public class CognitoService {
         }
 
         CognitoUser user = adminGetUser(pool.getId(), username);
+        if (!user.isEnabled()) {
+            throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
+        }
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);
         }
@@ -687,6 +706,9 @@ public class CognitoService {
         }
 
         CognitoUser user = adminGetUser(pool.getId(), username);
+        if (!user.isEnabled()) {
+            throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
+        }
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -709,4 +709,78 @@ class CognitoServiceTest {
 
         assertEquals(0, groupStore.scan(k -> k.startsWith(prefix)).size());
     }
+
+    // =========================================================================
+    // Issue #433 — AdminEnableUser / AdminDisableUser
+    // =========================================================================
+
+    @Test
+    void adminDisableUserSetsEnabledFalse() {
+        UserPool pool = createPoolAndUser();
+
+        CognitoUser before = service.adminGetUser(pool.getId(), "alice");
+        assertTrue(before.isEnabled(), "User should be enabled by default");
+
+        service.adminDisableUser(pool.getId(), "alice");
+
+        CognitoUser after = service.adminGetUser(pool.getId(), "alice");
+        assertFalse(after.isEnabled(), "User should be disabled after adminDisableUser");
+    }
+
+    @Test
+    void adminEnableUserSetsEnabledTrue() {
+        UserPool pool = createPoolAndUser();
+        service.adminDisableUser(pool.getId(), "alice");
+
+        service.adminEnableUser(pool.getId(), "alice");
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "alice");
+        assertTrue(user.isEnabled(), "User should be enabled after adminEnableUser");
+    }
+
+    @Test
+    void disabledUserCannotAuthenticate() {
+        UserPool pool = createPoolAndUser();
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(), "c", false, false, List.of(), List.of());
+
+        service.adminDisableUser(pool.getId(), "alice");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.initiateAuth(client.getClientId(), "USER_PASSWORD_AUTH",
+                        Map.of("USERNAME", "alice", "PASSWORD", "Perm1234!")));
+        assertEquals("UserNotConfirmedException", ex.getErrorCode());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void reEnabledUserCanAuthenticate() {
+        UserPool pool = createPoolAndUser();
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(), "c", false, false, List.of(), List.of());
+
+        service.adminDisableUser(pool.getId(), "alice");
+        service.adminEnableUser(pool.getId(), "alice");
+
+        Map<String, Object> result = service.initiateAuth(
+                client.getClientId(), "USER_PASSWORD_AUTH",
+                Map.of("USERNAME", "alice", "PASSWORD", "Perm1234!"));
+        assertNotNull(((Map<String, Object>) result.get("AuthenticationResult")).get("AccessToken"));
+    }
+
+    @Test
+    void adminDisableUserNonexistentThrows() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+
+        assertThrows(AwsException.class, () ->
+                service.adminDisableUser(pool.getId(), "ghost"));
+    }
+
+    @Test
+    void adminEnableUserNonexistentThrows() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+
+        assertThrows(AwsException.class, () ->
+                service.adminEnableUser(pool.getId(), "ghost"));
+    }
 }


### PR DESCRIPTION
Closes #433

- Add adminEnableUser/adminDisableUser methods to CognitoService
- Wire up AdminEnableUser/AdminDisableUser in CognitoJsonHandler dispatch
- Add unit tests verifying enable/disable toggle, auth rejection for disabled users, re-enable flow, and nonexistent user error handling

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
