### PR TITLE
fix(dynamodb): return attributes for UPDATED_NEW/UPDATED_OLD on new items

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -294,10 +294,18 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", result.newItem());
         } else if ("ALL_OLD" .equals(returnValues) && result.oldItem() != null) {
             response.set("Attributes", result.oldItem());
-        } else if ("UPDATED_NEW".equals(returnValues) && result.oldItem() != null && result.newItem() != null) {
-            response.set("Attributes", getChangedAttributes(result.newItem(), result.oldItem()));
-        } else if ("UPDATED_OLD".equals(returnValues) && result.oldItem() != null && result.newItem() != null) {
-            response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
+        } else if ("UPDATED_NEW".equals(returnValues) && result.newItem() != null) {
+            if (result.oldItem() != null) {
+                response.set("Attributes", getChangedAttributes(result.newItem(), result.oldItem()));
+            } else {
+                response.set("Attributes", result.newItem());
+            }
+        } else if ("UPDATED_OLD".equals(returnValues) && result.oldItem() != null) {
+            if (result.newItem() != null) {
+                response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
+            } else {
+                response.set("Attributes", result.oldItem());
+            }
         }
         addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -295,17 +295,13 @@ public class DynamoDbJsonHandler {
         } else if ("ALL_OLD" .equals(returnValues) && result.oldItem() != null) {
             response.set("Attributes", result.oldItem());
         } else if ("UPDATED_NEW".equals(returnValues) && result.newItem() != null) {
-            if (result.oldItem() != null) {
-                response.set("Attributes", getChangedAttributes(result.newItem(), result.oldItem()));
-            } else {
-                response.set("Attributes", result.newItem());
-            }
+            // When oldItem is null (new item created), diff against the key so key
+            // attributes are excluded - matching AWS behavior where UPDATED_NEW
+            // returns only the attributes set by the expression.
+            JsonNode baseline = result.oldItem() != null ? result.oldItem() : key;
+            response.set("Attributes", getChangedAttributes(result.newItem(), baseline));
         } else if ("UPDATED_OLD".equals(returnValues) && result.oldItem() != null) {
-            if (result.newItem() != null) {
-                response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
-            } else {
-                response.set("Attributes", result.oldItem());
-            }
+            response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
         }
         addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -138,6 +138,8 @@ class DynamoDbJsonHandlerTest {
 
         assertTrue(attr.has("counter"), "Attributes should have counter");
         assertEquals("60000001", attr.get("counter").get("N").asText());
+
+        assertFalse(attr.has("userId"), "UPDATED_NEW should not include key attributes");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -109,6 +109,38 @@ class DynamoDbJsonHandlerTest {
     }
     
     @Test
+    void updateItemReturnValuesUpdatedNewOnNewItem() throws Exception {
+        createUsersTable();
+
+        // Item does not exist - UpdateItem creates it
+        ObjectNode key = item("userId", "u-new");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        ObjectNode startVal = mapper.createObjectNode();
+        startVal.put("N", "60000000");
+        ObjectNode incVal = mapper.createObjectNode();
+        incVal.put("N", "1");
+        exprValues.set(":start", startVal);
+        exprValues.set(":inc", incVal);
+
+        JsonNode request = createRequest("Users", key,
+                "SET counter = if_not_exists(counter, :start) + :inc",
+                null, exprValues, "UPDATED_NEW");
+
+        Response response = handler.handle("UpdateItem", request, "us-east-1");
+        assertNotNull(response);
+
+        JsonNode responseData = mapper.convertValue(response.getEntity(), JsonNode.class);
+
+        assertNotNull(responseData);
+        assertTrue(responseData.has("Attributes"), "Attributes must be present when item is newly created");
+        JsonNode attr = responseData.get("Attributes");
+
+        assertTrue(attr.has("counter"), "Attributes should have counter");
+        assertEquals("60000001", attr.get("counter").get("N").asText());
+    }
+
+    @Test
     void updateItemReturnValuesUpdatedOld()  throws Exception {
         createUsersTable();
 


### PR DESCRIPTION
## Summary

- `UPDATED_NEW` returned empty when `UpdateItem` creates a new item (e.g. via `if_not_exists`)
- Root cause: `oldItem` is null for new items, and the handler required `oldItem != null`
- When `oldItem` is null, return all `newItem` attributes (everything is "updated")
- Same fix for `UPDATED_OLD` with null `newItem`

Closes #537

## Test plan

- [x] New test: `updateItemReturnValuesUpdatedNewOnNewItem` in `DynamoDbJsonHandlerTest`
- [x] All existing tests pass (128 total, 0 failures)