### PR TITLE
feat(docker): centralize Docker config and add private registry authe…

### DIFF
--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -68,6 +68,13 @@ floci:
     validate-signatures: false               # Set to true to enforce AWS SigV4 validation
     presign-secret: local-emulator-secret    # HMAC secret for S3 pre-signed URL verification
 
+  docker:
+    log-max-size: "10m"                      # Max size per container log file before rotation
+    log-max-file: "3"                        # Number of rotated log files to retain
+    docker-host: unix:///var/run/docker.sock # Docker daemon socket (shared by Lambda, RDS, ElastiCache)
+    docker-config-path: ""                   # Path to dir containing Docker's config.json (e.g. /root/.docker)
+    registry-credentials: []                 # Per-registry explicit credentials for private registries
+
   services:
     ssm:
       enabled: true
@@ -93,7 +100,6 @@ floci:
       ephemeral: false                        # true = remove container after each invocation
       default-memory-mb: 128
       default-timeout-seconds: 3
-      docker-host: unix:///var/run/docker.sock
       runtime-api-base-port: 9200             # Port range for Lambda Runtime API
       runtime-api-max-port: 9299
       code-path: ./data/lambda-code           # Where ZIP archives are stored

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -143,6 +143,10 @@ volumes:
 
 Named volumes are managed entirely by Docker and won't create files in your repository. This works with both the JVM and native images.
 
+## Docker Configuration
+
+For Docker daemon socket, private registry authentication, log rotation, and network settings see [Docker Configuration](./docker.md).
+
 ## Environment Variables Reference
 
 All `application.yml` options can be overridden via environment variables using the `FLOCI_` prefix with underscores replacing dots and dashes:
@@ -154,7 +158,11 @@ All `application.yml` options can be overridden via environment variables using 
 | `FLOCI_DEFAULT_ACCOUNT_ID` | `000000000000` | AWS account ID used in ARNs |
 | `FLOCI_STORAGE_MODE` | `memory` | Global storage mode (`memory`, `persistent`, `hybrid`, `wal`) |
 | `FLOCI_STORAGE_PERSISTENT_PATH` | `./data` | Directory for persistent storage |
-| `FLOCI_SERVICES_LAMBDA_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker host for Lambda containers |
+| `FLOCI_DOCKER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket (shared by Lambda, RDS, ElastiCache) |
+| `FLOCI_DOCKER_DOCKER_CONFIG_PATH` | `` | Path to dir with Docker's config.json (e.g. `/root/.docker`) |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__SERVER` | `` | Registry hostname for explicit credential entry 0 |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__USERNAME` | `` | Username for explicit credential entry 0 |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__PASSWORD` | `` | Password for explicit credential entry 0 |
 | `FLOCI_SERVICES_LAMBDA_EPHEMERAL` | `false` | Remove Lambda containers after each invocation |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_MEMORY_MB` | `128` | Default Lambda memory allocation |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_TIMEOUT_SECONDS` | `3` | Default Lambda timeout |

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -1,0 +1,132 @@
+# Docker Configuration
+
+Floci spawns real Docker containers for services that need them: Lambda, RDS, ElastiCache, OpenSearch, MSK, and ECS. All of these share the same Docker client configuration, controlled under `floci.docker`.
+
+## Docker Daemon Socket
+
+By default Floci connects to the local Docker daemon via the Unix socket. Override it with `docker-host` when needed (e.g. a remote Docker host or a non-standard socket path):
+
+```yaml
+floci:
+  docker:
+    docker-host: unix:///var/run/docker.sock
+```
+
+Environment variable: `FLOCI_DOCKER_DOCKER_HOST`
+
+When running Floci inside Docker Compose, mount the host socket:
+
+```yaml
+services:
+  floci:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+## Private Registry Authentication
+
+Any service that pulls a container image from a private registry (Lambda image functions, custom OpenSearch images, private Postgres images, etc.) needs Docker credentials. Two approaches are supported and can be combined.
+
+### Mount the host Docker config
+
+Reuses existing `docker login` sessions and credential helpers from the host machine. Mount the host `~/.docker` directory and point Floci at it:
+
+```yaml
+services:
+  floci:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.docker:/root/.docker:ro
+    environment:
+      FLOCI_DOCKER_DOCKER_CONFIG_PATH: /root/.docker
+```
+
+Or in `application.yml`:
+
+```yaml
+floci:
+  docker:
+    docker-config-path: /root/.docker
+```
+
+This works with any credential helper configured on the host (`docker-credential-desktop`, `ecr-credential-helper`, etc.) as long as the helper binary is also available inside the Floci container.
+
+### Explicit per-registry credentials
+
+For CI environments or air-gapped setups where mounting the host filesystem is not practical:
+
+```yaml
+services:
+  floci:
+    environment:
+      FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__SERVER: myregistry.example.com
+      FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__USERNAME: myuser
+      FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__PASSWORD: mypassword
+      # Add more registries by incrementing the index:
+      # FLOCI_DOCKER_REGISTRY_CREDENTIALS_1__SERVER: other.registry.io
+      # FLOCI_DOCKER_REGISTRY_CREDENTIALS_1__USERNAME: ...
+      # FLOCI_DOCKER_REGISTRY_CREDENTIALS_1__PASSWORD: ...
+```
+
+Or in `application.yml`:
+
+```yaml
+floci:
+  docker:
+    registry-credentials:
+      - server: myregistry.example.com
+        username: myuser
+        password: mypassword
+      - server: other.registry.io
+        username: otheruser
+        password: otherpassword
+```
+
+The `server` field must match the registry hostname exactly as it appears in the image URI (e.g. `myregistry.example.com` for `myregistry.example.com/repo:tag`). Docker Hub images (e.g. `ubuntu:22.04`) have an empty hostname and are not matched by any explicit credential entry — use the Docker config mount approach for Docker Hub authentication.
+
+### Precedence
+
+Explicit credentials take precedence for registries they cover. For everything else, Floci falls back to the Docker config file (if `docker-config-path` is set) and then to an anonymous pull.
+
+## Container Log Settings
+
+Configure log rotation for all containers spawned by Floci:
+
+```yaml
+floci:
+  docker:
+    log-max-size: "10m"   # Max size per log file before rotation (Docker json-file format)
+    log-max-file: "3"     # Number of rotated log files to retain per container
+```
+
+## Docker Network
+
+Containers spawned by Floci (Lambda, RDS, ElastiCache, OpenSearch, MSK, ECS) need to be on the same Docker network to communicate with each other and with Floci itself.
+
+Set the shared network at the top level:
+
+```yaml
+floci:
+  services:
+    docker-network: my-project_default
+```
+
+Environment variable: `FLOCI_SERVICES_DOCKER_NETWORK`
+
+Individual services can override the network with their own `docker-network` setting (e.g. `floci.services.lambda.docker-network`).
+
+!!! tip
+    In Docker Compose, the default network name is `<project-name>_default`. If your compose file is in a directory named `myapp`, the network is `myapp_default`.
+
+## Full Reference
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `FLOCI_DOCKER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket |
+| `FLOCI_DOCKER_DOCKER_CONFIG_PATH` | _(unset)_ | Path to directory containing Docker's `config.json` |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__SERVER` | _(unset)_ | Registry hostname for credential entry 0 |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__USERNAME` | _(unset)_ | Username for credential entry 0 |
+| `FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__PASSWORD` | _(unset)_ | Password for credential entry 0 |
+| `FLOCI_DOCKER_LOG_MAX_SIZE` | `10m` | Max container log file size before rotation |
+| `FLOCI_DOCKER_LOG_MAX_FILE` | `3` | Number of rotated log files to retain |
+| `FLOCI_SERVICES_DOCKER_NETWORK` | _(unset)_ | Shared Docker network for all container-based services |

--- a/docs/services/ecs.md
+++ b/docs/services/ecs.md
@@ -170,7 +170,7 @@ services:
 
 ### Docker socket requirement
 
-When `mock: false` (the default), ECS launches real Docker containers and requires the Docker socket. Mount it and set the network so containers can reach each other:
+When `mock: false` (the default), ECS launches real Docker containers and requires the Docker socket. Mount it and set the network so containers can reach each other. For private registry authentication and other Docker settings see [Docker Configuration](../configuration/docker.md).
 
 ```yaml
 services:

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -33,7 +33,7 @@ floci:
 
 ### Docker Compose
 
-ElastiCache requires the Docker socket and port range exposure:
+ElastiCache requires the Docker socket and port range exposure. For private registry authentication and other Docker settings see [Docker Configuration](../configuration/docker.md).
 
 ```yaml
 services:

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -14,6 +14,7 @@ Lambda runs your function code inside real Docker containers — the same way re
 | `GetFunctionConfiguration` | Get runtime configuration |
 | `ListFunctions` | List all functions |
 | `UpdateFunctionCode` | Upload new code |
+| `UpdateFunctionConfiguration` | Update runtime, handler, memory, timeout, environment, architectures, tracing, layers, and more |
 | `DeleteFunction` | Remove a function |
 | `Invoke` | Invoke a function synchronously or asynchronously |
 | `CreateEventSourceMapping` | Connect SQS / Kinesis / DynamoDB Streams to a function |
@@ -107,7 +108,6 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
 
 - Layers (`PublishLayerVersion`, `DeleteLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
 - Provisioned concurrency (`PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
-- `UpdateFunctionConfiguration` (use `UpdateFunctionCode` for code-only updates; configuration-only updates are not separately supported)
 - Dead-letter, async invoke config, and event invoke config operations
 - `InvokeWithResponseStream`
 - Code signing management (only `GetFunctionCodeSigningConfig` is wired; there is no `PutFunctionCodeSigningConfig` or `CreateCodeSigningConfig`)
@@ -123,7 +123,6 @@ floci:
       ephemeral: false                     # Remove container after each invocation
       default-memory-mb: 128
       default-timeout-seconds: 3
-      docker-host: unix:///var/run/docker.sock
       runtime-api-base-port: 9200
       runtime-api-max-port: 9299
       code-path: ./data/lambda-code        # ZIP storage location
@@ -143,6 +142,10 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
+
+### Private registry authentication
+
+Container image functions (`"PackageType": "Image"`) that pull from private registries need Docker credentials. See [Docker Configuration → Private Registry Authentication](../configuration/docker.md#private-registry-authentication) for the full guide.
 
 ## Examples
 

--- a/docs/services/msk.md
+++ b/docs/services/msk.md
@@ -31,7 +31,7 @@ floci:
 
 ## How it works
 
-When `mock` is set to `false` (default), Floci uses the Docker API to start a Redpanda container for each created cluster.
+When `mock` is set to `false` (default), Floci uses the Docker API to start a Redpanda container for each created cluster. For Docker socket setup, private registry authentication, and other Docker settings see [Docker Configuration](../configuration/docker.md).
 
 - **Port Mapping**: The Kafka API (9092) is mapped to a dynamic host port.
 - **Persistence**: Data is stored in the Floci persistent path under `msk/<cluster-name>`.

--- a/docs/services/opensearch.md
+++ b/docs/services/opensearch.md
@@ -17,7 +17,7 @@ Domain metadata is stored in-process. No Docker containers are started. Domains 
 Floci starts an **OpenSearch** (`opensearchproject/opensearch:2`) Docker container per domain. The container is exposed on a host port from the configured range (`9400–9499`). Once `/_cluster/health` returns `green` or `yellow`, the domain transitions to `Created: true` and the `Endpoint` field is populated with the container's address.
 
 !!! note "Docker socket required"
-    Real mode starts Docker containers. Mount the Docker socket and set the Docker network so containers can reach each other.
+    Real mode starts Docker containers. Mount the Docker socket and set the Docker network so containers can reach each other. For private registry authentication and other Docker settings see [Docker Configuration](../configuration/docker.md).
 
 ```yaml
 services:

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -41,7 +41,7 @@ floci:
 
 ### Docker Compose
 
-RDS requires the Docker socket and port range exposure:
+RDS requires the Docker socket and port range exposure. For private registry authentication and other Docker settings see [Docker Configuration](../configuration/docker.md).
 
 ```yaml
 services:

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.config;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import java.util.List;
 import java.util.Optional;
 
 @ConfigMapping(prefix = "floci")
@@ -525,9 +526,6 @@ public interface EmulatorConfig {
         @WithDefault("3")
         int defaultTimeoutSeconds();
 
-        @WithDefault("unix:///var/run/docker.sock")
-        String dockerHost();
-
         Optional<String> dockerHostOverride();
 
         @WithDefault("9200")
@@ -642,5 +640,31 @@ public interface EmulatorConfig {
          */
         @WithDefault("3")
         String logMaxFile();
+
+        /** Unix socket or TCP URL for the Docker daemon (e.g. unix:///var/run/docker.sock). */
+        @WithDefault("unix:///var/run/docker.sock")
+        String dockerHost();
+
+        /**
+         * Path to a directory containing Docker's config.json (e.g. /root/.docker).
+         * When set, overrides the system default. Useful when Floci runs inside Docker
+         * and the host ~/.docker directory is mounted in.
+         */
+        Optional<String> dockerConfigPath();
+
+        /**
+         * Explicit credentials for private Docker registries.
+         * Each entry maps a registry hostname to a username/password pair.
+         * Use when mounting the host Docker config is impractical.
+         */
+        @WithDefault("")
+        List<RegistryCredential> registryCredentials();
+
+        interface RegistryCredential {
+            /** Registry hostname (e.g. myregistry.example.com). */
+            String server();
+            String username();
+            String password();
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
@@ -30,12 +30,16 @@ public class DockerClientProducer {
     @Produces
     @ApplicationScoped
     public DockerClient dockerClient() {
-        String dockerHost = config.services().lambda().dockerHost();
+        String dockerHost = config.docker().dockerHost();
         LOG.infov("Creating DockerClient for host: {0}", dockerHost);
 
-        DefaultDockerClientConfig clientConfig = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost(dockerHost)
-                .build();
+        DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder()
+                .withDockerHost(dockerHost);
+        config.docker().dockerConfigPath().ifPresent(path -> {
+            LOG.infov("Using Docker config path: {0}", path);
+            builder.withDockerConfig(path);
+        });
+        DefaultDockerClientConfig clientConfig = builder.build();
 
         ApacheDockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
                 .dockerHost(clientConfig.getDockerHost())

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
@@ -2,10 +2,13 @@ package io.github.hectorvent.floci.services.lambda.launcher;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.github.dockerjava.api.model.AuthConfig;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -20,12 +23,14 @@ public class ImageCacheService {
     private static final Logger LOG = Logger.getLogger(ImageCacheService.class);
 
     private final DockerClient dockerClient;
+    private final List<EmulatorConfig.DockerConfig.RegistryCredential> registryCredentials;
     private final Set<String> pulledImages = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, Object> locks = new ConcurrentHashMap<>();
 
     @Inject
-    public ImageCacheService(DockerClient dockerClient) {
+    public ImageCacheService(DockerClient dockerClient, EmulatorConfig config) {
         this.dockerClient = dockerClient;
+        this.registryCredentials = config.docker().registryCredentials();
     }
 
     public void ensureImageExists(String imageUri) {
@@ -40,6 +45,7 @@ public class ImageCacheService {
             LOG.infov("Pulling image: {0}", imageUri);
             try {
                 dockerClient.pullImageCmd(imageUri)
+                        .withAuthConfig(resolveAuth(imageUri))
                         .exec(new PullImageResultCallback())
                         .awaitCompletion(5, TimeUnit.MINUTES);
                 pulledImages.add(imageUri);
@@ -49,5 +55,24 @@ public class ImageCacheService {
                 throw new RuntimeException("Interrupted while pulling image: " + imageUri, e);
             }
         }
+    }
+
+    private AuthConfig resolveAuth(String imageUri) {
+        String host = extractRegistryHost(imageUri);
+        for (EmulatorConfig.DockerConfig.RegistryCredential cred : registryCredentials) {
+            if (cred.server().equals(host)) {
+                LOG.debugv("Using configured credentials for registry: {0}", host);
+                return new AuthConfig()
+                        .withUsername(cred.username())
+                        .withPassword(cred.password())
+                        .withRegistryAddress(cred.server());
+            }
+        }
+        return new AuthConfig();
+    }
+
+    static String extractRegistryHost(String imageUri) {
+        String firstSegment = imageUri.split("/")[0];
+        return (firstSegment.contains(".") || firstSegment.contains(":")) ? firstSegment : "";
     }
 }

--- a/src/main/resources/application.yml.bak
+++ b/src/main/resources/application.yml.bak
@@ -65,6 +65,7 @@ floci:
     log-max-file: "3"
     docker-host: unix:///var/run/docker.sock
     docker-config-path: ""
+    registry-credentials: []
 
   services:
     ssm:


### PR DESCRIPTION
…ntication

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
 - Moves docker-host from floci.services.lambda into the shared floci.docker block — it was always used by all container-based services (Lambda, RDS, ElastiCache, ECS, MSK,   
  OpenSearch) but was incorrectly scoped to Lambda. Env var changes from FLOCI_SERVICES_LAMBDA_DOCKER_HOST → FLOCI_DOCKER_DOCKER_HOST.
  - Adds docker-config-path to floci.docker — path to a directory containing Docker's config.json (e.g. a mounted ~/.docker). Wired into DockerClientProducer via .withDockerConfig(path) so existing docker login sessions and credential helpers are available when pulling private images.                                                   
  - Adds registry-credentials list to floci.docker — explicit per-registry username/password pairs for CI or air-gapped environments. ImageCacheService resolves the matching AuthConfig by registry hostname before calling pullImageCmd, falling back to anonymous if no match.                                                                           
  - Adds docs/configuration/docker.md as the single reference for all Docker configuration (socket, auth, log rotation, network). All service docs (Lambda, RDS, ElastiCache,
  OpenSearch, ECS, MSK) now link to it rather than duplicating the Docker socket setup instructions.                                                                            
                                                            
  **Test plan**                                                                                                                                                                     
                                                            
  - Pull a public image with no credentials configured — existing behaviour unchanged                                                                                           
  - Set FLOCI_DOCKER_DOCKER_CONFIG_PATH to a valid ~/.docker dir — verify DockerClientProducer log shows the path at startup
  - Configure FLOCI_DOCKER_REGISTRY_CREDENTIALS_0__* for a private registry — verify ImageCacheService selects the correct AuthConfig and pull succeeds                         
  - Verify FLOCI_DOCKER_DOCKER_HOST override still routes the Docker client correctly                                                                                           
  - Confirm extractRegistryHost handles Docker Hub images (no host), fully-qualified URIs, and port-qualified registries   

Closes #275 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
