### PR TITLE
fix(s3): wrap S3 Control XML errors in ErrorResponse wrapper

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
@@ -35,6 +35,10 @@ import java.util.UUID;
 @Produces(MediaType.APPLICATION_XML)
 public class S3ControlController {
 
+    private static final String AMZ_REQUEST_ID = "x-amz-request-id";
+    private static final String AMZN_REQUEST_ID = "x-amzn-RequestId";
+    private static final String AMZ_ID_2 = "x-amz-id-2";
+
     private final S3Service s3Service;
 
     @Inject
@@ -172,6 +176,9 @@ public class S3ControlController {
                 .build();
         return Response.status(e.getHttpStatus())
                 .type(MediaType.APPLICATION_XML)
+                .header(AMZ_REQUEST_ID, requestId)
+                .header(AMZN_REQUEST_ID, requestId)
+                .header(AMZ_ID_2, requestId)
                 .entity(xml)
                 .build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
@@ -150,17 +150,25 @@ public class S3ControlController {
 
     /**
      * S3 Control is a REST-XML protocol, so error responses must also be XML.
-     * The global {@code AwsExceptionMapper} emits JSON, which trips up the
-     * Go SDK's XML error deserializer with "unexpected EOF".
+     * AWS S3 Control wraps errors in an {@code <ErrorResponse xmlns=...>} envelope
+     * containing the inner {@code <Error>} block and a top-level {@code <RequestId>}.
+     *
+     * <p>References: AWS Go SDK v2 s3control error deserializer expects this wrapper;
+     * bare {@code <Error>} collapses to "UnknownError" at the SDK layer.
+     * See issue #557.
      */
     private Response xmlErrorResponse(AwsException e) {
+        String requestId = UUID.randomUUID().toString();
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("ErrorResponse", AwsNamespaces.S3_CONTROL)
                 .start("Error")
                 .elem("Code", e.getErrorCode())
                 .elem("Message", e.getMessage())
-                .elem("RequestId", UUID.randomUUID().toString())
+                .elem("RequestId", requestId)
                 .end("Error")
+                .elem("RequestId", requestId)
+                .end("ErrorResponse")
                 .build();
         return Response.status(e.getHttpStatus())
                 .type(MediaType.APPLICATION_XML)

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
+import io.restassured.response.Response;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -7,9 +9,14 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for S3 Control API handling of URL-encoded ARN path
@@ -32,6 +39,25 @@ class S3ControlUrlEncodedArnIntegrationTest {
     // What the Go SDK actually puts on the wire: colons AND slashes URL-encoded.
     private static final String ENCODED_ARN =
             "arn%3Aaws%3As3%3A" + REGION + "%3A" + ACCOUNT + "%3Abucket%2F" + BUCKET;
+
+    private void assertS3ControlErrorResponse(Response response) {
+        String body = response.getBody().asString();
+        List<String> requestIds = XmlParser.extractAll(body, "RequestId");
+
+        assertEquals(400, response.statusCode());
+        assertThat(response.getContentType(), containsString("xml"));
+        assertThat(body, containsString("<ErrorResponse xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">"));
+        assertThat(body, containsString("<Error>"));
+        assertThat(body, containsString("<Code>InvalidRequest</Code>"));
+        assertTrue(body.contains("</Error><RequestId>"),
+                "expected top-level RequestId sibling after the Error block");
+        assertEquals(2, requestIds.size(), "expected inner and top-level RequestId elements");
+        assertEquals(requestIds.get(0), requestIds.get(1),
+                "expected inner and top-level RequestId values to match");
+        assertEquals(requestIds.get(0), response.getHeader("x-amz-request-id"));
+        assertEquals(requestIds.get(0), response.getHeader("x-amzn-RequestId"));
+        assertEquals(requestIds.get(0), response.getHeader("x-amz-id-2"));
+    }
 
     @Test
     @Order(1)
@@ -134,17 +160,12 @@ class S3ControlUrlEncodedArnIntegrationTest {
     @DisplayName("Malformed ARN returns S3 Control ErrorResponse wrapper (#435, #557)")
     void malformedArnReturnsXmlError() {
         // Path param must not contain a literal ':bucket/' segment after decoding.
-        given()
+        Response response = given()
             .header("x-amz-account-id", ACCOUNT)
         .when()
-            .get("/v20180820/tags/arn%3Aaws%3As3%3A%3A%3Abogus%2F" + BUCKET)
-        .then()
-            .statusCode(400)
-            .contentType(containsString("xml"))
-            .body(containsString("<ErrorResponse xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">"))
-            .body(containsString("<Error>"))
-            .body(containsString("<Code>InvalidRequest</Code>"))
-            .body(containsString("<RequestId>"));
+            .get("/v20180820/tags/arn%3Aaws%3As3%3A%3A%3Abogus%2F" + BUCKET);
+
+        assertS3ControlErrorResponse(response);
     }
 
     @Test
@@ -152,16 +173,11 @@ class S3ControlUrlEncodedArnIntegrationTest {
     @DisplayName("Malformed percent-encoding returns S3 Control ErrorResponse wrapper (#435, #557)")
     void malformedPercentEncodingReturnsXmlError() {
         // %ZZ is not a valid percent-encoding sequence; URLDecoder throws IAE.
-        given()
+        Response response = given()
             .header("x-amz-account-id", ACCOUNT)
         .when()
-            .get("/v20180820/tags/arn%3Aaws%ZZbucket%2F" + BUCKET)
-        .then()
-            .statusCode(400)
-            .contentType(containsString("xml"))
-            .body(containsString("<ErrorResponse xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">"))
-            .body(containsString("<Error>"))
-            .body(containsString("<Code>InvalidRequest</Code>"))
-            .body(containsString("<RequestId>"));
+            .get("/v20180820/tags/arn%3Aaws%ZZbucket%2F" + BUCKET);
+
+        assertS3ControlErrorResponse(response);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
@@ -131,7 +131,7 @@ class S3ControlUrlEncodedArnIntegrationTest {
 
     @Test
     @Order(6)
-    @DisplayName("Malformed ARN returns valid S3-style XML error body (#435)")
+    @DisplayName("Malformed ARN returns S3 Control ErrorResponse wrapper (#435, #557)")
     void malformedArnReturnsXmlError() {
         // Path param must not contain a literal ':bucket/' segment after decoding.
         given()
@@ -141,13 +141,15 @@ class S3ControlUrlEncodedArnIntegrationTest {
         .then()
             .statusCode(400)
             .contentType(containsString("xml"))
+            .body(containsString("<ErrorResponse xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">"))
             .body(containsString("<Error>"))
-            .body(containsString("<Code>InvalidRequest</Code>"));
+            .body(containsString("<Code>InvalidRequest</Code>"))
+            .body(containsString("<RequestId>"));
     }
 
     @Test
     @Order(7)
-    @DisplayName("Malformed percent-encoding returns XML error, not JSON 500 (#435)")
+    @DisplayName("Malformed percent-encoding returns S3 Control ErrorResponse wrapper (#435, #557)")
     void malformedPercentEncodingReturnsXmlError() {
         // %ZZ is not a valid percent-encoding sequence; URLDecoder throws IAE.
         given()
@@ -157,7 +159,9 @@ class S3ControlUrlEncodedArnIntegrationTest {
         .then()
             .statusCode(400)
             .contentType(containsString("xml"))
+            .body(containsString("<ErrorResponse xmlns=\"http://awss3control.amazonaws.com/doc/2018-08-20/\">"))
             .body(containsString("<Error>"))
-            .body(containsString("<Code>InvalidRequest</Code>"));
+            .body(containsString("<Code>InvalidRequest</Code>"))
+            .body(containsString("<RequestId>"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #557.

Wrap S3 Control error responses in the AWS-compatible `<ErrorResponse xmlns="http://awss3control.amazonaws.com/doc/2018-08-20/">` envelope instead of returning a bare `<Error>` payload.

This fixes the S3 Control wire shape expected by the Go AWS SDK v2, which currently collapses Floci's S3 Control 4xx responses to `UnknownError: UnknownError` when the outer wrapper is missing.

Changes in this PR:
- update `S3ControlController.xmlErrorResponse(...)` to emit `ErrorResponse` with the S3 Control namespace
- include a top-level `RequestId` sibling to the inner `Error` block
- keep `x-amz-request-id`, `x-amzn-RequestId`, and `x-amz-id-2` aligned with the XML body request id
- strengthen the S3 Control integration tests to assert the wrapper, top-level `RequestId`, and header/body request-id alignment for malformed ARN / malformed percent-encoding error paths

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Issue #557 showed that Floci returned this shape for S3 Control errors:

```xml
<Error>
  <Code>InvalidRequest</Code>
  <Message>...</Message>
  <RequestId>...</RequestId>
</Error>
```

The S3 Control protocol expects:

```xml
<ErrorResponse xmlns="http://awss3control.amazonaws.com/doc/2018-08-20/">
  <Error>
    <Code>InvalidRequest</Code>
    <Message>...</Message>
    <RequestId>...</RequestId>
  </Error>
  <RequestId>...</RequestId>
</ErrorResponse>
```

Without that wrapper, Go AWS SDK v2 `s3control` consumers lose the real error code/message and surface `UnknownError` instead.

This PR also keeps the response headers aligned with the XML body request id so clients do not see conflicting request identifiers in the same S3 Control error response.

Local validation performed:
- `./mvnw test -Dtest=S3ControlUrlEncodedArnIntegrationTest,S3OwnershipControlsIntegrationTest`
- `./mvnw -DskipTests package`
- clean `origin/main` repro of `CloudFormationIntegrationTest#createStack_ecrAutoName_isLowercase` to confirm one unrelated full-suite failure is pre-existing

Notes:
- full `./mvnw test` does not pass locally in this environment because unrelated tests outside this diff fail
- in addition to the clean-`origin/main` CloudFormation failure above, Docker-backed tests such as `EcrIntegrationTest` and `LambdaReactiveSyncIntegrationTest` fail here with `java.net.BindException: Permission denied` when trying to start containers
- this PR adds regression coverage specifically for the S3 Control protocol-compatibility bug fixed here

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
