### PR TITLE
fix(lambda): restore create-copy-start ordering for provided runtimes

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaTest.java
@@ -306,6 +306,40 @@ class LambdaTest {
 
     @Test
     @Order(17)
+    void providedRuntimeInvoke() {
+        String providedFn = "sdk-test-provided-fn";
+
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(providedFn)
+                .runtime(Runtime.PROVIDED_AL2023)
+                .role(ROLE)
+                .handler("bootstrap")
+                .timeout(30)
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.providedRuntimeZip()))
+                        .build())
+                .build());
+
+        // RequestResponse invoke — the bootstrap shell script POSTs a
+        // response via the Runtime API, so we should get a real payload
+        // back rather than a timeout.
+        InvokeResponse response = lambda.invoke(InvokeRequest.builder()
+                .functionName(providedFn)
+                .invocationType(InvocationType.REQUEST_RESPONSE)
+                .payload(SdkBytes.fromUtf8String("{\"test\":true}"))
+                .build());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.functionError()).isNull();
+        String payload = response.payload().asUtf8String();
+        assertThat(payload).contains("hello from provided runtime");
+
+        lambda.deleteFunction(DeleteFunctionRequest.builder()
+                .functionName(providedFn).build());
+    }
+
+    @Test
+    @Order(18)
     void rubyRuntimeSupport() {
         String rubyFn = "sdk-test-ruby-fn";
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaTest.java
@@ -33,6 +33,10 @@ class LambdaTest {
                 lambda.deleteFunction(DeleteFunctionRequest.builder()
                         .functionName("sdk-test-ruby-fn").build());
             } catch (Exception ignored) {}
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder()
+                        .functionName("sdk-test-provided-fn").build());
+            } catch (Exception ignored) {}
             lambda.close();
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -65,10 +65,11 @@ public class ContainerLifecycleManager {
      * start it after any pre-start setup (e.g. copying files into the
      * container filesystem).
      *
+     * @param spec the container specification
      * @return the container ID
      */
     public String create(ContainerSpec spec) {
-        LOG.debugv("Creating container (no start) from spec: image={0}, name={1}", spec.image(), spec.name());
+        LOG.debugv("Creating container from spec: image={0}, name={1}", spec.image(), spec.name());
 
         imageCacheService.ensureImageExists(spec.image());
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -118,6 +118,76 @@ public class ContainerLifecycleManager {
     }
 
     /**
+     * Creates a container without starting it. Use {@link #startCreated} to
+     * start it after any pre-start setup (e.g. copying files into the
+     * container filesystem).
+     *
+     * @return the container ID
+     */
+    public String create(ContainerSpec spec) {
+        LOG.debugv("Creating container (no start) from spec: image={0}, name={1}", spec.image(), spec.name());
+
+        imageCacheService.ensureImageExists(spec.image());
+
+        HostConfig hostConfig = buildHostConfig(spec);
+
+        CreateContainerCmd createCmd = dockerClient.createContainerCmd(spec.image())
+                .withHostConfig(hostConfig);
+
+        if (spec.name() != null) {
+            createCmd.withName(spec.name());
+        }
+        if (spec.env() != null && !spec.env().isEmpty()) {
+            createCmd.withEnv(spec.env());
+        }
+        if (spec.cmd() != null && !spec.cmd().isEmpty()) {
+            createCmd.withCmd(spec.cmd());
+        }
+        if (spec.entrypoint() != null && !spec.entrypoint().isEmpty()) {
+            createCmd.withEntrypoint(spec.entrypoint());
+        }
+        if (spec.exposedPorts() != null && !spec.exposedPorts().isEmpty()) {
+            ExposedPort[] exposed = spec.exposedPorts().stream()
+                    .map(ExposedPort::tcp)
+                    .toArray(ExposedPort[]::new);
+            createCmd.withExposedPorts(exposed);
+        }
+
+        CreateContainerResponse response = createCmd.exec();
+        String containerId = response.getId();
+        LOG.infov("Created container {0} (name={1}, not yet started)", containerId, spec.name());
+        return containerId;
+    }
+
+    /**
+     * Starts a previously created container and resolves its endpoints.
+     *
+     * @param containerId the container ID returned by {@link #create}
+     * @param spec the original spec (needed for network and endpoint resolution)
+     * @return information about the running container including resolved endpoints
+     */
+    public ContainerInfo startCreated(String containerId, ContainerSpec spec) {
+        dockerClient.startContainerCmd(containerId).exec();
+        LOG.infov("Started container {0}", containerId);
+
+        if (spec.networkMode() != null && !spec.networkMode().isBlank() && spec.hasPortBindings()) {
+            try {
+                dockerClient.connectToNetworkCmd()
+                        .withContainerId(containerId)
+                        .withNetworkId(spec.networkMode())
+                        .exec();
+                LOG.debugv("Connected container {0} to network {1}", containerId, spec.networkMode());
+            } catch (Exception e) {
+                LOG.warnv("Could not connect container {0} to network {1}: {2}",
+                        containerId, spec.networkMode(), e.getMessage());
+            }
+        }
+
+        Map<Integer, EndpointInfo> endpoints = resolveEndpoints(containerId, spec);
+        return new ContainerInfo(containerId, endpoints);
+    }
+
+    /**
      * Stops and removes a container, closing any associated log stream.
      *
      * @param containerId the container ID to stop and remove

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -48,73 +48,16 @@ public class ContainerLifecycleManager {
     }
 
     /**
-     * Creates and starts a container from the given specification.
-     * Automatically pulls the image if not present locally.
+     * Creates and immediately starts a container. Delegates to
+     * {@link #create} and {@link #startCreated}. Suitable when no
+     * filesystem modifications are needed between creation and start.
      *
      * @param spec the container specification
      * @return information about the created container including resolved endpoints
      */
     public ContainerInfo createAndStart(ContainerSpec spec) {
-        LOG.debugv("Creating container from spec: image={0}, name={1}", spec.image(), spec.name());
-
-        // Ensure image is available
-        imageCacheService.ensureImageExists(spec.image());
-
-        // Build HostConfig
-        HostConfig hostConfig = buildHostConfig(spec);
-
-        // Create container command
-        CreateContainerCmd createCmd = dockerClient.createContainerCmd(spec.image())
-                .withHostConfig(hostConfig);
-
-        if (spec.name() != null) {
-            createCmd.withName(spec.name());
-        }
-        if (spec.env() != null && !spec.env().isEmpty()) {
-            createCmd.withEnv(spec.env());
-        }
-        if (spec.cmd() != null && !spec.cmd().isEmpty()) {
-            createCmd.withCmd(spec.cmd());
-        }
-        if (spec.entrypoint() != null && !spec.entrypoint().isEmpty()) {
-            createCmd.withEntrypoint(spec.entrypoint());
-        }
-        if (spec.exposedPorts() != null && !spec.exposedPorts().isEmpty()) {
-            ExposedPort[] exposed = spec.exposedPorts().stream()
-                    .map(ExposedPort::tcp)
-                    .toArray(ExposedPort[]::new);
-            createCmd.withExposedPorts(exposed);
-        }
-
-        // Create the container
-        CreateContainerResponse response = createCmd.exec();
-        String containerId = response.getId();
-        LOG.infov("Created container {0} (name={1})", containerId, spec.name());
-
-        // Start the container
-        dockerClient.startContainerCmd(containerId).exec();
-        LOG.infov("Started container {0}", containerId);
-
-        // For containers with port bindings, withNetworkMode was skipped during creation
-        // (it suppresses port publishing on macOS Docker Desktop). Connect to the
-        // configured network now, after the host port bindings are established.
-        if (spec.networkMode() != null && !spec.networkMode().isBlank() && spec.hasPortBindings()) {
-            try {
-                dockerClient.connectToNetworkCmd()
-                        .withContainerId(containerId)
-                        .withNetworkId(spec.networkMode())
-                        .exec();
-                LOG.debugv("Connected container {0} to network {1}", containerId, spec.networkMode());
-            } catch (Exception e) {
-                LOG.warnv("Could not connect container {0} to network {1}: {2}",
-                        containerId, spec.networkMode(), e.getMessage());
-            }
-        }
-
-        // Resolve endpoints
-        Map<Integer, EndpointInfo> endpoints = resolveEndpoints(containerId, spec);
-
-        return new ContainerInfo(containerId, endpoints);
+        String containerId = create(spec);
+        return startCreated(containerId, spec);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -3,7 +3,6 @@ package io.github.hectorvent.floci.services.lambda.launcher;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
-import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
@@ -191,7 +190,7 @@ public class ContainerLauncher {
         }
 
         // Now start the container with code in place
-        ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+        lifecycleManager.startCreated(containerId, spec);
 
         ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), runtimeApiServer, ContainerState.WARM);
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -165,9 +165,9 @@ public class ContainerLauncher {
 
         ContainerSpec spec = specBuilder.build();
 
-        // Create container (but don't start yet - need to copy code first for Zip packages)
-        ContainerInfo info = lifecycleManager.createAndStart(spec);
-        String containerId = info.containerId();
+        // Create container without starting — provided.* runtimes exec
+        // /var/runtime/bootstrap on start, so code must be copied first.
+        String containerId = lifecycleManager.create(spec);
         LOG.infov("Created container {0} for function {1}", containerId, fn.getFunctionName());
 
         // Copy code into container via Docker API tar stream (works inside Docker too)
@@ -189,6 +189,9 @@ public class ContainerLauncher {
                 }
             }
         }
+
+        // Now start the container with code in place
+        ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
         ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), runtimeApiServer, ContainerState.WARM);
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -11,23 +11,23 @@ import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServer;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServerFactory;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.model.Bind;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,15 +47,13 @@ class ContainerLauncherTest {
     Path tempDir;
 
     ContainerLauncher launcher;
-    ContainerBuilder containerBuilder;
 
     @BeforeEach
     void setUp() {
-        // Setup config mocks
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.LambdaServiceConfig lambda = mock(EmulatorConfig.LambdaServiceConfig.class);
         EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
-        
+
         when(config.services()).thenReturn(services);
         when(services.lambda()).thenReturn(lambda);
         when(lambda.dockerNetwork()).thenReturn(Optional.empty());
@@ -63,23 +61,25 @@ class ContainerLauncherTest {
         when(docker.logMaxSize()).thenReturn("10m");
         when(docker.logMaxFile()).thenReturn("3");
 
-        containerBuilder = new ContainerBuilder(config, dockerHostResolver);
+        ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver);
         launcher = new ContainerLauncher(containerBuilder, lifecycleManager, logStreamer, imageResolver,
                 runtimeApiServerFactory, dockerHostResolver, config, ecrRegistryManager);
 
         when(runtimeApiServerFactory.create()).thenReturn(runtimeApiServer);
         when(runtimeApiServer.getPort()).thenReturn(9000);
         when(dockerHostResolver.resolve()).thenReturn("127.0.0.1");
-        
-        ContainerLifecycleManager.ContainerInfo info = new ContainerLifecycleManager.ContainerInfo("c1", Map.of());
-        when(lifecycleManager.createAndStart(any())).thenReturn(info);
+
+        when(lifecycleManager.create(any())).thenReturn("container-123");
+        ContainerLifecycleManager.ContainerInfo info =
+                new ContainerLifecycleManager.ContainerInfo("container-123", Map.of());
+        when(lifecycleManager.startCreated(eq("container-123"), any())).thenReturn(info);
         when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
     }
 
     @Test
     void launchFunctionCopiesCode() throws Exception {
         Path codePath = Files.createDirectory(tempDir.resolve("code"));
-        
+
         LambdaFunction fn = new LambdaFunction();
         fn.setFunctionName("standard-fn");
         fn.setRuntime("nodejs20.x");
@@ -89,12 +89,57 @@ class ContainerLauncherTest {
         launcher.launch(fn);
 
         ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
-        verify(lifecycleManager).createAndStart(specCaptor.capture());
+        verify(lifecycleManager).create(specCaptor.capture());
 
         ContainerSpec spec = specCaptor.getValue();
         assertTrue(spec.binds().isEmpty(), "Function should NOT have bind mounts");
-        
-        // Function should attempt to copy code
+
         verify(lifecycleManager, atLeastOnce()).getDockerClient();
+    }
+
+    @Test
+    void launchFunction_createsBeforeCopyAndStartsAfter() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("order-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        // Verify ordering: create → getDockerClient (for copy) → startCreated
+        InOrder inOrder = inOrder(lifecycleManager);
+        inOrder.verify(lifecycleManager).create(any());
+        inOrder.verify(lifecycleManager).getDockerClient();
+        inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
+    }
+
+    @Test
+    void launchProvidedRuntime_copiesBootstrapBeforeStart() throws Exception {
+        // Set up code dir with a bootstrap file
+        Path codePath = Files.createDirectory(tempDir.resolve("provided-code"));
+        Files.writeString(codePath.resolve("bootstrap"), "#!/bin/sh\necho hello");
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("provided-fn");
+        fn.setRuntime("provided.al2023");
+        fn.setHandler("bootstrap");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        // The critical invariant: create must happen before any Docker copy,
+        // and start must happen after. This is what #466 broke — it called
+        // createAndStart so the container ran /var/runtime/bootstrap before
+        // the file was copied in, causing exit 127.
+        InOrder inOrder = inOrder(lifecycleManager);
+        inOrder.verify(lifecycleManager).create(any());
+        inOrder.verify(lifecycleManager, atLeastOnce()).getDockerClient();
+        inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
+
+        // createAndStart must NOT be called — Lambda uses the split path
+        verify(lifecycleManager, never()).createAndStart(any());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -138,9 +138,10 @@ class ContainerLauncherTest {
 
         launcher.launch(fn);
 
-        // Verify ordering: create → Docker copy (to /var/task) → startCreated
+        // Verify ordering: create → getDockerClient → Docker copy (to /var/task) → startCreated
         InOrder inOrder = inOrder(lifecycleManager, dockerClient);
         inOrder.verify(lifecycleManager).create(any());
+        inOrder.verify(lifecycleManager).getDockerClient();
         inOrder.verify(dockerClient).copyArchiveToContainerCmd("container-123");
         inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
 
@@ -165,6 +166,7 @@ class ContainerLauncherTest {
         // and start must happen after. This is the exact regression from #466.
         InOrder inOrder = inOrder(lifecycleManager, dockerClient);
         inOrder.verify(lifecycleManager).create(any());
+        inOrder.verify(lifecycleManager).getDockerClient();
         // Two copies: code to /var/task + bootstrap to /var/runtime
         inOrder.verify(dockerClient, times(2)).copyArchiveToContainerCmd("container-123");
         inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -77,7 +77,7 @@ class ContainerLauncherTest {
     }
 
     @Test
-    void launchFunctionCopiesCode() throws Exception {
+    void launchFunction_createsWithoutBindMounts() throws Exception {
         Path codePath = Files.createDirectory(tempDir.resolve("code"));
 
         LambdaFunction fn = new LambdaFunction();
@@ -93,8 +93,6 @@ class ContainerLauncherTest {
 
         ContainerSpec spec = specCaptor.getValue();
         assertTrue(spec.binds().isEmpty(), "Function should NOT have bind mounts");
-
-        verify(lifecycleManager, atLeastOnce()).getDockerClient();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -12,7 +12,6 @@ import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServer;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServerFactory;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
-import static org.mockito.Mockito.doAnswer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServer;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServerFactory;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
+import static org.mockito.Mockito.doAnswer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,12 +44,13 @@ class ContainerLauncherTest {
     @Mock EcrRegistryManager ecrRegistryManager;
     @Mock RuntimeApiServer runtimeApiServer;
     @Mock DockerClient dockerClient;
-    @Mock CopyArchiveToContainerCmd copyCmd;
 
     @TempDir
     Path tempDir;
 
     ContainerLauncher launcher;
+    /** Collects remote paths passed to withRemotePath across all copy mocks. */
+    final java.util.List<String> capturedRemotePaths = new java.util.ArrayList<>();
 
     @BeforeEach
     void setUp() {
@@ -78,10 +80,31 @@ class ContainerLauncherTest {
         when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
 
         // Stub the Docker copy chain so copyDirToContainer / copyFileToContainer
-        // don't throw when the mock DockerClient is used.
-        when(dockerClient.copyArchiveToContainerCmd(any())).thenReturn(copyCmd);
-        when(copyCmd.withRemotePath(any())).thenReturn(copyCmd);
-        when(copyCmd.withTarInputStream(any())).thenReturn(copyCmd);
+        // don't throw when the mock DockerClient is used. Each invocation
+        // returns a fresh mock that drains the tar InputStream on exec() to
+        // prevent the background PipedOutputStream writer thread from blocking
+        // when the pipe buffer fills.
+        capturedRemotePaths.clear();
+        when(dockerClient.copyArchiveToContainerCmd(any())).thenAnswer(inv -> {
+            CopyArchiveToContainerCmd cmd = mock(CopyArchiveToContainerCmd.class);
+            final java.io.InputStream[] captured = {null};
+            when(cmd.withRemotePath(any())).thenAnswer(pathInv -> {
+                capturedRemotePaths.add(pathInv.getArgument(0));
+                return cmd;
+            });
+            when(cmd.withTarInputStream(any())).thenAnswer(streamInv -> {
+                captured[0] = streamInv.getArgument(0);
+                return cmd;
+            });
+            doAnswer(execInv -> {
+                if (captured[0] != null) {
+                    try { captured[0].transferTo(java.io.OutputStream.nullOutputStream()); }
+                    catch (Exception ignored) {}
+                }
+                return null;
+            }).when(cmd).exec();
+            return cmd;
+        });
     }
 
     @Test
@@ -147,10 +170,10 @@ class ContainerLauncherTest {
         inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
 
         // Verify both /var/task and /var/runtime were targeted
-        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
-        verify(copyCmd, atLeast(2)).withRemotePath(pathCaptor.capture());
-        assertTrue(pathCaptor.getAllValues().contains("/var/task"));
-        assertTrue(pathCaptor.getAllValues().contains("/var/runtime"));
+        assertTrue(capturedRemotePaths.contains("/var/task"),
+                "code should be copied to /var/task");
+        assertTrue(capturedRemotePaths.contains("/var/runtime"),
+                "bootstrap should be copied to /var/runtime");
 
         verify(lifecycleManager, never()).createAndStart(any());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServer;
 import io.github.hectorvent.floci.services.lambda.runtime.RuntimeApiServerFactory;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +43,7 @@ class ContainerLauncherTest {
     @Mock EcrRegistryManager ecrRegistryManager;
     @Mock RuntimeApiServer runtimeApiServer;
     @Mock DockerClient dockerClient;
+    @Mock CopyArchiveToContainerCmd copyCmd;
 
     @TempDir
     Path tempDir;
@@ -74,6 +76,12 @@ class ContainerLauncherTest {
                 new ContainerLifecycleManager.ContainerInfo("container-123", Map.of());
         when(lifecycleManager.startCreated(eq("container-123"), any())).thenReturn(info);
         when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+
+        // Stub the Docker copy chain so copyDirToContainer / copyFileToContainer
+        // don't throw when the mock DockerClient is used.
+        when(dockerClient.copyArchiveToContainerCmd(any())).thenReturn(copyCmd);
+        when(copyCmd.withRemotePath(any())).thenReturn(copyCmd);
+        when(copyCmd.withTarInputStream(any())).thenReturn(copyCmd);
     }
 
     @Test
@@ -107,16 +115,18 @@ class ContainerLauncherTest {
 
         launcher.launch(fn);
 
-        // Verify ordering: create → getDockerClient (for copy) → startCreated
-        InOrder inOrder = inOrder(lifecycleManager);
+        // Verify ordering: create → Docker copy (to /var/task) → startCreated
+        InOrder inOrder = inOrder(lifecycleManager, dockerClient);
         inOrder.verify(lifecycleManager).create(any());
-        inOrder.verify(lifecycleManager).getDockerClient();
+        inOrder.verify(dockerClient).copyArchiveToContainerCmd("container-123");
         inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
+
+        // createAndStart must NOT be called — Lambda uses the split path
+        verify(lifecycleManager, never()).createAndStart(any());
     }
 
     @Test
     void launchProvidedRuntime_copiesBootstrapBeforeStart() throws Exception {
-        // Set up code dir with a bootstrap file
         Path codePath = Files.createDirectory(tempDir.resolve("provided-code"));
         Files.writeString(codePath.resolve("bootstrap"), "#!/bin/sh\necho hello");
 
@@ -129,15 +139,19 @@ class ContainerLauncherTest {
         launcher.launch(fn);
 
         // The critical invariant: create must happen before any Docker copy,
-        // and start must happen after. This is what #466 broke — it called
-        // createAndStart so the container ran /var/runtime/bootstrap before
-        // the file was copied in, causing exit 127.
-        InOrder inOrder = inOrder(lifecycleManager);
+        // and start must happen after. This is the exact regression from #466.
+        InOrder inOrder = inOrder(lifecycleManager, dockerClient);
         inOrder.verify(lifecycleManager).create(any());
-        inOrder.verify(lifecycleManager, atLeastOnce()).getDockerClient();
+        // Two copies: code to /var/task + bootstrap to /var/runtime
+        inOrder.verify(dockerClient, times(2)).copyArchiveToContainerCmd("container-123");
         inOrder.verify(lifecycleManager).startCreated(eq("container-123"), any());
 
-        // createAndStart must NOT be called — Lambda uses the split path
+        // Verify both /var/task and /var/runtime were targeted
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(copyCmd, atLeast(2)).withRemotePath(pathCaptor.capture());
+        assertTrue(pathCaptor.getAllValues().contains("/var/task"));
+        assertTrue(pathCaptor.getAllValues().contains("/var/runtime"));
+
         verify(lifecycleManager, never()).createAndStart(any());
     }
 }


### PR DESCRIPTION
## Summary

Lambda functions using `provided.*` runtimes (`provided.al2023`,
`provided.al2`, `provided`) fail on 1.5.4 with
`/var/runtime/bootstrap: No such file or directory` (exit 127) followed
by a timeout. The entrypoint execs the bootstrap file immediately on
container start, but the refactor in #466 changed `ContainerLauncher`
from `create → copy → start` to `createAndStart → copy`, so the file
is copied after the container has already started and exited.

This PR splits `ContainerLifecycleManager` into `create(spec)` and
`startCreated(containerId, spec)`, and refactors `createAndStart` to
delegate to both so there is no duplicated container-creation logic.
`ContainerLauncher` uses the split path to copy code and the bootstrap
file before starting, restoring the 1.5.3 ordering while preserving
the #466 improvements (log rotation, shared infrastructure, network
connection, endpoint resolution).

Other container-spawning services (ECS, ECR, EKS, MSK, ElastiCache,
RDS) continue using `createAndStart` since they have no pre-start file
copy requirement.

Fixes #494

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`provided.*` runtimes now invoke successfully again, matching 1.5.3
and real AWS behavior. Verified with a Go-based `provided.al2023`
Lambda (arm64):

```
StatusCode: 200
payload: {"body":"hello from provided.al2023","statusCode":200}
```

On 1.5.4 the same function returns:
```
{"errorMessage":"Task timed out after 30 seconds","errorType":"Function.TimedOut"}
```

## Checklist

- [x] `./mvnw test` passes locally (`ContainerLauncherTest` 3 tests +
  `LambdaServiceTest` 30 tests green)
- [x] New or updated integration test added:
  - `ContainerLauncherTest`: 3 unit tests verifying create → copy →
    startCreated ordering via Mockito InOrder, with Docker copy chain
    fully stubbed (InputStream drained to prevent thread leaks) and
    remote path assertions (`/var/task`, `/var/runtime`)
  - `LambdaTest.providedRuntimeInvoke` (SDK compat): creates and
    invokes a `provided.al2023` function using a shell bootstrap.
    Confirmed to FAIL on 1.5.4 (120s timeout) and PASS on the fix.
- [x] Manual end-to-end verification: Docker image built, Go bootstrap
  Lambda created and invoked successfully
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)