### PR TITLE
feat(appconfig): implement resource tagging and predefined deployment strategies

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -164,22 +164,25 @@ public class AppConfigService {
             case "AppConfig.AllAtOnce" -> {
                 DeploymentStrategy s = new DeploymentStrategy();
                 s.setId(id); s.setName(id);
+                s.setDescription("Quick");
                 s.setDeploymentDurationInMinutes(0); s.setGrowthFactor(100f);
-                s.setFinalBakeTimeInMinutes(0); s.setGrowthType("LINEAR");
+                s.setFinalBakeTimeInMinutes(10); s.setGrowthType("LINEAR");
                 s.setReplicateTo("NONE");
                 yield s;
             }
             case "AppConfig.Linear50PercentEvery30Seconds" -> {
                 DeploymentStrategy s = new DeploymentStrategy();
                 s.setId(id); s.setName(id);
+                s.setDescription("Test/Demo");
                 s.setDeploymentDurationInMinutes(1); s.setGrowthFactor(50f);
-                s.setFinalBakeTimeInMinutes(0); s.setGrowthType("LINEAR");
+                s.setFinalBakeTimeInMinutes(1); s.setGrowthType("LINEAR");
                 s.setReplicateTo("NONE");
                 yield s;
             }
             case "AppConfig.Canary10Percent20Minutes" -> {
                 DeploymentStrategy s = new DeploymentStrategy();
                 s.setId(id); s.setName(id);
+                s.setDescription("AWS Recommended");
                 s.setDeploymentDurationInMinutes(20); s.setGrowthFactor(10f);
                 s.setFinalBakeTimeInMinutes(10); s.setGrowthType("EXPONENTIAL");
                 s.setReplicateTo("NONE");

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -153,7 +153,40 @@ public class AppConfigService {
     }
 
     public DeploymentStrategy getDeploymentStrategy(String id) {
+        // AWS predefined built-in strategies
+        DeploymentStrategy builtin = builtinStrategy(id);
+        if (builtin != null) return builtin;
         return strategyStore.get(id).orElseThrow(() -> new AwsException("ResourceNotFoundException", "Deployment strategy not found", 404));
+    }
+
+    private static DeploymentStrategy builtinStrategy(String id) {
+        return switch (id) {
+            case "AppConfig.AllAtOnce" -> {
+                DeploymentStrategy s = new DeploymentStrategy();
+                s.setId(id); s.setName(id);
+                s.setDeploymentDurationInMinutes(0); s.setGrowthFactor(100f);
+                s.setFinalBakeTimeInMinutes(0); s.setGrowthType("LINEAR");
+                s.setReplicateTo("NONE");
+                yield s;
+            }
+            case "AppConfig.Linear50PercentEvery30Seconds" -> {
+                DeploymentStrategy s = new DeploymentStrategy();
+                s.setId(id); s.setName(id);
+                s.setDeploymentDurationInMinutes(1); s.setGrowthFactor(50f);
+                s.setFinalBakeTimeInMinutes(0); s.setGrowthType("LINEAR");
+                s.setReplicateTo("NONE");
+                yield s;
+            }
+            case "AppConfig.Canary10Percent20Minutes" -> {
+                DeploymentStrategy s = new DeploymentStrategy();
+                s.setId(id); s.setName(id);
+                s.setDeploymentDurationInMinutes(20); s.setGrowthFactor(10f);
+                s.setFinalBakeTimeInMinutes(10); s.setGrowthType("EXPONENTIAL");
+                s.setReplicateTo("NONE");
+                yield s;
+            }
+            default -> null;
+        };
     }
 
     // ──────────────────────────── Deployment ────────────────────────────
@@ -193,6 +226,24 @@ public class AppConfigService {
 
     public String getActiveVersion(String envId, String profileId) {
         return activeConfigStore.get(envId + "::" + profileId).orElse(null);
+    }
+
+    // ──────────────────────────── Tags ────────────────────────────
+
+    public Map<String, String> getApplicationTags(String appId) {
+        return getApplication(appId).getTags();
+    }
+
+    public void tagApplication(String appId, Map<String, String> tags) {
+        Application app = getApplication(appId);
+        app.getTags().putAll(tags);
+        applicationStore.put(appId, app);
+    }
+
+    public void untagApplication(String appId, List<String> tagKeys) {
+        Application app = getApplication(appId);
+        tagKeys.forEach(app.getTags()::remove);
+        applicationStore.put(appId, app);
     }
 
     private static String shortId(int length) {

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
@@ -1,0 +1,83 @@
+package io.github.hectorvent.floci.services.appconfig;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.TagHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link TagHandler} implementation for AppConfig.
+ *
+ * <p>Supported ARN formats:
+ * <ul>
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>}
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>/environment/<envId>}
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>/configurationprofile/<profileId>}
+ * </ul>
+ * Only application-level tags are stored; environment and configurationprofile tag calls
+ * are accepted (no-op) to satisfy Terraform provider reads.
+ */
+@ApplicationScoped
+public class AppConfigTagHandler implements TagHandler {
+
+    private final AppConfigService service;
+
+    @Inject
+    public AppConfigTagHandler(AppConfigService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "appconfig";
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        ResourceRef ref = parseArn(arn);
+        return switch (ref.type()) {
+            case "application" -> service.getApplicationTags(ref.id());
+            default -> Map.of();
+        };
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        ResourceRef ref = parseArn(arn);
+        if ("application".equals(ref.type())) {
+            service.tagApplication(ref.id(), tags);
+        }
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        ResourceRef ref = parseArn(arn);
+        if ("application".equals(ref.type())) {
+            service.untagApplication(ref.id(), tagKeys);
+        }
+    }
+
+    private record ResourceRef(String type, String id) {}
+
+    private static ResourceRef parseArn(String arn) {
+        // arn:aws:appconfig:<region>:<account>:<resource>
+        String[] arnParts = arn.split(":", 6);
+        if (arnParts.length < 6) {
+            throw new AwsException("BadRequestException", "Invalid resource ARN: " + arn, 400);
+        }
+        String[] parts = arnParts[5].split("/");
+        if (parts.length >= 2 && "application".equals(parts[0])) {
+            // application/<appId>
+            if (parts.length == 2) return new ResourceRef("application", parts[1]);
+            // application/<appId>/environment/<envId>
+            // application/<appId>/configurationprofile/<profileId>
+            if (parts.length == 4) return new ResourceRef(parts[2], parts[3]);
+            // application/<appId>/environment/<envId>/deployment/<num>
+            if (parts.length == 6) return new ResourceRef(parts[4], parts[5]);
+        }
+        throw new AwsException("BadRequestException", "Invalid resource ARN: " + arn, 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/model/Application.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/model/Application.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Application {
@@ -13,6 +16,7 @@ public class Application {
     private String name;
     @JsonProperty("Description")
     private String description;
+    private Map<String, String> tags = new HashMap<>();
 
     public Application() {}
 
@@ -24,4 +28,7 @@ public class Application {
 
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags != null ? tags : new HashMap<>(); }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -300,7 +300,7 @@ class AppConfigIntegrationTest {
                 .body("tags", anEmptyMap());
     }
 
-    @Test @Order(22)
+    @Test @Order(21)
     void emptyConfigurationReturnsEmptyPayload() {
         emptyAppId = given()
                 .contentType(ContentType.JSON)

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -210,7 +210,97 @@ class AppConfigIntegrationTest {
                 .header("Next-Poll-Configuration-Token", notNullValue());
     }
 
+    // ──────────────────────────── Builtin deployment strategies ────────────────────────────
+
     @Test @Order(13)
+    void builtinStrategyAllAtOnceCanBeUsedWithoutCreating() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ConfigurationProfileId\": \"" + profileId + "\", \"ConfigurationVersion\": \"1\", \"DeploymentStrategyId\": \"AppConfig.AllAtOnce\"}")
+                .when().post("/applications/" + appId + "/environments/" + envId + "/deployments")
+                .then()
+                .statusCode(201)
+                .body("State", equalTo("COMPLETE"))
+                .body("DeploymentStrategyId", equalTo("AppConfig.AllAtOnce"));
+    }
+
+    // ──────────────────────────── Application tagging ────────────────────────────
+
+    @Test @Order(14)
+    void listTagsOnNewApplicationIsEmpty() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags", anEmptyMap());
+    }
+
+    @Test @Order(15)
+    void tagApplication() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"tags\": {\"env\": \"local\", \"team\": \"platform\"}}")
+                .when().put("/tags/" + arn)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(16)
+    void listTagsAfterTagging() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("local"))
+                .body("tags.team", equalTo("platform"));
+    }
+
+    @Test @Order(17)
+    void untagApplication() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
+        given()
+                .when().delete("/tags/" + arn + "?tagKeys=env")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(18)
+    void listTagsAfterUntagging() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags", not(hasKey("env")))
+                .body("tags.team", equalTo("platform"));
+    }
+
+    // ──────────────────────────── Tags on non-application resources (no-op) ────────────────────────────
+
+    @Test @Order(19)
+    void listTagsForEnvironmentArnReturnsEmpty() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId + "/environment/" + envId;
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags", anEmptyMap());
+    }
+
+    @Test @Order(20)
+    void listTagsForDeploymentArnReturnsEmpty() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId + "/environment/" + envId + "/deployment/1";
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags", anEmptyMap());
+    }
+
+    @Test @Order(22)
     void emptyConfigurationReturnsEmptyPayload() {
         emptyAppId = given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION

Add AppConfigTagHandler to handle ListTagsForResource/TagResource/UntagResource for AppConfig ARNs, and seed built-in strategies (AppConfig.AllAtOnce etc) so Terraform's aws_appconfig_* resources provision without errors.

## Summary

Closes #532 

## Type of change

- [ ] Bug fix (`fix:`)
- [X ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI v2.17.46 against the Terraform AWS provider v6.38.0
(`hashicorp/aws` — see `.terraform.lock.hcl`). No additional SDK client was
used; wire protocol was exercised via Terraform resource creation and
`aws appconfig` CLI commands pointed at `--endpoint-url http://localhost:4566`.

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
