### PR TITLE
fix(storage): make scan() return mutable list across backends (#482)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/HybridStorage.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/HybridStorage.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +22,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Hybrid storage: in-memory reads with async flush to disk.
@@ -75,7 +77,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
         return store.entrySet().stream()
                 .filter(e -> keyFilter.test(e.getKey()))
                 .map(Map.Entry::getValue)
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/src/main/java/io/github/hectorvent/floci/core/storage/PersistentStorage.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/PersistentStorage.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * JSON file-backed persistent storage.
@@ -64,7 +66,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
         return store.entrySet().stream()
                 .filter(e -> keyFilter.test(e.getKey()))
                 .map(Map.Entry::getValue)
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackend.java
@@ -19,6 +19,10 @@ public interface StorageBackend<K, V> {
 
     void delete(K key);
 
+    /**
+     * Return a new mutable list of values whose keys pass the filter. Callers may sort,
+     * filter, or otherwise mutate the returned list without affecting the underlying store.
+     */
     List<V> scan(Predicate<K> keyFilter);
 
     /** Return all keys in this store. */

--- a/src/main/java/io/github/hectorvent/floci/core/storage/WalStorage.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/WalStorage.java
@@ -11,6 +11,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Write-Ahead Log storage: in-memory reads with append-only binary WAL for durability.
@@ -105,7 +107,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
         return store.entrySet().stream()
                 .filter(e -> keyFilter.test(e.getKey()))
                 .map(Map.Entry::getValue)
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override

--- a/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
@@ -68,6 +68,15 @@ class HybridStorageTest {
     }
 
     @Test
+    void scanReturnsMutableList() {
+        storage.put("a", "1");
+        storage.put("b", "2");
+        var result = storage.scan(key -> true);
+        assertDoesNotThrow(() -> result.sort(String::compareTo));
+        assertDoesNotThrow(() -> result.add("3"));
+    }
+
+    @Test
     void clearRemovesAll() {
         storage.put("key1", "value1");
         storage.put("key2", "value2");

--- a/src/test/java/io/github/hectorvent/floci/core/storage/InMemoryStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/InMemoryStorageTest.java
@@ -62,6 +62,15 @@ class InMemoryStorageTest {
     }
 
     @Test
+    void scanReturnsMutableList() {
+        storage.put("a", "1");
+        storage.put("b", "2");
+        List<String> result = storage.scan(k -> true);
+        assertDoesNotThrow(() -> result.sort(String::compareTo));
+        assertDoesNotThrow(() -> result.add("3"));
+    }
+
+    @Test
     void scanWithNoMatchesReturnsEmptyList() {
         storage.put("key1", "value1");
         List<String> result = storage.scan(key -> key.startsWith("nonexistent"));

--- a/src/test/java/io/github/hectorvent/floci/core/storage/PersistentStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/PersistentStorageTest.java
@@ -61,6 +61,15 @@ class PersistentStorageTest {
     }
 
     @Test
+    void scanReturnsMutableList() {
+        storage.put("a", "1");
+        storage.put("b", "2");
+        List<String> result = storage.scan(key -> true);
+        assertDoesNotThrow(() -> result.sort(String::compareTo));
+        assertDoesNotThrow(() -> result.add("3"));
+    }
+
+    @Test
     void clear() {
         storage.put("key1", "value1");
         storage.clear();

--- a/src/test/java/io/github/hectorvent/floci/core/storage/WalStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/WalStorageTest.java
@@ -66,6 +66,15 @@ class WalStorageTest {
     }
 
     @Test
+    void scanReturnsMutableList() {
+        storage.put("a", "1");
+        storage.put("b", "2");
+        var result = storage.scan(key -> true);
+        assertDoesNotThrow(() -> result.sort(String::compareTo));
+        assertDoesNotThrow(() -> result.add("3"));
+    }
+
+    @Test
     void clearRemovesAllEntries() {
         storage.put("key1", "value1");
         storage.put("key2", "value2");


### PR DESCRIPTION
## Summary

Root cause of #482. `StorageBackend.scan()` implementations disagreed on result mutability: `InMemoryStorage` returns a mutable `ArrayList`, but `PersistentStorage`, `HybridStorage`, and `WalStorage` used `Stream.toList()` which returns an unmodifiable list in Java 16+. Any caller that mutates the scan result works fine in unit tests (all using in-memory) and crashes at runtime under persistent/hybrid/wal storage.

This is exactly what @bkindersleytrulioo hit in [his comment](https://github.com/floci-io/floci/issues/482#issuecomment-4271742911) once #487 landed and the real stack trace showed up:

```
java.lang.UnsupportedOperationException
    at java.base/java.util.ImmutableCollections$AbstractImmutableList.sort(Unknown Source)
    at CloudWatchLogsService.describeLogGroups(CloudWatchLogsService.java:118)
```

`describeLogGroups` calls `result.sort(...)` on the scan result. Same latent bug at `CloudWatchLogsService.getLogEvents` and `CognitoService.listGroups` (those callers copy into an `ArrayList` first, so they happen to work today).

## Approach

Rather than patch individual call sites, align the three non-memory backends on the same contract `InMemoryStorage` already follows, and document it on the interface. One class of bug fixed once, no future landmines.

- `PersistentStorage`, `HybridStorage`, `WalStorage`: switch `.toList()` → `.collect(Collectors.toCollection(ArrayList::new))`
- `StorageBackend.scan`: javadoc'd as "returns a new mutable list"
- Added `scanReturnsMutableList` tests to all four backend test classes

## Test plan

- [x] `./mvnw test -Dtest='InMemoryStorageTest,PersistentStorageTest,HybridStorageTest,WalStorageTest,CloudWatchLogsServiceTest'` (57/57 pass
- [x] `./mvnw test` (full unit + integration)) 2362 pass; the 12 failures are pre-existing Docker flakes in `ElastiCacheIntegrationTest` + `LambdaReactiveSyncIntegrationTest` (connection refused / read timeouts), unrelated to storage
- [x] Codex + Gemini reviews (focused), both clean
- [ ] @diego-lambrechts-wp rerun Terraform flow against this branch to confirm `DescribeLogGroups` round-trips cleanly with hybrid storage

## Related

- Fixes #482
- Built on top of #487 (stack traces in `AwsJson11Controller`) which exposed the root cause