### PR TITLE
fix(lambda): destroy container handle on interrupt and generic exception (#525)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorService.java
@@ -113,11 +113,11 @@ public class LambdaExecutorService {
                     null, requestId);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            warmPool.release(handle);
+            warmPool.destroyHandle(handle);
             return new InvokeResult(200, "Unhandled", buildErrorPayload("Invocation interrupted", "Interrupted"), null, requestId);
         } catch (Exception e) {
             LOG.warnv("Invocation error for function {0}: {1}", fn.getFunctionName(), e.getMessage());
-            warmPool.release(handle);
+            warmPool.destroyHandle(handle);
             return new InvokeResult(200, "Unhandled", buildErrorPayload(e.getMessage(), "InvocationError"), null, requestId);
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorServiceTest.java
@@ -17,6 +17,9 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -117,5 +120,58 @@ class LambdaExecutorServiceTest {
         verify(warmPool, never()).release(any());
         verify(warmPool, never()).destroyHandle(any());
         assertEquals(204, result.getStatusCode());
+    }
+
+    @Test
+    void interruptedInvocation_destroysHandle_doesNotRelease() throws Exception {
+        fn.setTimeout(30);
+        RuntimeApiServer rtas = mock(RuntimeApiServer.class);
+        ContainerHandle handle = new ContainerHandle("cid-int", "test-fn", rtas, ContainerState.WARM);
+
+        when(warmPool.acquire(any())).thenReturn(handle);
+        CountDownLatch enqueued = new CountDownLatch(1);
+        doAnswer(inv -> {
+            PendingInvocation pi = inv.getArgument(0);
+            enqueued.countDown();
+            return pi.getResultFuture();
+        }).when(rtas).enqueue(any(PendingInvocation.class));
+
+        AtomicReference<InvokeResult> resultRef = new AtomicReference<>();
+        Thread worker = new Thread(() -> resultRef.set(
+                executor.invoke(fn, "{}".getBytes(), InvocationType.RequestResponse)));
+        worker.start();
+
+        assertTrue(enqueued.await(5, TimeUnit.SECONDS), "enqueue never called");
+        worker.interrupt();
+        worker.join(5_000);
+
+        InvokeResult result = resultRef.get();
+        assertNotNull(result, "invoke did not return");
+        verify(warmPool).destroyHandle(handle);
+        verify(warmPool, never()).release(handle);
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("Interrupted"));
+    }
+
+    @Test
+    void exceptionDuringInvocation_destroysHandle_doesNotRelease() {
+        RuntimeApiServer rtas = mock(RuntimeApiServer.class);
+        ContainerHandle handle = new ContainerHandle("cid-exc", "test-fn", rtas, ContainerState.WARM);
+
+        when(warmPool.acquire(any())).thenReturn(handle);
+        doAnswer(inv -> {
+            PendingInvocation pi = inv.getArgument(0);
+            pi.getResultFuture().completeExceptionally(new RuntimeException("runtime crash"));
+            return pi.getResultFuture();
+        }).when(rtas).enqueue(any(PendingInvocation.class));
+
+        InvokeResult result = executor.invoke(fn, "{}".getBytes(), InvocationType.RequestResponse);
+
+        verify(warmPool).destroyHandle(handle);
+        verify(warmPool, never()).release(handle);
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("InvocationError"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #525. Follow-up to #529 (timeout path).

`LambdaExecutorService.executeSync` still had two paths returning a potentially-dirty container to the warm pool via `warmPool.release(handle)`:

- **`InterruptedException`**: the container may still be processing the previous request, so the response from the old invocation could be delivered to a new one, causing data corruption or protocol errors.
- **`Exception`** (e.g. runtime API communication failure): container state is unknown and shouldn't be trusted for reuse.

Both now call `warmPool.destroyHandle(handle)`, matching AWS Lambda behavior where a container is discarded after any internal error.

## Changes

| File | Change |
|------|--------|
| `LambdaExecutorService.java` | Two 1-line swaps in `executeSync`: `release(handle)` → `destroyHandle(handle)` in the `InterruptedException` and generic `Exception` branches. |
| `LambdaExecutorServiceTest.java` | Two new tests mirroring `timeoutInvocation_destroysHandle_doesNotRelease`. |

### New tests

- `interruptedInvocation_destroysHandle_doesNotRelease`: starts `invoke` on a worker thread, uses a `CountDownLatch` driven from a Mockito `doAnswer` on `enqueue` to confirm the thread has reached the blocking `.get()` call, then interrupts. Asserts `destroyHandle` called, `release` never called, and the response payload contains `Interrupted`.
- `exceptionDuringInvocation_destroysHandle_doesNotRelease`: `doAnswer` on `enqueue` completes the future exceptionally with a `RuntimeException`, which surfaces as `ExecutionException` in the `catch (Exception)` branch. Asserts `destroyHandle` called, `release` never called, payload contains `InvocationError`.

## Test plan

- [x] `./mvnw test -Dtest=LambdaExecutorServiceTest`, 6/6 green (4 existing + 2 new)
- [x] External review: Codex (no defects), Gemini (2 advisory suggestions, no blockers)

## Out of scope

- `RuntimeApiServer.stop()` doesn't wake a worker blocked in `pendingQueue.poll(30s)`. Flagged in the #504 review but not a test-breaker; separate issue/PR if worth pursuing.
