### PR TITLE
feat(opensearch): add real os with docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ flowchart LR
 | **ECR** | In-process + **real OCI registry** | Repositories, image push / pull via stock `docker`, image-backed Lambda functions |
 | **SES** | In-process | Send email / raw email, identity verification, DKIM attributes |
 | **SES v2 (HTTP)** | In-process | REST JSON API, identities, DKIM, feedback attributes, account sending |
-| **OpenSearch** | In-process | Domain CRUD, tags, versions, instance types, upgrade stubs |
+| **OpenSearch** | **Real Docker containers** | Domain CRUD, tags, versions, instance types, upgrade stubs |
 | **AppConfig** | In-process | Applications, environments, profiles, hosted configuration versions, deployments |
 | **AppConfigData** | In-process | Configuration sessions, dynamic configuration retrieval |
 | **Bedrock Runtime** | In-process (stub) | Dummy Converse and InvokeModel responses for local development; streaming returns 501 |
 | **EKS** | **Real Docker containers** (mock mode available) | Clusters, tagging; real mode starts k3s per cluster with a live Kubernetes API server |
 
-> **Lambda, ElastiCache, RDS, MSK, ECS, and EKS** spin up real Docker containers and support IAM authentication and SigV4 request signing — the same auth flow as production AWS. **ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane.
+> **Lambda, ElastiCache, RDS, MSK, ECS, EKS, and OpenSearch** spin up real Docker containers and support IAM authentication and SigV4 request signing — the same auth flow as production AWS. **ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane.
 >
 > For per-service operation counts and endpoint protocols, see the [Services Overview](https://floci.io/floci/services/) in the documentation site.
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OpenSearchTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OpenSearchTest.java
@@ -1,0 +1,194 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.opensearch.OpenSearchClient;
+import software.amazon.awssdk.services.opensearch.model.*;
+import software.amazon.awssdk.services.opensearch.model.Tag;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("OpenSearch Service")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class OpenSearchTest {
+
+    private static OpenSearchClient opensearch;
+    private static final String DOMAIN_NAME = "os-domain-" + UUID.randomUUID().toString().substring(0, 8);
+    private static String domainEndpoint;
+
+    @BeforeAll
+    static void setUp() {
+        String endpoint = System.getenv("FLOCI_ENDPOINT");
+        if (endpoint == null || endpoint.isBlank()) {
+            endpoint = "http://localhost:4566";
+        }
+        if (!endpoint.startsWith("http")) {
+            endpoint = "http://" + endpoint;
+        }
+
+        opensearch = OpenSearchClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("test", "test")))
+                .build();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (opensearch != null) {
+            try {
+                opensearch.deleteDomain(DeleteDomainRequest.builder()
+                        .domainName(DOMAIN_NAME)
+                        .build());
+            } catch (Exception ignored) {}
+            opensearch.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createDomain() {
+        CreateDomainResponse response = opensearch.createDomain(CreateDomainRequest.builder()
+                .domainName(DOMAIN_NAME)
+                .engineVersion("OpenSearch_2.11")
+                .clusterConfig(ClusterConfig.builder()
+                        .instanceType(OpenSearchPartitionInstanceType.T3_SMALL_SEARCH)
+                        .instanceCount(1)
+                        .build())
+                .tagList(Tag.builder().key("env").value("test").build())
+                .build());
+
+        assertThat(response.domainStatus()).isNotNull();
+        assertThat(response.domainStatus().domainName()).isEqualTo(DOMAIN_NAME);
+        assertThat(response.domainStatus().arn()).isNotBlank();
+    }
+
+    @Test
+    @Order(2)
+    void listDomainNames() {
+        ListDomainNamesResponse response = opensearch.listDomainNames(ListDomainNamesRequest.builder().build());
+        assertThat(response.domainNames()).anyMatch(d -> d.domainName().equals(DOMAIN_NAME));
+    }
+
+    @Test
+    @Order(3)
+    void describeDomain() {
+        DescribeDomainResponse response = opensearch.describeDomain(DescribeDomainRequest.builder()
+                .domainName(DOMAIN_NAME)
+                .build());
+
+        assertThat(response.domainStatus().domainName()).isEqualTo(DOMAIN_NAME);
+        domainEndpoint = response.domainStatus().endpoint();
+    }
+
+    @Test
+    @Order(4)
+    void addTags() {
+        DescribeDomainResponse describe = opensearch.describeDomain(DescribeDomainRequest.builder()
+                .domainName(DOMAIN_NAME)
+                .build());
+
+        opensearch.addTags(AddTagsRequest.builder()
+                .arn(describe.domainStatus().arn())
+                .tagList(Tag.builder().key("new-tag").value("new-value").build())
+                .build());
+
+        ListTagsResponse response = opensearch.listTags(ListTagsRequest.builder()
+                .arn(describe.domainStatus().arn())
+                .build());
+
+        assertThat(response.tagList()).anyMatch(t -> t.key().equals("new-tag"));
+    }
+
+    @Test
+    @Order(5)
+    void removeTags() {
+        DescribeDomainResponse describe = opensearch.describeDomain(DescribeDomainRequest.builder()
+                .domainName(DOMAIN_NAME)
+                .build());
+
+        opensearch.removeTags(RemoveTagsRequest.builder()
+                .arn(describe.domainStatus().arn())
+                .tagKeys("new-tag")
+                .build());
+
+        ListTagsResponse response = opensearch.listTags(ListTagsRequest.builder()
+                .arn(describe.domainStatus().arn())
+                .build());
+
+        assertThat(response.tagList()).noneMatch(t -> t.key().equals("new-tag"));
+    }
+
+    @Test
+    @Order(6)
+    void createDuplicateDomainFails() {
+        assertThatThrownBy(() -> opensearch.createDomain(CreateDomainRequest.builder()
+                        .domainName(DOMAIN_NAME)
+                        .build()))
+                .isInstanceOf(ResourceAlreadyExistsException.class);
+    }
+
+    @Test
+    @Order(7)
+    void domainEndpointReachable() {
+        if (domainEndpoint == null || domainEndpoint.isBlank()) {
+            // Mock mode: endpoint is empty — skip HTTP probe
+            return;
+        }
+
+        // Wait for domain to be ready (processing = false)
+        long start = System.currentTimeMillis();
+        boolean ready = false;
+        while (System.currentTimeMillis() - start < 180000) { // 3 minutes timeout
+            DescribeDomainResponse response = opensearch.describeDomain(DescribeDomainRequest.builder()
+                    .domainName(DOMAIN_NAME)
+                    .build());
+            if (!response.domainStatus().processing()) {
+                ready = true;
+                break;
+            }
+            try { Thread.sleep(5000); } catch (InterruptedException e) {}
+        }
+
+        assertThat(ready).as("Domain did not become ready in time").isTrue();
+
+        try {
+            HttpURLConnection conn = (HttpURLConnection)
+                    URI.create(domainEndpoint + "/_cluster/health").toURL().openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            int code = conn.getResponseCode();
+            assertThat(code).isEqualTo(200);
+        } catch (Exception e) {
+            fail("OpenSearch endpoint " + domainEndpoint + " not reachable: " + e.getMessage());
+        }
+    }
+
+    @Test
+    @Order(8)
+    void deleteDomain() {
+        DeleteDomainResponse response = opensearch.deleteDomain(DeleteDomainRequest.builder()
+                .domainName(DOMAIN_NAME)
+                .build());
+
+        assertThat(response.domainStatus()).isNotNull();
+        assertThat(response.domainStatus().domainName()).isEqualTo(DOMAIN_NAME);
+    }
+
+    @Test
+    @Order(9)
+    void describeDomainAfterDeleteFails() {
+        assertThatThrownBy(() -> opensearch.describeDomain(DescribeDomainRequest.builder()
+                        .domainName(DOMAIN_NAME)
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   floci:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.native
     ports:
       - "4566:4566"
       - "6379-6399:6379-6399"

--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -167,10 +167,12 @@ floci:
 
     opensearch:
       enabled: true
-      mode: mock                              # mock | real
+      mock: false                             # true = metadata only, no Docker (useful for CI)
       default-image: "opensearchproject/opensearch:2"
       proxy-base-port: 9400
       proxy-max-port: 9499
+      keep-running-on-shutdown: false         # leave containers running after Floci stops
+      # docker network is inherited from floci.services.docker-network
 
     ec2:
       enabled: true
@@ -222,6 +224,8 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 | `FLOCI_SERVICES_ECS_DEFAULT_MEMORY_MB`             | `512`            | Default memory (MB) when task definition omits it             |
 | `FLOCI_SERVICES_ECS_DEFAULT_CPU_UNITS`             | `256`            | Default CPU units when task definition omits it               |
 | `FLOCI_SERVICES_IAM_ENFORCEMENT_ENABLED`           | `false`          | Enforce IAM identity-based policies on every request when `true` |
+| `FLOCI_SERVICES_OPENSEARCH_MOCK`                   | `false`          | Skip Docker; domains appear active immediately (useful for CI)   |
+| `FLOCI_SERVICES_OPENSEARCH_KEEP_RUNNING_ON_SHUTDOWN` | `false`        | Leave OpenSearch containers running after Floci stops            |
 
 Per-queue SQS redrive policy (`maxReceiveCount`) is configured at queue creation time via `SetQueueAttributes` / `CreateQueue`, not as a global default.
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -2,19 +2,45 @@
 
 ## Port Overview
 
-| Port / Range | Protocol | Purpose |
-|---|---|---|
-| `4566` | HTTP | All AWS API calls (every service) |
-| `5100–5199` | HTTP | ECR Registry sidecar (`floci-ecr-registry`) — bound directly by that container, not the floci container |
-| `6379–6399` | TCP | ElastiCache Redis proxy, one port per replication group |
-| `6500–6599` | HTTPS | EKS k3s API server, one port per cluster (real mode only) |
-| `7001–7099` | TCP | RDS proxy, one port per DB instance |
-| `9200–9299` | HTTP | Lambda Runtime API (internal: consumed by spawned Lambda containers, not host-mapped) |
-| `9400–9499` | HTTP | OpenSearch proxy, reserved for `opensearch.mode: real` (not yet available) |
+| Port / Range | Protocol | Purpose | docker-compose mapping required? |
+|---|---|---|---|
+| `4566` | HTTP | All AWS API calls (every service) | Yes |
+| `5100–5199` | HTTP | ECR Registry sidecar — bound directly by the `registry:2` container | **No** (see note) |
+| `6379–6399` | TCP | ElastiCache Redis proxy (inside Floci) | Yes |
+| `6500–6599` | HTTPS | EKS k3s API server — bound directly by each k3s container | **No** |
+| `7001–7099` | TCP | RDS proxy (inside Floci) | Yes |
+| `9200–9299` | HTTP | Lambda Runtime API (internal, Docker-network only) | **No** |
+| `9400–9499` | HTTP | OpenSearch data-plane — bound directly by each OpenSearch container | **No** |
+
+## Why some ports don't need docker-compose mapping
+
+There are two distinct patterns Floci uses to expose container ports:
+
+### Proxy-in-Floci (ElastiCache, RDS)
+
+Floci runs a **TCP proxy process inside its own container**. The proxy listens on the host port and forwards traffic to the backend container.
+
+```
+host:6379  →  [docker-compose ports mapping]  →  Floci container:6379  →  Redis container:6379
+```
+
+Because the listener is inside the Floci container, `ports:` in `docker-compose.yml` is required to make it reachable from the host.
+
+### Direct container binding (ECR, EKS, OpenSearch)
+
+Floci tells the Docker daemon to start a sidecar/service container and bind its port **directly on the host**. Floci itself communicates with the container via the shared Docker network (container name + internal port). The host port is bound by Docker, not by Floci.
+
+```
+host:9400  ←──  opensearch container:9200  (Docker binds 9400 directly on the host)
+                        ↑
+       Floci reaches it via Docker network: floci-opensearch-{name}:9200
+```
+
+No `docker-compose.yml` `ports:` mapping is needed — the port is already on the host.
 
 ## Port 4566 — AWS API
 
-Every AWS SDK and CLI call goes to port `4566`. This includes all management-plane operations: creating queues, putting items, invoking lambdas, etc.
+Every AWS SDK and CLI call goes to port `4566`. This includes all management-plane operations: creating queues, putting items, invoking Lambdas, etc.
 
 ```bash
 aws s3 ls --endpoint-url http://localhost:4566
@@ -24,42 +50,36 @@ aws lambda list-functions --endpoint-url http://localhost:4566
 
 ## Ports 6379–6399 — ElastiCache
 
-When you create an ElastiCache replication group, Floci starts a Valkey/Redis Docker container and creates a TCP proxy on the next available port in the `6379–6399` range.
-
-Connect to a Redis cluster:
+When you create an ElastiCache replication group, Floci starts a Valkey/Redis Docker container and creates a TCP proxy on the next available port in the `6379–6399` range. The proxy runs inside the Floci container, so this range must be mapped in `docker-compose.yml`.
 
 ```bash
-# First create the replication group
+# Create a replication group
 aws elasticache create-replication-group \
   --replication-group-id my-redis \
   --replication-group-description "dev cache" \
   --endpoint-url http://localhost:4566
 
-# Then connect directly on the proxied port
+# Connect directly on the proxied port (returned in DescribeReplicationGroups Endpoint.Port)
 redis-cli -h localhost -p 6379
 ```
 
-The port assigned to a replication group is returned in the `PrimaryEndpoint.Port` field of the `DescribeReplicationGroups` response.
-
 !!! note
-    The proxy range starts at `6379` by default (matching the standard Redis port for the first cluster). Configure the range with `FLOCI_SERVICES_ELASTICACHE_PROXY_BASE_PORT` and `FLOCI_SERVICES_ELASTICACHE_PROXY_MAX_PORT`.
+    Configure the range with `FLOCI_SERVICES_ELASTICACHE_PROXY_BASE_PORT` and `FLOCI_SERVICES_ELASTICACHE_PROXY_MAX_PORT`.
 
 ## Ports 6500–6599 — EKS (real mode)
 
-When you create an EKS cluster in real mode, Floci starts a k3s Docker container and binds its API server to the next available port in the `6500–6599` range. The Kubernetes endpoint returned by `DescribeCluster` points to `https://localhost:<hostPort>`.
+When you create an EKS cluster in real mode, Floci asks the Docker daemon to start a k3s container and bind its API server port (6443) to the next available host port in `6500–6599`. The port is bound directly on the host by Docker — no `docker-compose.yml` mapping is needed.
 
-These ports are only needed in real mode (`FLOCI_SERVICES_EKS_MOCK=false`). In mock mode no k3s containers are started and no ports are used.
+The `endpoint` field returned by `DescribeCluster` points to `https://localhost:<hostPort>` when running outside a container, or `https://floci-eks-<name>:6443` when Floci is running inside Docker.
 
 ```bash
-# Create a cluster (real mode)
 aws eks create-cluster \
   --name my-cluster \
   --role-arn arn:aws:iam::000000000000:role/eks-role \
   --resources-vpc-config subnetIds=[],securityGroupIds=[] \
   --endpoint-url http://localhost:4566
 
-# The endpoint field in DescribeCluster tells you the API server port:
-# "endpoint": "https://localhost:6500"
+# DescribeCluster returns the API server address, e.g. https://localhost:6500
 ```
 
 !!! note
@@ -67,10 +87,9 @@ aws eks create-cluster \
 
 ## Ports 7001–7099 — RDS
 
-When you create an RDS DB instance, Floci starts a PostgreSQL or MySQL Docker container and creates a TCP proxy on the next available port in the `7001–7099` range.
+When you create an RDS DB instance, Floci starts a PostgreSQL or MySQL Docker container and creates a TCP proxy on the next available port in the `7001–7099` range. The proxy runs inside the Floci container, so this range must be mapped in `docker-compose.yml`.
 
 ```bash
-# Create a PostgreSQL instance
 aws rds create-db-instance \
   --db-instance-identifier mydb \
   --db-instance-class db.t3.micro \
@@ -86,35 +105,47 @@ psql -h localhost -p 7001 -U admin
 !!! note
     Configure the range with `FLOCI_SERVICES_RDS_PROXY_BASE_PORT` and `FLOCI_SERVICES_RDS_PROXY_MAX_PORT`.
 
-## Ports 9200–9299, Lambda Runtime API (internal)
+## Ports 9200–9299 — Lambda Runtime API (internal)
 
-Floci binds a Lambda Runtime API port in the `9200–9299` range for each warm Lambda container to poll. These ports are consumed by containers Floci spawns itself on the shared Docker network, so they do not need to be mapped to the host. Configure the range with `FLOCI_SERVICES_LAMBDA_RUNTIME_API_BASE_PORT` and `FLOCI_SERVICES_LAMBDA_RUNTIME_API_MAX_PORT`.
+Floci binds a Runtime API port in `9200–9299` for each warm Lambda container to poll. These ports are consumed by containers on the shared Docker network only — they are never accessed from the host and must **not** be mapped in `docker-compose.yml`.
 
-## Ports 9400–9499, OpenSearch (reserved)
+Configure the range with `FLOCI_SERVICES_LAMBDA_RUNTIME_API_BASE_PORT` and `FLOCI_SERVICES_LAMBDA_RUNTIME_API_MAX_PORT`.
 
-This range is reserved for OpenSearch `mode: real`, which will spin up an OpenSearch Docker container per domain and proxy data-plane traffic on the next available port in `9400–9499`. Real mode is not yet implemented: the default `mock` mode exposes only the management API on port `4566` and uses no proxy port. See [OpenSearch](../services/opensearch.md) for current status.
+## Ports 9400–9499 — OpenSearch (real mode)
+
+When you create an OpenSearch domain in real mode, Floci asks the Docker daemon to start an `opensearchproject/opensearch` container and bind its REST port (9200) to the next available host port in `9400–9499`. The port is bound directly on the host by Docker — no `docker-compose.yml` mapping is needed.
+
+The `endpoint` field returned by `DescribeDomain` points to `http://localhost:<hostPort>` when running outside a container, or `http://floci-opensearch-<name>:9200` when Floci is running inside Docker.
+
+```bash
+aws opensearch create-domain \
+  --domain-name my-search \
+  --engine-version OpenSearch_2.11 \
+  --endpoint-url http://localhost:4566
+
+# DescribeDomain returns the data-plane address, e.g. http://localhost:9400
+curl http://localhost:9400/_cluster/health
+```
 
 !!! note
- When real mode lands, configure the range with `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` and `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT`.
+    Configure the range with `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` and `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT`.
 
 ## Ports 5100–5199 — ECR Registry
 
-ECR is backed by a separate `registry:2` sidecar container (`floci-ecr-registry`) that Floci starts lazily on the first ECR API call. That container binds its own host port directly — **do not** add `5100-5199` to the floci service's `ports` in Docker Compose. Doing so pre-allocates those ports on the floci container and prevents the sidecar from binding them, causing the ECR registry to fail to start.
+ECR is backed by a separate `registry:2` sidecar container (`floci-ecr-registry`) that Floci starts on the first ECR API call. That container binds its port directly on the host — **do not** add `5100-5199` to the floci service's `ports` in Docker Compose. Doing so pre-allocates those ports on the Floci container and prevents the sidecar from binding them.
 
 ```
 host:5100  ←──  floci-ecr-registry (registry:2 container, started by Floci)
-                       ↑
-                 EcrRegistryManager manages this container's lifecycle
 ```
 
-`docker login localhost:5100` works because the sidecar has a direct host port binding. No docker-compose port mapping is needed.
+`docker login localhost:5100` works because the sidecar has a direct host port binding.
 
 !!! warning "Do not expose ECR port range on the floci service"
-    Adding `- "5100-5199:5100-5199"` to the floci service ports will conflict with the ECR sidecar container and break `docker push` / `docker pull`.
+    Adding `- "5100-5199:5100-5199"` to the floci service ports will conflict with the ECR sidecar and break `docker push` / `docker pull`.
 
 ## Exposing Ports in Docker Compose
 
-When running Floci inside Docker, expose these ranges to the host so your application (or Redis/psql CLI) can connect. **ECR ports are excluded** — they are handled by the registry sidecar:
+Only the proxy-based services (ElastiCache and RDS) need port mappings in `docker-compose.yml`. Direct-binding services (ECR, EKS, OpenSearch) bind their ports on the host automatically via Docker:
 
 ```yaml
 services:
@@ -122,13 +153,12 @@ services:
     image: hectorvent/floci:latest
     ports:
       - "4566:4566"           # All AWS API calls
-      - "6379-6399:6379-6399" # ElastiCache / Redis proxy ports
-      - "6500-6599:6500-6599" # EKS k3s API server ports (real mode only)
-      - "7001-7099:7001-7099" # RDS / PostgreSQL + MySQL proxy ports
+      - "6379-6399:6379-6399" # ElastiCache / Redis proxy (proxy in Floci)
+      - "7001-7099:7001-7099" # RDS proxy (proxy in Floci)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
 
-Omit `6500-6599` if you run EKS in mock mode (`FLOCI_SERVICES_EKS_MOCK=true`).
+EKS (6500–6599) and OpenSearch (9400–9499) ports are bound directly on the host by Docker and are accessible without any `ports:` entry. ECR (5100–5199) must not be added.
 
 If your application runs inside the same Docker Compose network, it can reach Floci directly on container port `4566` — the host port mapping is only needed for tools running on the host (CLI, IDE plugins, etc.).

--- a/docs/services/eks.md
+++ b/docs/services/eks.md
@@ -38,10 +38,12 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - "4566:4566"
-      - "6500-6599:6500-6599"   # k3s API server ports (real mode only)
     environment:
       FLOCI_SERVICES_EKS_DOCKER_NETWORK: my_project_default
 ```
+
+!!! note "No port mapping needed for k3s ports"
+    k3s containers bind their API server port (6500–6599) directly on the host via Docker — no `ports:` entry is required in `docker-compose.yml`. See [Ports Reference](../configuration/ports.md#ports-65006599-eks-real-mode) for the full explanation.
 
 ## Configuration
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -45,9 +45,9 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 | [EKS](eks.md) | `/clusters`, `/clusters/{name}`, `/tags/{resourceArn}` | REST JSON | 7 |
 
-**Lambda, ElastiCache, RDS, ECS, and EKS** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS.
+**Lambda, ElastiCache, RDS, MSK, ECS, EKS, and OpenSearch** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS.
 
-**ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane. **EKS** (real mode) starts a k3s container per cluster and exposes the Kubernetes API server on a host port.
+**ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane. **EKS** (real mode) starts a k3s container per cluster and exposes the Kubernetes API server on a host port. **OpenSearch** (real mode) starts an `opensearchproject/opensearch` container per domain and exposes the data-plane REST API on a host port.
 
 ## Common Setup
 

--- a/docs/services/opensearch.md
+++ b/docs/services/opensearch.md
@@ -1,17 +1,35 @@
 # OpenSearch Service
 
-**Protocol:** REST JSON
-**Endpoint:** `http://localhost:4566/2021-01-01/...`
+**Protocol:** REST JSON  
+**Endpoint:** `http://localhost:4566/2021-01-01/...`  
 **Credential scope:** `es`
 
-## Implementation Mode
+## Implementation Modes
 
-OpenSearch supports two implementation modes controlled by `FLOCI_SERVICES_OPENSEARCH_MODE`:
+OpenSearch supports two modes controlled by `FLOCI_SERVICES_OPENSEARCH_MOCK`.
 
-| Mode | Behaviour |
-|---|---|
-| `mock` *(default)* | Management API only. Domains are stored in the configured StorageBackend and appear `ACTIVE` immediately. No real search capability. |
-| `real` | *(v2, coming soon)* Spins up a real OpenSearch Docker container per domain and proxies data-plane requests to it. |
+### Mock mode (`mock: true`)
+
+Domain metadata is stored in-process. No Docker containers are started. Domains appear `Created: true` and `Processing: false` immediately. Use this in CI or whenever you only need the management API shape, not a real search cluster.
+
+### Real mode (`mock: false`, default)
+
+Floci starts an **OpenSearch** (`opensearchproject/opensearch:2`) Docker container per domain. The container is exposed on a host port from the configured range (`9400–9499`). Once `/_cluster/health` returns `green` or `yellow`, the domain transitions to `Created: true` and the `Endpoint` field is populated with the container's address.
+
+!!! note "Docker socket required"
+    Real mode starts Docker containers. Mount the Docker socket and set the Docker network so containers can reach each other.
+
+```yaml
+services:
+  floci:
+    image: hectorvent/floci:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "4566:4566"
+    environment:
+      FLOCI_SERVICES_DOCKER_NETWORK: my_project_default
+```
 
 ## Supported Operations
 
@@ -54,7 +72,7 @@ OpenSearch supports two implementation modes controlled by `FLOCI_SERVICES_OPENS
 | `DescribeDomainHealth` | Returns `ClusterHealth: Green` |
 | `GetUpgradeHistory` | Returns empty list |
 | `GetUpgradeStatus` | Returns `StepStatus: SUCCEEDED` |
-| `UpgradeDomain` | Stores new engine version, returns immediately |
+| `UpgradeDomain` | Stores new engine version, returns immediately with a generated `UpgradeId` |
 | `CancelDomainConfigChange` | Returns empty `CancelledChangeIds` |
 | `StartServiceSoftwareUpdate` | Returns no-op `ServiceSoftwareOptions` |
 | `CancelServiceSoftwareUpdate` | Returns no-op `ServiceSoftwareOptions` |
@@ -66,10 +84,13 @@ floci:
   services:
     opensearch:
       enabled: true
-      mode: mock                                    # mock | real (real is v2, not yet available)
-      default-image: "opensearchproject/opensearch:2"  # used only when mode=real
+      mock: false                                   # true = metadata only, no Docker
+      default-image: "opensearchproject/opensearch:2"
       proxy-base-port: 9400                         # port range for real-mode containers
       proxy-max-port: 9499
+      keep-running-on-shutdown: false               # leave containers running after Floci stops
+      # data-path is derived from floci.storage.persistent-path/opensearch
+      # docker network is shared with all other services via floci.services.docker-network
 
   storage:
     services:
@@ -82,21 +103,38 @@ floci:
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_OPENSEARCH_ENABLED` | `true` | Enable/disable the service |
-| `FLOCI_SERVICES_OPENSEARCH_MODE` | `mock` | `mock` or `real` |
-| `FLOCI_SERVICES_OPENSEARCH_DEFAULT_IMAGE` | `opensearchproject/opensearch:2` | Docker image for `real` mode |
-| `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` | `9400` | Port range start for `real` mode |
-| `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT` | `9499` | Port range end for `real` mode |
-| `FLOCI_STORAGE_SERVICES_OPENSEARCH_MODE` | *(global default)* | Storage mode override |
+| `FLOCI_SERVICES_OPENSEARCH_MOCK` | `false` | `true` = metadata only (no Docker) |
+| `FLOCI_SERVICES_OPENSEARCH_DEFAULT_IMAGE` | `opensearchproject/opensearch:2` | Docker image for real mode |
+| `FLOCI_SERVICES_OPENSEARCH_PROXY_BASE_PORT` | `9400` | Port range start for real mode |
+| `FLOCI_SERVICES_OPENSEARCH_PROXY_MAX_PORT` | `9499` | Port range end for real mode |
+| `FLOCI_SERVICES_OPENSEARCH_KEEP_RUNNING_ON_SHUTDOWN` | `false` | Leave containers running after Floci stops |
+| `FLOCI_SERVICES_DOCKER_NETWORK` | *(unset)* | Shared Docker network for all container-based services including OpenSearch |
 | `FLOCI_STORAGE_SERVICES_OPENSEARCH_FLUSH_INTERVAL_MS` | `5000` | Flush interval (ms) |
+
+### Mock mode (CI / tests)
+
+Use `FLOCI_SERVICES_OPENSEARCH_MOCK=true` when you only need the API shape:
+
+```yaml
+# docker-compose.yml — CI / test environment
+services:
+  floci:
+    image: hectorvent/floci:latest
+    environment:
+      FLOCI_SERVICES_OPENSEARCH_MOCK: "true"
+```
 
 ## Emulation Behaviour
 
 - **Domain name validation:** 3–28 characters, must start with a lowercase letter, only lowercase letters, digits, and hyphens.
 - **ARN format:** `arn:aws:es:{region}:{accountId}:domain/{domainName}`
 - **Domain ID format:** `{accountId}/{domainName}`
-- **Processing:** Always `false` in `mock` mode — domains are `ACTIVE` immediately.
+- **`Created` flag:** `true` immediately in mock mode; set to `true` by the readiness poller in real mode once `/_cluster/health` reports `green` or `yellow`.
+- **`Processing` flag:** `false` immediately in mock mode; `true` until the container is ready in real mode.
 - **Engine version default:** `OpenSearch_2.11`
+- **Supported engine versions:** `OpenSearch_2.13`, `OpenSearch_2.11`, `OpenSearch_2.9`, `OpenSearch_2.7`, `OpenSearch_2.5`, `OpenSearch_2.3`, `OpenSearch_1.3`, `OpenSearch_1.2`, `Elasticsearch_7.10`, `Elasticsearch_7.9`, `Elasticsearch_7.8`
 - **Cluster defaults:** `m5.large.search`, 1 instance, EBS enabled with 10 GiB `gp2` volume.
+- **Data path:** `{floci.storage.persistent-path}/opensearch/{domainName}` — follows the shared storage root.
 
 ## Examples
 
@@ -161,11 +199,15 @@ CreateDomainResponse created = os.createDomain(req -> req
 
 System.out.println("ARN: " + created.domainStatus().arn());
 
+// Wait for domain to be ready (real mode)
+// created.domainStatus().created() == true when ready
+
 // Describe the domain
 DescribeDomainResponse desc = os.describeDomain(req -> req
     .domainName("my-search"));
 
 System.out.println("Version: " + desc.domainStatus().engineVersion());
+System.out.println("Endpoint: " + desc.domainStatus().endpoint());
 
 // List domains
 os.listDomainNames(req -> req.build())
@@ -207,9 +249,9 @@ for d in domains["DomainNames"]:
 os_client.delete_domain(DomainName="my-search")
 ```
 
-## Limitations (v1)
+## Limitations
 
-- No real search capability in `mock` mode — data-plane endpoints (`/_search`, `/_index`, etc.) are not proxied.
-- No Elasticsearch-compatible endpoints (`/2015-01-01/es/domain/...`).
+- In mock mode, no data-plane endpoints (`/_search`, `/_index`, etc.) are served — only the management API is emulated.
+- No Elasticsearch-compatible management endpoints (`/2015-01-01/es/domain/...`).
 - VPC options, fine-grained access control, encryption-at-rest, and cross-cluster connections are accepted in the request but silently ignored.
-- All 41 "not applicable" operations (VPC endpoints, reserved instances, packages, applications, data sources) return `UnsupportedOperationException`.
+- All unsupported operations (VPC endpoints, reserved instances, packages, applications, data sources) return `UnsupportedOperationException`.

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -433,8 +433,9 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
 
-        @WithDefault("mock")
-        String mode();
+        /** When true, domains are simulated in-memory without real Docker containers. */
+        @WithDefault("false")
+        boolean mock();
 
         @WithDefault("opensearchproject/opensearch:2")
         String defaultImage();
@@ -445,7 +446,11 @@ public interface EmulatorConfig {
         @WithDefault("9499")
         int proxyMaxPort();
 
-        Optional<String> dockerNetwork();
+        @WithDefault("${floci.storage.persistent-path}/opensearch")
+        String dataPath();
+
+        @WithDefault("false")
+        boolean keepRunningOnShutdown();
     }
 
     interface EcsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @Path("/2021-01-01")
 @Produces(MediaType.APPLICATION_JSON)
@@ -400,6 +401,7 @@ public class OpenSearchController {
             Domain domain = service.upgradeDomain(domainName, targetVersion);
 
             ObjectNode response = objectMapper.createObjectNode();
+            response.put("UpgradeId", UUID.randomUUID().toString());
             response.put("DomainName", domain.getDomainName());
             response.put("TargetVersion", domain.getEngineVersion());
             response.put("PerformCheckOnly", false);
@@ -456,6 +458,7 @@ public class OpenSearchController {
         node.put("DomainId", domain.getDomainId());
         node.put("DomainName", domain.getDomainName());
         node.put("EngineVersion", domain.getEngineVersion());
+        node.put("Created", !domain.isProcessing());
         node.put("Processing", domain.isProcessing());
         node.put("Deleted", domain.isDeleted());
         node.put("Endpoint", domain.getEndpoint() != null ? domain.getEndpoint() : "");

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -1,0 +1,140 @@
+package io.github.hectorvent.floci.services.opensearch;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.PortAllocator;
+import io.github.hectorvent.floci.services.opensearch.model.Domain;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Manages the Docker lifecycle of OpenSearch containers for real-mode domains.
+ * Not used when {@code floci.services.opensearch.mock=true}.
+ */
+@ApplicationScoped
+public class OpenSearchDomainManager {
+
+    private static final Logger LOG = Logger.getLogger(OpenSearchDomainManager.class);
+    private static final int OPENSEARCH_PORT = 9200;
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerDetector containerDetector;
+    private final PortAllocator portAllocator;
+    private final EmulatorConfig config;
+
+    @Inject
+    public OpenSearchDomainManager(ContainerBuilder containerBuilder,
+                                   ContainerLifecycleManager lifecycleManager,
+                                   ContainerDetector containerDetector,
+                                   PortAllocator portAllocator,
+                                   EmulatorConfig config) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.containerDetector = containerDetector;
+        this.portAllocator = portAllocator;
+        this.config = config;
+    }
+
+    public void startDomain(Domain domain) {
+        String image = config.services().opensearch().defaultImage();
+        String containerName = "floci-opensearch-" + domain.getDomainName();
+
+        LOG.infov("Starting OpenSearch container for domain: {0} using image {1}",
+                domain.getDomainName(), image);
+
+        int hostPort = portAllocator.allocate(
+                config.services().opensearch().proxyBasePort(),
+                config.services().opensearch().proxyMaxPort());
+
+        Path dataPath = Path.of(config.services().opensearch().dataPath(), domain.getDomainName());
+        try {
+            Files.createDirectories(dataPath);
+        } catch (IOException e) {
+            LOG.warnv("Could not create OpenSearch data directory {0}: {1}", dataPath, e.getMessage());
+        }
+
+        lifecycleManager.removeIfExists(containerName);
+
+        String hostDataPath;
+        String hostPersistentPath = config.storage().hostPersistentPath();
+        if (hostPersistentPath.startsWith("/")) {
+            String dataPathStr = dataPath.toAbsolutePath().normalize().toString();
+            String persistentPathStr = Path.of(config.storage().persistentPath()).toAbsolutePath().normalize().toString();
+            hostDataPath = dataPathStr.replace(persistentPathStr, hostPersistentPath);
+        } else {
+            hostDataPath = "floci-opensearch-" + domain.getDomainName();
+        }
+
+        ContainerSpec spec = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+                .withPortBinding(OPENSEARCH_PORT, hostPort)
+                .withBind(hostDataPath, "/usr/share/opensearch/data")
+                .withDockerNetwork(config.services().dockerNetwork())
+                .withLogRotation()
+                .build();
+
+        ContainerInfo info = lifecycleManager.createAndStart(spec);
+        domain.setContainerId(info.containerId());
+
+        String hostname = config.hostname().orElse(null);
+        if (hostname != null) {
+            domain.setEndpoint("http://" + hostname + ":" + hostPort);
+        } else if (containerDetector.isRunningInContainer()) {
+            domain.setEndpoint("http://" + containerName + ":" + OPENSEARCH_PORT);
+        } else {
+            domain.setEndpoint("http://localhost:" + hostPort);
+        }
+
+        LOG.infov("OpenSearch container {0} started for domain {1} on port {2}",
+                info.containerId(), domain.getDomainName(), hostPort);
+    }
+
+    public boolean isReady(Domain domain) {
+        String containerName = "floci-opensearch-" + domain.getDomainName();
+        String url = "http://" + containerName + ":" + OPENSEARCH_PORT + "/_cluster/health";
+        try {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            conn.setConnectTimeout(2000);
+            conn.setReadTimeout(2000);
+            int code = conn.getResponseCode();
+            if (code == 200) {
+                String body = new String(conn.getInputStream().readAllBytes());
+                boolean ready = body.contains("\"green\"") || body.contains("\"yellow\"");
+                if (ready) {
+                    LOG.infov("OpenSearch domain {0} is ready (internal check)", domain.getDomainName());
+                }
+                return ready;
+            }
+            return false;
+        } catch (Exception e) {
+            // Silently ignore during polling
+            return false;
+        }
+    }
+
+    public void stopDomain(Domain domain) {
+        if (domain.getContainerId() == null) {
+            return;
+        }
+        if (config.services().opensearch().keepRunningOnShutdown()) {
+            LOG.infov("Leaving OpenSearch container for domain {0} running", domain.getDomainName());
+            return;
+        }
+        lifecycleManager.stopAndRemove(domain.getContainerId(), null);
+        LOG.infov("Stopped OpenSearch container for domain {0}", domain.getDomainName());
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -90,10 +90,7 @@ public class OpenSearchDomainManager {
         ContainerInfo info = lifecycleManager.createAndStart(spec);
         domain.setContainerId(info.containerId());
 
-        String hostname = config.hostname().orElse(null);
-        if (hostname != null) {
-            domain.setEndpoint("http://" + hostname + ":" + hostPort);
-        } else if (containerDetector.isRunningInContainer()) {
+        if (containerDetector.isRunningInContainer()) {
             domain.setEndpoint("http://" + containerName + ":" + OPENSEARCH_PORT);
         } else {
             domain.setEndpoint("http://localhost:" + hostPort);

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -8,6 +8,8 @@ import io.github.hectorvent.floci.services.opensearch.model.ClusterConfig;
 import io.github.hectorvent.floci.services.opensearch.model.Domain;
 import io.github.hectorvent.floci.services.opensearch.model.EbsOptions;
 import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -15,6 +17,9 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class OpenSearchService {
@@ -25,17 +30,40 @@ public class OpenSearchService {
 
     private final StorageBackend<String, Domain> domainStore;
     private final EmulatorConfig config;
+    private final OpenSearchDomainManager domainManager;
+    private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor();
 
     @Inject
-    public OpenSearchService(StorageFactory storageFactory, EmulatorConfig config) {
+    public OpenSearchService(StorageFactory storageFactory, EmulatorConfig config,
+                             OpenSearchDomainManager domainManager) {
         this.domainStore = storageFactory.create("opensearch", "opensearch-domains.json",
                 new TypeReference<Map<String, Domain>>() {});
         this.config = config;
+        this.domainManager = domainManager;
     }
 
-    OpenSearchService(StorageBackend<String, Domain> domainStore, EmulatorConfig config) {
+    OpenSearchService(StorageBackend<String, Domain> domainStore, EmulatorConfig config,
+                      OpenSearchDomainManager domainManager) {
         this.domainStore = domainStore;
         this.config = config;
+        this.domainManager = domainManager;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (!config.services().opensearch().mock()) {
+            startReadinessPoller();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        poller.shutdownNow();
+        if (!config.services().opensearch().mock()) {
+            for (Domain domain : domainStore.scan(k -> true)) {
+                domainManager.stopDomain(domain);
+            }
+        }
     }
 
     public Domain createDomain(String domainName, String engineVersion, ClusterConfig clusterConfig,
@@ -66,6 +94,13 @@ public class OpenSearchService {
         }
         if (tags != null) {
             domain.setTags(tags);
+        }
+
+        if (config.services().opensearch().mock()) {
+            domain.setProcessing(false);
+        } else {
+            domain.setProcessing(true);
+            domainManager.startDomain(domain);
         }
 
         domainStore.put(domainName, domain);
@@ -132,6 +167,9 @@ public class OpenSearchService {
     public Domain deleteDomain(String domainName) {
         Domain domain = describeDomain(domainName);
         domain.setDeleted(true);
+        if (!config.services().opensearch().mock()) {
+            domainManager.stopDomain(domain);
+        }
         domainStore.delete(domainName);
         LOG.infov("Deleted OpenSearch domain: {0}", domainName);
         return domain;
@@ -186,5 +224,18 @@ public class OpenSearchService {
             return engineVersion != null && engineVersion.startsWith("Elasticsearch");
         }
         return engineVersion == null || engineVersion.startsWith("OpenSearch");
+    }
+
+    private void startReadinessPoller() {
+        poller.scheduleWithFixedDelay(() -> {
+            for (Domain domain : domainStore.scan(k -> true)) {
+                if (domain.isProcessing() && domainManager.isReady(domain)) {
+                    domain.setProcessing(false);
+                    domainStore.put(domain.getDomainName(), domain);
+                    LOG.infov("OpenSearch domain {0} is ready at {1}",
+                            domain.getDomainName(), domain.getEndpoint());
+                }
+            }
+        }, 3, 3, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.opensearch.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -42,7 +43,11 @@ public class Domain {
     @JsonProperty("Tags")
     private Map<String, String> tags = new HashMap<>();
 
+    @JsonProperty("ContainerId")
+    private String containerId;
+
     @JsonProperty("CreatedAt")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Instant createdAt;
 
     public Domain() {}
@@ -125,6 +130,14 @@ public class Domain {
 
     public void setTags(Map<String, String> tags) {
         this.tags = tags != null ? new HashMap<>(tags) : new HashMap<>();
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+
+    public void setContainerId(String containerId) {
+        this.containerId = containerId;
     }
 
     public Instant getCreatedAt() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,10 +149,11 @@ floci:
       enabled: true
     opensearch:
       enabled: true
-      mode: mock
+      mock: false
       default-image: "opensearchproject/opensearch:2"
       proxy-base-port: 9400
       proxy-max-port: 9499
+      keep-running-on-shutdown: false
     ec2:
       enabled: true
     ecs:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -122,7 +122,7 @@ floci:
       enabled: true
     opensearch:
       enabled: true
-      mode: mock
+      mock: true
       default-image: "opensearchproject/opensearch:2"
       proxy-base-port: 9400
       proxy-max-port: 9499


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Updated OpenSearch documentation and README to correctly reflect its real-mode Docker capabilities and expanded engine version support.

   * Service Classification: Updated README.md and docs/services/index.md to list OpenSearch as a service using real Docker containers (joining Lambda, RDS, MSK, etc.).
   * Version Support: Updated docs/services/opensearch.md to include OpenSearch_2.13 and Elasticsearch 7.x compatibility.
   * Consistency: Synchronized the list of container-based services (Lambda, ElastiCache, RDS, MSK, ECS, EKS, OpenSearch) across the main README and the service overview.
   * Validation: Verified implementation via OpenSearchTest in the Java compatibility suite (9/9 tests passed).



## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
