### PR TITLE
bug(secretsmanager): incorrect update of AWSPENDING on secret value update

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.secretsmanager;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -7,7 +8,6 @@ import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -161,6 +162,18 @@ public class SecretsManagerService {
                 continue;
             }
             List<String> newStages = new ArrayList<>(version.getVersionStages());
+            // if stage is AWSCURRENT, the previous AWSCURRENT will become
+            // AWSPREVIOUS, and the previous AWSPREVIOUS will drop that stage
+            // name
+            if (stage.equals(AWSCURRENT)) {
+                SecretVersion previous = findVersionByStage(secret, AWSPREVIOUS);
+                if (previous != null) {
+                    List<String> oldPrevious = new ArrayList<>(previous.getVersionStages());
+                    oldPrevious.remove(AWSPREVIOUS);
+                    previous.setVersionStages(oldPrevious);
+                }
+                newStages.add(AWSPREVIOUS);
+            }
             newStages.remove(stage);
 
             version.setVersionStages(newStages);

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -98,16 +98,25 @@ class SecretsManagerServiceTest {
 
     @Test
     void putSecretValueMultiStage() {
+        // create secret, single secret version exists
         service.createSecret("my-secret", "v1", null, null, null, null, REGION);
-        service.putSecretValue("my-secret", "v2", null, REGION, List.of("AWSCURRENT"));
-        service.putSecretValue("my-secret", "v3", null, REGION, List.of("AWSCURRENT", "AWSPENDING"));
-
-        SecretVersion previous = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION);
-        assertEquals("v2", previous.getSecretString());
-
         SecretVersion current = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION);
-        assertEquals("v3", current.getSecretString());
+        assertEquals("v1", current.getSecretString());
 
+        // adding new secret version, previous will be v1, current will be v2
+        service.putSecretValue("my-secret", "v2", null, REGION, List.of("AWSCURRENT"));
+        SecretVersion previous = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION);
+        assertEquals("v1", previous.getSecretString());
+        current = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION);
+        assertEquals("v2", current.getSecretString());
+
+        // adding new secret version v3, current and pending will be v3,
+        // previous will be v2
+        service.putSecretValue("my-secret", "v3", null, REGION, List.of("AWSCURRENT", "AWSPENDING"));
+        previous = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION);
+        assertEquals("v2", previous.getSecretString());
+        current = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION);
+        assertEquals("v3", current.getSecretString());
         SecretVersion pending = service.getSecretValue("my-secret", null, "AWSPENDING", REGION);
         assertEquals("v3", pending.getSecretString());
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/floci-io/floci/issues/541

this is a logic bug added in https://github.com/floci-io/floci/pull/527

Test was flaky, dependent in the hashmap returning the right/wrong value before the other one

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
