### PR TITLE
feat(cognito): implement AdminResetUserPassword action

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -49,6 +49,7 @@ public class CognitoJsonHandler {
             case "ListResourceServers" -> handleListResourceServers(request);
             case "UpdateResourceServer" -> handleUpdateResourceServer(request);
             case "DeleteResourceServer" -> handleDeleteResourceServer(request);
+            case "AdminResetUserPassword" -> handleAdminResetUserPassword(request);
             case "AdminCreateUser" -> handleAdminCreateUser(request);
             case "AdminGetUser" -> handleAdminGetUser(request);
             case "AdminDeleteUser" -> handleAdminDeleteUser(request);
@@ -255,6 +256,11 @@ public class CognitoJsonHandler {
             attr.put("Value", v);
         });
         return Response.ok(response).build();
+    }
+
+    private Response handleAdminResetUserPassword(JsonNode request) {
+        service.adminResetUserPassword(request.path("UserPoolId").asText(), request.path("Username").asText());
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     private Response handleAdminDeleteUser(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -427,6 +427,17 @@ public class CognitoService {
         LOG.infov("Disabled user {0} in pool {1}", user.getUsername(), userPoolId);
     }
 
+    public void adminResetUserPassword(String userPoolId, String username) {
+        CognitoUser user = adminGetUser(userPoolId, username);
+        user.setUserStatus("RESET_REQUIRED");
+        user.setPasswordHash(null);
+        user.setSrpVerifier(null);
+        user.setSrpSalt(null);
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        userStore.put(userKey(userPoolId, user.getUsername()), user);
+        LOG.infov("Reset password for user {0} in pool {1}", user.getUsername(), userPoolId);
+    }
+
     public List<CognitoUser> listUsers(String userPoolId, String filter) {
         String prefix = userPoolId + "::";
         List<CognitoUser> all = userStore.scan(k -> k.startsWith(prefix));
@@ -627,13 +638,20 @@ public class CognitoService {
         UserPoolClient client = describeUserPoolClient(userPoolId, clientId);
         UserPool pool = describeUserPool(userPoolId);
 
+        String username = authParameters.get("USERNAME");
+        if (username != null) {
+            CognitoUser user = adminGetUser(userPoolId, username);
+            if ("RESET_REQUIRED".equals(user.getUserStatus())) {
+                throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
+            }
+        }
+
         return switch (authFlow) {
             case "ADMIN_USER_PASSWORD_AUTH", "USER_PASSWORD_AUTH" ->
                     authenticateWithPassword(pool, authParameters, clientId);
             case "REFRESH_TOKEN_AUTH", "REFRESH_TOKEN" -> handleRefreshToken(pool, authParameters, clientId);
             case "ADMIN_USER_SRP_AUTH" -> handleUserSrpAuth(pool, client, authParameters);
             default -> {
-                String username = authParameters.get("USERNAME");
                 CognitoUser user = adminGetUser(userPoolId, username);
                 Map<String, Object> result = new HashMap<>();
                 result.put("AuthenticationResult", generateAuthResult(user, pool, clientId));
@@ -654,6 +672,10 @@ public class CognitoService {
         if (!user.isEnabled()) {
             throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
         }
+        if ("RESET_REQUIRED".equals(user.getUserStatus())) {
+            throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
+        }
+
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);
         }
@@ -709,6 +731,10 @@ public class CognitoService {
         if (!user.isEnabled()) {
             throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
         }
+        if ("RESET_REQUIRED".equals(user.getUserStatus())) {
+            throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
+        }
+
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);
         }
@@ -870,6 +896,10 @@ public class CognitoService {
 
         if (!user.isEnabled()) {
             throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
+        }
+
+        if ("RESET_REQUIRED".equals(user.getUserStatus())) {
+            throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
         }
 
         if ("UNCONFIRMED".equals(user.getUserStatus())) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -847,6 +847,62 @@ class CognitoIntegrationTest {
         oauthToken(rotClientId, secret2Value).then().statusCode(200);
     }
 
+    @Test
+    @Order(90)
+    void adminResetUserPasswordBlocksAuth() throws Exception {
+        // 1. Reset the user's password
+        cognitoAction("AdminResetUserPassword", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(poolId, username))
+                .then()
+                .statusCode(200);
+
+        // 2. Authentication should now fail with PasswordResetRequiredException
+        cognitoAction("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {
+                    "USERNAME": "%s",
+                    "PASSWORD": "%s"
+                  }
+                }
+                """.formatted(clientId, username, password))
+                .then()
+                .statusCode(400)
+                .body("__type", org.hamcrest.Matchers.containsString("PasswordResetRequiredException"));
+
+        // 3. Admin sets a new password
+        String newPassword = "NewPassword123!";
+        cognitoAction("AdminSetUserPassword", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s",
+                  "Password": "%s",
+                  "Permanent": true
+                }
+                """.formatted(poolId, username, newPassword))
+                .then()
+                .statusCode(200);
+
+        // 4. Authentication works again with new password
+        cognitoAction("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {
+                    "USERNAME": "%s",
+                    "PASSWORD": "%s"
+                  }
+                }
+                """.formatted(clientId, username, newPassword))
+                .then()
+                .statusCode(200);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────
 
     private static Response oauthToken(String oauthClientId, String oauthClientSecret) {


### PR DESCRIPTION
- Added AdminResetUserPassword to CognitoJsonHandler.
- Implemented reset logic in CognitoService to invalidate credentials and set status to RESET_REQUIRED.
- Enforced PasswordResetRequiredException during SRP and Password authentication flows.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
