### PR TITLE
feature(secretsmanager): add handling for UpdateSecretVersionStage

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/secretsmanager.bats
+++ b/compatibility-tests/sdk-test-awscli/test/secretsmanager.bats
@@ -120,3 +120,107 @@ teardown() {
     found=$(echo "$output" | jq '.Tags // [] | any(.Key == "Environment")')
     [ "$found" = "false" ]
 }
+
+# --- Secrets Manager Version Stage Tests ---
+
+@test "Secrets Manager: add custom stage to version" {
+    out=$(aws_cmd secretsmanager create-secret \
+        --name "$SECRET_NAME" \
+        --secret-string '{"key":"value"}')
+    v1=$(json_get "$out" '.VersionId')
+
+    run aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage MYSTAGE \
+        --move-to-version-id "$v1"
+    assert_success
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$SECRET_NAME"
+    assert_success
+    has_mystage=$(echo "$output" | jq --arg vid "$v1" '.VersionIdsToStages[$vid] | any(. == "MYSTAGE")')
+    [ "$has_mystage" = "true" ]
+    has_current=$(echo "$output" | jq --arg vid "$v1" '.VersionIdsToStages[$vid] | any(. == "AWSCURRENT")')
+    [ "$has_current" = "true" ]
+}
+
+@test "Secrets Manager: move custom stage between versions" {
+    out=$(aws_cmd secretsmanager create-secret \
+        --name "$SECRET_NAME" \
+        --secret-string '{"key":"v1"}')
+    v1=$(json_get "$out" '.VersionId')
+
+    out=$(aws_cmd secretsmanager update-secret \
+        --secret-id "$SECRET_NAME" \
+        --secret-string '{"key":"v2"}')
+    v2=$(json_get "$out" '.VersionId')
+
+    aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage MYSTAGE \
+        --move-to-version-id "$v1" >/dev/null
+
+    run aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage MYSTAGE \
+        --move-to-version-id "$v2" \
+        --remove-from-version-id "$v1"
+    assert_success
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$SECRET_NAME"
+    assert_success
+    on_v2=$(echo "$output" | jq --arg vid "$v2" '.VersionIdsToStages[$vid] | any(. == "MYSTAGE")')
+    [ "$on_v2" = "true" ]
+    on_v1=$(echo "$output" | jq --arg vid "$v1" '(.VersionIdsToStages[$vid] // []) | any(. == "MYSTAGE")')
+    [ "$on_v1" = "false" ]
+}
+
+@test "Secrets Manager: move AWSCURRENT updates AWSPREVIOUS" {
+    out=$(aws_cmd secretsmanager create-secret \
+        --name "$SECRET_NAME" \
+        --secret-string '{"key":"v1"}')
+    v1=$(json_get "$out" '.VersionId')
+
+    out=$(aws_cmd secretsmanager update-secret \
+        --secret-id "$SECRET_NAME" \
+        --secret-string '{"key":"v2"}')
+    v2=$(json_get "$out" '.VersionId')
+
+    run aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage AWSCURRENT \
+        --move-to-version-id "$v1" \
+        --remove-from-version-id "$v2"
+    assert_success
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$SECRET_NAME"
+    assert_success
+    v1_current=$(echo "$output" | jq --arg vid "$v1" '.VersionIdsToStages[$vid] | any(. == "AWSCURRENT")')
+    [ "$v1_current" = "true" ]
+    v2_previous=$(echo "$output" | jq --arg vid "$v2" '.VersionIdsToStages[$vid] | any(. == "AWSPREVIOUS")')
+    [ "$v2_previous" = "true" ]
+}
+
+@test "Secrets Manager: remove custom stage from version" {
+    out=$(aws_cmd secretsmanager create-secret \
+        --name "$SECRET_NAME" \
+        --secret-string '{"key":"value"}')
+    v1=$(json_get "$out" '.VersionId')
+
+    aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage MYSTAGE \
+        --move-to-version-id "$v1" >/dev/null
+
+    run aws_cmd secretsmanager update-secret-version-stage \
+        --secret-id "$SECRET_NAME" \
+        --version-stage MYSTAGE \
+        --remove-from-version-id "$v1"
+    assert_success
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$SECRET_NAME"
+    assert_success
+    has_mystage=$(echo "$output" | jq --arg vid "$v1" '(.VersionIdsToStages[$vid] // []) | any(. == "MYSTAGE")')
+    [ "$has_mystage" = "false" ]
+    has_current=$(echo "$output" | jq --arg vid "$v1" '.VersionIdsToStages[$vid] | any(. == "AWSCURRENT")')
+    [ "$has_current" = "true" ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -47,6 +47,7 @@ public class SecretsManagerJsonHandler {
             case "BatchGetSecretValue" -> handleBatchGetSecretValue(request, region);
             case "DeleteResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
             case "PutResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
+            case "UpdateSecretVersionStage" -> handleUpdateSecretVersionStage(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -400,6 +401,21 @@ public class SecretsManagerJsonHandler {
                     .entity(new AwsErrorResponse("InvalidParameterException", e.getMessage()))
                     .build();
         }
+    }
+
+    private Response handleUpdateSecretVersionStage(JsonNode request, String region) {
+        String secretId = request.path("SecretId").asText();
+        String moveToVersionId = request.path("MoveToVersionId").asText(null);
+        String removeFromVersionId = request.path("RemoveFromVersionId").asText(null);
+        String versionStage = request.path("VersionStage").asText();
+
+        Secret secret = service.updateSecretVersionStage(secretId,
+                moveToVersionId, removeFromVersionId, versionStage, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ARN", secret.getArn());
+        response.put("Name", secret.getName());
+        return Response.ok(response).build();
     }
 
     private List<Secret.Tag> parseTags(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -335,6 +336,82 @@ public class SecretsManagerService {
             }
         }
         return result;
+    }
+
+    public Secret updateSecretVersionStage(String secretId, String moveToVersionId, String removeFromVersionId, String versionStage, String region) {
+
+        if (secretId == null || secretId.isEmpty() || secretId.length() > 2048) {
+            throw new AwsException("InvalidParameterException", "Parameter validation failed. Invalid SecretId.", 400);
+        } else if (versionStage == null || versionStage.isEmpty() || versionStage.length() > 256) {
+            throw new AwsException("InvalidParameterException", "Parameter validation failed. Invalid VersionStage.", 400);
+        } else if (moveToVersionId != null && (moveToVersionId.length() < 32 || moveToVersionId.length() > 64)) {
+            throw new AwsException("InvalidParameterException", "Parameter validation failed. Invalid MoveToVersionId.", 400);
+        } else if (removeFromVersionId != null && (removeFromVersionId.length() < 32 || removeFromVersionId.length() > 64)) {
+            throw new AwsException("InvalidParameterException", "Parameter validation failed. Invalid RemoveFromVersionId.", 400);
+        }
+
+        Secret secret = resolveSecret(secretId, region);
+        if (secret.getDeletedDate() != null) {
+            throw new AwsException("ResourceNotFoundException", "Secrets Manager can't find the specified secret.", 400);
+        }
+
+        SecretVersion versionByStage = findVersionByStage(secret, versionStage);
+        String currentVersionId = versionByStage != null
+                ? versionByStage.getVersionId() : null;
+
+        if (currentVersionId != null) {
+
+            // If the label is attached and you either do not specify
+            // this parameter, or the version ID does not match, then the
+            // operation fails.
+            if (removeFromVersionId == null) {
+                throw new AwsException("InvalidParameterException",
+                        ("The parameter RemoveFromVersionId can't be empty. Staging label %s is currently attached to "
+                            + "version %s, so you must explicitly reference that version in RemoveFromVersionId.")
+                        .formatted(versionByStage, currentVersionId), 400);
+            } else if (!Objects.equals(currentVersionId, removeFromVersionId)) {
+                throw new AwsException("InvalidParameterException",
+                        ("When you move staging label %s, if you specify RemoveFromVersionId, it must be set to the "
+                            + "version that currently has the staging label %s.")
+                        .formatted(versionByStage, currentVersionId), 400);
+            }
+
+            List<String> mutableStages = new ArrayList<>(secret.getVersions()
+                    .get(removeFromVersionId).getVersionStages());
+            mutableStages.remove(versionStage);
+
+            if (AWSCURRENT.equals(versionStage)) {
+                mutableStages.add(AWSPREVIOUS);
+
+                // remove AWSPREVIOUS tag from the previous SecretVersion
+                SecretVersion previous = findVersionByStage(secret, AWSPREVIOUS);
+                if (previous != null) {
+                    List<String> mutablePrevStages =
+                            new ArrayList<>(previous.getVersionStages());
+                    mutablePrevStages.remove(AWSPREVIOUS);
+                    previous.setVersionStages(mutablePrevStages);
+                }
+            }
+            secret.getVersions().get(removeFromVersionId).setVersionStages(mutableStages);
+        }
+
+        if (moveToVersionId != null) {
+            // check whether it exists
+            if (!secret.getVersions().containsKey(moveToVersionId)) {
+                throw new AwsException("ResourceNotFoundException",
+                        "Secrets Manager can't find the specified secret value for VersionId: %s.".formatted(moveToVersionId),
+                        400);
+            }
+
+            // we are adding versionStage to this ID
+            List<String> mutableStages = new ArrayList<>(secret.getVersions().get(moveToVersionId).getVersionStages());
+            mutableStages.add(versionStage);
+            secret.getVersions().get(moveToVersionId).setVersionStages(mutableStages);
+        }
+
+        store.put(regionKey(region, secret.getName()), secret);
+
+        return secret;
     }
 
     public record BatchSecretValue(

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -351,4 +351,199 @@ class SecretsManagerServiceTest {
         Secret updated = service.describeSecret("kms-secret", REGION);
         assertEquals("arn:aws:kms:us-east-1:000000000000:key/other-key", updated.getKmsKeyId());
     }
+
+    @Test
+    void updateSecretVersionStageInvalidSecretIdThrows() {
+        String validStage = "AWSCURRENT";
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage(null, null, null, validStage, REGION));
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("", null, null, validStage, REGION));
+        String longId = RandomStringUtils.randomAlphanumeric(2049);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage(longId, null, null, validStage, REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageInvalidVersionStageThrows() {
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, null, null, REGION));
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, null, "", REGION));
+        String longStage = RandomStringUtils.randomAlphanumeric(257);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, null, longStage, REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageInvalidMoveToVersionIdThrows() {
+        String shortId = RandomStringUtils.randomAlphanumeric(31);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", shortId, null, "AWSCURRENT", REGION));
+        String longId = RandomStringUtils.randomAlphanumeric(65);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", longId, null, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageInvalidRemoveFromVersionIdThrows() {
+        String shortId = RandomStringUtils.randomAlphanumeric(31);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, shortId, "AWSCURRENT", REGION));
+        String longId = RandomStringUtils.randomAlphanumeric(65);
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, longId, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageSecretNotFoundThrows() {
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("non-existent", null, null, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageDeletedSecretThrows() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, null, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageRemoveFromRequiredWhenStageAttached() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        String v1Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", v1Id, null, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageRemoveFromMustMatchCurrentVersion() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.putSecretValue("my-secret", "v2", null, REGION, null);
+
+        String v1Id = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION).getVersionId();
+        String v2Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", v1Id, v1Id, "AWSCURRENT", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageMoveToNonExistentVersionThrows() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        String fakeVersionId = RandomStringUtils.randomAlphanumeric(36);
+
+        assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", fakeVersionId, null, "NEWLABEL", REGION));
+    }
+
+    @Test
+    void updateSecretVersionStageMovesCustomLabel() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.putSecretValue("my-secret", "v2", null, REGION, List.of("AWSCURRENT", "MYSTAGE"));
+
+        String v1Id = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION).getVersionId();
+        String v2Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v1Id, v2Id, "MYSTAGE", REGION);
+
+        SecretVersion v1After = service.getSecretValue("my-secret", v1Id, null, REGION);
+        SecretVersion v2After = service.getSecretValue("my-secret", v2Id, null, REGION);
+
+        assertTrue(v1After.getVersionStages().contains("MYSTAGE"));
+        assertFalse(v2After.getVersionStages().contains("MYSTAGE"));
+    }
+
+    @Test
+    void updateSecretVersionStageMoveAwsCurrentAddsAwsPrevious() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.putSecretValue("my-secret", "v2", null, REGION, null);
+
+        String v1Id = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION).getVersionId();
+        String v2Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v1Id, v2Id, "AWSCURRENT", REGION);
+
+        SecretVersion v1After = service.getSecretValue("my-secret", v1Id, null, REGION);
+        SecretVersion v2After = service.getSecretValue("my-secret", v2Id, null, REGION);
+
+        assertTrue(v1After.getVersionStages().contains("AWSCURRENT"));
+        assertFalse(v1After.getVersionStages().contains("AWSPREVIOUS"));
+        assertFalse(v2After.getVersionStages().contains("AWSCURRENT"));
+        assertTrue(v2After.getVersionStages().contains("AWSPREVIOUS"));
+    }
+
+    @Test
+    void updateSecretVersionStageAddsLabelWhenNotAttached() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        String v1Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v1Id, null, "NEWLABEL", REGION);
+
+        SecretVersion v1After = service.getSecretValue("my-secret", v1Id, null, REGION);
+        assertTrue(v1After.getVersionStages().contains("NEWLABEL"));
+        assertTrue(v1After.getVersionStages().contains("AWSCURRENT"));
+    }
+
+    @Test
+    void updateSecretVersionStageMoveAwsCurrentCleansUpPreviousFromMultiStageVersion() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.putSecretValue("my-secret", "v2", null, REGION, null);
+        service.putSecretValue("my-secret", "v3", null, REGION, null);
+
+        String v1Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+        String v3Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+        String v2Id = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v2Id, null, "CUSTOMLABEL", REGION);
+
+        Secret described = service.describeSecret("my-secret", REGION);
+        String v1Id2 = described.getVersions().keySet().stream()
+                .filter(id -> !id.equals(v2Id) && !id.equals(v3Id))
+                .findFirst().orElseThrow();
+
+        service.updateSecretVersionStage("my-secret", v1Id2, v3Id, "AWSCURRENT", REGION);
+
+        SecretVersion v2After = service.getSecretValue("my-secret", v2Id, null, REGION);
+        assertFalse(v2After.getVersionStages().contains("AWSPREVIOUS"));
+        assertTrue(v2After.getVersionStages().contains("CUSTOMLABEL"));
+    }
+
+    @Test
+    void updateSecretVersionStageMoveAwsCurrentRemovesPreviousOnlyVersion() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        service.putSecretValue("my-secret", "v2", null, REGION, null);
+        service.putSecretValue("my-secret", "v3", null, REGION, null);
+
+        String v3Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+        String v2Id = service.getSecretValue("my-secret", null, "AWSPREVIOUS", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v2Id, v3Id, "AWSCURRENT", REGION);
+
+        SecretVersion v2After = service.getSecretValue("my-secret", v2Id, null, REGION);
+        assertTrue(v2After.getVersionStages().contains("AWSCURRENT"));
+        assertFalse(v2After.getVersionStages().contains("AWSPREVIOUS"));
+
+        SecretVersion v3After = service.getSecretValue("my-secret", v3Id, null, REGION);
+        assertTrue(v3After.getVersionStages().contains("AWSPREVIOUS"));
+    }
+
+    @Test
+    void updateSecretVersionStageRemovesLabelOnly() {
+        service.createSecret("my-secret", "v1", null, null, null, null, REGION);
+        String v1Id = service.getSecretValue("my-secret", null, "AWSCURRENT", REGION).getVersionId();
+
+        service.updateSecretVersionStage("my-secret", v1Id, null, "CUSTOMLABEL", REGION);
+        assertTrue(service.getSecretValue("my-secret", v1Id, null, REGION)
+                .getVersionStages().contains("CUSTOMLABEL"));
+
+        service.updateSecretVersionStage("my-secret", null, v1Id, "CUSTOMLABEL", REGION);
+
+        SecretVersion v1After = service.getSecretValue("my-secret", v1Id, null, REGION);
+        assertFalse(v1After.getVersionStages().contains("CUSTOMLABEL"));
+        assertTrue(v1After.getVersionStages().contains("AWSCURRENT"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/floci-io/floci/issues/523

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

new logic tested with aws-cli/2.34.28 Python/3.14.3 Linux/6.19.11-200.fc43.x86_64 exe/x86_64.fedora.43

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
