### PR TITLE
fix(lambda): wake blocked /next poller and drain queue on RuntimeApiServer.stop()

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -32,6 +32,14 @@ public class RuntimeApiServer {
     private static final String ERROR_PATH = "/" + RUNTIME_API_VERSION + "/runtime/invocation/:requestId/error";
     private static final String INIT_ERROR_PATH = "/" + RUNTIME_API_VERSION + "/runtime/init/error";
 
+    private static final byte[] CONTAINER_STOPPED_PAYLOAD =
+            "{\"errorMessage\":\"Container stopped\",\"errorType\":\"ContainerStopped\"}".getBytes();
+
+    // Sentinel used to wake a /next handler blocked in pendingQueue.poll() when stop() is called.
+    // Compared by identity (==), not equals.
+    private static final PendingInvocation SHUTDOWN_SENTINEL =
+            new PendingInvocation("<shutdown>", new byte[0], 0L, "", new CompletableFuture<>());
+
     private final Vertx vertx;
     private final int port;
     private final LinkedBlockingQueue<PendingInvocation> pendingQueue = new LinkedBlockingQueue<>();
@@ -61,6 +69,17 @@ public class RuntimeApiServer {
                 PendingInvocation invocation = null;
                 while (invocation == null && !stopped) {
                     invocation = pendingQueue.poll(30, TimeUnit.SECONDS);
+                    if (invocation == SHUTDOWN_SENTINEL) {
+                        invocation = null;
+                        break;
+                    }
+                }
+                // If stop() ran after poll() returned a real invocation (narrow race before
+                // inFlight.put), complete it here so the caller doesn't hang.
+                if (invocation != null && stopped) {
+                    invocation.getResultFuture().complete(
+                            new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
+                    invocation = null;
                 }
                 if (invocation == null) {
                     ctx.response().setStatusCode(204).end();
@@ -132,17 +151,44 @@ public class RuntimeApiServer {
         if (httpServer != null) {
             httpServer.close();
         }
-        // Complete any in-flight invocations with error
-        inFlight.values().forEach(inv -> {
-            byte[] errorPayload = "{\"errorMessage\":\"Container stopped\",\"errorType\":\"ContainerStopped\"}".getBytes();
-            inv.getResultFuture().complete(new InvokeResult(200, "Unhandled", errorPayload, null, inv.getRequestId()));
-        });
+
+        // Drain queued invocations that were never consumed by /next, completing each future
+        // with ContainerStopped so callers (LambdaExecutorService) don't hang waiting for a result.
+        PendingInvocation pending;
+        while ((pending = pendingQueue.poll()) != null) {
+            if (pending == SHUTDOWN_SENTINEL) {
+                continue;
+            }
+            pending.getResultFuture().complete(
+                    new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, pending.getRequestId()));
+        }
+
+        // Offer sentinel AFTER drain so it cannot be discarded. Wakes any /next handler
+        // currently blocked in poll(). N=1 today: a single RuntimeApiServer serves one container,
+        // so one sentinel suffices.
+        pendingQueue.offer(SHUTDOWN_SENTINEL);
+
+        // Complete any in-flight invocations with error.
+        inFlight.values().forEach(inv ->
+                inv.getResultFuture().complete(
+                        new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, inv.getRequestId())));
         inFlight.clear();
-        pendingQueue.clear();
     }
 
     public CompletableFuture<InvokeResult> enqueue(PendingInvocation invocation) {
+        if (stopped) {
+            // stop() already ran; don't queue. Complete immediately so caller doesn't hang.
+            invocation.getResultFuture().complete(
+                    new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
+            return invocation.getResultFuture();
+        }
         pendingQueue.offer(invocation);
+        // Close the check-then-offer race: if stop() ran between the guard and offer(),
+        // the drain is done and our invocation would sit forever. Remove and complete.
+        if (stopped && pendingQueue.remove(invocation)) {
+            invocation.getResultFuture().complete(
+                    new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
+        }
         return invocation.getResultFuture();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -134,6 +134,69 @@ class RuntimeApiServerTest {
         assertTrue(payload.contains("ContainerStopped"));
     }
 
+    @Test
+    @Timeout(15)
+    void stopWakesBlockedPollerImmediately() throws Exception {
+        // GET /next on a background thread — blocks in pendingQueue.poll(30s).
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/2018-06-01/runtime/invocation/next"))
+                .GET()
+                .build();
+        CompletableFuture<HttpResponse<String>> asyncResponse =
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+
+        // Give the handler time to enter poll()
+        Thread.sleep(500);
+        assertFalse(asyncResponse.isDone(), "handler should be blocked in poll");
+
+        long start = System.currentTimeMillis();
+        server.stop();
+        HttpResponse<String> response = asyncResponse.get(2, TimeUnit.SECONDS);
+        long elapsed = System.currentTimeMillis() - start;
+
+        // 204 requires the handler to have: woken from poll, observed sentinel, exited loop,
+        // written the response. Proves the worker thread is released (not just the socket closed).
+        assertEquals(204, response.statusCode());
+        assertTrue(elapsed < 1000, "stop() should wake poller in <1s, took " + elapsed + "ms");
+    }
+
+    @Test
+    @Timeout(15)
+    void stopCompletesQueuedInvocationsWithContainerStopped() throws Exception {
+        // Enqueue an invocation, but never call /next — it sits in pendingQueue.
+        PendingInvocation invocation = new PendingInvocation(
+                "req-queued", "{}".getBytes(), System.currentTimeMillis() + 60_000,
+                "arn:aws:lambda:us-east-1:000000000000:function:test",
+                new CompletableFuture<>());
+        server.enqueue(invocation);
+
+        // stop() must drain the queue and complete the future — not discard it silently.
+        server.stop();
+
+        InvokeResult result = invocation.getResultFuture().get(2, TimeUnit.SECONDS);
+        assertNotNull(result);
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("ContainerStopped"));
+    }
+
+    @Test
+    @Timeout(15)
+    void enqueueAfterStopCompletesImmediately() throws Exception {
+        server.stop();
+
+        PendingInvocation invocation = new PendingInvocation(
+                "req-late", "{}".getBytes(), System.currentTimeMillis() + 60_000,
+                "arn:aws:lambda:us-east-1:000000000000:function:test",
+                new CompletableFuture<>());
+        server.enqueue(invocation);
+
+        // Future is completed synchronously by enqueue() when stopped, so no /next is needed.
+        assertTrue(invocation.getResultFuture().isDone(), "future should be already done");
+        InvokeResult result = invocation.getResultFuture().get(0, TimeUnit.SECONDS);
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("ContainerStopped"));
+    }
+
     private static int findFreePort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();


### PR DESCRIPTION
## Summary

`RuntimeApiServer.stop()` had two independent shutdown bugs flagged during #504 review and left out of scope so #504/#529/#530 could merge. This fixes both in a small, focused PR.

### Bug 1: blocked `/next` poller not woken

The `/next` handler loops on `pendingQueue.poll(30s)` and only checks `stopped` *after* `poll()` returns. `stop()` flips the flag but never nudges the queue, so a tearing-down container can hold a Vert.x worker thread for up to 30s.

### Bug 2: queued invocations dropped without completing futures

`stop()` ended with `pendingQueue.clear()`, silently discarding any invocation that was enqueued but not yet consumed by `/next`. `LambdaExecutorService` was already awaiting the result; the caller hung until its own timeout fired. Deterministic, not probabilistic, more impactful than Bug 1 in practice.

## Fix

- Add `SHUTDOWN_SENTINEL`, offered *after* the drain so it cannot be discarded. `/next` recognises it by identity, exits the loop, returns 204.
- Replace `pendingQueue.clear()` with a drain loop that completes each queued invocation's future with `ContainerStopped`.
- Harden `enqueue()` to short-circuit when stopped, with a post-offer recheck that closes the check-then-offer race.
- Add a post-loop `stopped` check in the `/next` handler so an invocation polled just before `stop()` gets completed locally rather than parked in `inFlight` after cleanup.

Keeps `poll(30s)` rather than `take()` as a belt-and-braces timeout if the sentinel is ever missed for any reason.

## Order inside `stop()`

1. `stopped = true` (enqueue short-circuits)
2. `httpServer.close()` (reject new HTTP requests)
3. Drain `pendingQueue` completing each future (fixes Bug 2)
4. Offer sentinel *after* drain so it can't be discarded (fixes Bug 1 without the offer-then-clear race)
5. Complete and clear `inFlight`

## Test plan

- [x] 3 new unit tests in `RuntimeApiServerTest`:
  - `stopWakesBlockedPollerImmediately` asserts 204 within 1s (proves the worker thread exited poll, not just that the socket closed)
  - `stopCompletesQueuedInvocationsWithContainerStopped` covers Bug 2 directly
  - `enqueueAfterStopCompletesImmediately` covers the enqueue hardening path
- [x] Existing `RuntimeApiServerTest` cases pass unchanged (6/6)
- [x] Full `./mvnw clean test` suite: 2437/2439 pass; the two failing `LambdaReactiveSyncIntegrationTest` cases fail the same way on `main` without this diff (Docker/ECR `SocketTimeout`, environmental, not caused by this change)

## Scope

Single-container contract today (one `RuntimeApiServer` per container, AWS Runtime API serial: `/next` → process → `/response` → `/next`), so one sentinel suffices. If multiple concurrent `/next` pollers per instance ever becomes real, revisit to offer N sentinels.

## Related

- #485 worker-pool exhaustion RCA (root cause)
- #504 original PR (closed), #529 rebase-merge, #530 interrupt follow-up