### PR TITLE
feat(s3): preserve explicit object SSE headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
 
 * **bedrock-runtime:** add stub for Converse and InvokeModel ([#87](https://github.com/floci-io/floci/issues/87))
+* **s3:** preserve explicit object server-side-encryption headers on PutObject, GetObject, HeadObject, CopyObject, and multipart uploads
 
 
 ### Bug Fixes

--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -139,6 +139,7 @@ Floci now persists and returns the following object attribute state on S3 object
 - checksum metadata for object reads and `GetObjectAttributes`
 - multipart part manifests for `GetObjectAttributes(ObjectParts)`
 - canned object ACLs from `x-amz-acl` on `PutObject`, `CopyObject`, and multipart initiation
+- explicit object SSE headers from `x-amz-server-side-encryption` on `PutObject`, `CopyObject`, and multipart initiation, replayed on `GetObject` and `HeadObject`
 
 Current limitations:
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -410,6 +410,7 @@ public class S3Controller {
             String persistedEncoding = toPersistedContentEncoding(contentEncoding);
             String contentDisposition = httpHeaders.getHeaderString("Content-Disposition");
             String cacheControl = httpHeaders.getHeaderString("Cache-Control");
+            String serverSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
             String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     httpHeaders.getHeaderString("x-amz-storage-class"),
@@ -417,6 +418,7 @@ public class S3Controller {
                     lockMode, retainUntil, legalHold,
                     contentDisposition,
                     cacheControl,
+                    serverSideEncryption,
                     cannedAcl);
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
@@ -745,6 +747,7 @@ public class S3Controller {
                         extractUserMetadata(httpHeaders),
                         httpHeaders.getHeaderString("x-amz-storage-class"),
                         httpHeaders.getHeaderString("Content-Disposition"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption"),
                         httpHeaders.getHeaderString("x-amz-acl"));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
@@ -1327,6 +1330,9 @@ public class S3Controller {
         if (obj.getCacheControl() != null) {
             resp.header("Cache-Control", obj.getCacheControl());
         }
+        if (obj.getServerSideEncryption() != null) {
+            resp.header("x-amz-server-side-encryption", obj.getServerSideEncryption());
+        }
         if (obj.getMetadata() != null) {
             for (Map.Entry<String, String> entry : obj.getMetadata().entrySet()) {
                 resp.header("x-amz-meta-" + entry.getKey(), entry.getValue());
@@ -1373,6 +1379,7 @@ public class S3Controller {
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
         String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
+        String copyServerSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
         String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
         S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
                 httpHeaders.getHeaderString("x-amz-metadata-directive"),
@@ -1382,6 +1389,7 @@ public class S3Controller {
                 copyContentEncoding,
                 copyContentDisposition,
                 copyCacheControl,
+                copyServerSideEncryption,
                 cannedAcl);
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -43,6 +44,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,8 +65,16 @@ public class S3Controller {
     private static final DateTimeFormatter RFC_822 = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
+    private static final XMLInputFactory NOTIFICATION_XML_FACTORY;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        NOTIFICATION_XML_FACTORY = XMLInputFactory.newInstance();
+        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
+        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    }
 
     private final S3Service s3Service;
     private final S3SelectService s3SelectService;
@@ -1069,25 +1082,90 @@ public class S3Controller {
 
     private static List<ParsedNotificationGroup> parseNotificationGroups(
             String xml, String groupElement, String arnElement) {
-        var groups = XmlParser.extractGroupsMulti(xml, groupElement);
-        var filters = XmlParser.extractPairsPerGroup(xml, groupElement,
-                "FilterRule", "Name", "Value");
         List<ParsedNotificationGroup> result = new ArrayList<>();
-        for (int i = 0; i < groups.size(); i++) {
-            var group = groups.get(i);
-            String id = group.getOrDefault("Id", List.of("")).getFirst();
-            List<String> arns = group.get(arnElement);
-            List<String> events = group.get("Event");
-            if (arns != null && !arns.isEmpty() && events != null && !events.isEmpty()) {
-                List<FilterRule> rules = i < filters.size()
-                        ? filters.get(i).entrySet().stream()
-                            .map(e -> new FilterRule(e.getKey(), e.getValue()))
-                            .toList()
-                        : List.of();
-                result.add(new ParsedNotificationGroup(id, arns.getFirst(), events, rules));
+        if (xml == null || xml.isEmpty()) {
+            return result;
+        }
+        try {
+            XMLStreamReader reader = NOTIFICATION_XML_FACTORY.createXMLStreamReader(new StringReader(xml));
+            while (reader.hasNext()) {
+                int event = reader.next();
+                if (event == XMLStreamConstants.START_ELEMENT && groupElement.equals(reader.getLocalName())) {
+                    ParsedNotificationGroup parsed = readNotificationGroup(reader, groupElement, arnElement);
+                    if (parsed.arn() != null && !parsed.events().isEmpty()) {
+                        result.add(parsed);
+                    }
+                }
             }
+            reader.close();
+        } catch (Exception ignored) {
         }
         return result;
+    }
+
+    private static ParsedNotificationGroup readNotificationGroup(
+            XMLStreamReader reader, String groupElement, String arnElement) throws XMLStreamException {
+        String id = "";
+        String arn = null;
+        List<String> events = new ArrayList<>();
+        List<FilterRule> filterRules = new ArrayList<>();
+        int depth = 1;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String local = reader.getLocalName();
+                if (depth == 1 && "Id".equals(local)) {
+                    id = reader.getElementText();
+                } else if (depth == 1 && arnElement.equals(local)) {
+                    arn = reader.getElementText();
+                } else if (depth == 1 && "Event".equals(local)) {
+                    events.add(reader.getElementText());
+                } else if ("FilterRule".equals(local)) {
+                    FilterRule rule = readFilterRule(reader);
+                    if (rule != null) {
+                        filterRules.add(rule);
+                    }
+                } else {
+                    depth++;
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                String local = reader.getLocalName();
+                if (groupElement.equals(local) && depth == 1) {
+                    break;
+                }
+                depth--;
+            }
+        }
+
+        return new ParsedNotificationGroup(id, arn, events, filterRules);
+    }
+
+    private static FilterRule readFilterRule(XMLStreamReader reader) throws XMLStreamException {
+        String name = null;
+        String value = null;
+        int depth = 1;
+
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String local = reader.getLocalName();
+                if (depth == 1 && "Name".equals(local)) {
+                    name = reader.getElementText();
+                } else if (depth == 1 && "Value".equals(local)) {
+                    value = reader.getElementText();
+                } else {
+                    depth++;
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                if ("FilterRule".equals(reader.getLocalName()) && depth == 1) {
+                    break;
+                }
+                depth--;
+            }
+        }
+
+        return name != null && value != null ? new FilterRule(name, value) : null;
     }
 
     private static void appendFilterRules(XmlBuilder xml, List<FilterRule> rules) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -13,9 +13,11 @@ import io.github.hectorvent.floci.services.s3.model.MultipartUpload;
 import io.github.hectorvent.floci.services.s3.model.FilterRule;
 import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
 import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
+import io.github.hectorvent.floci.services.s3.model.CopyObjectOptions;
 import io.github.hectorvent.floci.services.s3.model.QueueNotification;
 import io.github.hectorvent.floci.services.s3.model.ObjectLockRetention;
 import io.github.hectorvent.floci.services.s3.model.Part;
+import io.github.hectorvent.floci.services.s3.model.PutObjectOptions;
 import io.github.hectorvent.floci.services.s3.model.S3Checksum;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import io.github.hectorvent.floci.services.s3.model.TopicNotification;
@@ -413,13 +415,16 @@ public class S3Controller {
             String serverSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
             String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
-                    httpHeaders.getHeaderString("x-amz-storage-class"),
-                    persistedEncoding,
-                    lockMode, retainUntil, legalHold,
-                    contentDisposition,
-                    cacheControl,
-                    serverSideEncryption,
-                    cannedAcl);
+                    new PutObjectOptions()
+                            .withStorageClass(httpHeaders.getHeaderString("x-amz-storage-class"))
+                            .withContentEncoding(persistedEncoding)
+                            .withObjectLockMode(lockMode)
+                            .withRetainUntilDate(retainUntil)
+                            .withLegalHoldStatus(legalHold)
+                            .withContentDisposition(contentDisposition)
+                            .withCacheControl(cacheControl)
+                            .withServerSideEncryption(serverSideEncryption)
+                            .withAcl(cannedAcl));
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
@@ -1382,15 +1387,16 @@ public class S3Controller {
         String copyServerSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
         String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
         S3Object copy = s3Service.copyObject(sourceBucket, sourceKey, destBucket, destKey,
-                httpHeaders.getHeaderString("x-amz-metadata-directive"),
-                extractUserMetadata(httpHeaders),
-                httpHeaders.getHeaderString("x-amz-storage-class"),
-                contentType,
-                copyContentEncoding,
-                copyContentDisposition,
-                copyCacheControl,
-                copyServerSideEncryption,
-                cannedAcl);
+                new CopyObjectOptions()
+                        .withMetadataDirective(httpHeaders.getHeaderString("x-amz-metadata-directive"))
+                        .withReplacementMetadata(extractUserMetadata(httpHeaders))
+                        .withStorageClass(httpHeaders.getHeaderString("x-amz-storage-class"))
+                        .withContentType(contentType)
+                        .withContentEncoding(copyContentEncoding)
+                        .withContentDisposition(copyContentDisposition)
+                        .withCacheControl(copyCacheControl)
+                        .withServerSideEncryption(copyServerSideEncryption)
+                        .withAcl(cannedAcl));
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyObjectResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -188,30 +188,31 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return putObject(bucketName, key, data, contentType, metadata, storageClass, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String contentEncoding,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                              String contentDisposition, String cacheControl, String acl) {
+                              String contentDisposition, String cacheControl, String serverSideEncryption, String acl) {
         S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl, acl);
+                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl,
+                serverSideEncryption, acl);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
     }
@@ -222,7 +223,7 @@ public class S3Service {
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
         return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
@@ -230,14 +231,15 @@ public class S3Service {
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
         return storeObject(bucketName, key, data, contentType, metadata, storageClass, checksum, parts,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
+                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null, null);
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata, String storageClass,
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                                 String contentEncoding, String contentDisposition, String cacheControl, String acl) {
+                                 String contentEncoding, String contentDisposition, String cacheControl,
+                                 String serverSideEncryption, String acl) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
@@ -252,6 +254,7 @@ public class S3Service {
         object.setContentEncoding(contentEncoding);
         object.setContentDisposition(contentDisposition);
         object.setCacheControl(cacheControl);
+        object.setServerSideEncryption(serverSideEncryption);
         object.setAcl(cannedObjectAclXml(acl));
 
         if (bucket.isVersioningEnabled()) {
@@ -597,7 +600,7 @@ public class S3Service {
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey) {
         return copyObject(sourceBucket, sourceKey, destBucket, destKey,
-                null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
@@ -605,14 +608,14 @@ public class S3Service {
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType) {
         return copyObject(sourceBucket, sourceKey, destBucket, destKey, metadataDirective,
-                replacementMetadata, storageClass, contentType, null, null, null, null);
+                replacementMetadata, storageClass, contentType, null, null, null, null, null);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey,
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType, String contentEncoding,
-                               String contentDisposition, String cacheControl, String acl) {
+                               String contentDisposition, String cacheControl, String serverSideEncryption, String acl) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
 
@@ -627,9 +630,10 @@ public class S3Service {
         String effectiveContentEncoding = replaceMetadata && contentEncoding != null ? contentEncoding : source.getContentEncoding();
         String effectiveContentDisposition = replaceMetadata && contentDisposition != null ? contentDisposition : source.getContentDisposition();
         String effectiveCacheControl = replaceMetadata && cacheControl != null ? cacheControl : source.getCacheControl();
+        String effectiveServerSideEncryption = serverSideEncryption != null ? serverSideEncryption : source.getServerSideEncryption();
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
                 effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null,
-                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl, acl);
+                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl, effectiveServerSideEncryption, acl);
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
@@ -918,17 +922,17 @@ public class S3Service {
     // --- Multipart Upload Operations ---
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType) {
-        return initiateMultipartUpload(bucket, key, contentType, null, null, null, null);
+        return initiateMultipartUpload(bucket, key, contentType, null, null, null, null, null);
     }
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass) {
-        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, null, null);
+        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, null, null, null);
     }
 
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass,
-                                                   String contentDisposition, String acl) {
+                                                   String contentDisposition, String serverSideEncryption, String acl) {
         ensureBucketExists(bucket);
         if (acl != null && !acl.isBlank()) {
             cannedObjectAclXml(acl);
@@ -939,6 +943,7 @@ public class S3Service {
         }
         upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
         upload.setContentDisposition(contentDisposition);
+        upload.setServerSideEncryption(serverSideEncryption);
         upload.setAcl(acl);
 
         if (inMemory) {
@@ -1046,7 +1051,7 @@ public class S3Service {
             S3Checksum checksum = buildChecksum(allData, completedParts, true);
             S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
                     upload.getStorageClass(), checksum, completedParts, null, null, null,
-                    null, upload.getContentDisposition(), null, upload.getAcl());
+                    null, upload.getContentDisposition(), null, upload.getServerSideEncryption(), upload.getAcl());
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);
@@ -1686,6 +1691,7 @@ public class S3Service {
         copy.setContentEncoding(source.getContentEncoding());
         copy.setContentDisposition(source.getContentDisposition());
         copy.setCacheControl(source.getCacheControl());
+        copy.setServerSideEncryption(source.getServerSideEncryption());
         copy.setSize(source.getSize());
         copy.setLastModified(source.getLastModified());
         copy.setETag(source.getETag());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -41,6 +41,7 @@ public class S3Service {
     private static final String DEFAULT_OWNER_DISPLAY_NAME = "floci";
     private static final String ALL_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AllUsers";
     private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+    private static final Set<String> SUPPORTED_SERVER_SIDE_ENCRYPTION_VALUES = Set.of("AES256", "aws:kms", "aws:kms:dsse", "aws:fsx");
 
     @FunctionalInterface
     interface LambdaInvoker {
@@ -188,21 +189,28 @@ public class S3Service {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null, null, null, null, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata, new PutObjectOptions());
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
-        return putObject(bucketName, key, data, contentType, metadata, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata,
+                new PutObjectOptions()
+                        .withObjectLockMode(objectLockMode)
+                        .withRetainUntilDate(retainUntilDate)
+                        .withLegalHoldStatus(legalHoldStatus));
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, String storageClass,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
-        return putObject(bucketName, key, data, contentType, metadata, storageClass, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null);
+        return putObject(bucketName, key, data, contentType, metadata,
+                new PutObjectOptions()
+                        .withStorageClass(storageClass)
+                        .withObjectLockMode(objectLockMode)
+                        .withRetainUntilDate(retainUntilDate)
+                        .withLegalHoldStatus(legalHoldStatus));
     }
 
     public S3Object putObject(String bucketName, String key, byte[] data,
@@ -210,9 +218,22 @@ public class S3Service {
                               String contentEncoding,
                               String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
                               String contentDisposition, String cacheControl, String serverSideEncryption, String acl) {
-        S3Object object = storeObject(bucketName, key, data, contentType, metadata, storageClass, null, null,
-                objectLockMode, retainUntilDate, legalHoldStatus, contentEncoding, contentDisposition, cacheControl,
-                serverSideEncryption, acl);
+        return putObject(bucketName, key, data, contentType, metadata,
+                new PutObjectOptions()
+                        .withStorageClass(storageClass)
+                        .withContentEncoding(contentEncoding)
+                        .withObjectLockMode(objectLockMode)
+                        .withRetainUntilDate(retainUntilDate)
+                        .withLegalHoldStatus(legalHoldStatus)
+                        .withContentDisposition(contentDisposition)
+                        .withCacheControl(cacheControl)
+                        .withServerSideEncryption(serverSideEncryption)
+                        .withAcl(acl));
+    }
+
+    public S3Object putObject(String bucketName, String key, byte[] data,
+                              String contentType, Map<String, String> metadata, PutObjectOptions options) {
+        S3Object object = storeObject(bucketName, key, data, contentType, metadata, null, null, options);
         fireNotifications(bucketName, key, "ObjectCreated:Put", object);
         return object;
     }
@@ -222,40 +243,42 @@ public class S3Service {
      */
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata) {
-        return storeObject(bucketName, key, data, contentType, metadata, null, null, null,
-                null, null, null, null, null, null, null, null);
+        return storeObject(bucketName, key, data, contentType, metadata, null, null, new PutObjectOptions());
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
                                  String contentType, Map<String, String> metadata, String storageClass,
                                  S3Checksum checksum, List<Part> parts,
                                  String objectLockMode, Instant retainUntilDate, String legalHoldStatus) {
-        return storeObject(bucketName, key, data, contentType, metadata, storageClass, checksum, parts,
-                objectLockMode, retainUntilDate, legalHoldStatus, null, null, null, null, null);
+        return storeObject(bucketName, key, data, contentType, metadata, checksum, parts,
+                new PutObjectOptions()
+                        .withStorageClass(storageClass)
+                        .withObjectLockMode(objectLockMode)
+                        .withRetainUntilDate(retainUntilDate)
+                        .withLegalHoldStatus(legalHoldStatus));
     }
 
     private S3Object storeObject(String bucketName, String key, byte[] data,
-                                 String contentType, Map<String, String> metadata, String storageClass,
-                                 S3Checksum checksum, List<Part> parts,
-                                 String objectLockMode, Instant retainUntilDate, String legalHoldStatus,
-                                 String contentEncoding, String contentDisposition, String cacheControl,
-                                 String serverSideEncryption, String acl) {
+                                 String contentType, Map<String, String> metadata,
+                                 S3Checksum checksum, List<Part> parts, PutObjectOptions options) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
+        PutObjectOptions effectiveOptions = options != null ? options : new PutObjectOptions();
+        String normalizedServerSideEncryption = normalizeServerSideEncryption(effectiveOptions.getServerSideEncryption());
 
         S3Object object = new S3Object(bucketName, key, data, contentType);
         if (metadata != null) {
             object.getMetadata().putAll(metadata);
         }
-        object.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
+        object.setStorageClass(ObjectAttributeName.normalizeStorageClass(effectiveOptions.getStorageClass()));
         object.setChecksum(checksum != null ? copyChecksum(checksum) : buildChecksum(data, parts, false));
         object.setParts(copyParts(parts));
-        object.setContentEncoding(contentEncoding);
-        object.setContentDisposition(contentDisposition);
-        object.setCacheControl(cacheControl);
-        object.setServerSideEncryption(serverSideEncryption);
-        object.setAcl(cannedObjectAclXml(acl));
+        object.setContentEncoding(effectiveOptions.getContentEncoding());
+        object.setContentDisposition(effectiveOptions.getContentDisposition());
+        object.setCacheControl(effectiveOptions.getCacheControl());
+        object.setServerSideEncryption(normalizedServerSideEncryption);
+        object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();
@@ -275,7 +298,10 @@ public class S3Service {
             });
 
             // Apply lock fields from request or bucket default
-            applyObjectLock(object, bucket, objectLockMode, retainUntilDate, legalHoldStatus);
+            applyObjectLock(object, bucket,
+                    effectiveOptions.getObjectLockMode(),
+                    effectiveOptions.getRetainUntilDate(),
+                    effectiveOptions.getLegalHoldStatus());
 
             // Store versioned copy and update latest pointer
             objectStore.put(versionedKey(bucketName, key, versionId), object);
@@ -294,7 +320,10 @@ public class S3Service {
             }
 
             // Apply lock fields from request or bucket default
-            applyObjectLock(object, bucket, objectLockMode, retainUntilDate, legalHoldStatus);
+            applyObjectLock(object, bucket,
+                    effectiveOptions.getObjectLockMode(),
+                    effectiveOptions.getRetainUntilDate(),
+                    effectiveOptions.getLegalHoldStatus());
 
             objectStore.put(objectKey(bucketName, key), object);
             writeFile(bucketName, key, data);
@@ -599,16 +628,19 @@ public class S3Service {
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey) {
-        return copyObject(sourceBucket, sourceKey, destBucket, destKey,
-                null, null, null, null, null, null, null, null, null);
+        return copyObject(sourceBucket, sourceKey, destBucket, destKey, new CopyObjectOptions());
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey,
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType) {
-        return copyObject(sourceBucket, sourceKey, destBucket, destKey, metadataDirective,
-                replacementMetadata, storageClass, contentType, null, null, null, null, null);
+        return copyObject(sourceBucket, sourceKey, destBucket, destKey,
+                new CopyObjectOptions()
+                        .withMetadataDirective(metadataDirective)
+                        .withReplacementMetadata(replacementMetadata)
+                        .withStorageClass(storageClass)
+                        .withContentType(contentType));
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
@@ -616,24 +648,59 @@ public class S3Service {
                                String metadataDirective, Map<String, String> replacementMetadata,
                                String storageClass, String contentType, String contentEncoding,
                                String contentDisposition, String cacheControl, String serverSideEncryption, String acl) {
+        return copyObject(sourceBucket, sourceKey, destBucket, destKey,
+                new CopyObjectOptions()
+                        .withMetadataDirective(metadataDirective)
+                        .withReplacementMetadata(replacementMetadata)
+                        .withStorageClass(storageClass)
+                        .withContentType(contentType)
+                        .withContentEncoding(contentEncoding)
+                        .withContentDisposition(contentDisposition)
+                        .withCacheControl(cacheControl)
+                        .withServerSideEncryption(serverSideEncryption)
+                        .withAcl(acl));
+    }
+
+    public S3Object copyObject(String sourceBucket, String sourceKey,
+                               String destBucket, String destKey, CopyObjectOptions options) {
         S3Object source = getObject(sourceBucket, sourceKey);
         ensureBucketExists(destBucket);
+        CopyObjectOptions effectiveOptions = options != null ? options : new CopyObjectOptions();
+        String normalizedServerSideEncryption = normalizeServerSideEncryption(effectiveOptions.getServerSideEncryption());
 
-        boolean replaceMetadata = "REPLACE".equalsIgnoreCase(metadataDirective);
+        boolean replaceMetadata = "REPLACE".equalsIgnoreCase(effectiveOptions.getMetadataDirective());
         Map<String, String> metadata = replaceMetadata ? new LinkedHashMap<>() : new LinkedHashMap<>(source.getMetadata());
-        if (replaceMetadata && replacementMetadata != null) {
-            metadata.putAll(replacementMetadata);
+        if (replaceMetadata && effectiveOptions.getReplacementMetadata() != null) {
+            metadata.putAll(effectiveOptions.getReplacementMetadata());
         }
 
-        String effectiveContentType = replaceMetadata && contentType != null ? contentType : source.getContentType();
-        String effectiveStorageClass = storageClass != null ? storageClass : source.getStorageClass();
-        String effectiveContentEncoding = replaceMetadata && contentEncoding != null ? contentEncoding : source.getContentEncoding();
-        String effectiveContentDisposition = replaceMetadata && contentDisposition != null ? contentDisposition : source.getContentDisposition();
-        String effectiveCacheControl = replaceMetadata && cacheControl != null ? cacheControl : source.getCacheControl();
-        String effectiveServerSideEncryption = serverSideEncryption != null ? serverSideEncryption : source.getServerSideEncryption();
+        String effectiveContentType = replaceMetadata && effectiveOptions.getContentType() != null
+                ? effectiveOptions.getContentType()
+                : source.getContentType();
+        String effectiveStorageClass = effectiveOptions.getStorageClass() != null
+                ? effectiveOptions.getStorageClass()
+                : source.getStorageClass();
+        String effectiveContentEncoding = replaceMetadata && effectiveOptions.getContentEncoding() != null
+                ? effectiveOptions.getContentEncoding()
+                : source.getContentEncoding();
+        String effectiveContentDisposition = replaceMetadata && effectiveOptions.getContentDisposition() != null
+                ? effectiveOptions.getContentDisposition()
+                : source.getContentDisposition();
+        String effectiveCacheControl = replaceMetadata && effectiveOptions.getCacheControl() != null
+                ? effectiveOptions.getCacheControl()
+                : source.getCacheControl();
+        String effectiveServerSideEncryption = normalizedServerSideEncryption != null
+                ? normalizedServerSideEncryption
+                : source.getServerSideEncryption();
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
-                effectiveStorageClass, source.getChecksum(), source.getParts(), null, null, null,
-                effectiveContentEncoding, effectiveContentDisposition, effectiveCacheControl, effectiveServerSideEncryption, acl);
+                source.getChecksum(), source.getParts(),
+                new PutObjectOptions()
+                        .withStorageClass(effectiveStorageClass)
+                        .withContentEncoding(effectiveContentEncoding)
+                        .withContentDisposition(effectiveContentDisposition)
+                        .withCacheControl(effectiveCacheControl)
+                        .withServerSideEncryption(effectiveServerSideEncryption)
+                        .withAcl(effectiveOptions.getAcl()));
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
@@ -937,13 +1004,14 @@ public class S3Service {
         if (acl != null && !acl.isBlank()) {
             cannedObjectAclXml(acl);
         }
+        String normalizedServerSideEncryption = normalizeServerSideEncryption(serverSideEncryption);
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
         if (metadata != null) {
             upload.getMetadata().putAll(metadata);
         }
         upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
         upload.setContentDisposition(contentDisposition);
-        upload.setServerSideEncryption(serverSideEncryption);
+        upload.setServerSideEncryption(normalizedServerSideEncryption);
         upload.setAcl(acl);
 
         if (inMemory) {
@@ -1050,8 +1118,12 @@ public class S3Service {
                     .toList();
             S3Checksum checksum = buildChecksum(allData, completedParts, true);
             S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
-                    upload.getStorageClass(), checksum, completedParts, null, null, null,
-                    null, upload.getContentDisposition(), null, upload.getServerSideEncryption(), upload.getAcl());
+                    checksum, completedParts,
+                    new PutObjectOptions()
+                            .withStorageClass(upload.getStorageClass())
+                            .withContentDisposition(upload.getContentDisposition())
+                            .withServerSideEncryption(upload.getServerSideEncryption())
+                            .withAcl(upload.getAcl()));
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);
@@ -1421,6 +1493,24 @@ public class S3Service {
             default -> throw new AwsException("InvalidArgument",
                     "Unsupported x-amz-acl value: " + cannedAcl, 400);
         };
+    }
+
+    static String normalizeServerSideEncryption(String serverSideEncryption) {
+        if (serverSideEncryption == null) {
+            return null;
+        }
+
+        String normalized = serverSideEncryption.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        if (!SUPPORTED_SERVER_SIDE_ENCRYPTION_VALUES.contains(normalized)) {
+            throw new AwsException("InvalidArgument",
+                    "Unsupported x-amz-server-side-encryption value: " + normalized, 400);
+        }
+
+        return normalized;
     }
 
     private static String ownerFullControlGrant() {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import java.util.Map;
+
+public class CopyObjectOptions {
+    private String metadataDirective;
+    private Map<String, String> replacementMetadata;
+    private String storageClass;
+    private String contentType;
+    private String contentEncoding;
+    private String contentDisposition;
+    private String cacheControl;
+    private String serverSideEncryption;
+    private String acl;
+
+    public String getMetadataDirective() { return metadataDirective; }
+    public CopyObjectOptions withMetadataDirective(String metadataDirective) { this.metadataDirective = metadataDirective; return this; }
+
+    public Map<String, String> getReplacementMetadata() { return replacementMetadata; }
+    public CopyObjectOptions withReplacementMetadata(Map<String, String> replacementMetadata) { this.replacementMetadata = replacementMetadata; return this; }
+
+    public String getStorageClass() { return storageClass; }
+    public CopyObjectOptions withStorageClass(String storageClass) { this.storageClass = storageClass; return this; }
+
+    public String getContentType() { return contentType; }
+    public CopyObjectOptions withContentType(String contentType) { this.contentType = contentType; return this; }
+
+    public String getContentEncoding() { return contentEncoding; }
+    public CopyObjectOptions withContentEncoding(String contentEncoding) { this.contentEncoding = contentEncoding; return this; }
+
+    public String getContentDisposition() { return contentDisposition; }
+    public CopyObjectOptions withContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; return this; }
+
+    public String getCacheControl() { return cacheControl; }
+    public CopyObjectOptions withCacheControl(String cacheControl) { this.cacheControl = cacheControl; return this; }
+
+    public String getServerSideEncryption() { return serverSideEncryption; }
+    public CopyObjectOptions withServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; return this; }
+
+    public String getAcl() { return acl; }
+    public CopyObjectOptions withAcl(String acl) { this.acl = acl; return this; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -17,6 +17,7 @@ public class MultipartUpload {
     private String contentType;
     private String storageClass;
     private String contentDisposition;
+    private String serverSideEncryption;
     private String acl;
     private Map<String, String> metadata;
     private Instant initiated;
@@ -54,6 +55,9 @@ public class MultipartUpload {
 
     public String getContentDisposition() { return contentDisposition; }
     public void setContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; }
+
+    public String getServerSideEncryption() { return serverSideEncryption; }
+    public void setServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; }
 
     public String getAcl() { return acl; }
     public void setAcl(String acl) { this.acl = acl; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.s3.model;
+
+import java.time.Instant;
+
+public class PutObjectOptions {
+    private String storageClass;
+    private String contentEncoding;
+    private String objectLockMode;
+    private Instant retainUntilDate;
+    private String legalHoldStatus;
+    private String contentDisposition;
+    private String cacheControl;
+    private String serverSideEncryption;
+    private String acl;
+
+    public String getStorageClass() { return storageClass; }
+    public PutObjectOptions withStorageClass(String storageClass) { this.storageClass = storageClass; return this; }
+
+    public String getContentEncoding() { return contentEncoding; }
+    public PutObjectOptions withContentEncoding(String contentEncoding) { this.contentEncoding = contentEncoding; return this; }
+
+    public String getObjectLockMode() { return objectLockMode; }
+    public PutObjectOptions withObjectLockMode(String objectLockMode) { this.objectLockMode = objectLockMode; return this; }
+
+    public Instant getRetainUntilDate() { return retainUntilDate; }
+    public PutObjectOptions withRetainUntilDate(Instant retainUntilDate) { this.retainUntilDate = retainUntilDate; return this; }
+
+    public String getLegalHoldStatus() { return legalHoldStatus; }
+    public PutObjectOptions withLegalHoldStatus(String legalHoldStatus) { this.legalHoldStatus = legalHoldStatus; return this; }
+
+    public String getContentDisposition() { return contentDisposition; }
+    public PutObjectOptions withContentDisposition(String contentDisposition) { this.contentDisposition = contentDisposition; return this; }
+
+    public String getCacheControl() { return cacheControl; }
+    public PutObjectOptions withCacheControl(String cacheControl) { this.cacheControl = cacheControl; return this; }
+
+    public String getServerSideEncryption() { return serverSideEncryption; }
+    public PutObjectOptions withServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; return this; }
+
+    public String getAcl() { return acl; }
+    public PutObjectOptions withAcl(String acl) { this.acl = acl; return this; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -24,6 +24,7 @@ public class S3Object {
     private String contentEncoding;
     private String contentDisposition;
     private String cacheControl;
+    private String serverSideEncryption;
     private long size;
     private Instant lastModified;
     private String eTag;
@@ -88,6 +89,9 @@ public class S3Object {
 
     public String getCacheControl() { return cacheControl; }
     public void setCacheControl(String cacheControl) { this.cacheControl = cacheControl; }
+
+    public String getServerSideEncryption() { return serverSideEncryption; }
+    public void setServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; }
 
     public long getSize() { return size; }
     public void setSize(long size) { this.size = size; }

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -153,18 +153,33 @@ public class SecretsManagerService {
             stages = List.of(AWSCURRENT);
         }
 
+        SecretVersion previousCurrent = stages.contains(AWSCURRENT) ? findVersionByStage(secret, AWSCURRENT) : null;
+
         for (String stage : stages) {
             SecretVersion version = findVersionByStage(secret, stage);
             if (version == null) {
                 continue;
             }
             List<String> newStages = new ArrayList<>(version.getVersionStages());
-            if (stage.equals(AWSCURRENT)) {
-                newStages.add(AWSPREVIOUS);
-            }
             newStages.remove(stage);
 
             version.setVersionStages(newStages);
+        }
+
+        if (previousCurrent != null) {
+            for (SecretVersion version : secret.getVersions().values()) {
+                List<String> assignedStages = version.getVersionStages();
+                if (assignedStages == null || !assignedStages.contains(AWSPREVIOUS)) {
+                    continue;
+                }
+                List<String> newStages = new ArrayList<>(assignedStages);
+                newStages.removeIf(AWSPREVIOUS::equals);
+                version.setVersionStages(newStages);
+            }
+
+            List<String> newStages = new ArrayList<>(previousCurrent.getVersionStages());
+            newStages.add(AWSPREVIOUS);
+            previousCurrent.setVersionStages(newStages);
         }
 
         SecretVersion newVersion = new SecretVersion();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -51,37 +51,55 @@ public class SesService {
     }
 
     public Identity verifyEmailIdentity(String emailAddress, String region) {
-        if (emailAddress == null || emailAddress.isBlank()) {
+        String normalizedEmailAddress = normalizeIdentity(emailAddress);
+        if (normalizedEmailAddress == null || normalizedEmailAddress.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Email address is required.", 400);
         }
-        String key = identityKey(region, emailAddress);
+        String key = identityKey(region, normalizedEmailAddress);
         Identity existing = identityStore.get(key).orElse(null);
         if (existing != null) return existing;
 
-        Identity identity = new Identity(emailAddress, "EmailAddress");
+        Identity identity = new Identity(normalizedEmailAddress, "EmailAddress");
         identityStore.put(key, identity);
-        LOG.infov("Verified email identity: {0} in region {1}", emailAddress, region);
+        LOG.infov("Verified email identity: {0} in region {1}", normalizedEmailAddress, region);
         return identity;
     }
 
     public Identity verifyDomainIdentity(String domain, String region) {
-        if (domain == null || domain.isBlank()) {
+        String normalizedDomain = normalizeIdentity(domain);
+        if (normalizedDomain == null || normalizedDomain.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
         }
-        String key = identityKey(region, domain);
+        String key = identityKey(region, normalizedDomain);
         Identity existing = identityStore.get(key).orElse(null);
         if (existing != null) return existing;
 
-        Identity identity = new Identity(domain, "Domain");
+        Identity identity = new Identity(normalizedDomain, "Domain");
         identityStore.put(key, identity);
-        LOG.infov("Verified domain identity: {0} in region {1}", domain, region);
+        LOG.infov("Verified domain identity: {0} in region {1}", normalizedDomain, region);
         return identity;
     }
 
     public void deleteIdentity(String identityValue, String region) {
-        String key = identityKey(region, identityValue);
+        String normalizedIdentity = normalizeIdentity(identityValue);
+        if (normalizedIdentity == null || normalizedIdentity.isBlank()) {
+            return;
+        }
+        String key = identityKey(region, normalizedIdentity);
         identityStore.delete(key);
-        LOG.infov("Deleted identity: {0}", identityValue);
+
+        String prefix = "identity::" + region + "::";
+        List<String> keys = new ArrayList<>(identityStore.keys().stream()
+                .filter(k -> k.startsWith(prefix))
+                .toList());
+        for (String storedKey : keys) {
+            Identity storedIdentity = identityStore.get(storedKey).orElse(null);
+            if (storedIdentity != null && normalizedIdentity.equals(normalizeIdentity(storedIdentity.getIdentity()))) {
+                identityStore.delete(storedKey);
+            }
+        }
+
+        LOG.infov("Deleted identity: {0}", normalizedIdentity);
     }
 
     public List<Identity> listIdentities(String identityType, String region) {
@@ -220,6 +238,11 @@ public class SesService {
     }
 
     private static String identityKey(String region, String identity) {
-        return "identity::" + region + "::" + identity;
+        String normalizedIdentity = normalizeIdentity(identity);
+        return "identity::" + region + "::" + normalizedIdentity;
+    }
+
+    private static String normalizeIdentity(String identity) {
+        return identity == null ? null : identity.trim();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -51,41 +51,40 @@ public class SesService {
     }
 
     public Identity verifyEmailIdentity(String emailAddress, String region) {
-        String normalizedEmailAddress = normalizeIdentity(emailAddress);
-        if (normalizedEmailAddress == null || normalizedEmailAddress.isBlank()) {
+        validateIdentityWhitespace(emailAddress, "Email address");
+        if (emailAddress == null || emailAddress.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Email address is required.", 400);
         }
-        String key = identityKey(region, normalizedEmailAddress);
+        String key = identityKey(region, emailAddress);
         Identity existing = identityStore.get(key).orElse(null);
         if (existing != null) return existing;
 
-        Identity identity = new Identity(normalizedEmailAddress, "EmailAddress");
+        Identity identity = new Identity(emailAddress, "EmailAddress");
         identityStore.put(key, identity);
-        LOG.infov("Verified email identity: {0} in region {1}", normalizedEmailAddress, region);
+        LOG.infov("Verified email identity: {0} in region {1}", emailAddress, region);
         return identity;
     }
 
     public Identity verifyDomainIdentity(String domain, String region) {
-        String normalizedDomain = normalizeIdentity(domain);
-        if (normalizedDomain == null || normalizedDomain.isBlank()) {
+        validateIdentityWhitespace(domain, "Domain");
+        if (domain == null || domain.isBlank()) {
             throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
         }
-        String key = identityKey(region, normalizedDomain);
+        String key = identityKey(region, domain);
         Identity existing = identityStore.get(key).orElse(null);
         if (existing != null) return existing;
 
-        Identity identity = new Identity(normalizedDomain, "Domain");
+        Identity identity = new Identity(domain, "Domain");
         identityStore.put(key, identity);
-        LOG.infov("Verified domain identity: {0} in region {1}", normalizedDomain, region);
+        LOG.infov("Verified domain identity: {0} in region {1}", domain, region);
         return identity;
     }
 
     public void deleteIdentity(String identityValue, String region) {
-        String normalizedIdentity = normalizeIdentity(identityValue);
-        if (normalizedIdentity == null || normalizedIdentity.isBlank()) {
+        if (identityValue == null || identityValue.isBlank()) {
             return;
         }
-        String key = identityKey(region, normalizedIdentity);
+        String key = identityKey(region, identityValue);
         identityStore.delete(key);
 
         String prefix = "identity::" + region + "::";
@@ -94,12 +93,12 @@ public class SesService {
                 .toList());
         for (String storedKey : keys) {
             Identity storedIdentity = identityStore.get(storedKey).orElse(null);
-            if (storedIdentity != null && normalizedIdentity.equals(normalizeIdentity(storedIdentity.getIdentity()))) {
+            if (storedIdentity != null && identityValue.equals(storedIdentity.getIdentity())) {
                 identityStore.delete(storedKey);
             }
         }
 
-        LOG.infov("Deleted identity: {0}", normalizedIdentity);
+        LOG.infov("Deleted identity: {0}", identityValue);
     }
 
     public List<Identity> listIdentities(String identityType, String region) {
@@ -238,11 +237,16 @@ public class SesService {
     }
 
     private static String identityKey(String region, String identity) {
-        String normalizedIdentity = normalizeIdentity(identity);
-        return "identity::" + region + "::" + normalizedIdentity;
+        validateIdentityWhitespace(identity, "Identity");
+        return "identity::" + region + "::" + identity;
     }
 
-    private static String normalizeIdentity(String identity) {
-        return identity == null ? null : identity.trim();
+    private static void validateIdentityWhitespace(String identity, String fieldName) {
+        if (identity == null || identity.isBlank()) {
+            return;
+        }
+        if (Character.isWhitespace(identity.charAt(0)) || Character.isWhitespace(identity.charAt(identity.length() - 1))) {
+            throw new AwsException("InvalidParameterValue", fieldName + " must not contain leading or trailing whitespace.", 400);
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1084,6 +1084,77 @@ class S3IntegrationTest {
         given().delete("/content-disposition-bucket");
     }
 
+    // --- Server-Side Encryption header preservation ---
+
+    @Test
+    @Order(136)
+    void createSseBucketAndPutObject() {
+        given()
+            .put("/sse-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption", "AES256")
+            .body("encrypted-content")
+        .when()
+            .put("/sse-bucket/encrypted.txt")
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue())
+            .header("x-amz-server-side-encryption", equalTo("AES256"));
+    }
+
+    @Test
+    @Order(137)
+    void getObjectReturnsServerSideEncryption() {
+        given()
+        .when()
+            .get("/sse-bucket/encrypted.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption", equalTo("AES256"));
+    }
+
+    @Test
+    @Order(138)
+    void headObjectReturnsServerSideEncryption() {
+        given()
+        .when()
+            .head("/sse-bucket/encrypted.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption", equalTo("AES256"));
+    }
+
+    @Test
+    @Order(139)
+    void copyObjectPreservesServerSideEncryption() {
+        given()
+            .header("x-amz-copy-source", "/sse-bucket/encrypted.txt")
+        .when()
+            .put("/sse-bucket/encrypted-copy.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .head("/sse-bucket/encrypted-copy.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption", equalTo("AES256"));
+    }
+
+    @Test
+    @Order(140)
+    void cleanupSseBucket() {
+        given().delete("/sse-bucket/encrypted.txt");
+        given().delete("/sse-bucket/encrypted-copy.txt");
+        given().delete("/sse-bucket");
+    }
+
     // --- S3 Notification Configuration with Filter ---
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1149,6 +1149,21 @@ class S3IntegrationTest {
 
     @Test
     @Order(140)
+    void putObjectRejectsUnsupportedServerSideEncryption() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption", "totally-unsupported")
+            .body("bad encryption")
+        .when()
+            .put("/sse-bucket/invalid-encryption.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("Unsupported x-amz-server-side-encryption value"));
+    }
+
+    @Test
+    @Order(141)
     void cleanupSseBucket() {
         given().delete("/sse-bucket/encrypted.txt");
         given().delete("/sse-bucket/encrypted-copy.txt");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -33,6 +33,7 @@ class S3MultipartIntegrationTest {
             .header("x-amz-meta-owner", "team-a")
             .header("x-amz-storage-class", "STANDARD_IA")
             .header("Content-Disposition", "attachment; filename=\"multipart.bin\"")
+            .header("x-amz-server-side-encryption", "AES256")
         .when()
             .post("/" + BUCKET + "/" + KEY + "?uploads")
         .then()
@@ -127,6 +128,7 @@ class S3MultipartIntegrationTest {
         .then()
             .statusCode(200)
             .header("Content-Disposition", equalTo("attachment; filename=\"multipart.bin\""))
+            .header("x-amz-server-side-encryption", equalTo("AES256"))
             .header("x-amz-meta-owner", equalTo("team-a"))
             .header("x-amz-storage-class", equalTo("STANDARD_IA"))
             .body(equalTo("Part1Data-HelloPart2Data-World"));

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -262,6 +262,19 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(14)
+    void initiateMultipartUploadRejectsUnsupportedServerSideEncryption() {
+        given()
+            .header("x-amz-server-side-encryption", "totally-unsupported")
+        .when()
+            .post("/" + BUCKET + "/invalid-sse.bin?uploads")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("Unsupported x-amz-server-side-encryption value"));
+    }
+
+    @Test
+    @Order(15)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/source-for-copy.bin").then().statusCode(204);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
 import io.github.hectorvent.floci.services.s3.model.LambdaNotification;
 import io.github.hectorvent.floci.services.s3.model.NotificationConfiguration;
 import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
+import io.github.hectorvent.floci.services.s3.model.PutObjectOptions;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +110,41 @@ class S3ServiceTest {
         S3Object got = s3Service.getObject("test-bucket", "greeting.txt");
         assertArrayEquals(data, got.getData());
         assertEquals("text/plain", got.getContentType());
+    }
+
+    @Test
+    void putObjectTrimsBlankServerSideEncryptionToAbsent() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+
+        S3Object put = s3Service.putObject(
+                "test-bucket",
+                "blank-sse.txt",
+                "data".getBytes(StandardCharsets.UTF_8),
+                "text/plain",
+                null,
+                new PutObjectOptions().withServerSideEncryption("   ")
+        );
+
+        assertNull(put.getServerSideEncryption());
+    }
+
+    @Test
+    void putObjectRejectsUnsupportedServerSideEncryption() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                s3Service.putObject(
+                        "test-bucket",
+                        "invalid-sse.txt",
+                        "data".getBytes(StandardCharsets.UTF_8),
+                        "text/plain",
+                        null,
+                        new PutObjectOptions().withServerSideEncryption("totally-unsupported")
+                )
+        );
+
+        assertEquals("InvalidArgument", exception.getErrorCode());
+        assertTrue(exception.getMessage().contains("Unsupported x-amz-server-side-encryption value"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -382,6 +382,38 @@ class SesIntegrationTest {
 
     @Test
     @Order(21)
+    void verifyEmailIdentity_rejectsLeadingTrailingWhitespace() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "VerifyEmailIdentity")
+            .formParam("EmailAddress", " sender@example.com ")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"))
+            .body(containsString("leading or trailing whitespace"));
+    }
+
+    @Test
+    @Order(22)
+    void verifyDomainIdentity_rejectsLeadingTrailingWhitespace() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "VerifyDomainIdentity")
+            .formParam("Domain", " example.com ")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"))
+            .body(containsString("leading or trailing whitespace"));
+    }
+
+    @Test
+    @Order(23)
     void unsupportedAction_returns400() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -357,6 +357,31 @@ class SesIntegrationTest {
 
     @Test
     @Order(20)
+    void deleteDomainIdentity() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "DeleteIdentity")
+            .formParam("Identity", "example.com")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteIdentityResult"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "ListIdentities")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("example.com")));
+    }
+
+    @Test
+    @Order(21)
     void unsupportedAction_returns400() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -296,6 +296,23 @@ class SesV2IntegrationTest {
             .body("MessageId", notNullValue());
     }
 
+    @Test
+    @Order(14)
+    void createEmailIdentity_rejectsLeadingTrailingWhitespace() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": " padded@example.com "}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("leading or trailing whitespace"));
+    }
+
     // ──────────────── DKIM Attributes ────────────────
 
     @Test


### PR DESCRIPTION
## Summary
- preserve explicit `x-amz-server-side-encryption` metadata on S3 object writes
- replay the header on `GetObject` and `HeadObject`
- carry the same value through `CopyObject` and multipart completion when explicitly set

## Why
When a client explicitly sets `x-amz-server-side-encryption` on an object write, object metadata reads should continue to surface that value consistently.

Today Floci accepts the explicit header on write paths, but `GetObject` and `HeadObject` can drop it from the response. That means SDKs cannot round-trip the object-level SSE setting through normal metadata APIs.

This change keeps the scope limited to explicit object-level SSE metadata. It does not change bucket defaults or introduce KMS-specific behavior.

## Validation
- `./mvnw -q -Dtest=S3IntegrationTest,S3MultipartIntegrationTest,S3AclIntegrationTest,S3ServiceTest test`
