### PR TITLE
fix(lambda): support nested python handler module paths

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1035,15 +1035,21 @@ public class LambdaService {
             // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
             if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {
                 String handlerFile = resolveHandlerFilePath(fn);
-                boolean found = Files.walk(codePath)
-                        .filter(Files::isRegularFile)
-                        .anyMatch(p -> {
-                            String relative = codePath.relativize(p).toString();
-                            String withoutExt = relative.contains(".")
-                                    ? relative.substring(0, relative.lastIndexOf('.'))
-                                    : relative;
-                            return withoutExt.replace('\\', '/').equals(handlerFile);
-                        });
+                boolean pythonRuntime = fn.getRuntime().startsWith("python");
+                boolean found;
+                try (var walk = Files.walk(codePath)) {
+                    found = walk
+                            .filter(Files::isRegularFile)
+                            .anyMatch(p -> {
+                                String relative = codePath.relativize(p).toString();
+                                String withoutExt = relative.contains(".")
+                                        ? relative.substring(0, relative.lastIndexOf('.'))
+                                        : relative;
+                                String normalized = withoutExt.replace('\\', '/');
+                                return normalized.equals(handlerFile)
+                                        || (pythonRuntime && normalized.equals(handlerFile + "/__init__"));
+                            });
+                }
                 if (!found) {
                     throw new AwsException("InvalidParameterValueException",
                             "Handler file '" + handlerFile + "' not found in deployment package", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1034,7 +1034,7 @@ public class LambdaService {
 
             // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
             if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {
-                String handlerFile = fn.getHandler().split("\\.")[0];
+                String handlerFile = resolveHandlerFilePath(fn);
                 boolean found = Files.walk(codePath)
                         .filter(Files::isRegularFile)
                         .anyMatch(p -> {
@@ -1042,7 +1042,7 @@ public class LambdaService {
                             String withoutExt = relative.contains(".")
                                     ? relative.substring(0, relative.lastIndexOf('.'))
                                     : relative;
-                            return withoutExt.equals(handlerFile);
+                            return withoutExt.replace('\\', '/').equals(handlerFile);
                         });
                 if (!found) {
                     throw new AwsException("InvalidParameterValueException",
@@ -1072,6 +1072,16 @@ public class LambdaService {
                     "Unable to fetch code from s3://" + s3Bucket + "/" + s3Key + ": " + e.getMessage(), 400);
         }
         extractZipCode(fn, Base64.getEncoder().encodeToString(obj.getData()));
+    }
+
+    private String resolveHandlerFilePath(LambdaFunction fn) {
+        String handler = fn.getHandler();
+        int lastDot = handler.lastIndexOf('.');
+        String modulePath = lastDot >= 0 ? handler.substring(0, lastDot) : handler;
+        if (fn.getRuntime().startsWith("python")) {
+            return modulePath.replace('.', '/');
+        }
+        return modulePath;
     }
 
     // ──────────────────────────── Permissions (Policy) ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -265,6 +265,19 @@ class LambdaServiceTest {
     }
 
     @Test
+    void createFunctionWithNestedPythonModuleHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "nested-python-handler-fn",
+                "Runtime", "python3.11",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "apps.foo.src.lambda_handler.lambda_handler",
+                "Code", Map.of("ZipFile", createZipBase64("apps/foo/src/lambda_handler.py"))
+        ));
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("apps.foo.src.lambda_handler.lambda_handler", fn.getHandler());
+    }
+
+    @Test
     void createFunctionWithMissingHandler() throws Exception {
         Map<String, Object> req = new java.util.HashMap<>(Map.of(
                 "FunctionName", "missing-handler-fn",
@@ -275,6 +288,20 @@ class LambdaServiceTest {
         ));
         AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
         assertEquals("InvalidParameterValueException", ex.getErrorCode());
+    }
+
+    @Test
+    void createFunctionWithMissingNestedPythonModuleHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "missing-nested-python-handler-fn",
+                "Runtime", "python3.11",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "apps.foo.src.lambda_handler.lambda_handler",
+                "Code", Map.of("ZipFile", createZipBase64("apps/foo/src/other.py"))
+        ));
+        AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
+        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("apps/foo/src/lambda_handler"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -278,6 +278,19 @@ class LambdaServiceTest {
     }
 
     @Test
+    void createFunctionWithNestedPythonPackageHandler() throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "nested-python-package-handler-fn",
+                "Runtime", "python3.11",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "apps.foo.src.lambda_handler.lambda_handler",
+                "Code", Map.of("ZipFile", createZipBase64("apps/foo/src/lambda_handler/__init__.py"))
+        ));
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("apps.foo.src.lambda_handler.lambda_handler", fn.getHandler());
+    }
+
+    @Test
     void createFunctionWithMissingHandler() throws Exception {
         Map<String, Object> req = new java.util.HashMap<>(Map.of(
                 "FunctionName", "missing-handler-fn",


### PR DESCRIPTION
## Summary
- derive the handler file path from the last `.` instead of the first one
- translate nested Python module paths into deployment-package paths before validating the zip contents
- add regression tests for nested Python handlers and the missing-file failure case

## Validation
- `./mvnw test -Dtest=LambdaServiceTest`

## Full suite note
- `./mvnw test` is red in this environment due pre-existing Docker-dependent integration failures
- reproduced the same failures on clean `origin/main` with `./mvnw test -Dtest=EcrIntegrationTest,CloudFormationIntegrationTest,LambdaReactiveSyncIntegrationTest`
- reproduced failures:
  - `EcrIntegrationTest.*`
  - `CloudFormationIntegrationTest.createStack_ecrAutoName_isLowercase`
  - `LambdaReactiveSyncIntegrationTest.*` (`java.net.BindException: Permission denied`)

Fixes #547
