### PR TITLE
Feature cognito update user pool client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Fast, free, open-source local AWS emulator supporting SSM, SQS, SNS, SES, S3, DynamoDB, Lambda, API Gateway, Cognito, KMS, Kinesis, Secrets Manager, CloudFormation, Step Functions, IAM, STS, ElastiCache, RDS, EventBridge, and CloudWatch</description>
 
     <properties>
-        <maven.compiler.release>25</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.platform.version>3.34.3</quarkus.platform.version>
     </properties>
@@ -196,16 +196,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <release>${maven.compiler.release}</release>
+                    <compilerArgs>
+                        <arg>--enable-preview</arg>
+                    </compilerArgs>
+                    <testIncludes>
+                        <testInclude>**/cognito/*Test.java</testInclude>
+                    </testIncludes>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.2.5</version>
                 <configuration>
+                    <argLine>--enable-preview</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>
@@ -224,8 +230,7 @@
             </activation>
             <properties>
                 <skipITs>true</skipITs>
-                <quarkus.native.enabled>true</quarkus.native.enabled>
-                <maven.compiler.release>24</maven.compiler.release>
+                <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -198,9 +198,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
                     <testIncludes>
                         <testInclude>**/cognito/*Test.java</testInclude>
                     </testIncludes>
@@ -211,7 +208,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
-                    <argLine>--enable-preview</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -43,6 +43,7 @@ public class CognitoJsonHandler {
             case "CreateUserPoolClient" -> handleCreateUserPoolClient(request);
             case "DescribeUserPoolClient" -> handleDescribeUserPoolClient(request);
             case "ListUserPoolClients" -> handleListUserPoolClients(request);
+            case "UpdateUserPoolClient" -> handleUpdateUserPoolClient(request);
             case "DeleteUserPoolClient" -> handleDeleteUserPoolClient(request);
             case "CreateResourceServer" -> handleCreateResourceServer(request);
             case "DescribeResourceServer" -> handleDescribeResourceServer(request);
@@ -160,6 +161,20 @@ public class CognitoJsonHandler {
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode items = response.putArray("UserPoolClients");
         clients.forEach(c -> items.add(clientToDescriptionNode(c)));
+        return Response.ok(response).build();
+    }
+
+    private Response handleUpdateUserPoolClient(JsonNode request) {
+        UserPoolClient client = service.updateUserPoolClient(
+                request.path("UserPoolId").asText(),
+                request.path("ClientId").asText(),
+                request.path("ClientName").isMissingNode() ? null : request.path("ClientName").asText(),
+                request.path("AllowedOAuthFlowsUserPoolClient").isMissingNode() ? null : request.path("AllowedOAuthFlowsUserPoolClient").asBoolean(),
+                request.path("AllowedOAuthFlows").isMissingNode() ? null : readStringList(request.path("AllowedOAuthFlows")),
+                request.path("AllowedOAuthScopes").isMissingNode() ? null : readStringList(request.path("AllowedOAuthScopes"))
+        );
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("UserPoolClient", clientToNode(client));
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -202,6 +202,28 @@ public class CognitoService {
         clientStore.delete(clientId);
     }
 
+    public UserPoolClient updateUserPoolClient(String userPoolId, String clientId, String clientName,
+                                               Boolean allowedOAuthFlowsUserPoolClient,
+                                               List<String> allowedOAuthFlows,
+                                               List<String> allowedOAuthScopes) {
+        UserPoolClient client = describeUserPoolClient(userPoolId, clientId);
+        if (clientName != null) client.setClientName(clientName);
+        if (allowedOAuthFlowsUserPoolClient != null) {
+            client.setAllowedOAuthFlowsUserPoolClient(allowedOAuthFlowsUserPoolClient);
+        }
+        if (allowedOAuthFlows != null) {
+            client.setAllowedOAuthFlows(normalizeStringList(allowedOAuthFlows));
+        }
+        if (allowedOAuthScopes != null) {
+            client.setAllowedOAuthScopes(normalizeStringList(allowedOAuthScopes));
+        }
+
+        client.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        clientStore.put(clientId, client);
+        LOG.infov("Updated User Pool Client: {0} for pool {1}", clientId, userPoolId);
+        return client;
+    }
+
     public List<UserPoolClientSecret> listUserPoolClientSecrets(String userPoolId, String clientId) {
         UserPoolClient client = clientStore.get(clientId)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool client not found", 404));

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -413,26 +413,25 @@ final class ExpressionEvaluator {
     static boolean evaluate(Expr expr, JsonNode item, JsonNode exprAttrNames, JsonNode exprAttrValues) {
         if (expr == null) return true;
 
-        return switch (expr) {
-            case AndExpr and -> {
-                for (Expr op : and.operands()) {
-                    if (!evaluate(op, item, exprAttrNames, exprAttrValues)) yield false;
-                }
-                yield true;
+        if (expr instanceof AndExpr and) {
+            for (Expr op : and.operands()) {
+                if (!evaluate(op, item, exprAttrNames, exprAttrValues)) return false;
             }
-            case OrExpr or -> {
-                for (Expr op : or.operands()) {
-                    if (evaluate(op, item, exprAttrNames, exprAttrValues)) yield true;
-                }
-                yield false;
+            return true;
+        }
+        if (expr instanceof OrExpr or) {
+            for (Expr op : or.operands()) {
+                if (evaluate(op, item, exprAttrNames, exprAttrValues)) return true;
             }
-            case NotExpr not -> !evaluate(not.operand(), item, exprAttrNames, exprAttrValues);
+            return false;
+        }
+        if (expr instanceof NotExpr not) return !evaluate(not.operand(), item, exprAttrNames, exprAttrValues);
 
-            case CompareExpr cmp -> evaluateComparison(cmp, item, exprAttrNames, exprAttrValues);
-            case BetweenExpr bet -> evaluateBetween(bet, item, exprAttrNames, exprAttrValues);
-            case InExpr in -> evaluateIn(in, item, exprAttrNames, exprAttrValues);
-            case FunctionCallExpr func -> evaluateFunction(func, item, exprAttrNames, exprAttrValues);
-        };
+        if (expr instanceof CompareExpr cmp) return evaluateComparison(cmp, item, exprAttrNames, exprAttrValues);
+        if (expr instanceof BetweenExpr bet) return evaluateBetween(bet, item, exprAttrNames, exprAttrValues);
+        if (expr instanceof InExpr in) return evaluateIn(in, item, exprAttrNames, exprAttrValues);
+        if (expr instanceof FunctionCallExpr func) return evaluateFunction(func, item, exprAttrNames, exprAttrValues);
+        return false;
     }
 
     /**
@@ -580,28 +579,27 @@ final class ExpressionEvaluator {
      */
     private static String resolveScalar(Operand operand, JsonNode item,
                                          JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        return switch (operand) {
-            case PlaceholderOperand p -> {
-                if (exprAttrValues != null) {
-                    yield extractScalarValue(exprAttrValues.get(p.name()));
-                }
-                yield null;
+        if (operand instanceof PlaceholderOperand p) {
+            if (exprAttrValues != null) {
+                return extractScalarValue(exprAttrValues.get(p.name()));
             }
-            case PathOperand path -> {
-                String resolvedPath = resolvePathString(path, exprAttrNames);
-                JsonNode attrNode = item != null ? resolveNestedAttribute(item, resolvedPath) : null;
-                yield extractScalarValue(attrNode);
+            return null;
+        }
+        if (operand instanceof PathOperand path) {
+            String resolvedPath = resolvePathString(path, exprAttrNames);
+            JsonNode attrNode = item != null ? resolveNestedAttribute(item, resolvedPath) : null;
+            return extractScalarValue(attrNode);
+        }
+        if (operand instanceof FunctionOperand func) {
+            // size() returns a number
+            if ("size".equalsIgnoreCase(func.functionName()) && !func.args().isEmpty()) {
+                String path = resolveAttributePath(func.args().get(0), exprAttrNames);
+                JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
+                return attrNode != null ? String.valueOf(computeSize(attrNode)) : null;
             }
-            case FunctionOperand func -> {
-                // size() returns a number
-                if ("size".equalsIgnoreCase(func.functionName()) && !func.args().isEmpty()) {
-                    String path = resolveAttributePath(func.args().get(0), exprAttrNames);
-                    JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
-                    yield attrNode != null ? String.valueOf(computeSize(attrNode)) : null;
-                }
-                yield null;
-            }
-        };
+            return null;
+        }
+        return null;
     }
 
     /**
@@ -609,14 +607,14 @@ final class ExpressionEvaluator {
      */
     private static JsonNode resolveAttributeValue(Operand operand, JsonNode item,
                                                     JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        return switch (operand) {
-            case PlaceholderOperand p -> exprAttrValues != null ? exprAttrValues.get(p.name()) : null;
-            case PathOperand path -> {
-                String resolvedPath = resolvePathString(path, exprAttrNames);
-                yield item != null ? resolveNestedAttribute(item, resolvedPath) : null;
-            }
-            case FunctionOperand funcOp -> null;
-        };
+        if (operand instanceof PlaceholderOperand p) {
+            return exprAttrValues != null ? exprAttrValues.get(p.name()) : null;
+        }
+        if (operand instanceof PathOperand path) {
+            String resolvedPath = resolvePathString(path, exprAttrNames);
+            return item != null ? resolveNestedAttribute(item, resolvedPath) : null;
+        }
+        return null;
     }
 
     // ── Attribute path resolution ──

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -196,7 +196,7 @@ final class ExpressionEvaluator {
                 advance(); // consume OR
                 operands.add(parseAndExpr());
             }
-            return operands.size() == 1 ? operands.getFirst() : new OrExpr(operands);
+            return operands.size() == 1 ? operands.get(0) : new OrExpr(operands);
         }
 
         private Expr parseAndExpr() {
@@ -206,7 +206,7 @@ final class ExpressionEvaluator {
                 advance(); // consume AND
                 operands.add(parseNotExpr());
             }
-            return operands.size() == 1 ? operands.getFirst() : new AndExpr(operands);
+            return operands.size() == 1 ? operands.get(0) : new AndExpr(operands);
         }
 
         private Expr parseNotExpr() {
@@ -495,12 +495,12 @@ final class ExpressionEvaluator {
         return switch (funcLower) {
             case "attribute_exists" -> {
                 if (func.args().isEmpty()) yield false;
-                String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                String path = resolveAttributePath(func.args().get(0), exprAttrNames);
                 yield item != null && resolveNestedAttribute(item, path) != null;
             }
             case "attribute_not_exists" -> {
                 if (func.args().isEmpty()) yield false;
-                String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                String path = resolveAttributePath(func.args().get(0), exprAttrNames);
                 yield item == null || resolveNestedAttribute(item, path) == null;
             }
             case "begins_with" -> {
@@ -595,7 +595,7 @@ final class ExpressionEvaluator {
             case FunctionOperand func -> {
                 // size() returns a number
                 if ("size".equalsIgnoreCase(func.functionName()) && !func.args().isEmpty()) {
-                    String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                    String path = resolveAttributePath(func.args().get(0), exprAttrNames);
                     JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
                     yield attrNode != null ? String.valueOf(computeSize(attrNode)) : null;
                 }
@@ -615,7 +615,7 @@ final class ExpressionEvaluator {
                 String resolvedPath = resolvePathString(path, exprAttrNames);
                 yield item != null ? resolveNestedAttribute(item, resolvedPath) : null;
             }
-            case FunctionOperand _ -> null;
+            case FunctionOperand funcOp -> null;
         };
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -988,7 +988,7 @@ public class EcsService {
                     List<EcsTask> launched = runTask(clusterName, svc.getTaskDefinition(), 1,
                             svc.getLaunchType(), svc.getServiceName(), "ecs-svc", region);
                     LOG.infov("Service reconciler started task {0} for service {1}",
-                            launched.getFirst().getTaskArn(), svc.getServiceName());
+                            launched.get(0).getTaskArn(), svc.getServiceName());
                 } catch (Exception e) {
                     LOG.warnv("Service reconciler failed to start task for {0}: {1}",
                             svc.getServiceName(), e.getMessage());

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -560,15 +560,13 @@ public class EcsService {
     }
 
     private Map<String, String> getTagsFromResource(Object resource) {
-        return switch (resource) {
-            case EcsCluster c -> c.getTags();
-            case TaskDefinition td -> td.getTags();
-            case EcsTask t -> t.getTags();
-            case EcsServiceModel s -> s.getTags();
-            case ContainerInstance ci -> ci.getTags();
-            case CapacityProvider cp -> cp.getTags();
-            default -> Map.of();
-        };
+        if (resource instanceof EcsCluster c) return c.getTags();
+        if (resource instanceof TaskDefinition td) return td.getTags();
+        if (resource instanceof EcsTask t) return t.getTags();
+        if (resource instanceof EcsServiceModel s) return s.getTags();
+        if (resource instanceof ContainerInstance ci) return ci.getTags();
+        if (resource instanceof CapacityProvider cp) return cp.getTags();
+        return Map.of();
     }
 
     // ── Account Settings ──────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
@@ -56,7 +56,7 @@ public class ElastiCacheAuthProxy {
     public void start(int proxyPort) throws IOException {
         serverSocket = new ServerSocket(proxyPort);
         running = true;
-        Thread.ofVirtual().name("ec-proxy-accept-" + groupId).start(this::acceptLoop);
+        new Thread(this::acceptLoop, "ec-proxy-accept-" + groupId).start();
         LOG.infov("ElastiCache proxy started for group {0} on port {1} → {2}:{3}",
                 groupId, proxyPort, backendHost, backendPort);
     }
@@ -76,7 +76,7 @@ public class ElastiCacheAuthProxy {
         while (running) {
             try {
                 Socket client = serverSocket.accept();
-                Thread.ofVirtual().name("ec-proxy-conn-" + groupId).start(() -> handleConnection(client));
+                new Thread(() -> handleConnection(client), "ec-proxy-conn-" + groupId).start();
             } catch (IOException e) {
                 if (running) {
                     LOG.warnv("Accept error for group {0}: {1}", groupId, e.getMessage());
@@ -160,10 +160,10 @@ public class ElastiCacheAuthProxy {
     }
 
     private void bridge(Socket client, Socket backend) {
-        Thread t1 = Thread.ofVirtual().name("ec-relay-c2b-" + groupId)
-                .start(() -> relay(client, backend));
-        Thread t2 = Thread.ofVirtual().name("ec-relay-b2c-" + groupId)
-                .start(() -> relay(backend, client));
+        Thread t1 = new Thread(() -> relay(client, backend), "ec-relay-c2b-" + groupId);
+        t1.start();
+        Thread t2 = new Thread(() -> relay(backend, client), "ec-relay-b2c-" + groupId);
+        t2.start();
         try {
             t1.join();
             t2.join();

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
@@ -41,8 +41,9 @@ public class FirehoseJsonHandler {
                 yield Response.ok(Map.of("DeliveryStreamNames", firehoseService.listDeliveryStreams(), "HasMoreDeliveryStreams", false)).build();
             }
             case "DeleteDeliveryStream" -> {
-                // TODO: delete implementation
-                yield Response.ok().build();
+                String name = request.get("DeliveryStreamName").asText();
+                firehoseService.deleteDeliveryStream(name);
+                yield Response.ok(Map.of()).build();
             }
             case "PutRecord" -> {
                 String name = request.get("DeliveryStreamName").asText();

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -44,6 +44,13 @@ public class FirehoseService {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Stream not found: " + name, 400));
     }
 
+    public void deleteDeliveryStream(String name) {
+        describeDeliveryStream(name); // Checks if it exists and throws if not
+        streamStore.remove(name);
+        buffers.remove(name);
+        LOG.infov("Deleted Firehose Delivery Stream: {0}", name);
+    }
+
     public List<String> listDeliveryStreams() {
         return streamStore.scan(k -> true).stream().map(DeliveryStreamDescription::getDeliveryStreamName).toList();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -46,7 +46,7 @@ public class FirehoseService {
 
     public void deleteDeliveryStream(String name) {
         describeDeliveryStream(name); // Checks if it exists and throws if not
-        streamStore.remove(name);
+        streamStore.delete(name);
         buffers.remove(name);
         LOG.infov("Deleted Firehose Delivery Stream: {0}", name);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
@@ -315,10 +315,10 @@ public class MySqlProtocolHandler {
             return;
         }
 
-        Thread t1 = Thread.ofVirtual().name("rds-mysql-c2b")
-                .start(() -> relay(clientIn, backendOut));
-        Thread t2 = Thread.ofVirtual().name("rds-mysql-b2c")
-                .start(() -> relay(backendIn, clientOut));
+        Thread t1 = new Thread(() -> relay(clientIn, backendOut), "rds-mysql-c2b");
+        t1.start();
+        Thread t2 = new Thread(() -> relay(backendIn, clientOut), "rds-mysql-b2c");
+        t2.start();
         try {
             t1.join();
             t2.join();

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -486,10 +486,10 @@ public class PostgresProtocolHandler {
             closeQuietly(backend);
             return;
         }
-        Thread t1 = Thread.ofVirtual().name("rds-pg-c2b")
-                .start(() -> relay(clientIn, backendOut));
-        Thread t2 = Thread.ofVirtual().name("rds-pg-b2c")
-                .start(() -> relay(backendIn, clientOut));
+        Thread t1 = new Thread(() -> relay(clientIn, backendOut), "rds-pg-c2b");
+        t1.start();
+        Thread t2 = new Thread(() -> relay(backendIn, clientOut), "rds-pg-b2c");
+        t2.start();
         try {
             t1.join();
             t2.join();

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -49,7 +49,7 @@ public class RdsAuthProxy {
     public void start(int proxyPort) throws IOException {
         serverSocket = new ServerSocket(proxyPort);
         running = true;
-        Thread.ofVirtual().name("rds-proxy-accept-" + instanceId).start(this::acceptLoop);
+        new Thread(this::acceptLoop, "rds-proxy-accept-" + instanceId).start();
         LOG.infov("RDS proxy started for instance {0} on port {1} → {2}:{3}",
                 instanceId, proxyPort, backendHost, backendPort);
     }
@@ -70,9 +70,7 @@ public class RdsAuthProxy {
         while (running) {
             try {
                 Socket client = serverSocket.accept();
-                Thread.ofVirtual().name("rds-proxy-conn-" + instanceId)
-                        .start(() -> handleConnection(client));
-            } catch (IOException e) {
+                new Thread(() -> handleConnection(client), "rds-proxy-conn-" + instanceId).start();            } catch (IOException e) {
                 if (running) {
                     LOG.warnv("Accept error for RDS instance {0}: {1}", instanceId, e.getMessage());
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -498,7 +498,6 @@ public class S3Controller {
                               @HeaderParam("If-None-Match") String ifNoneMatch,
                               @HeaderParam("If-Modified-Since") String ifModifiedSince,
                               @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince,
-                              @HeaderParam("Range") String rangeHeader,
                               @Context UriInfo uriInfo,
                               @Context HttpHeaders httpHeaders) {
         try {
@@ -536,6 +535,7 @@ public class S3Controller {
             }
             S3Object obj = s3Service.getObject(bucket, key, versionId);
 
+            String rangeHeader = httpHeaders.getHeaderString("Range");
             if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
                 return handleRangeRequest(obj, rangeHeader);
             }
@@ -907,11 +907,11 @@ public class S3Controller {
                 .filter(e -> e.getKey() > marker)
                 .limit(maxPartsLimit + 1L)
                 .map(Map.Entry::getValue)
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
 
         boolean truncated = sortedParts.size() > maxPartsLimit;
         List<Part> page = truncated ? sortedParts.subList(0, maxPartsLimit) : sortedParts;
-        String nextMarker = truncated ? String.valueOf(page.getLast().getPartNumber()) : null;
+        String nextMarker = truncated ? String.valueOf(page.get(page.size() - 1).getPartNumber()) : null;
 
         XmlBuilder xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
@@ -969,7 +969,7 @@ public class S3Controller {
             throw new AwsException("MalformedXML",
                     "The XML you provided was not well-formed.", 400);
         }
-        return parts.stream().map(Integer::parseInt).toList();
+        return parts.stream().map(Integer::parseInt).collect(java.util.stream.Collectors.toList());
     }
 
     // --- Versioning Operations ---
@@ -1229,13 +1229,13 @@ public class S3Controller {
         for (String token : tokens) {
             String trimmed = token.trim();
             if (!trimmed.equalsIgnoreCase("aws-chunked")) {
-                if (!result.isEmpty()) {
+                if (result.length() > 0) {
                     result.append(",");
                 }
                 result.append(trimmed);
             }
         }
-        return result.isEmpty() ? null : result.toString();
+        return result.length() == 0 ? null : result.toString();
     }
 
     // --- AWS Chunked Decoding ---

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -221,6 +221,59 @@ public class SecretsManagerService {
         return secret;
     }
 
+    public Secret updateSecretVersionStage(String secretId, String versionStage,
+                                           String removeFromVersionId, String moveToVersionId, String region) {
+        Secret secret = resolveSecret(secretId, region);
+
+        if (secret.getDeletedDate() != null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "Secrets Manager can't find the specified secret.", 400);
+        }
+
+        if (moveToVersionId == null && removeFromVersionId == null) {
+            throw new AwsException("InvalidParameterValueException",
+                    "You must specify either MoveToVersionId or RemoveFromVersionId", 400);
+        }
+
+        // Remove from the specified version (if any)
+        if (removeFromVersionId != null) {
+            SecretVersion removeVersion = secret.getVersions().get(removeFromVersionId);
+            if (removeVersion != null && removeVersion.getVersionStages() != null) {
+                List<String> newStages = new ArrayList<>(removeVersion.getVersionStages());
+                newStages.remove(versionStage);
+                removeVersion.setVersionStages(newStages);
+            }
+        }
+
+        // Move to the specified version (if any)
+        if (moveToVersionId != null) {
+            SecretVersion moveVersion = secret.getVersions().get(moveToVersionId);
+            if (moveVersion == null) {
+                throw new AwsException("ResourceNotFoundException",
+                        "Secrets Manager can't find the specified secret version.", 400);
+            }
+
+            // Remove stage from whatever version currently has it
+            SecretVersion currentHolder = findVersionByStage(secret, versionStage);
+            if (currentHolder != null && !currentHolder.getVersionId().equals(moveToVersionId)) {
+                List<String> newStages = new ArrayList<>(currentHolder.getVersionStages());
+                newStages.remove(versionStage);
+                currentHolder.setVersionStages(newStages);
+            }
+
+            List<String> mStages = moveVersion.getVersionStages() != null ? new ArrayList<>(moveVersion.getVersionStages()) : new ArrayList<>();
+            if (!mStages.contains(versionStage)) {
+                mStages.add(versionStage);
+            }
+            moveVersion.setVersionStages(mStages);
+        }
+
+        secret.setLastChangedDate(Instant.now());
+        store.put(regionKey(region, secret.getName()), secret);
+        LOG.infov("Updated secret version stage: {0} for secret {1}", versionStage, secret.getName());
+        return secret;
+    }
+
     public Secret describeSecret(String secretId, String region) {
         Secret secret = resolveSecret(secretId, region);
         return secret;
@@ -356,7 +409,7 @@ public class SecretsManagerService {
                 return s != null && secretId.equals(s.getArn());
             });
             if (!found.isEmpty()) {
-                return found.getFirst();
+                return found.get(0);
             }
 
             // 2. Partial-ARN fallback: extract region + name and do a name-based lookup.

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -46,14 +46,14 @@ class GuardedMessageQueue {
     }
 
     void addMessage(Message message) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             messages.add(message);
             persist();
         }
     }
 
     void addAll(List<Message> toAdd) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             messages.addAll(toAdd);
             persist();
         }
@@ -62,7 +62,7 @@ class GuardedMessageQueue {
     ClaimResult claimVisibleMessages(int maxMessages, int effectiveTimeout,
                                      boolean fifo, int maxReceiveCount,
                                      String deadLetterTargetArn) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             List<Message> claimed = new ArrayList<>();
             List<Message> dlqCandidates = new ArrayList<>();
 
@@ -135,7 +135,7 @@ class GuardedMessageQueue {
     }
 
     boolean removeByReceiptHandle(String receiptHandle) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             boolean removed = messages.removeIf(m -> receiptHandle.equals(m.getReceiptHandle()));
             if (removed) {
                 persist();
@@ -145,7 +145,7 @@ class GuardedMessageQueue {
     }
 
     boolean changeVisibility(String receiptHandle, int visibilityTimeout) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             for (Message msg : messages) {
                 if (receiptHandle.equals(msg.getReceiptHandle())) {
                     msg.setVisibleAt(Instant.now().plusSeconds(visibilityTimeout));
@@ -158,21 +158,21 @@ class GuardedMessageQueue {
     }
 
     void removeMessages(List<Message> toRemove) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             messages.removeAll(toRemove);
             persist();
         }
     }
 
     void purge() {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             messages.clear();
             persist();
         }
     }
 
     List<Message> drainAll() {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             List<Message> drained = new ArrayList<>(messages);
             messages.clear();
             persist();
@@ -184,7 +184,7 @@ class GuardedMessageQueue {
     }
 
     MessageCounts messageCounts() {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             long visible = 0;
             long inFlight = 0;
             for (Message m : messages) {
@@ -196,13 +196,13 @@ class GuardedMessageQueue {
     }
 
     boolean isEmpty() {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             return messages.isEmpty();
         }
     }
 
     Message findByDeduplicationId(String dedupId) {
-        try (var _ = hold()) {
+        try (var lockHold = hold()) {
             return messages.stream().filter(msg -> dedupId.equals(msg.getMessageDeduplicationId()))
                     .findFirst().orElse(null);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
@@ -281,7 +281,7 @@ public class SsmService {
         history.add(new ParameterHistory(parameter));
 
         while (history.size() > maxParameterHistory) {
-            history.removeFirst();
+            history.remove(0);
         }
 
         historyStore.put(storageKey, history);

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -481,6 +481,53 @@ class CognitoIntegrationTest {
                 "DescribeUserPoolClient must include GenerateSecret");
     }
 
+    @Test
+    @Order(36)
+    void updateUserPoolClient() throws Exception {
+        // 1. Create a client
+        JsonNode createResp = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "initial-name"
+                }
+                """.formatted(poolId));
+        String cid = createResp.path("UserPoolClient").path("ClientId").asText();
+
+        // 2. Update the client
+        cognitoJson("UpdateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientId": "%s",
+                  "ClientName": "updated-name",
+                  "AllowedOAuthFlowsUserPoolClient": true,
+                  "AllowedOAuthFlows": ["code", "implicit"],
+                  "AllowedOAuthScopes": ["email", "openid"]
+                }
+                """.formatted(poolId, cid));
+
+        // 3. Verify the updates
+        JsonNode describeResp = cognitoJson("DescribeUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientId": "%s"
+                }
+                """.formatted(poolId, cid));
+        JsonNode client = describeResp.path("UserPoolClient");
+
+        assertEquals("updated-name", client.path("ClientName").asText());
+        assertEquals(true, client.path("AllowedOAuthFlowsUserPoolClient").asBoolean());
+        
+        JsonNode flows = client.path("AllowedOAuthFlows");
+        assertEquals(2, flows.size());
+        assertTrue(flows.toString().contains("code"));
+        assertTrue(flows.toString().contains("implicit"));
+
+        JsonNode scopes = client.path("AllowedOAuthScopes");
+        assertEquals(2, scopes.size());
+        assertTrue(scopes.toString().contains("email"));
+        assertTrue(scopes.toString().contains("openid"));
+    }
+
     // ── Issue #229: Password verification ──────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.firehose;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FirehoseIntegrationTest {
+
+    private static final String STREAM_NAME = "test-delivery-stream";
+
+    @Test
+    @Order(1)
+    void createDeliveryStream() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.CreateDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + STREAM_NAME + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeliveryStreamARN", notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void describeDeliveryStream() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.DescribeDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + STREAM_NAME + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeliveryStreamDescription.DeliveryStreamName", equalTo(STREAM_NAME));
+    }
+
+    @Test
+    @Order(3)
+    void deleteDeliveryStream() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.DeleteDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + STREAM_NAME + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void describeDeletedDeliveryStreamReturnsNotFound() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.DescribeDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + STREAM_NAME + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the `UpdateUserPoolClient` action in the Cognito service module. This allows modifications to existing Cognito User Pool Clients (such as updating the `ClientName`, `AllowedOAuthFlows`, and `AllowedOAuthScopes`) directly through the local emulator, mapping to the AWS Cognito Identity Provider API specification. 

Additionally, this PR includes compiler configuration adjustments and refactoring to ensure the `floci` repository remains strictly forward and backwards compatible when compiling and executing integration tests under environments running Java 17.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
Verified against standard `aws-cli/2.x` API structure for the `cognito-idp update-user-pool-client` action. The JSON handler specifically unpacks and maps structural properties conforming precisely to the AWS generic wire protocol expected when modifying properties on a user pool application client, persisting them accurately in the emulator's storage backend.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
