### PR TITLE
fix(kms): support HMAC_* key specs in CreateKey

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/kms.bats
+++ b/compatibility-tests/sdk-test-awscli/test/kms.bats
@@ -113,6 +113,23 @@ teardown() {
     aws_cmd kms delete-alias --alias-name "$alias_name" >/dev/null 2>&1 || true
 }
 
+@test "KMS: create HMAC key and describe returns MacAlgorithms" {
+    out=$(aws_cmd kms create-key \
+        --description "bats-hmac-$(unique_name)" \
+        --key-spec HMAC_256 \
+        --key-usage GENERATE_VERIFY_MAC)
+    KEY_ID=$(json_get "$out" '.KeyMetadata.KeyId')
+    [ -n "$KEY_ID" ]
+
+    spec=$(json_get "$out" '.KeyMetadata.KeySpec')
+    [ "$spec" = "HMAC_256" ]
+
+    run aws_cmd kms describe-key --key-id "$KEY_ID"
+    assert_success
+    macs=$(echo "$output" | jq -r '.KeyMetadata.MacAlgorithms[0]')
+    [ "$macs" = "HMAC_SHA_256" ]
+}
+
 @test "KMS: delete alias" {
     out=$(aws_cmd kms create-key --description "bats-test-key")
     KEY_ID=$(json_get "$out" '.KeyMetadata.KeyId')

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -350,6 +350,10 @@ public class KmsJsonHandler {
         node.put("KeyManager", "CUSTOMER");
         node.put("CustomerMasterKeySpec", k.getCustomerMasterKeySpec());
         node.put("KeySpec", k.getCustomerMasterKeySpec());
+        String macAlgo = KmsService.macAlgorithmFor(k.getCustomerMasterKeySpec());
+        if (macAlgo != null) {
+            node.putArray("MacAlgorithms").add(macAlgo);
+        }
         if (k.getDeletionDate() > 0) {
             node.put("DeletionDate", k.getDeletionDate());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -81,12 +81,16 @@ public class KmsService {
         String keyId = UUID.randomUUID().toString();
         String arn = regionResolver.buildArn("kms", region, "key/" + keyId);
 
+        String effectiveUsage = keyUsage != null ? keyUsage : "ENCRYPT_DECRYPT";
+        String effectiveSpec = customerMasterKeySpec != null ? customerMasterKeySpec : "SYMMETRIC_DEFAULT";
+        validateKeyUsageForSpec(effectiveUsage, effectiveSpec);
+
         KmsKey key = new KmsKey();
         key.setKeyId(keyId);
         key.setArn(arn);
         key.setDescription(description);
-        key.setKeyUsage(keyUsage != null ? keyUsage : "ENCRYPT_DECRYPT");
-        key.setCustomerMasterKeySpec(customerMasterKeySpec != null ? customerMasterKeySpec : "SYMMETRIC_DEFAULT");
+        key.setKeyUsage(effectiveUsage);
+        key.setCustomerMasterKeySpec(effectiveSpec);
         key.setPolicy(policy != null ? policy : DEFAULT_KEY_POLICY);
         if (tags != null) {
             key.getTags().putAll(tags);
@@ -103,6 +107,14 @@ public class KmsService {
         String spec = key.getCustomerMasterKeySpec();
         if ("SYMMETRIC_DEFAULT".equals(spec)) {
             return; // Use existing mock behavior for symmetric keys
+        }
+        if (isHmac(spec)) {
+            // HMAC keys are symmetric byte strings; generate outside the try block
+            // so ValidationException (400) isn't rewrapped as InternalFailure (500).
+            byte[] material = new byte[hmacKeyByteLength(spec)];
+            new SecureRandom().nextBytes(material);
+            key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(material));
+            return;
         }
 
         try {
@@ -141,10 +153,53 @@ public class KmsService {
 
     public KmsKey getPublicKey(String keyId, String region) {
         KmsKey key = resolveKey(keyId, region);
-        if ("SYMMETRIC_DEFAULT".equals(key.getCustomerMasterKeySpec())) {
+        String spec = key.getCustomerMasterKeySpec();
+        if ("SYMMETRIC_DEFAULT".equals(spec) || isHmac(spec)) {
             throw new AwsException("UnsupportedOperationException", "GetPublicKey is not supported for symmetric keys.", 400);
         }
         return key;
+    }
+
+    private static boolean isHmac(String spec) {
+        return spec != null && spec.startsWith("HMAC_");
+    }
+
+    private static void validateKeyUsageForSpec(String keyUsage, String spec) {
+        if (isHmac(spec) && !"GENERATE_VERIFY_MAC".equals(keyUsage)) {
+            throw new AwsException("ValidationException",
+                    "KeyUsage " + keyUsage + " is not compatible with KeySpec " + spec
+                            + ". HMAC key specs require KeyUsage GENERATE_VERIFY_MAC.",
+                    400);
+        }
+        if ("GENERATE_VERIFY_MAC".equals(keyUsage) && !isHmac(spec)) {
+            throw new AwsException("ValidationException",
+                    "KeyUsage GENERATE_VERIFY_MAC requires an HMAC KeySpec (HMAC_224, HMAC_256, HMAC_384, or HMAC_512).",
+                    400);
+        }
+    }
+
+    private static int hmacKeyByteLength(String spec) {
+        return switch (spec) {
+            case "HMAC_224" -> 28;
+            case "HMAC_256" -> 32;
+            case "HMAC_384" -> 48;
+            case "HMAC_512" -> 64;
+            default -> throw new AwsException("InvalidCustomerMasterKeySpecException",
+                    "Unsupported HMAC key spec: " + spec, 400);
+        };
+    }
+
+    static String macAlgorithmFor(String spec) {
+        if (!isHmac(spec)) {
+            return null;
+        }
+        return switch (spec) {
+            case "HMAC_224" -> "HMAC_SHA_224";
+            case "HMAC_256" -> "HMAC_SHA_256";
+            case "HMAC_384" -> "HMAC_SHA_384";
+            case "HMAC_512" -> "HMAC_SHA_512";
+            default -> null;
+        };
     }
 
     public KmsKey describeKey(String keyId, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -367,4 +367,50 @@ class KmsServiceTest {
         assertThrows(AwsException.class, () ->
                 kmsService.enableKeyRotation(key.getKeyId(), REGION));
     }
+
+    // ── Issue #497 — HMAC key specs ─────────────────────────────────────────
+
+    @ParameterizedTest
+    @ValueSource(strings = {"HMAC_224", "HMAC_256", "HMAC_384", "HMAC_512"})
+    void createHmacKey_allSpecs(String spec) {
+        KmsKey key = kmsService.createKey("hmac key", "GENERATE_VERIFY_MAC", spec, null, Map.of(), REGION);
+
+        assertEquals(spec, key.getCustomerMasterKeySpec());
+        assertEquals("GENERATE_VERIFY_MAC", key.getKeyUsage());
+        assertNotNull(key.getPrivateKeyEncoded());
+
+        int expectedBytes = switch (spec) {
+            case "HMAC_224" -> 28;
+            case "HMAC_256" -> 32;
+            case "HMAC_384" -> 48;
+            case "HMAC_512" -> 64;
+            default -> -1;
+        };
+        assertEquals(expectedBytes, Base64.getDecoder().decode(key.getPrivateKeyEncoded()).length);
+
+        KmsKey found = kmsService.describeKey(key.getKeyId(), REGION);
+        assertEquals(spec, found.getCustomerMasterKeySpec());
+    }
+
+    @Test
+    void createHmacKey_requiresGenerateVerifyMacUsage() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createKey("hmac key", "ENCRYPT_DECRYPT", "HMAC_256", null, Map.of(), REGION));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void createSymmetricKey_rejectsGenerateVerifyMacUsage() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createKey("bad", "GENERATE_VERIFY_MAC", "SYMMETRIC_DEFAULT", null, Map.of(), REGION));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void getPublicKeyForHmacKey_throwsUnsupportedOperation() {
+        KmsKey key = kmsService.createKey("hmac key", "GENERATE_VERIFY_MAC", "HMAC_256", null, Map.of(), REGION);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.getPublicKey(key.getKeyId(), REGION));
+        assertEquals("UnsupportedOperationException", ex.getErrorCode());
+    }
 }


### PR DESCRIPTION
## Summary

- `aws kms create-key --key-spec HMAC_{224,256,384,512} --key-usage GENERATE_VERIFY_MAC` now succeeds; material generated via `SecureRandom` at the correct byte length (28/32/48/64) and stored on the existing `privateKeyEncoded` field.
- `DescribeKey` (and `CreateKey`) responses include `MacAlgorithms: ["HMAC_SHA_<bits>"]` for HMAC keys. Non-HMAC responses are unchanged.
- Validation: `ValidationException` for `HMAC_*` without `GENERATE_VERIFY_MAC`, and for `GENERATE_VERIFY_MAC` with any non-HMAC spec (matches real KMS behaviour).
- `GetPublicKey` rejects HMAC keys with `UnsupportedOperationException` (same as existing symmetric rejection).
- HMAC generation sits before the existing try/catch block in `generateKeyMaterial`, so 400-level `ValidationException`s don't get rewrapped as 500 `InternalFailure`.

Closes #497.

## Out of scope (follow-up PRs)

- `GenerateMac` / `VerifyMac` operations
- HMAC key rotation support (current `validateRotationSupported` still rejects, which is stricter than real AWS but unchanged here)
- The 400→500 rewrap bug in `generateKeyMaterial` for the asymmetric branch

## Test plan

- [x] 5 new `KmsServiceTest` cases (parameterised over all four HMAC specs, plus validation rejections and `GetPublicKey` rejection)
- [x] 1 new bats compat test: `aws kms create-key --key-spec HMAC_256 --key-usage GENERATE_VERIFY_MAC` + `describe-key` asserting `MacAlgorithms[0] == "HMAC_SHA_256"`
- [x] `./mvnw test -Dtest=KmsServiceTest` 44/44 pass
- [x] Full `./mvnw test` 2457/2459 pass (two `LambdaReactiveSyncIntegrationTest` failures are pre-existing container→host networking flakes, unrelated to KMS)