### PR TITLE
feat(pipes): add EventBridge Pipes service skeleton with CRUD API

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -236,6 +236,7 @@ public interface EmulatorConfig {
         ResourceGroupsTaggingServiceConfig tagging();
         BedrockRuntimeServiceConfig bedrockRuntime();
         EksServiceConfig eks();
+        PipesServiceConfig pipes();
     }
 
     interface SsmServiceConfig {
@@ -576,6 +577,11 @@ public interface EmulatorConfig {
     }
 
     interface AppConfigDataServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface PipesServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeControll
 import io.github.hectorvent.floci.services.cognito.CognitoOAuthController;
 import io.github.hectorvent.floci.services.cognito.CognitoWellKnownController;
 import io.github.hectorvent.floci.services.eks.EksController;
+import io.github.hectorvent.floci.services.pipes.PipesController;
 import io.github.hectorvent.floci.services.lambda.LambdaController;
 import io.github.hectorvent.floci.services.opensearch.OpenSearchController;
 import io.github.hectorvent.floci.services.ses.SesController;
@@ -198,7 +199,11 @@ public class ResolvedServiceCatalog {
                 descriptor("eks", "eks", config.services().eks().enabled(), true,
                         "eks", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
-                        Set.of(), Set.of("eks"), Set.of(), Set.of(EksController.class))
+                        Set.of(), Set.of("eks"), Set.of(), Set.of(EksController.class)),
+                descriptor("pipes", "pipes", config.services().pipes().enabled(), true,
+                        "pipes", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("pipes"), Set.of(), Set.of(PipesController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesController.java
@@ -1,0 +1,268 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.pipes.model.DesiredState;
+import io.github.hectorvent.floci.services.pipes.model.Pipe;
+import io.github.hectorvent.floci.services.pipes.model.PipeState;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * EventBridge Pipes REST-JSON controller.
+ *
+ * <p>Pipes uses standard HTTP verbs with JSON bodies — not JSON 1.1 (X-Amz-Target) or Query protocol.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PipesController {
+
+    private static final Logger LOG = Logger.getLogger(PipesController.class);
+
+    private final PipesService pipesService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public PipesController(PipesService pipesService, RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.pipesService = pipesService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/v1/pipes/{name}")
+    public Response createPipe(@PathParam("name") String name,
+                               @Context HttpHeaders headers,
+                               String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            String source = textOrNull(request, "Source");
+            String target = textOrNull(request, "Target");
+            String roleArn = textOrNull(request, "RoleArn");
+            String description = textOrNull(request, "Description");
+            String enrichment = textOrNull(request, "Enrichment");
+            DesiredState desiredState = parseDesiredState(textOrNull(request, "DesiredState"));
+            JsonNode sourceParameters = request.path("SourceParameters").isMissingNode() ? null : request.get("SourceParameters");
+            JsonNode targetParameters = request.path("TargetParameters").isMissingNode() ? null : request.get("TargetParameters");
+            JsonNode enrichmentParameters = request.path("EnrichmentParameters").isMissingNode() ? null : request.get("EnrichmentParameters");
+            Map<String, String> tags = parseTags(request.get("Tags"));
+
+            Pipe pipe = pipesService.createPipe(name, source, target, roleArn, description,
+                    desiredState, enrichment, sourceParameters, targetParameters,
+                    enrichmentParameters, tags, region);
+
+            return Response.ok(buildPipeResponse(pipe)).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            LOG.errorv("Error creating pipe: {0}", e.getMessage());
+            return Response.status(500)
+                    .entity(new AwsErrorResponse("InternalException", e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/v1/pipes/{name}")
+    public Response describePipe(@PathParam("name") String name,
+                                 @Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            Pipe pipe = pipesService.describePipe(name, region);
+            return Response.ok(pipe).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        }
+    }
+
+    @PUT
+    @Path("/v1/pipes/{name}")
+    public Response updatePipe(@PathParam("name") String name,
+                               @Context HttpHeaders headers,
+                               String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            String target = textOrNull(request, "Target");
+            String roleArn = textOrNull(request, "RoleArn");
+            String description = textOrNull(request, "Description");
+            String enrichment = textOrNull(request, "Enrichment");
+            DesiredState desiredState = parseDesiredState(textOrNull(request, "DesiredState"));
+            JsonNode sourceParameters = request.path("SourceParameters").isMissingNode() ? null : request.get("SourceParameters");
+            JsonNode targetParameters = request.path("TargetParameters").isMissingNode() ? null : request.get("TargetParameters");
+            JsonNode enrichmentParameters = request.path("EnrichmentParameters").isMissingNode() ? null : request.get("EnrichmentParameters");
+
+            Pipe pipe = pipesService.updatePipe(name, target, roleArn, description,
+                    desiredState, enrichment, sourceParameters, targetParameters,
+                    enrichmentParameters, region);
+
+            return Response.ok(buildPipeResponse(pipe)).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        } catch (Exception e) {
+            LOG.errorv("Error updating pipe: {0}", e.getMessage());
+            return Response.status(500)
+                    .entity(new AwsErrorResponse("InternalException", e.getMessage()))
+                    .build();
+        }
+    }
+
+    @DELETE
+    @Path("/v1/pipes/{name}")
+    public Response deletePipe(@PathParam("name") String name,
+                               @Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            pipesService.deletePipe(name, region);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        }
+    }
+
+    @GET
+    @Path("/v1/pipes")
+    public Response listPipes(@QueryParam("NamePrefix") String namePrefix,
+                              @QueryParam("SourcePrefix") String sourcePrefix,
+                              @QueryParam("TargetPrefix") String targetPrefix,
+                              @QueryParam("DesiredState") String desiredStateStr,
+                              @QueryParam("CurrentState") String currentStateStr,
+                              @Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            DesiredState desiredState = parseDesiredState(desiredStateStr);
+            PipeState currentState = parsePipeState(currentStateStr);
+            List<Pipe> pipes = pipesService.listPipes(namePrefix, sourcePrefix, targetPrefix,
+                    desiredState, currentState, region);
+
+            ObjectNode response = objectMapper.createObjectNode();
+            var pipesArray = response.putArray("Pipes");
+            for (Pipe pipe : pipes) {
+                pipesArray.add(buildPipeListEntry(pipe));
+            }
+            return Response.ok(response).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/v1/pipes/{name}/start")
+    public Response startPipe(@PathParam("name") String name,
+                              @Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            Pipe pipe = pipesService.startPipe(name, region);
+            return Response.ok(buildPipeResponse(pipe)).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/v1/pipes/{name}/stop")
+    public Response stopPipe(@PathParam("name") String name,
+                             @Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            Pipe pipe = pipesService.stopPipe(name, region);
+            return Response.ok(buildPipeResponse(pipe)).build();
+        } catch (AwsException e) {
+            return Response.status(e.getHttpStatus())
+                    .entity(new AwsErrorResponse(e.getErrorCode(), e.getMessage()))
+                    .build();
+        }
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private ObjectNode buildPipeResponse(Pipe pipe) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Arn", pipe.getArn());
+        node.put("Name", pipe.getName());
+        node.put("Source", pipe.getSource());
+        node.put("Target", pipe.getTarget());
+        node.put("RoleArn", pipe.getRoleArn());
+        node.put("DesiredState", pipe.getDesiredState().name());
+        node.put("CurrentState", pipe.getCurrentState().name());
+        if (pipe.getDescription() != null) node.put("Description", pipe.getDescription());
+        if (pipe.getEnrichment() != null) node.put("Enrichment", pipe.getEnrichment());
+        if (pipe.getCreationTime() != null) node.put("CreationTime", pipe.getCreationTime().getEpochSecond());
+        if (pipe.getLastModifiedTime() != null) node.put("LastModifiedTime", pipe.getLastModifiedTime().getEpochSecond());
+        if (pipe.getStateReason() != null) node.put("StateReason", pipe.getStateReason());
+        return node;
+    }
+
+    private ObjectNode buildPipeListEntry(Pipe pipe) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Arn", pipe.getArn());
+        node.put("Name", pipe.getName());
+        node.put("Source", pipe.getSource());
+        node.put("Target", pipe.getTarget());
+        node.put("DesiredState", pipe.getDesiredState().name());
+        node.put("CurrentState", pipe.getCurrentState().name());
+        if (pipe.getCreationTime() != null) node.put("CreationTime", pipe.getCreationTime().getEpochSecond());
+        if (pipe.getLastModifiedTime() != null) node.put("LastModifiedTime", pipe.getLastModifiedTime().getEpochSecond());
+        return node;
+    }
+
+    private String textOrNull(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull() || value.isMissingNode()) return null;
+        return value.asText();
+    }
+
+    private DesiredState parseDesiredState(String state) {
+        if (state == null || state.isBlank()) return null;
+        try {
+            return DesiredState.valueOf(state.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private PipeState parsePipeState(String state) {
+        if (state == null || state.isBlank()) return null;
+        try {
+            return PipeState.valueOf(state.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private Map<String, String> parseTags(JsonNode tagsNode) {
+        Map<String, String> tags = new HashMap<>();
+        if (tagsNode != null && tagsNode.isObject()) {
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
@@ -1,0 +1,213 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.TagHandler;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.pipes.model.DesiredState;
+import io.github.hectorvent.floci.services.pipes.model.Pipe;
+import io.github.hectorvent.floci.services.pipes.model.PipeState;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class PipesService implements TagHandler {
+
+    private static final Logger LOG = Logger.getLogger(PipesService.class);
+
+    private final StorageBackend<String, Pipe> storage;
+    private final EmulatorConfig config;
+
+    @Inject
+    public PipesService(StorageFactory storageFactory, EmulatorConfig config) {
+        this.storage = storageFactory.create("pipes", "pipes.json",
+                new TypeReference<Map<String, Pipe>>() {});
+        this.config = config;
+    }
+
+    public Pipe createPipe(String name, String source, String target, String roleArn,
+                           String description, DesiredState desiredState, String enrichment,
+                           JsonNode sourceParameters, JsonNode targetParameters,
+                           JsonNode enrichmentParameters, Map<String, String> tags,
+                           String region) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required", 400);
+        }
+        if (source == null || source.isBlank()) {
+            throw new AwsException("ValidationException", "Source is required", 400);
+        }
+        if (target == null || target.isBlank()) {
+            throw new AwsException("ValidationException", "Target is required", 400);
+        }
+        if (roleArn == null || roleArn.isBlank()) {
+            throw new AwsException("ValidationException", "RoleArn is required", 400);
+        }
+
+        String key = region + "::" + name;
+        if (storage.get(key).isPresent()) {
+            throw new AwsException("ConflictException",
+                    "Pipe " + name + " already exists.", 409);
+        }
+
+        String accountId = config.defaultAccountId();
+        String arn = "arn:aws:pipes:" + region + ":" + accountId + ":pipe/" + name;
+        Instant now = Instant.now();
+
+        Pipe pipe = new Pipe();
+        pipe.setName(name);
+        pipe.setArn(arn);
+        pipe.setSource(source);
+        pipe.setTarget(target);
+        pipe.setRoleArn(roleArn);
+        pipe.setDescription(description);
+        DesiredState effectiveDesiredState = desiredState != null ? desiredState : DesiredState.RUNNING;
+        pipe.setDesiredState(effectiveDesiredState);
+        pipe.setCurrentState(effectiveDesiredState == DesiredState.RUNNING ? PipeState.RUNNING : PipeState.STOPPED);
+        pipe.setEnrichment(enrichment);
+        pipe.setSourceParameters(sourceParameters);
+        pipe.setTargetParameters(targetParameters);
+        pipe.setEnrichmentParameters(enrichmentParameters);
+        pipe.setTags(tags != null ? new HashMap<>(tags) : new HashMap<>());
+        pipe.setCreationTime(now);
+        pipe.setLastModifiedTime(now);
+
+        storage.put(key, pipe);
+        LOG.infov("Created pipe: {0}", name);
+        return pipe;
+    }
+
+    public Pipe describePipe(String name, String region) {
+        String key = region + "::" + name;
+        return storage.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Pipe " + name + " does not exist.", 404));
+    }
+
+    public Pipe updatePipe(String name, String target, String roleArn, String description,
+                           DesiredState desiredState, String enrichment,
+                           JsonNode sourceParameters, JsonNode targetParameters,
+                           JsonNode enrichmentParameters, String region) {
+        String key = region + "::" + name;
+        Pipe pipe = storage.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Pipe " + name + " does not exist.", 404));
+
+        if (target != null) pipe.setTarget(target);
+        if (roleArn != null) pipe.setRoleArn(roleArn);
+        if (description != null) pipe.setDescription(description);
+        if (desiredState != null) {
+            pipe.setDesiredState(desiredState);
+            pipe.setCurrentState(desiredState == DesiredState.RUNNING ? PipeState.RUNNING : PipeState.STOPPED);
+        }
+        if (enrichment != null) pipe.setEnrichment(enrichment);
+        if (sourceParameters != null) pipe.setSourceParameters(sourceParameters);
+        if (targetParameters != null) pipe.setTargetParameters(targetParameters);
+        if (enrichmentParameters != null) pipe.setEnrichmentParameters(enrichmentParameters);
+
+        pipe.setLastModifiedTime(Instant.now());
+        storage.put(key, pipe);
+        LOG.infov("Updated pipe: {0}", name);
+        return pipe;
+    }
+
+    public void deletePipe(String name, String region) {
+        String key = region + "::" + name;
+        if (storage.get(key).isEmpty()) {
+            throw new AwsException("NotFoundException",
+                    "Pipe " + name + " does not exist.", 404);
+        }
+        storage.delete(key);
+        LOG.infov("Deleted pipe: {0}", name);
+    }
+
+    public List<Pipe> listPipes(String namePrefix, String sourcePrefix, String targetPrefix,
+                                DesiredState desiredState, PipeState currentState, String region) {
+        String regionPrefix = region + "::";
+        return storage.scan(key -> key.startsWith(regionPrefix)).stream()
+                .filter(pipe -> namePrefix == null || pipe.getName().startsWith(namePrefix))
+                .filter(pipe -> sourcePrefix == null || pipe.getSource().startsWith(sourcePrefix))
+                .filter(pipe -> targetPrefix == null || pipe.getTarget().startsWith(targetPrefix))
+                .filter(pipe -> desiredState == null || pipe.getDesiredState() == desiredState)
+                .filter(pipe -> currentState == null || pipe.getCurrentState() == currentState)
+                .collect(Collectors.toList());
+    }
+
+    public Pipe startPipe(String name, String region) {
+        String key = region + "::" + name;
+        Pipe pipe = storage.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Pipe " + name + " does not exist.", 404));
+
+        pipe.setDesiredState(DesiredState.RUNNING);
+        pipe.setCurrentState(PipeState.RUNNING);
+        pipe.setLastModifiedTime(Instant.now());
+        storage.put(key, pipe);
+        LOG.infov("Started pipe: {0}", name);
+        return pipe;
+    }
+
+    public Pipe stopPipe(String name, String region) {
+        String key = region + "::" + name;
+        Pipe pipe = storage.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Pipe " + name + " does not exist.", 404));
+
+        pipe.setDesiredState(DesiredState.STOPPED);
+        pipe.setCurrentState(PipeState.STOPPED);
+        pipe.setLastModifiedTime(Instant.now());
+        storage.put(key, pipe);
+        LOG.infov("Stopped pipe: {0}", name);
+        return pipe;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "pipes";
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        Pipe pipe = findByArn(arn, region);
+        if (pipe.getTags() == null) {
+            pipe.setTags(new HashMap<>());
+        }
+        pipe.getTags().putAll(tags);
+        String key = region + "::" + pipe.getName();
+        storage.put(key, pipe);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        Pipe pipe = findByArn(arn, region);
+        if (pipe.getTags() != null && tagKeys != null) {
+            tagKeys.forEach(pipe.getTags()::remove);
+        }
+        String key = region + "::" + pipe.getName();
+        storage.put(key, pipe);
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        Pipe pipe = findByArn(arn, region);
+        return pipe.getTags() != null ? pipe.getTags() : Map.of();
+    }
+
+    private Pipe findByArn(String arn, String region) {
+        String regionPrefix = region + "::";
+        return storage.scan(key -> key.startsWith(regionPrefix)).stream()
+                .filter(pipe -> arn.equals(pipe.getArn()))
+                .findFirst()
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Resource " + arn + " does not exist.", 404));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/model/DesiredState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/model/DesiredState.java
@@ -1,0 +1,6 @@
+package io.github.hectorvent.floci.services.pipes.model;
+
+public enum DesiredState {
+    RUNNING,
+    STOPPED
+}

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/model/Pipe.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/model/Pipe.java
@@ -1,0 +1,117 @@
+package io.github.hectorvent.floci.services.pipes.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Pipe {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Arn")
+    private String arn;
+
+    @JsonProperty("Source")
+    private String source;
+
+    @JsonProperty("Target")
+    private String target;
+
+    @JsonProperty("RoleArn")
+    private String roleArn;
+
+    @JsonProperty("Description")
+    private String description;
+
+    @JsonProperty("DesiredState")
+    private DesiredState desiredState;
+
+    @JsonProperty("CurrentState")
+    private PipeState currentState;
+
+    @JsonProperty("Enrichment")
+    private String enrichment;
+
+    @JsonProperty("SourceParameters")
+    private JsonNode sourceParameters;
+
+    @JsonProperty("TargetParameters")
+    private JsonNode targetParameters;
+
+    @JsonProperty("EnrichmentParameters")
+    private JsonNode enrichmentParameters;
+
+    @JsonProperty("Tags")
+    private Map<String, String> tags;
+
+    @JsonProperty("CreationTime")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Instant creationTime;
+
+    @JsonProperty("LastModifiedTime")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Instant lastModifiedTime;
+
+    @JsonProperty("StateReason")
+    private String stateReason;
+
+    public Pipe() {}
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+
+    public String getTarget() { return target; }
+    public void setTarget(String target) { this.target = target; }
+
+    public String getRoleArn() { return roleArn; }
+    public void setRoleArn(String roleArn) { this.roleArn = roleArn; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public DesiredState getDesiredState() { return desiredState; }
+    public void setDesiredState(DesiredState desiredState) { this.desiredState = desiredState; }
+
+    public PipeState getCurrentState() { return currentState; }
+    public void setCurrentState(PipeState currentState) { this.currentState = currentState; }
+
+    public String getEnrichment() { return enrichment; }
+    public void setEnrichment(String enrichment) { this.enrichment = enrichment; }
+
+    public JsonNode getSourceParameters() { return sourceParameters; }
+    public void setSourceParameters(JsonNode sourceParameters) { this.sourceParameters = sourceParameters; }
+
+    public JsonNode getTargetParameters() { return targetParameters; }
+    public void setTargetParameters(JsonNode targetParameters) { this.targetParameters = targetParameters; }
+
+    public JsonNode getEnrichmentParameters() { return enrichmentParameters; }
+    public void setEnrichmentParameters(JsonNode enrichmentParameters) { this.enrichmentParameters = enrichmentParameters; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+    public Instant getCreationTime() { return creationTime; }
+    public void setCreationTime(Instant creationTime) { this.creationTime = creationTime; }
+
+    public Instant getLastModifiedTime() { return lastModifiedTime; }
+    public void setLastModifiedTime(Instant lastModifiedTime) { this.lastModifiedTime = lastModifiedTime; }
+
+    public String getStateReason() { return stateReason; }
+    public void setStateReason(String stateReason) { this.stateReason = stateReason; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/model/PipeState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/model/PipeState.java
@@ -1,0 +1,16 @@
+package io.github.hectorvent.floci.services.pipes.model;
+
+public enum PipeState {
+    RUNNING,
+    STOPPED,
+    CREATING,
+    UPDATING,
+    DELETING,
+    STARTING,
+    STOPPING,
+    CREATE_FAILED,
+    UPDATE_FAILED,
+    START_FAILED,
+    STOP_FAILED,
+    DELETE_FAILED
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
@@ -50,7 +50,8 @@ class HealthControllerIntegrationTest {
                 "ecr": "running",
                 "tagging": "running",
                 "bedrock-runtime": "running",
-                "eks": "running"
+                "eks": "running",
+                "pipes": "running"
               },
               "edition": "floci-always-free",
               "version": "dev"

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesIntegrationTest.java
@@ -1,0 +1,215 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PipesIntegrationTest {
+
+    @Test
+    @Order(1)
+    void createPipe() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:source-queue",
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:target-queue",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+                    "Description": "Integration test pipe",
+                    "DesiredState": "RUNNING"
+                }
+                """)
+        .when()
+            .post("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("integration-pipe"))
+            .body("Arn", containsString("pipe/integration-pipe"))
+            .body("Source", equalTo("arn:aws:sqs:us-east-1:000000000000:source-queue"))
+            .body("Target", equalTo("arn:aws:sqs:us-east-1:000000000000:target-queue"))
+            .body("CurrentState", equalTo("RUNNING"))
+            .body("DesiredState", equalTo("RUNNING"));
+    }
+
+    @Test
+    @Order(2)
+    void createDuplicatePipeReturnsConflict() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:source-queue",
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:target-queue",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role"
+                }
+                """)
+        .when()
+            .post("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(3)
+    void describePipe() {
+        given()
+            .contentType("application/json")
+        .when()
+            .get("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("integration-pipe"))
+            .body("Source", equalTo("arn:aws:sqs:us-east-1:000000000000:source-queue"))
+            .body("Description", equalTo("Integration test pipe"));
+    }
+
+    @Test
+    @Order(4)
+    void describeNonexistentPipeReturns404() {
+        given()
+            .contentType("application/json")
+        .when()
+            .get("/v1/pipes/does-not-exist")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(5)
+    void listPipes() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:other-source",
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:other-target",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+                    "DesiredState": "STOPPED"
+                }
+                """)
+        .when()
+            .post("/v1/pipes/second-pipe")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+        .when()
+            .get("/v1/pipes")
+        .then()
+            .statusCode(200)
+            .body("Pipes.size()", equalTo(2));
+    }
+
+    @Test
+    @Order(6)
+    void listPipesWithNamePrefixFilter() {
+        given()
+            .contentType("application/json")
+            .queryParam("NamePrefix", "integration")
+        .when()
+            .get("/v1/pipes")
+        .then()
+            .statusCode(200)
+            .body("Pipes.size()", equalTo(1))
+            .body("Pipes[0].Name", equalTo("integration-pipe"));
+    }
+
+    @Test
+    @Order(7)
+    void updatePipe() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:updated-target",
+                    "Description": "Updated description",
+                    "DesiredState": "STOPPED"
+                }
+                """)
+        .when()
+            .put("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(200)
+            .body("Target", equalTo("arn:aws:sqs:us-east-1:000000000000:updated-target"))
+            .body("CurrentState", equalTo("STOPPED"))
+            .body("DesiredState", equalTo("STOPPED"));
+    }
+
+    @Test
+    @Order(8)
+    void startPipe() {
+        given()
+            .contentType("application/json")
+        .when()
+            .post("/v1/pipes/integration-pipe/start")
+        .then()
+            .statusCode(200)
+            .body("CurrentState", equalTo("RUNNING"))
+            .body("DesiredState", equalTo("RUNNING"));
+    }
+
+    @Test
+    @Order(9)
+    void stopPipe() {
+        given()
+            .contentType("application/json")
+        .when()
+            .post("/v1/pipes/integration-pipe/stop")
+        .then()
+            .statusCode(200)
+            .body("CurrentState", equalTo("STOPPED"))
+            .body("DesiredState", equalTo("STOPPED"));
+    }
+
+    @Test
+    @Order(10)
+    void deletePipe() {
+        given()
+            .contentType("application/json")
+        .when()
+            .delete("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+        .when()
+            .get("/v1/pipes/integration-pipe")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(11)
+    void deleteNonexistentPipeReturns404() {
+        given()
+            .contentType("application/json")
+        .when()
+            .delete("/v1/pipes/ghost-pipe")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(12)
+    void createPipeMissingSourceReturns400() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:target-queue",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role"
+                }
+                """)
+        .when()
+            .post("/v1/pipes/bad-pipe")
+        .then()
+            .statusCode(400);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
@@ -1,0 +1,273 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.pipes.model.DesiredState;
+import io.github.hectorvent.floci.services.pipes.model.Pipe;
+import io.github.hectorvent.floci.services.pipes.model.PipeState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class PipesServiceTest {
+
+    private PipesService pipesService;
+
+    @BeforeEach
+    void setUp() {
+        StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(new InMemoryStorage<>());
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        when(config.defaultAccountId()).thenReturn("000000000000");
+
+        pipesService = new PipesService(storageFactory, config);
+    }
+
+    @Test
+    void createPipe() {
+        Pipe pipe = pipesService.createPipe("test-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source-queue",
+                "arn:aws:sqs:us-east-1:000000000000:target-queue",
+                "arn:aws:iam::000000000000:role/pipe-role",
+                "A test pipe", DesiredState.RUNNING, null,
+                null, null, null, Map.of("env", "test"), "us-east-1");
+
+        assertNotNull(pipe);
+        assertEquals("test-pipe", pipe.getName());
+        assertEquals("arn:aws:pipes:us-east-1:000000000000:pipe/test-pipe", pipe.getArn());
+        assertEquals(DesiredState.RUNNING, pipe.getDesiredState());
+        assertEquals(PipeState.RUNNING, pipe.getCurrentState());
+        assertEquals("A test pipe", pipe.getDescription());
+        assertNotNull(pipe.getCreationTime());
+        assertNotNull(pipe.getLastModifiedTime());
+        assertEquals("test", pipe.getTags().get("env"));
+    }
+
+    @Test
+    void createPipeDefaultsDesiredStateToRunning() {
+        Pipe pipe = pipesService.createPipe("pipe-no-state",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        assertEquals(DesiredState.RUNNING, pipe.getDesiredState());
+        assertEquals(PipeState.RUNNING, pipe.getCurrentState());
+    }
+
+    @Test
+    void createPipeDuplicateNameThrowsConflict() {
+        pipesService.createPipe("dup-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.createPipe("dup-pipe",
+                        "arn:aws:sqs:us-east-1:000000000000:source",
+                        "arn:aws:sqs:us-east-1:000000000000:target",
+                        "arn:aws:iam::000000000000:role/role",
+                        null, null, null, null, null, null, null, "us-east-1"));
+        assertEquals("ConflictException", ex.getErrorCode());
+        assertEquals(409, ex.getHttpStatus());
+    }
+
+    @Test
+    void createPipeMissingRequiredFieldsThrowsValidation() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.createPipe(null, "source", "target", "role",
+                        null, null, null, null, null, null, null, "us-east-1"));
+        assertEquals("ValidationException", ex.getErrorCode());
+
+        ex = assertThrows(AwsException.class, () ->
+                pipesService.createPipe("name", null, "target", "role",
+                        null, null, null, null, null, null, null, "us-east-1"));
+        assertEquals("ValidationException", ex.getErrorCode());
+
+        ex = assertThrows(AwsException.class, () ->
+                pipesService.createPipe("name", "source", null, "role",
+                        null, null, null, null, null, null, null, "us-east-1"));
+        assertEquals("ValidationException", ex.getErrorCode());
+
+        ex = assertThrows(AwsException.class, () ->
+                pipesService.createPipe("name", "source", "target", null,
+                        null, null, null, null, null, null, null, "us-east-1"));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void describePipe() {
+        pipesService.createPipe("my-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        Pipe pipe = pipesService.describePipe("my-pipe", "us-east-1");
+        assertEquals("my-pipe", pipe.getName());
+    }
+
+    @Test
+    void describePipeNotFoundThrows() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.describePipe("nonexistent", "us-east-1"));
+        assertEquals("NotFoundException", ex.getErrorCode());
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void updatePipe() {
+        pipesService.createPipe("update-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                "original", DesiredState.RUNNING, null, null, null, null, null, "us-east-1");
+
+        Pipe updated = pipesService.updatePipe("update-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:new-target",
+                null, "updated desc", DesiredState.STOPPED, null, null, null, null, "us-east-1");
+
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:new-target", updated.getTarget());
+        assertEquals("updated desc", updated.getDescription());
+        assertEquals(DesiredState.STOPPED, updated.getDesiredState());
+        assertEquals(PipeState.STOPPED, updated.getCurrentState());
+    }
+
+    @Test
+    void deletePipe() {
+        pipesService.createPipe("del-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        pipesService.deletePipe("del-pipe", "us-east-1");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.describePipe("del-pipe", "us-east-1"));
+        assertEquals("NotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void deleteNonexistentPipeThrows() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.deletePipe("ghost", "us-east-1"));
+        assertEquals("NotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void listPipes() {
+        pipesService.createPipe("pipe-a",
+                "arn:aws:sqs:us-east-1:000000000000:source-a",
+                "arn:aws:sqs:us-east-1:000000000000:target-a",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.RUNNING, null, null, null, null, null, "us-east-1");
+        pipesService.createPipe("pipe-b",
+                "arn:aws:sqs:us-east-1:000000000000:source-b",
+                "arn:aws:sqs:us-east-1:000000000000:target-b",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.STOPPED, null, null, null, null, null, "us-east-1");
+
+        List<Pipe> all = pipesService.listPipes(null, null, null, null, null, "us-east-1");
+        assertEquals(2, all.size());
+
+        List<Pipe> filtered = pipesService.listPipes("pipe-a", null, null, null, null, "us-east-1");
+        assertEquals(1, filtered.size());
+        assertEquals("pipe-a", filtered.get(0).getName());
+    }
+
+    @Test
+    void listPipesFilterByDesiredState() {
+        pipesService.createPipe("running-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.RUNNING, null, null, null, null, null, "us-east-1");
+        pipesService.createPipe("stopped-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.STOPPED, null, null, null, null, null, "us-east-1");
+
+        List<Pipe> running = pipesService.listPipes(null, null, null, DesiredState.RUNNING, null, "us-east-1");
+        assertEquals(1, running.size());
+        assertEquals("running-pipe", running.get(0).getName());
+    }
+
+    @Test
+    void startPipe() {
+        pipesService.createPipe("start-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.STOPPED, null, null, null, null, null, "us-east-1");
+
+        Pipe pipe = pipesService.startPipe("start-pipe", "us-east-1");
+        assertEquals(DesiredState.RUNNING, pipe.getDesiredState());
+        assertEquals(PipeState.RUNNING, pipe.getCurrentState());
+    }
+
+    @Test
+    void stopPipe() {
+        pipesService.createPipe("stop-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, DesiredState.RUNNING, null, null, null, null, null, "us-east-1");
+
+        Pipe pipe = pipesService.stopPipe("stop-pipe", "us-east-1");
+        assertEquals(DesiredState.STOPPED, pipe.getDesiredState());
+        assertEquals(PipeState.STOPPED, pipe.getCurrentState());
+    }
+
+    @Test
+    void tagResource() {
+        Pipe pipe = pipesService.createPipe("tag-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        pipesService.tagResource("us-east-1", pipe.getArn(), Map.of("team", "platform"));
+        Map<String, String> tags = pipesService.listTags("us-east-1", pipe.getArn());
+        assertEquals("platform", tags.get("team"));
+    }
+
+    @Test
+    void untagResource() {
+        Pipe pipe = pipesService.createPipe("untag-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, Map.of("a", "1", "b", "2"), "us-east-1");
+
+        pipesService.untagResource("us-east-1", pipe.getArn(), List.of("a"));
+        Map<String, String> tags = pipesService.listTags("us-east-1", pipe.getArn());
+        assertFalse(tags.containsKey("a"));
+        assertEquals("2", tags.get("b"));
+    }
+
+    @Test
+    void regionIsolation() {
+        pipesService.createPipe("region-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:source",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, null, null, null, null, "us-east-1");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                pipesService.describePipe("region-pipe", "eu-west-1"));
+        assertEquals("NotFoundException", ex.getErrorCode());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -142,3 +142,5 @@ floci:
     eks:
       enabled: true
       mock: true
+    pipes:
+      enabled: true


### PR DESCRIPTION
## Summary

Adds EventBridge Pipes service (Phase 1 of multi-PR effort). This implements the service skeleton with full CRUD API support: CreatePipe, DescribePipe, UpdatePipe, DeletePipe, ListPipes, StartPipe, StopPipe, plus tagging operations.

Close #511 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Pipes uses REST JSON protocol (`Pipes_2015-10-07`) with path-based routing (`/v1/pipes/{Name}`). Wire format verified against AWS SDK for Java v2 `pipes` service model. Phase 1 covers state management only — actual source polling and target invocation will follow in subsequent PRs.

Supported actions:
- `POST /v1/pipes/{Name}` — CreatePipe
- `GET /v1/pipes/{Name}` — DescribePipe
- `PUT /v1/pipes/{Name}` — UpdatePipe
- `DELETE /v1/pipes/{Name}` — DeletePipe
- `GET /v1/pipes` — ListPipes (with NamePrefix, SourcePrefix, TargetPrefix, DesiredState, CurrentState filters)
- `POST /v1/pipes/{Name}/start` — StartPipe
- `POST /v1/pipes/{Name}/stop` — StopPipe
- `GET/POST/DELETE /tags/{resourceArn}` — Tagging

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)