### PR TITLE
feat(ses): implement email template CRUD with stored, inline, and ARN variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ All default images are configurable via environment variables, useful for pinnin
 | **EC2** | In-process | VPCs, subnets, security groups, instances, AMIs, key pairs, internet gateways, route tables, Elastic IPs, tags |
 | **ACM** | In-process | Certificate issuance, validation lifecycle |
 | **ECR** | In-process + **real OCI registry** | Repositories, image push / pull via stock `docker`, image-backed Lambda functions |
-| **SES** | In-process | Send email / raw email, identity verification, DKIM attributes |
-| **SES v2 (HTTP)** | In-process | REST JSON API, identities, DKIM, feedback attributes, account sending |
+| **SES** | In-process | Send email / raw email, identity verification, DKIM attributes, email templates with `{{var}}` substitution |
+| **SES v2 (HTTP)** | In-process | REST JSON API, identities, DKIM, feedback attributes, account sending, email templates with `{{var}}` substitution |
 | **OpenSearch** | **Real Docker containers** | Domain CRUD, tags, versions, instance types, upgrade stubs |
 | **AppConfig** | In-process | Applications, environments, profiles, hosted configuration versions, deployments |
 | **AppConfigData** | In-process | Configuration sessions, dynamic configuration retrieval |

--- a/compatibility-tests/sdk-test-awscli/test/ses.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ses.bats
@@ -140,3 +140,97 @@ teardown_file() {
     refute_output --partial "$TEST_EMAIL"
     refute_output --partial "$TEST_DOMAIN"
 }
+
+# ──────────────── Template CRUD ────────────────
+
+@test "SES: create template" {
+    local tpl_json
+    tpl_json=$(cat <<TMPL
+{"TemplateName":"cli-tpl-${BATS_ROOT_PID}","SubjectPart":"Hello {{name}}","TextPart":"Hi {{name}} from {{team}}","HtmlPart":"<p>Hi {{name}}</p>"}
+TMPL
+    )
+    run aws_cmd ses create-template --template "$tpl_json"
+    assert_success
+}
+
+@test "SES: create template - duplicate rejected" {
+    local tpl_json
+    tpl_json=$(cat <<TMPL
+{"TemplateName":"cli-tpl-${BATS_ROOT_PID}","SubjectPart":"Dup","TextPart":"Dup"}
+TMPL
+    )
+    run aws_cmd ses create-template --template "$tpl_json"
+    assert_failure
+    assert_output --partial "AlreadyExists"
+}
+
+@test "SES: get template" {
+    run aws_cmd ses get-template --template-name "cli-tpl-${BATS_ROOT_PID}"
+    assert_success
+    name=$(json_get "$output" '.Template.TemplateName')
+    subject=$(json_get "$output" '.Template.SubjectPart')
+    [ "$name" = "cli-tpl-${BATS_ROOT_PID}" ]
+    [ "$subject" = "Hello {{name}}" ]
+}
+
+@test "SES: get template - not found" {
+    run aws_cmd ses get-template --template-name "nonexistent-tpl"
+    assert_failure
+    assert_output --partial "TemplateDoesNotExist"
+}
+
+@test "SES: update template" {
+    local tpl_json
+    tpl_json=$(cat <<TMPL
+{"TemplateName":"cli-tpl-${BATS_ROOT_PID}","SubjectPart":"Updated {{name}}","TextPart":"Updated {{name}} {{team}}","HtmlPart":"<p>Updated {{name}}</p>"}
+TMPL
+    )
+    run aws_cmd ses update-template --template "$tpl_json"
+    assert_success
+
+    run aws_cmd ses get-template --template-name "cli-tpl-${BATS_ROOT_PID}"
+    assert_success
+    subject=$(json_get "$output" '.Template.SubjectPart')
+    [ "$subject" = "Updated {{name}}" ]
+}
+
+@test "SES: list templates includes created" {
+    run aws_cmd ses list-templates
+    assert_success
+    assert_output --partial "cli-tpl-${BATS_ROOT_PID}"
+}
+
+@test "SES: send templated email" {
+    # Ensure an identity exists for sending
+    aws_cmd ses verify-email-identity --email-address "tpl-sender@example.com" >/dev/null 2>&1 || true
+
+    run aws_cmd ses send-templated-email \
+        --source "tpl-sender@example.com" \
+        --destination "ToAddresses=recipient@example.com" \
+        --template "cli-tpl-${BATS_ROOT_PID}" \
+        --template-data '{"name":"Alice","team":"floci"}'
+    assert_success
+    message_id=$(json_get "$output" '.MessageId')
+    [ -n "$message_id" ]
+}
+
+@test "SES: send templated email - unknown template" {
+    run aws_cmd ses send-templated-email \
+        --source "tpl-sender@example.com" \
+        --destination "ToAddresses=recipient@example.com" \
+        --template "nonexistent-tpl" \
+        --template-data '{}'
+    assert_failure
+    assert_output --partial "TemplateDoesNotExist"
+}
+
+@test "SES: delete template" {
+    run aws_cmd ses delete-template --template-name "cli-tpl-${BATS_ROOT_PID}"
+    assert_success
+}
+
+@test "SES: delete template - not found" {
+    run aws_cmd ses delete-template --template-name "nonexistent-tpl"
+    assert_failure
+    assert_output --partial "TemplateDoesNotExist"
+}

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -174,6 +174,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ses</artifactId>
         </dependency>
+        <!-- SES V2 client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sesv2</artifactId>
+        </dependency>
         <!-- OpenSearch Service management client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.services.s3control.S3ControlClient;
 import software.amazon.awssdk.services.s3control.endpoints.S3ControlEndpointProvider;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sfn.SfnClient;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -386,6 +387,14 @@ public final class TestFixtures {
 
     public static SesClient sesClient() {
         return SesClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static SesV2Client sesV2Client() {
+        return SesV2Client.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
@@ -1,0 +1,457 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.CreateTemplateRequest;
+import software.amazon.awssdk.services.ses.model.DeleteIdentityRequest;
+import software.amazon.awssdk.services.ses.model.DeleteTemplateRequest;
+import software.amazon.awssdk.services.ses.model.GetTemplateRequest;
+import software.amazon.awssdk.services.ses.model.GetTemplateResponse;
+import software.amazon.awssdk.services.ses.model.ListTemplatesRequest;
+import software.amazon.awssdk.services.ses.model.ListTemplatesResponse;
+import software.amazon.awssdk.services.ses.model.SendTemplatedEmailRequest;
+import software.amazon.awssdk.services.ses.model.SendTemplatedEmailResponse;
+import software.amazon.awssdk.services.ses.model.UpdateTemplateRequest;
+import software.amazon.awssdk.services.ses.model.VerifyEmailIdentityRequest;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.EmailTemplateContent;
+import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateResponse;
+import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesRequest;
+import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesResponse;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
+import software.amazon.awssdk.services.sesv2.model.Template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SES email template compatibility tests against both the V1 (query) SES API
+ * and the V2 (REST JSON) SESv2 API.
+ */
+@DisplayName("SES Email Templates")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTemplateTest {
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+    private static String v1Template;
+    private static String v2Template;
+    private static String v1Sender;
+    private static String v2Sender;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        String suffix = TestFixtures.uniqueName();
+        v1Template = "sdk-v1-" + suffix;
+        v2Template = "sdk-v2-" + suffix;
+        v1Sender = suffix + "-v1-sender@example.com";
+        v2Sender = suffix + "-v2-sender@example.com";
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV1 != null) {
+            safelyDeleteV1Template(v1Template);
+            try {
+                sesV1.deleteIdentity(DeleteIdentityRequest.builder()
+                        .identity(v1Sender).build());
+            } catch (Exception ignored) {}
+            sesV1.close();
+        }
+        if (sesV2 != null) {
+            safelyDeleteV2Template(v2Template);
+            try {
+                sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder()
+                        .emailIdentity(v2Sender).build());
+            } catch (Exception ignored) {}
+            sesV2.close();
+        }
+    }
+
+    // ────────────────────────────── V2 (SESv2) ──────────────────────────────
+
+    @Test
+    @Order(1)
+    void v2CreateAndGetTemplate() {
+        sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                .templateName(v2Template)
+                .templateContent(EmailTemplateContent.builder()
+                        .subject("Hello {{name}}")
+                        .text("Hi {{name}}!")
+                        .html("<p>Hi <b>{{name}}</b>!</p>")
+                        .build())
+                .build());
+
+        GetEmailTemplateResponse response = sesV2.getEmailTemplate(
+                GetEmailTemplateRequest.builder().templateName(v2Template).build());
+        assertThat(response.templateName()).isEqualTo(v2Template);
+        assertThat(response.templateContent().subject()).isEqualTo("Hello {{name}}");
+        assertThat(response.templateContent().text()).isEqualTo("Hi {{name}}!");
+        assertThat(response.templateContent().html()).contains("{{name}}");
+    }
+
+    @Test
+    @Order(2)
+    void v2CreateDuplicateRejectedWith400() {
+        assertThatThrownBy(() -> sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                .templateName(v2Template)
+                .templateContent(EmailTemplateContent.builder()
+                        .subject("dup")
+                        .text("dup")
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(3)
+    void v2GetNonExistentReturns404() {
+        assertThatThrownBy(() -> sesV2.getEmailTemplate(GetEmailTemplateRequest.builder()
+                .templateName("sdk-v2-missing-" + System.currentTimeMillis())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(4)
+    void v2UpdateTemplate() {
+        sesV2.updateEmailTemplate(builder -> builder
+                .templateName(v2Template)
+                .templateContent(EmailTemplateContent.builder()
+                        .subject("Welcome {{name}}!")
+                        .text("Hello {{name}}, from {{team}}")
+                        .html("<p>Welcome {{name}}</p>")
+                        .build()));
+
+        GetEmailTemplateResponse response = sesV2.getEmailTemplate(
+                GetEmailTemplateRequest.builder().templateName(v2Template).build());
+        assertThat(response.templateContent().subject()).isEqualTo("Welcome {{name}}!");
+        assertThat(response.templateContent().text()).contains("{{team}}");
+    }
+
+    @Test
+    @Order(5)
+    void v2ListTemplatesIncludesCreated() {
+        ListEmailTemplatesResponse response = sesV2.listEmailTemplates(
+                ListEmailTemplatesRequest.builder().build());
+        assertThat(response.templatesMetadata())
+                .anyMatch(meta -> v2Template.equals(meta.templateName()));
+    }
+
+    @Test
+    @Order(6)
+    void v2SendEmailWithTemplateSubstitutesVariables() {
+        sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder()
+                .emailIdentity(v2Sender).build());
+
+        SendEmailResponse response = sesV2.sendEmail(SendEmailRequest.builder()
+                .fromEmailAddress(v2Sender)
+                .destination(Destination.builder()
+                        .toAddresses("recipient@example.com")
+                        .build())
+                .content(EmailContent.builder()
+                        .template(Template.builder()
+                                .templateName(v2Template)
+                                .templateData("{\"name\":\"Alice\",\"team\":\"floci\"}")
+                                .build())
+                        .build())
+                .build());
+        assertThat(response.messageId()).isNotBlank();
+    }
+
+    @Test
+    @Order(20)
+    void v2SendEmailWithInlineTemplateSubstitutesVariables() {
+        SendEmailResponse response = sesV2.sendEmail(SendEmailRequest.builder()
+                .fromEmailAddress(v2Sender)
+                .destination(Destination.builder()
+                        .toAddresses("recipient@example.com")
+                        .build())
+                .content(EmailContent.builder()
+                        .template(Template.builder()
+                                .templateContent(EmailTemplateContent.builder()
+                                        .subject("Inline {{name}}")
+                                        .text("Hello inline {{name}}")
+                                        .html("<p>Hello inline <b>{{name}}</b></p>")
+                                        .build())
+                                .templateData("{\"name\":\"Alice\"}")
+                                .build())
+                        .build())
+                .build());
+        assertThat(response.messageId()).isNotBlank();
+    }
+
+    @Test
+    @Order(22)
+    void v2SendEmailWithTemplateArnResolvesStoredTemplate() {
+        String name = "sdk-v2-arn-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hi {{name}}")
+                            .text("Hello {{name}}")
+                            .build())
+                    .build());
+
+            SendEmailResponse response = sesV2.sendEmail(SendEmailRequest.builder()
+                    .fromEmailAddress(v2Sender)
+                    .destination(Destination.builder()
+                            .toAddresses("recipient@example.com")
+                            .build())
+                    .content(EmailContent.builder()
+                            .template(Template.builder()
+                                    .templateArn("arn:aws:ses:us-east-1:000000000000:template/" + name)
+                                    .templateData("{\"name\":\"Alice\"}")
+                                    .build())
+                            .build())
+                    .build());
+            assertThat(response.messageId()).isNotBlank();
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(21)
+    void v2SendEmailWithBothNameAndInlineReturns400() {
+        assertThatThrownBy(() -> sesV2.sendEmail(SendEmailRequest.builder()
+                .fromEmailAddress(v2Sender)
+                .destination(Destination.builder()
+                        .toAddresses("recipient@example.com")
+                        .build())
+                .content(EmailContent.builder()
+                        .template(Template.builder()
+                                .templateName(v2Template)
+                                .templateContent(EmailTemplateContent.builder()
+                                        .subject("s")
+                                        .text("t")
+                                        .build())
+                                .templateData("{}")
+                                .build())
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(7)
+    void v2SendEmailWithUnknownTemplateReturns404() {
+        assertThatThrownBy(() -> sesV2.sendEmail(SendEmailRequest.builder()
+                .fromEmailAddress(v2Sender)
+                .destination(Destination.builder()
+                        .toAddresses("recipient@example.com")
+                        .build())
+                .content(EmailContent.builder()
+                        .template(Template.builder()
+                                .templateName("sdk-v2-missing-" + System.currentTimeMillis())
+                                .templateData("{}")
+                                .build())
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(8)
+    void v2DeleteTemplate() {
+        sesV2.deleteEmailTemplate(DeleteEmailTemplateRequest.builder()
+                .templateName(v2Template).build());
+
+        assertThatThrownBy(() -> sesV2.getEmailTemplate(GetEmailTemplateRequest.builder()
+                .templateName(v2Template).build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    // ────────────────────────────── V1 (SES) ──────────────────────────────
+
+    @Test
+    @Order(10)
+    void v1CreateAndGetTemplate() {
+        sesV1.createTemplate(CreateTemplateRequest.builder()
+                .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                        .templateName(v1Template)
+                        .subjectPart("Hello {{name}}")
+                        .textPart("Hi {{name}}!")
+                        .htmlPart("<p>Hi <b>{{name}}</b>!</p>")
+                        .build())
+                .build());
+
+        GetTemplateResponse response = sesV1.getTemplate(GetTemplateRequest.builder()
+                .templateName(v1Template).build());
+        software.amazon.awssdk.services.ses.model.Template template = response.template();
+        assertThat(template.templateName()).isEqualTo(v1Template);
+        assertThat(template.subjectPart()).isEqualTo("Hello {{name}}");
+        assertThat(template.textPart()).isEqualTo("Hi {{name}}!");
+        assertThat(template.htmlPart()).contains("{{name}}");
+    }
+
+    @Test
+    @Order(11)
+    void v1CreateDuplicateRejected() {
+        assertThatThrownBy(() -> sesV1.createTemplate(CreateTemplateRequest.builder()
+                .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                        .templateName(v1Template)
+                        .subjectPart("dup")
+                        .textPart("dup")
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(12)
+    void v1GetNonExistentRaises() {
+        assertThatThrownBy(() -> sesV1.getTemplate(GetTemplateRequest.builder()
+                .templateName("sdk-v1-missing-" + System.currentTimeMillis())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(13)
+    void v1UpdateTemplate() {
+        sesV1.updateTemplate(UpdateTemplateRequest.builder()
+                .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                        .templateName(v1Template)
+                        .subjectPart("Welcome {{name}}!")
+                        .textPart("Hello {{name}}, from {{team}}")
+                        .build())
+                .build());
+
+        GetTemplateResponse response = sesV1.getTemplate(GetTemplateRequest.builder()
+                .templateName(v1Template).build());
+        assertThat(response.template().subjectPart()).isEqualTo("Welcome {{name}}!");
+        assertThat(response.template().textPart()).contains("{{team}}");
+    }
+
+    @Test
+    @Order(14)
+    void v1ListTemplatesIncludesCreated() {
+        ListTemplatesResponse response = sesV1.listTemplates(ListTemplatesRequest.builder().build());
+        assertThat(response.templatesMetadata())
+                .anyMatch(meta -> v1Template.equals(meta.name()));
+    }
+
+    @Test
+    @Order(15)
+    void v1SendTemplatedEmail() {
+        sesV1.verifyEmailIdentity(VerifyEmailIdentityRequest.builder()
+                .emailAddress(v1Sender).build());
+
+        SendTemplatedEmailResponse response = sesV1.sendTemplatedEmail(
+                SendTemplatedEmailRequest.builder()
+                        .source(v1Sender)
+                        .destination(d -> d.toAddresses("recipient@example.com"))
+                        .template(v1Template)
+                        .templateData("{\"name\":\"Alice\",\"team\":\"floci\"}")
+                        .build());
+        assertThat(response.messageId()).isNotBlank();
+    }
+
+    @Test
+    @Order(16)
+    void v1SendTemplatedEmailUnknownTemplateRaises() {
+        assertThatThrownBy(() -> sesV1.sendTemplatedEmail(SendTemplatedEmailRequest.builder()
+                .source(v1Sender)
+                .destination(d -> d.toAddresses("recipient@example.com"))
+                .template("sdk-v1-missing-" + System.currentTimeMillis())
+                .templateData("{}")
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(17)
+    void v1DeleteTemplate() {
+        sesV1.deleteTemplate(DeleteTemplateRequest.builder()
+                .templateName(v1Template).build());
+
+        assertThatThrownBy(() -> sesV1.getTemplate(GetTemplateRequest.builder()
+                .templateName(v1Template).build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(30)
+    void v1SendTemplatedEmailWithTemplateArnAndName() {
+        // boto3 and AWS Java SDK v2 both require the V1 Template (name) field on
+        // SendTemplatedEmail — TemplateArn is supplementary for cross-account
+        // addressing on real AWS. Floci accepts both and resolves via the name.
+        String name = "sdk-v1-arn-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hi {{name}}")
+                            .textPart("Hello {{name}}")
+                            .build())
+                    .build());
+
+            SendTemplatedEmailResponse response = sesV1.sendTemplatedEmail(
+                    SendTemplatedEmailRequest.builder()
+                            .source(v1Sender)
+                            .destination(d -> d.toAddresses("recipient@example.com"))
+                            .template(name)
+                            .templateArn("arn:aws:ses:us-east-1:000000000000:template/" + name)
+                            .templateData("{\"name\":\"Alice\"}")
+                            .build());
+            assertThat(response.messageId()).isNotBlank();
+        } finally {
+            safelyDeleteV1Template(name);
+        }
+    }
+
+    // ─────────────────────────────── Helpers ───────────────────────────────
+
+    private static void safelyDeleteV1Template(String name) {
+        try {
+            sesV1.deleteTemplate(DeleteTemplateRequest.builder()
+                    .templateName(name).build());
+        } catch (Exception ignored) {}
+    }
+
+    private static void safelyDeleteV2Template(String name) {
+        try {
+            sesV2.deleteEmailTemplate(DeleteEmailTemplateRequest.builder()
+                    .templateName(name).build());
+        } catch (Exception ignored) {}
+    }
+}

--- a/compatibility-tests/sdk-test-python/conftest.py
+++ b/compatibility-tests/sdk-test-python/conftest.py
@@ -151,6 +151,18 @@ def pipes_client(aws_config, client_config):
     return boto3.client("pipes", config=client_config, **aws_config)
 
 
+@pytest.fixture
+def ses_client(aws_config, client_config):
+    """Create SES (v1) client."""
+    return boto3.client("ses", config=client_config, **aws_config)
+
+
+@pytest.fixture
+def sesv2_client(aws_config, client_config):
+    """Create SES v2 client."""
+    return boto3.client("sesv2", config=client_config, **aws_config)
+
+
 # ============================================
 # Utility Fixtures
 # ============================================

--- a/compatibility-tests/sdk-test-python/tests/test_ses_templates.py
+++ b/compatibility-tests/sdk-test-python/tests/test_ses_templates.py
@@ -1,0 +1,481 @@
+"""SES email template SDK compatibility tests.
+
+Exercises both the V1 SES client (Query protocol) and the V2 SESv2 client
+(REST JSON protocol) via boto3, covering CRUD and templated send with
+Mustache-style variable substitution.
+"""
+
+import json
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+# ============================================
+# SES V2 (sesv2) - REST JSON
+# ============================================
+
+
+class TestSesV2EmailTemplateCrud:
+    """Template CRUD via the SESv2 REST JSON API."""
+
+    def test_create_and_get_email_template(self, sesv2_client, unique_name):
+        name = f"pytest-tpl-{unique_name}"
+        try:
+            sesv2_client.create_email_template(
+                TemplateName=name,
+                TemplateContent={
+                    "Subject": "Hello {{name}}",
+                    "Text": "Hi {{name}}!",
+                    "Html": "<p>Hi <b>{{name}}</b>!</p>",
+                },
+            )
+            response = sesv2_client.get_email_template(TemplateName=name)
+            assert response["TemplateName"] == name
+            assert response["TemplateContent"]["Subject"] == "Hello {{name}}"
+            assert response["TemplateContent"]["Text"] == "Hi {{name}}!"
+            assert "{{name}}" in response["TemplateContent"]["Html"]
+        finally:
+            _safe_delete_v2(sesv2_client, name)
+
+    def test_list_email_templates_includes_created(self, sesv2_client, unique_name):
+        name = f"pytest-tpl-{unique_name}"
+        try:
+            sesv2_client.create_email_template(
+                TemplateName=name,
+                TemplateContent={"Subject": "s", "Text": "t"},
+            )
+            response = sesv2_client.list_email_templates()
+            names = [t["TemplateName"] for t in response.get("TemplatesMetadata", [])]
+            assert name in names
+        finally:
+            _safe_delete_v2(sesv2_client, name)
+
+    def test_update_email_template(self, sesv2_client, unique_name):
+        name = f"pytest-tpl-{unique_name}"
+        try:
+            sesv2_client.create_email_template(
+                TemplateName=name,
+                TemplateContent={"Subject": "original", "Text": "original body"},
+            )
+            sesv2_client.update_email_template(
+                TemplateName=name,
+                TemplateContent={
+                    "Subject": "updated {{who}}",
+                    "Text": "updated body for {{who}}",
+                },
+            )
+            response = sesv2_client.get_email_template(TemplateName=name)
+            assert response["TemplateContent"]["Subject"] == "updated {{who}}"
+            assert "{{who}}" in response["TemplateContent"]["Text"]
+        finally:
+            _safe_delete_v2(sesv2_client, name)
+
+    def test_delete_email_template(self, sesv2_client, unique_name):
+        name = f"pytest-tpl-{unique_name}"
+        sesv2_client.create_email_template(
+            TemplateName=name,
+            TemplateContent={"Subject": "s", "Text": "t"},
+        )
+        sesv2_client.delete_email_template(TemplateName=name)
+        with pytest.raises(ClientError) as exc_info:
+            sesv2_client.get_email_template(TemplateName=name)
+        assert (
+            exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        )
+
+
+class TestSesV2EmailTemplateErrors:
+    """Error paths for V2 template operations."""
+
+    def test_create_duplicate_rejected(self, sesv2_client, unique_name):
+        name = f"pytest-tpl-{unique_name}"
+        try:
+            sesv2_client.create_email_template(
+                TemplateName=name,
+                TemplateContent={"Subject": "s", "Text": "t"},
+            )
+            with pytest.raises(ClientError) as exc_info:
+                sesv2_client.create_email_template(
+                    TemplateName=name,
+                    TemplateContent={"Subject": "dup", "Text": "dup"},
+                )
+            assert (
+                exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+            )
+        finally:
+            _safe_delete_v2(sesv2_client, name)
+
+    def test_get_nonexistent(self, sesv2_client, unique_name):
+        with pytest.raises(ClientError) as exc_info:
+            sesv2_client.get_email_template(
+                TemplateName=f"pytest-missing-{unique_name}"
+            )
+        assert (
+            exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        )
+
+
+class TestSesV2SendTemplatedEmail:
+    """Content.Template substitution via SESv2 SendEmail."""
+
+    def test_send_email_substitutes_template_variables(
+        self, sesv2_client, unique_name
+    ):
+        template_name = f"pytest-tpl-{unique_name}"
+        sender = f"pytest-sender-{unique_name}@example.com"
+        recipient = f"pytest-recipient-{unique_name}@example.com"
+
+        try:
+            sesv2_client.create_email_identity(EmailIdentity=sender)
+            sesv2_client.create_email_template(
+                TemplateName=template_name,
+                TemplateContent={
+                    "Subject": "Welcome {{name}}",
+                    "Text": "Hello {{name}}, from {{team}}",
+                    "Html": "<p>Welcome <b>{{name}}</b> ({{team}})</p>",
+                },
+            )
+
+            response = sesv2_client.send_email(
+                FromEmailAddress=sender,
+                Destination={"ToAddresses": [recipient]},
+                Content={
+                    "Template": {
+                        "TemplateName": template_name,
+                        "TemplateData": json.dumps(
+                            {"name": "Alice", "team": "floci"}
+                        ),
+                    }
+                },
+            )
+            assert response["MessageId"]
+        finally:
+            _safe_delete_v2(sesv2_client, template_name)
+            _safe_delete_identity_v2(sesv2_client, sender)
+
+    def test_send_email_with_inline_template_substitutes_variables(
+        self, sesv2_client, unique_name
+    ):
+        sender = f"pytest-inline-sender-{unique_name}@example.com"
+        try:
+            sesv2_client.create_email_identity(EmailIdentity=sender)
+            response = sesv2_client.send_email(
+                FromEmailAddress=sender,
+                Destination={"ToAddresses": ["recipient@example.com"]},
+                Content={
+                    "Template": {
+                        "TemplateContent": {
+                            "Subject": "Inline {{name}}",
+                            "Text": "Hello inline {{name}}",
+                            "Html": "<p>Hello inline <b>{{name}}</b></p>",
+                        },
+                        "TemplateData": json.dumps({"name": "Alice"}),
+                    }
+                },
+            )
+            assert response["MessageId"]
+        finally:
+            _safe_delete_identity_v2(sesv2_client, sender)
+
+    def test_send_email_with_both_name_and_inline_raises(
+        self, sesv2_client, unique_name
+    ):
+        sender = f"pytest-both-sender-{unique_name}@example.com"
+        try:
+            sesv2_client.create_email_identity(EmailIdentity=sender)
+            with pytest.raises(ClientError) as exc_info:
+                sesv2_client.send_email(
+                    FromEmailAddress=sender,
+                    Destination={"ToAddresses": ["recipient@example.com"]},
+                    Content={
+                        "Template": {
+                            "TemplateName": "whatever",
+                            "TemplateContent": {"Subject": "s", "Text": "t"},
+                            "TemplateData": "{}",
+                        }
+                    },
+                )
+            assert (
+                exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+            )
+        finally:
+            _safe_delete_identity_v2(sesv2_client, sender)
+
+    def test_send_email_with_template_arn_resolves_stored_template(
+        self, sesv2_client, unique_name
+    ):
+        template_name = f"pytest-arn-tpl-{unique_name}"
+        sender = f"pytest-arn-sender-{unique_name}@example.com"
+        arn = f"arn:aws:ses:us-east-1:000000000000:template/{template_name}"
+        try:
+            sesv2_client.create_email_identity(EmailIdentity=sender)
+            sesv2_client.create_email_template(
+                TemplateName=template_name,
+                TemplateContent={"Subject": "Hi {{name}}", "Text": "Hello {{name}}"},
+            )
+            response = sesv2_client.send_email(
+                FromEmailAddress=sender,
+                Destination={"ToAddresses": ["recipient@example.com"]},
+                Content={
+                    "Template": {
+                        "TemplateArn": arn,
+                        "TemplateData": json.dumps({"name": "Alice"}),
+                    }
+                },
+            )
+            assert response["MessageId"]
+        finally:
+            _safe_delete_v2(sesv2_client, template_name)
+            _safe_delete_identity_v2(sesv2_client, sender)
+
+    def test_send_email_with_unknown_template_raises(
+        self, sesv2_client, unique_name
+    ):
+        sender = f"pytest-sender-{unique_name}@example.com"
+        try:
+            sesv2_client.create_email_identity(EmailIdentity=sender)
+            with pytest.raises(ClientError) as exc_info:
+                sesv2_client.send_email(
+                    FromEmailAddress=sender,
+                    Destination={"ToAddresses": ["recipient@example.com"]},
+                    Content={
+                        "Template": {
+                            "TemplateName": f"pytest-missing-{unique_name}",
+                            "TemplateData": "{}",
+                        }
+                    },
+                )
+            assert (
+                exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+            )
+        finally:
+            _safe_delete_identity_v2(sesv2_client, sender)
+
+
+# ============================================
+# SES V1 (ses) - Query / XML
+# ============================================
+
+
+class TestSesV1TemplateCrud:
+    """Template CRUD via the V1 SES Query API."""
+
+    def test_create_and_get_template(self, ses_client, unique_name):
+        name = f"pytest-v1-tpl-{unique_name}"
+        try:
+            ses_client.create_template(
+                Template={
+                    "TemplateName": name,
+                    "SubjectPart": "Hello {{name}}",
+                    "TextPart": "Hi {{name}}!",
+                    "HtmlPart": "<p>Hi <b>{{name}}</b>!</p>",
+                }
+            )
+            response = ses_client.get_template(TemplateName=name)
+            template = response["Template"]
+            assert template["TemplateName"] == name
+            assert template["SubjectPart"] == "Hello {{name}}"
+            assert template["TextPart"] == "Hi {{name}}!"
+            assert "{{name}}" in template["HtmlPart"]
+        finally:
+            _safe_delete_v1(ses_client, name)
+
+    def test_list_templates_includes_created(self, ses_client, unique_name):
+        name = f"pytest-v1-tpl-{unique_name}"
+        try:
+            ses_client.create_template(
+                Template={
+                    "TemplateName": name,
+                    "SubjectPart": "s",
+                    "TextPart": "t",
+                }
+            )
+            response = ses_client.list_templates()
+            names = [
+                t["Name"] for t in response.get("TemplatesMetadata", [])
+            ]
+            assert name in names
+        finally:
+            _safe_delete_v1(ses_client, name)
+
+    def test_update_template(self, ses_client, unique_name):
+        name = f"pytest-v1-tpl-{unique_name}"
+        try:
+            ses_client.create_template(
+                Template={
+                    "TemplateName": name,
+                    "SubjectPart": "original",
+                    "TextPart": "original",
+                }
+            )
+            ses_client.update_template(
+                Template={
+                    "TemplateName": name,
+                    "SubjectPart": "updated {{who}}",
+                    "TextPart": "updated body {{who}}",
+                }
+            )
+            response = ses_client.get_template(TemplateName=name)
+            assert response["Template"]["SubjectPart"] == "updated {{who}}"
+        finally:
+            _safe_delete_v1(ses_client, name)
+
+    def test_delete_template(self, ses_client, unique_name):
+        name = f"pytest-v1-tpl-{unique_name}"
+        ses_client.create_template(
+            Template={"TemplateName": name, "SubjectPart": "s", "TextPart": "t"}
+        )
+        ses_client.delete_template(TemplateName=name)
+        with pytest.raises(ClientError) as exc_info:
+            ses_client.get_template(TemplateName=name)
+        assert (
+            exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+        )
+
+
+class TestSesV1TemplateErrors:
+    """Error paths for V1 template operations."""
+
+    def test_create_duplicate_rejected(self, ses_client, unique_name):
+        name = f"pytest-v1-tpl-{unique_name}"
+        try:
+            ses_client.create_template(
+                Template={
+                    "TemplateName": name,
+                    "SubjectPart": "s",
+                    "TextPart": "t",
+                }
+            )
+            with pytest.raises(ClientError) as exc_info:
+                ses_client.create_template(
+                    Template={
+                        "TemplateName": name,
+                        "SubjectPart": "dup",
+                        "TextPart": "dup",
+                    }
+                )
+            assert (
+                exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+            )
+        finally:
+            _safe_delete_v1(ses_client, name)
+
+    def test_get_nonexistent(self, ses_client, unique_name):
+        with pytest.raises(ClientError) as exc_info:
+            ses_client.get_template(TemplateName=f"pytest-missing-{unique_name}")
+        assert (
+            exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+        )
+
+
+class TestSesV1SendTemplatedEmail:
+    """SendTemplatedEmail resolves stored templates via the V1 Query API."""
+
+    def test_send_templated_email(self, ses_client, unique_name):
+        template_name = f"pytest-v1-tpl-{unique_name}"
+        sender = f"pytest-v1-sender-{unique_name}@example.com"
+        recipient = f"pytest-v1-recipient-{unique_name}@example.com"
+
+        try:
+            ses_client.verify_email_identity(EmailAddress=sender)
+            ses_client.create_template(
+                Template={
+                    "TemplateName": template_name,
+                    "SubjectPart": "Welcome {{name}}",
+                    "TextPart": "Hello {{name}}, from {{team}}",
+                }
+            )
+
+            response = ses_client.send_templated_email(
+                Source=sender,
+                Destination={"ToAddresses": [recipient]},
+                Template=template_name,
+                TemplateData=json.dumps({"name": "Alice", "team": "floci"}),
+            )
+            assert response["MessageId"]
+        finally:
+            _safe_delete_v1(ses_client, template_name)
+            _safe_delete_identity_v1(ses_client, sender)
+
+    def test_send_templated_email_with_template_arn_and_name(
+        self, ses_client, unique_name
+    ):
+        """boto3 requires Template (name) on SendTemplatedEmail; TemplateArn is
+        supplied alongside for cross-account addressing on real AWS. Floci
+        accepts both and resolves via the name."""
+        template_name = f"pytest-v1-arn-tpl-{unique_name}"
+        sender = f"pytest-v1-arn-sender-{unique_name}@example.com"
+        arn = f"arn:aws:ses:us-east-1:000000000000:template/{template_name}"
+        try:
+            ses_client.verify_email_identity(EmailAddress=sender)
+            ses_client.create_template(
+                Template={
+                    "TemplateName": template_name,
+                    "SubjectPart": "Hi {{name}}",
+                    "TextPart": "Hello {{name}}",
+                }
+            )
+            response = ses_client.send_templated_email(
+                Source=sender,
+                Destination={"ToAddresses": ["recipient@example.com"]},
+                Template=template_name,
+                TemplateArn=arn,
+                TemplateData=json.dumps({"name": "Alice"}),
+            )
+            assert response["MessageId"]
+        finally:
+            _safe_delete_v1(ses_client, template_name)
+            _safe_delete_identity_v1(ses_client, sender)
+
+    def test_send_templated_email_with_unknown_template_raises(
+        self, ses_client, unique_name
+    ):
+        sender = f"pytest-v1-sender-{unique_name}@example.com"
+        try:
+            ses_client.verify_email_identity(EmailAddress=sender)
+            with pytest.raises(ClientError) as exc_info:
+                ses_client.send_templated_email(
+                    Source=sender,
+                    Destination={"ToAddresses": ["recipient@example.com"]},
+                    Template=f"pytest-missing-{unique_name}",
+                    TemplateData="{}",
+                )
+            assert (
+                exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+            )
+        finally:
+            _safe_delete_identity_v1(ses_client, sender)
+
+
+# ============================================
+# Cleanup helpers
+# ============================================
+
+
+def _safe_delete_v2(client, template_name):
+    try:
+        client.delete_email_template(TemplateName=template_name)
+    except ClientError:
+        pass
+
+
+def _safe_delete_v1(client, template_name):
+    try:
+        client.delete_template(TemplateName=template_name)
+    except ClientError:
+        pass
+
+
+def _safe_delete_identity_v2(client, email):
+    try:
+        client.delete_email_identity(EmailIdentity=email)
+    except ClientError:
+        pass
+
+
+def _safe_delete_identity_v1(client, email):
+    try:
+        client.delete_identity(Identity=email)
+    except ClientError:
+        pass

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -17,6 +17,12 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `GetIdentityVerificationAttributes` | Get verification status for one or more identities        |
 | `SendEmail`                         | Send a structured email with text or HTML body            |
 | `SendRawEmail`                      | Send a raw MIME payload                                   |
+| `SendTemplatedEmail`                | Send an email by resolving a stored template             |
+| `CreateTemplate`                    | Create an email template with subject / text / html parts |
+| `GetTemplate`                       | Read a stored template                                    |
+| `UpdateTemplate`                    | Replace the content of a stored template                  |
+| `DeleteTemplate`                    | Remove a stored template                                  |
+| `ListTemplates`                     | List stored templates                                     |
 | `GetSendQuota`                      | Return local send quota counters                          |
 | `GetSendStatistics`                 | Return aggregate delivery stats for sent messages         |
 | `GetAccountSendingEnabled`          | Report whether sending is enabled                         |
@@ -167,5 +173,10 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `POST` | `/v2/email/outbound-emails` | `SendEmail` (simple / raw / templated) |
 | `GET` | `/v2/email/account` | `GetAccount` |
 | `PUT` | `/v2/email/account/sending` | `PutAccountSendingAttributes` |
+| `POST` | `/v2/email/templates` | `CreateEmailTemplate` |
+| `GET` | `/v2/email/templates` | `ListEmailTemplates` |
+| `GET` | `/v2/email/templates/{templateName}` | `GetEmailTemplate` |
+| `PUT` | `/v2/email/templates/{templateName}` | `UpdateEmailTemplate` |
+| `DELETE` | `/v2/email/templates/{templateName}` | `DeleteEmailTemplate` |
 
-Identity and sent-message state is shared with the v1 Query API, so messages sent through v2 appear in the same `GET /_aws/ses` inspection mailbox.
+Identity, template, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), and every send appears in the same `GET /_aws/ses` inspection mailbox.

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -257,7 +257,9 @@ public class AwsQueryController {
             "SendEmail", "SendRawEmail", "GetSendQuota", "GetSendStatistics",
             "GetAccountSendingEnabled", "ListVerifiedEmailAddresses", "DeleteVerifiedEmailAddress",
             "SetIdentityNotificationTopic", "GetIdentityNotificationAttributes",
-            "GetIdentityDkimAttributes"
+            "GetIdentityDkimAttributes",
+            "CreateTemplate", "UpdateTemplate", "GetTemplate", "DeleteTemplate",
+            "ListTemplates", "SendTemplatedEmail"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -295,7 +295,7 @@ public class SesController {
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
-        } catch (Exception e) {
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
     }
@@ -345,7 +345,7 @@ public class SesController {
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
-        } catch (Exception e) {
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -226,10 +227,38 @@ public class SesController {
                 messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
                         bccAddresses, replyToAddresses, subject, bodyText, bodyHtml, region);
             } else if (content.has("Template")) {
-                String subject = content.path("Template").path("TemplateName").asText("(template)");
-                String templateData = content.path("Template").path("TemplateData").asText("");
-                messageId = sesService.sendEmail(fromEmailAddress, toAddresses, ccAddresses,
-                        bccAddresses, replyToAddresses, subject, templateData, null, region);
+                JsonNode template = content.path("Template");
+                String templateName = template.path("TemplateName").asText(null);
+                String templateArn = template.path("TemplateArn").asText(null);
+                boolean hasName = templateName != null && !templateName.isBlank();
+                boolean hasArn = templateArn != null && !templateArn.isBlank();
+                boolean hasInline = template.has("TemplateContent");
+                int selectorCount = (hasName ? 1 : 0) + (hasArn ? 1 : 0) + (hasInline ? 1 : 0);
+                if (selectorCount > 1) {
+                    throw new AwsException("BadRequestException",
+                            "Content.Template must specify exactly one of TemplateName, TemplateArn, or TemplateContent.",
+                            400);
+                }
+                if (selectorCount == 0) {
+                    throw new AwsException("BadRequestException",
+                            "Content.Template requires TemplateName, TemplateArn, or TemplateContent.", 400);
+                }
+                JsonNode templateData = parseTemplateData(template.path("TemplateData").asText(""));
+                if (hasName || hasArn) {
+                    String resolvedName = hasName
+                            ? templateName
+                            : SesService.templateNameFromArn(templateArn);
+                    messageId = sesService.sendTemplatedEmail(fromEmailAddress, toAddresses, ccAddresses,
+                            bccAddresses, replyToAddresses, resolvedName, templateData, region);
+                } else {
+                    JsonNode inline = template.path("TemplateContent");
+                    String subject = inline.path("Subject").asText(null);
+                    String text = inline.path("Text").asText(null);
+                    String html = inline.path("Html").asText(null);
+                    messageId = sesService.sendInlineTemplatedEmail(fromEmailAddress, toAddresses,
+                            ccAddresses, bccAddresses, replyToAddresses,
+                            subject, text, html, templateData, region);
+                }
             } else {
                 throw new AwsException("BadRequestException",
                         "Content must contain Raw, Simple, or Template.", 400);
@@ -245,6 +274,93 @@ public class SesController {
             throw remapV1Exception(e);
         } catch (Exception e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── Templates ────────────────────────────
+
+    @POST
+    @Path("/templates")
+    public Response createEmailTemplate(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            String templateName = request.path("TemplateName").asText(null);
+            if (templateName == null || templateName.isBlank()) {
+                throw new AwsException("BadRequestException", "TemplateName is required.", 400);
+            }
+            EmailTemplate template = parseTemplateContent(templateName, request.path("TemplateContent"));
+            sesService.createTemplate(template, region);
+            LOG.infov("SES V2 CreateEmailTemplate: {0}", templateName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/templates")
+    public Response listEmailTemplates(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        List<EmailTemplate> templates = sesService.listTemplates(region);
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode items = result.putArray("TemplatesMetadata");
+        for (EmailTemplate t : templates) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("TemplateName", t.getTemplateName());
+            if (t.getCreatedTimestamp() != null) {
+                item.put("CreatedTimestamp", t.getCreatedTimestamp().getEpochSecond());
+            }
+            items.add(item);
+        }
+        return Response.ok(result).build();
+    }
+
+    @GET
+    @Path("/templates/{templateName}")
+    public Response getEmailTemplate(@Context HttpHeaders headers,
+                                      @PathParam("templateName") String templateName) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            EmailTemplate template = sesService.getTemplate(templateName, region);
+            return Response.ok(buildTemplateResponse(template)).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/templates/{templateName}")
+    public Response updateEmailTemplate(@Context HttpHeaders headers,
+                                         @PathParam("templateName") String templateName,
+                                         String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            EmailTemplate template = parseTemplateContent(templateName, request.path("TemplateContent"));
+            sesService.updateTemplate(template, region);
+            LOG.infov("SES V2 UpdateEmailTemplate: {0}", templateName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/templates/{templateName}")
+    public Response deleteEmailTemplate(@Context HttpHeaders headers,
+                                         @PathParam("templateName") String templateName) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            sesService.deleteTemplate(templateName, region);
+            LOG.infov("SES V2 DeleteEmailTemplate: {0}", templateName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
         }
     }
 
@@ -354,10 +470,50 @@ public class SesController {
         return all;
     }
 
-    private static AwsException remapV1Exception(AwsException e) {
-        if ("InvalidParameterValue".equals(e.getErrorCode())) {
-            return new AwsException("BadRequestException", e.getMessage(), 400);
+    private EmailTemplate parseTemplateContent(String templateName, JsonNode content) {
+        String subject = content.path("Subject").asText(null);
+        String text = content.path("Text").asText(null);
+        String html = content.path("Html").asText(null);
+        return new EmailTemplate(templateName, subject, text, html);
+    }
+
+    private ObjectNode buildTemplateResponse(EmailTemplate template) {
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("TemplateName", template.getTemplateName());
+        ObjectNode content = result.putObject("TemplateContent");
+        if (template.getSubject() != null) {
+            content.put("Subject", template.getSubject());
         }
-        return e;
+        if (template.getTextPart() != null) {
+            content.put("Text", template.getTextPart());
+        }
+        if (template.getHtmlPart() != null) {
+            content.put("Html", template.getHtmlPart());
+        }
+        return result;
+    }
+
+    private JsonNode parseTemplateData(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return objectMapper.createObjectNode();
+        }
+        try {
+            return objectMapper.readTree(raw);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException",
+                    "Invalid TemplateData JSON: " + e.getMessage(), 400);
+        }
+    }
+
+    private static AwsException remapV1Exception(AwsException e) {
+        return switch (e.getErrorCode()) {
+            case "InvalidParameterValue", "InvalidTemplate" ->
+                    new AwsException("BadRequestException", e.getMessage(), 400);
+            case "TemplateDoesNotExist" ->
+                    new AwsException("NotFoundException", e.getMessage(), 404);
+            case "AlreadyExists" ->
+                    new AwsException("AlreadyExistsException", e.getMessage(), 400);
+            default -> e;
+        };
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -350,7 +350,7 @@ public class SesQueryHandler {
         }
         try {
             return objectMapper.readTree(raw);
-        } catch (Exception e) {
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("InvalidTemplate",
                     "Invalid TemplateData JSON: " + e.getMessage(), 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -4,7 +4,10 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -24,10 +27,12 @@ public class SesQueryHandler {
     private static final Logger LOG = Logger.getLogger(SesQueryHandler.class);
 
     private final SesService sesService;
+    private final ObjectMapper objectMapper;
 
     @Inject
-    public SesQueryHandler(SesService sesService) {
+    public SesQueryHandler(SesService sesService, ObjectMapper objectMapper) {
         this.sesService = sesService;
+        this.objectMapper = objectMapper;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params, String region) {
@@ -51,6 +56,12 @@ public class SesQueryHandler {
                 case "SetIdentityNotificationTopic" -> handleSetIdentityNotificationTopic(params, region);
                 case "GetIdentityNotificationAttributes" -> handleGetIdentityNotificationAttributes(params, region);
                 case "GetIdentityDkimAttributes" -> handleGetIdentityDkimAttributes(params, region);
+                case "CreateTemplate" -> handleCreateTemplate(params, region);
+                case "UpdateTemplate" -> handleUpdateTemplate(params, region);
+                case "GetTemplate" -> handleGetTemplate(params, region);
+                case "DeleteTemplate" -> handleDeleteTemplate(params, region);
+                case "ListTemplates" -> handleListTemplates(region);
+                case "SendTemplatedEmail" -> handleSendTemplatedEmail(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -244,6 +255,105 @@ public class SesQueryHandler {
         }
         xml.end("DkimAttributes");
         return Response.ok(AwsQueryResponse.envelope("GetIdentityDkimAttributes", AwsNamespaces.SES, xml.build())).build();
+    }
+
+    // --- Templates ---
+
+    private Response handleCreateTemplate(MultivaluedMap<String, String> params, String region) {
+        EmailTemplate template = readTemplateParams(params);
+        sesService.createTemplate(template, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("CreateTemplate", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleUpdateTemplate(MultivaluedMap<String, String> params, String region) {
+        EmailTemplate template = readTemplateParams(params);
+        sesService.updateTemplate(template, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("UpdateTemplate", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleGetTemplate(MultivaluedMap<String, String> params, String region) {
+        String templateName = getParam(params, "TemplateName");
+        EmailTemplate template = sesService.getTemplate(templateName, region);
+        var xml = new XmlBuilder().start("Template")
+                .elem("TemplateName", template.getTemplateName());
+        if (template.getSubject() != null) {
+            xml.elem("SubjectPart", template.getSubject());
+        }
+        if (template.getTextPart() != null) {
+            xml.elem("TextPart", template.getTextPart());
+        }
+        if (template.getHtmlPart() != null) {
+            xml.elem("HtmlPart", template.getHtmlPart());
+        }
+        xml.end("Template");
+        return Response.ok(AwsQueryResponse.envelope("GetTemplate", AwsNamespaces.SES, xml.build())).build();
+    }
+
+    private Response handleDeleteTemplate(MultivaluedMap<String, String> params, String region) {
+        String templateName = getParam(params, "TemplateName");
+        sesService.deleteTemplate(templateName, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("DeleteTemplate", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleListTemplates(String region) {
+        List<EmailTemplate> templates = sesService.listTemplates(region);
+        var xml = new XmlBuilder().start("TemplatesMetadata");
+        for (EmailTemplate t : templates) {
+            xml.start("member")
+                    .elem("Name", t.getTemplateName());
+            if (t.getCreatedTimestamp() != null) {
+                xml.elem("CreatedTimestamp", t.getCreatedTimestamp().toString());
+            }
+            xml.end("member");
+        }
+        xml.end("TemplatesMetadata");
+        return Response.ok(AwsQueryResponse.envelope("ListTemplates", AwsNamespaces.SES, xml.build())).build();
+    }
+
+    private Response handleSendTemplatedEmail(MultivaluedMap<String, String> params, String region) {
+        String source = getParam(params, "Source");
+        List<String> toAddresses = extractMembers(params, "Destination.ToAddresses");
+        List<String> ccAddresses = extractMembers(params, "Destination.CcAddresses");
+        List<String> bccAddresses = extractMembers(params, "Destination.BccAddresses");
+        List<String> replyToAddresses = extractMembers(params, "ReplyToAddresses");
+        String templateName = getParam(params, "Template");
+        String templateArn = getParam(params, "TemplateArn");
+        String templateDataRaw = getParam(params, "TemplateData");
+
+        boolean hasName = templateName != null && !templateName.isBlank();
+        boolean hasArn = templateArn != null && !templateArn.isBlank();
+        if (!hasName && !hasArn) {
+            throw new AwsException("InvalidParameterValue",
+                    "Template or TemplateArn is required.", 400);
+        }
+        String resolvedName = hasName ? templateName : SesService.templateNameFromArn(templateArn);
+
+        JsonNode templateData = parseTemplateData(templateDataRaw);
+        String messageId = sesService.sendTemplatedEmail(source, toAddresses, ccAddresses,
+                bccAddresses, replyToAddresses, resolvedName, templateData, region);
+
+        String result = new XmlBuilder().elem("MessageId", messageId).build();
+        return Response.ok(AwsQueryResponse.envelope("SendTemplatedEmail", AwsNamespaces.SES, result)).build();
+    }
+
+    private EmailTemplate readTemplateParams(MultivaluedMap<String, String> params) {
+        String name = getParam(params, "Template.TemplateName");
+        String subject = getParam(params, "Template.SubjectPart");
+        String text = getParam(params, "Template.TextPart");
+        String html = getParam(params, "Template.HtmlPart");
+        return new EmailTemplate(name, subject, text, html);
+    }
+
+    private JsonNode parseTemplateData(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return objectMapper.createObjectNode();
+        }
+        try {
+            return objectMapper.readTree(raw);
+        } catch (Exception e) {
+            throw new AwsException("InvalidTemplate",
+                    "Invalid TemplateData JSON: " + e.getMessage(), 400);
+        }
     }
 
     // --- Helpers ---

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -3,27 +3,36 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class SesService {
 
     private static final Logger LOG = Logger.getLogger(SesService.class);
 
+    private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\{\\{\\s*([\\w-]+)\\s*\\}\\}");
+
     private final StorageBackend<String, Identity> identityStore;
     private final StorageBackend<String, SentEmail> emailStore;
     private final StorageBackend<String, Boolean> accountSettingsStore;
+    private final StorageBackend<String, EmailTemplate> templateStore;
     private final SmtpRelay smtpRelay;
 
     @Inject
@@ -34,16 +43,20 @@ public class SesService {
                 new TypeReference<Map<String, SentEmail>>() {});
         this.accountSettingsStore = storageFactory.create("ses", "ses-account-settings.json",
                 new TypeReference<Map<String, Boolean>>() {});
+        this.templateStore = storageFactory.create("ses", "ses-templates.json",
+                new TypeReference<Map<String, EmailTemplate>>() {});
         this.smtpRelay = smtpRelay;
     }
 
     SesService(StorageBackend<String, Identity> identityStore,
                StorageBackend<String, SentEmail> emailStore,
                StorageBackend<String, Boolean> accountSettingsStore,
+               StorageBackend<String, EmailTemplate> templateStore,
                SmtpRelay smtpRelay) {
         this.identityStore = identityStore;
         this.emailStore = emailStore;
         this.accountSettingsStore = accountSettingsStore;
+        this.templateStore = templateStore;
         this.smtpRelay = smtpRelay;
     }
 
@@ -237,6 +250,161 @@ public class SesService {
     public void setAccountSendingEnabled(String region, boolean enabled) {
         accountSettingsStore.put("sending::" + region, enabled);
         LOG.infov("Updated account sending enabled for region {0}: {1}", region, enabled);
+    }
+
+    // ──────────────────────────── Templates ────────────────────────────
+
+    public EmailTemplate createTemplate(EmailTemplate template, String region) {
+        validateTemplate(template);
+        String key = templateKey(region, template.getTemplateName());
+        if (templateStore.get(key).isPresent()) {
+            throw new AwsException("AlreadyExists",
+                    "Template " + template.getTemplateName() + " already exists.", 400);
+        }
+        Instant now = Instant.now();
+        template.setCreatedTimestamp(now);
+        template.setLastUpdatedTimestamp(now);
+        templateStore.put(key, template);
+        LOG.infov("Created SES template: {0} in region {1}", template.getTemplateName(), region);
+        return template;
+    }
+
+    public EmailTemplate getTemplate(String templateName, String region) {
+        return templateStore.get(templateKey(region, templateName))
+                .orElseThrow(() -> new AwsException("TemplateDoesNotExist",
+                        "Template " + templateName + " does not exist.", 400));
+    }
+
+    public EmailTemplate updateTemplate(EmailTemplate template, String region) {
+        validateTemplate(template);
+        String key = templateKey(region, template.getTemplateName());
+        EmailTemplate existing = templateStore.get(key)
+                .orElseThrow(() -> new AwsException("TemplateDoesNotExist",
+                        "Template " + template.getTemplateName() + " does not exist.", 400));
+        template.setCreatedTimestamp(existing.getCreatedTimestamp());
+        template.setLastUpdatedTimestamp(Instant.now());
+        templateStore.put(key, template);
+        LOG.infov("Updated SES template: {0} in region {1}", template.getTemplateName(), region);
+        return template;
+    }
+
+    public void deleteTemplate(String templateName, String region) {
+        String key = templateKey(region, templateName);
+        if (templateStore.get(key).isEmpty()) {
+            throw new AwsException("TemplateDoesNotExist",
+                    "Template " + templateName + " does not exist.", 400);
+        }
+        templateStore.delete(key);
+        LOG.infov("Deleted SES template: {0} in region {1}", templateName, region);
+    }
+
+    public List<EmailTemplate> listTemplates(String region) {
+        String prefix = "template::" + region + "::";
+        List<EmailTemplate> all = new ArrayList<>(templateStore.scan(k -> k.startsWith(prefix)));
+        all.sort(Comparator.comparing(EmailTemplate::getCreatedTimestamp,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(EmailTemplate::getTemplateName,
+                        Comparator.nullsLast(Comparator.naturalOrder())));
+        return all;
+    }
+
+    public String sendTemplatedEmail(String source, List<String> toAddresses, List<String> ccAddresses,
+                                     List<String> bccAddresses, List<String> replyToAddresses,
+                                     String templateName, JsonNode templateData, String region) {
+        EmailTemplate template = getTemplate(templateName, region);
+        return sendInlineTemplatedEmail(source, toAddresses, ccAddresses, bccAddresses,
+                replyToAddresses, template.getSubject(), template.getTextPart(),
+                template.getHtmlPart(), templateData, region);
+    }
+
+    public String sendInlineTemplatedEmail(String source, List<String> toAddresses, List<String> ccAddresses,
+                                            List<String> bccAddresses, List<String> replyToAddresses,
+                                            String subject, String textPart, String htmlPart,
+                                            JsonNode templateData, String region) {
+        boolean hasSubject = subject != null && !subject.isBlank();
+        boolean hasText = textPart != null && !textPart.isBlank();
+        boolean hasHtml = htmlPart != null && !htmlPart.isBlank();
+        if (!hasSubject && !hasText && !hasHtml) {
+            throw new AwsException("InvalidTemplate",
+                    "Template must have at least a subject, text, or html part.", 400);
+        }
+        return sendEmail(source, toAddresses, ccAddresses, bccAddresses, replyToAddresses,
+                applyTemplateData(subject, templateData),
+                applyTemplateData(textPart, templateData),
+                applyTemplateData(htmlPart, templateData),
+                region);
+    }
+
+    static String applyTemplateData(String text, JsonNode data) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        Matcher matcher = TEMPLATE_VARIABLE.matcher(text);
+        StringBuilder out = new StringBuilder();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String replacement = "";
+            if (data != null && data.hasNonNull(key)) {
+                JsonNode value = data.get(key);
+                replacement = value.isValueNode() ? value.asText() : value.toString();
+            }
+            matcher.appendReplacement(out, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(out);
+        return out.toString();
+    }
+
+    private static void validateTemplate(EmailTemplate template) {
+        if (template == null) {
+            throw new AwsException("InvalidTemplate", "Template is required.", 400);
+        }
+        validateTemplateName(template.getTemplateName());
+        boolean hasSubject = template.getSubject() != null && !template.getSubject().isBlank();
+        boolean hasText = template.getTextPart() != null && !template.getTextPart().isBlank();
+        boolean hasHtml = template.getHtmlPart() != null && !template.getHtmlPart().isBlank();
+        if (!hasSubject && !hasText && !hasHtml) {
+            throw new AwsException("InvalidTemplate",
+                    "Template must have at least a subject, text, or html part.", 400);
+        }
+    }
+
+    private static void validateTemplateName(String templateName) {
+        if (templateName == null || templateName.isBlank()) {
+            throw new AwsException("InvalidTemplate", "TemplateName is required.", 400);
+        }
+        if (Character.isWhitespace(templateName.charAt(0))
+                || Character.isWhitespace(templateName.charAt(templateName.length() - 1))) {
+            throw new AwsException("InvalidTemplate",
+                    "TemplateName must not contain leading or trailing whitespace.", 400);
+        }
+    }
+
+    private static String templateKey(String region, String templateName) {
+        validateTemplateName(templateName);
+        return "template::" + region + "::" + templateName;
+    }
+
+    /**
+     * Extracts the template name from an SES template ARN of the form
+     * {@code arn:aws:ses:<region>:<account>:template/<name>}. Region and
+     * account segments are not validated; only the {@code template/<name>}
+     * suffix is required.
+     */
+    public static String templateNameFromArn(String arn) {
+        if (arn == null || arn.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "TemplateArn is required.", 400);
+        }
+        int marker = arn.indexOf(":template/");
+        if (!arn.startsWith("arn:") || marker < 0) {
+            throw new AwsException("InvalidParameterValue",
+                    "TemplateArn is not a valid SES template ARN: " + arn, 400);
+        }
+        String name = arn.substring(marker + ":template/".length());
+        if (name.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "TemplateArn is missing a template name: " + arn, 400);
+        }
+        return name;
     }
 
     private static String identityKey(String region, String identity) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/EmailTemplate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/EmailTemplate.java
@@ -1,0 +1,57 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EmailTemplate {
+
+    @JsonProperty("TemplateName")
+    private String templateName;
+
+    @JsonProperty("Subject")
+    private String subject;
+
+    @JsonProperty("TextPart")
+    private String textPart;
+
+    @JsonProperty("HtmlPart")
+    private String htmlPart;
+
+    @JsonProperty("CreatedTimestamp")
+    private Instant createdTimestamp;
+
+    @JsonProperty("LastUpdatedTimestamp")
+    private Instant lastUpdatedTimestamp;
+
+    public EmailTemplate() {}
+
+    public EmailTemplate(String templateName, String subject, String textPart, String htmlPart) {
+        this.templateName = templateName;
+        this.subject = subject;
+        this.textPart = textPart;
+        this.htmlPart = htmlPart;
+    }
+
+    public String getTemplateName() { return templateName; }
+    public void setTemplateName(String templateName) { this.templateName = templateName; }
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getTextPart() { return textPart; }
+    public void setTextPart(String textPart) { this.textPart = textPart; }
+
+    public String getHtmlPart() { return htmlPart; }
+    public void setHtmlPart(String htmlPart) { this.htmlPart = htmlPart; }
+
+    public Instant getCreatedTimestamp() { return createdTimestamp; }
+    public void setCreatedTimestamp(Instant createdTimestamp) { this.createdTimestamp = createdTimestamp; }
+
+    public Instant getLastUpdatedTimestamp() { return lastUpdatedTimestamp; }
+    public void setLastUpdatedTimestamp(Instant lastUpdatedTimestamp) { this.lastUpdatedTimestamp = lastUpdatedTimestamp; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, Identity>(),
                 emailStore,
                 new InMemoryStorage<String, Boolean>(),
+                new InMemoryStorage<String, EmailTemplate>(),
                 smtpRelay);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -1,0 +1,114 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link SesService#applyTemplateData} covering
+ * template variable substitution edge cases.
+ */
+class SesServiceTemplateTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void undefinedVariable_replacedWithEmptyString() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
+        String result = SesService.applyTemplateData("Hello {{name}}, team {{team}}", data);
+        assertEquals("Hello Alice, team ", result);
+    }
+
+    @Test
+    void spacedVariable_matchesCorrectly() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
+        String result = SesService.applyTemplateData("Hello {{ name }}", data);
+        assertEquals("Hello Alice", result);
+    }
+
+    @Test
+    void hyphenatedVariableName() {
+        JsonNode data = MAPPER.createObjectNode().put("first-name", "Alice");
+        String result = SesService.applyTemplateData("Hello {{first-name}}", data);
+        assertEquals("Hello Alice", result);
+    }
+
+    @Test
+    void unclosedBraces_leftAsIs() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
+        String result = SesService.applyTemplateData("Hello {{name}} and {{foo", data);
+        assertEquals("Hello Alice and {{foo", result);
+    }
+
+    @Test
+    void nonStringJsonValues() throws Exception {
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("count", 42);
+        data.put("active", true);
+        data.set("nested", MAPPER.readTree("{\"key\":\"val\"}"));
+
+        assertEquals("Items: 42", SesService.applyTemplateData("Items: {{count}}", data));
+        assertEquals("Active: true", SesService.applyTemplateData("Active: {{active}}", data));
+        assertEquals("Data: {\"key\":\"val\"}", SesService.applyTemplateData("Data: {{nested}}", data));
+    }
+
+    @Test
+    void emptyTemplateData_allVariablesCleared() {
+        JsonNode data = MAPPER.createObjectNode();
+        String result = SesService.applyTemplateData("Hello {{name}}, {{team}}", data);
+        assertEquals("Hello , ", result);
+    }
+
+    @Test
+    void nullTemplateData_allVariablesCleared() {
+        String result = SesService.applyTemplateData("Hello {{name}}", null);
+        assertEquals("Hello ", result);
+    }
+
+    @Test
+    void nullText_returnsNull() {
+        assertNull(SesService.applyTemplateData(null, MAPPER.createObjectNode()));
+    }
+
+    @Test
+    void emptyText_returnsEmpty() {
+        assertEquals("", SesService.applyTemplateData("", MAPPER.createObjectNode()));
+    }
+
+    @Test
+    void noVariables_textUnchanged() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
+        assertEquals("Hello world", SesService.applyTemplateData("Hello world", data));
+    }
+
+    @Test
+    void duplicateVariables_allReplaced() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
+        String result = SesService.applyTemplateData("{{name}} and {{name}}", data);
+        assertEquals("Alice and Alice", result);
+    }
+
+    @Test
+    void replacementWithRegexMetacharacters() {
+        JsonNode data = MAPPER.createObjectNode().put("val", "price is $100 (50% off)");
+        String result = SesService.applyTemplateData("The {{val}}", data);
+        assertEquals("The price is $100 (50% off)", result);
+    }
+
+    @Test
+    void variableNameCaseSensitive() {
+        JsonNode data = MAPPER.createObjectNode().put("Name", "Alice");
+        String result = SesService.applyTemplateData("Hello {{name}} and {{Name}}", data);
+        assertEquals("Hello  and Alice", result);
+    }
+
+    @Test
+    void emptyStringValue() {
+        JsonNode data = MAPPER.createObjectNode().put("name", "");
+        assertEquals("Hello ", SesService.applyTemplateData("Hello {{name}}", data));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV1IntegrationTest.java
@@ -1,0 +1,326 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration tests for SES V1 Query-protocol template actions.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTemplateV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-welcome")
+            .formParam("Template.SubjectPart", "Hello {{name}}")
+            .formParam("Template.TextPart", "Hi {{name}}!")
+            .formParam("Template.HtmlPart", "<p>Hi <b>{{name}}</b>!</p>")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CreateTemplateResponse"));
+    }
+
+    @Test
+    @Order(2)
+    void createTemplate_duplicateRejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-welcome")
+            .formParam("Template.SubjectPart", "dup")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>AlreadyExists</Code>"));
+    }
+
+    @Test
+    @Order(3)
+    void getTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetTemplate")
+            .formParam("TemplateName", "v1-welcome")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<TemplateName>v1-welcome</TemplateName>"))
+            .body(containsString("<SubjectPart>Hello {{name}}</SubjectPart>"))
+            .body(containsString("<TextPart>Hi {{name}}!</TextPart>"));
+    }
+
+    @Test
+    @Order(4)
+    void getTemplate_notFound() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetTemplate")
+            .formParam("TemplateName", "missing-template")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(5)
+    void updateTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "UpdateTemplate")
+            .formParam("Template.TemplateName", "v1-welcome")
+            .formParam("Template.SubjectPart", "Welcome {{name}}!")
+            .formParam("Template.TextPart", "Hello {{name}}, from {{team}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("UpdateTemplateResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetTemplate")
+            .formParam("TemplateName", "v1-welcome")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubjectPart>Welcome {{name}}!</SubjectPart>"))
+            .body(containsString("{{team}}"));
+    }
+
+    @Test
+    @Order(6)
+    void listTemplates_includesCreated() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "ListTemplates")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<TemplatesMetadata>"))
+            .body(containsString("<Name>v1-welcome</Name>"));
+    }
+
+    @Test
+    @Order(7)
+    void sendTemplatedEmail_substitutesVariables() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "VerifyEmailIdentity")
+            .formParam("EmailAddress", "v1-sender@example.com")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String body = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("Template", "v1-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\",\"team\":\"floci\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("SendTemplatedEmailResponse"))
+            .body(containsString("<MessageId>"))
+            .extract().body().asString();
+
+        String messageId = body.replaceAll("(?s).*<MessageId>([^<]+)</MessageId>.*", "$1");
+
+        given()
+            .queryParam("id", messageId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Welcome Alice!"))
+            .body("messages[0].Body.text_part", equalTo("Hello Alice, from floci"));
+    }
+
+    @Test
+    @Order(8)
+    void sendTemplatedEmail_unknownTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("Template", "ghost")
+            .formParam("TemplateData", "{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(9)
+    void deleteTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteTemplate")
+            .formParam("TemplateName", "v1-welcome")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteTemplateResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetTemplate")
+            .formParam("TemplateName", "v1-welcome")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(10)
+    void deleteTemplate_notFound() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteTemplate")
+            .formParam("TemplateName", "already-gone")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(11)
+    void createTemplate_rejectsLeadingTrailingWhitespace() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", " padded ")
+            .formParam("Template.SubjectPart", "s")
+            .formParam("Template.TextPart", "t")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidTemplate</Code>"));
+    }
+
+    @Test
+    @Order(12)
+    void sendTemplatedEmail_withTemplateArn_resolvesStoredTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-arn-welcome")
+            .formParam("Template.SubjectPart", "Hi {{name}}")
+            .formParam("Template.TextPart", "Hello {{name}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "VerifyEmailIdentity")
+            .formParam("EmailAddress", "v1-arn-sender@example.com")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-arn-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("TemplateArn", "arn:aws:ses:us-east-1:000000000000:template/v1-arn-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+    }
+
+    @Test
+    @Order(13)
+    void sendTemplatedEmail_withNameAndArn_accepted() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-arn-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("Template", "v1-arn-welcome")
+            .formParam("TemplateArn", "arn:aws:ses:us-east-1:000000000000:template/v1-arn-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+    }
+
+    @Test
+    @Order(14)
+    void sendTemplatedEmail_withMalformedArn_returns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-arn-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("TemplateArn", "not-an-arn")
+            .formParam("TemplateData", "{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
@@ -494,4 +494,56 @@ class SesTemplateV2IntegrationTest {
             .body("__type", equalTo("BadRequestException"));
     }
 
+    // ──────────────── Cross-region isolation ────────────────
+
+    private static final String AUTH_EU_WEST_1 =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/eu-west-1/ses/aws4_request";
+
+    @Test
+    @Order(20)
+    void crossRegionIsolation_templateNotVisibleInOtherRegion() {
+        // Create template in eu-west-1
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_EU_WEST_1)
+            .body("""
+                {
+                  "TemplateName": "region-test",
+                  "TemplateContent": {
+                    "Subject": "Regional",
+                    "Text": "Hello from eu-west-1"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+
+        // Verify it exists in eu-west-1
+        given()
+            .header("Authorization", AUTH_EU_WEST_1)
+        .when()
+            .get("/v2/email/templates/region-test")
+        .then()
+            .statusCode(200)
+            .body("TemplateName", equalTo("region-test"));
+
+        // Verify it does NOT exist in us-east-1
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/region-test")
+        .then()
+            .statusCode(404);
+
+        // Clean up
+        given()
+            .header("Authorization", AUTH_EU_WEST_1)
+        .when()
+            .delete("/v2/email/templates/region-test")
+        .then()
+            .statusCode(200);
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
@@ -1,0 +1,497 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for SES V2 email template CRUD and templated send
+ * via the REST JSON protocol at /v2/email/templates.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTemplateV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "v2-welcome",
+                  "TemplateContent": {
+                    "Subject": "Hello {{name}}",
+                    "Text": "Hi {{name}}!",
+                    "Html": "<p>Hi <b>{{name}}</b>!</p>"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void createTemplate_duplicateRejected() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "v2-welcome",
+                  "TemplateContent": {"Subject": "dup", "Text": "dup"}
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"));
+    }
+
+    @Test
+    @Order(3)
+    void createTemplate_missingName() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateContent": {"Subject": "x"}}
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(4)
+    void getTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/v2-welcome")
+        .then()
+            .statusCode(200)
+            .body("TemplateName", equalTo("v2-welcome"))
+            .body("TemplateContent.Subject", equalTo("Hello {{name}}"))
+            .body("TemplateContent.Text", equalTo("Hi {{name}}!"))
+            .body("TemplateContent.Html", containsString("{{name}}"));
+    }
+
+    @Test
+    @Order(5)
+    void getTemplate_notFound() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/does-not-exist")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(6)
+    void updateTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateContent": {
+                    "Subject": "Welcome {{name}}!",
+                    "Text": "Hello {{name}}, from {{team}}",
+                    "Html": "<p>Welcome {{name}}</p>"
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/templates/v2-welcome")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/v2-welcome")
+        .then()
+            .statusCode(200)
+            .body("TemplateContent.Subject", equalTo("Welcome {{name}}!"))
+            .body("TemplateContent.Text", containsString("{{team}}"));
+    }
+
+    @Test
+    @Order(7)
+    void updateTemplate_notFound() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateContent": {"Subject": "x"}}
+                """)
+        .when()
+            .put("/v2/email/templates/ghost")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(8)
+    void listTemplates_includesCreated() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates")
+        .then()
+            .statusCode(200)
+            .body("TemplatesMetadata", notNullValue())
+            .body("TemplatesMetadata.TemplateName", hasItem("v2-welcome"));
+    }
+
+    @Test
+    @Order(9)
+    void sendEmail_withTemplate_substitutesVariables() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "sender@example.com"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        String messageId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateName": "v2-welcome",
+                      "TemplateData": "{\\"name\\":\\"Alice\\",\\"team\\":\\"floci\\"}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200)
+            .body("MessageId", notNullValue())
+            .extract().path("MessageId");
+
+        given()
+            .queryParam("id", messageId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Welcome Alice!"))
+            .body("messages[0].Body.text_part", equalTo("Hello Alice, from floci"))
+            .body("messages[0].Body.html_part", equalTo("<p>Welcome Alice</p>"));
+    }
+
+    @Test
+    @Order(10)
+    void sendEmail_withUnknownTemplate_returns404() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateName": "ghost",
+                      "TemplateData": "{}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(11)
+    void sendEmail_withTemplate_missingName_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {"Template": {"TemplateData": "{}"}}
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(12)
+    void deleteTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/templates/v2-welcome")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/v2-welcome")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(13)
+    void deleteTemplate_notFound() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/templates/already-gone")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(14)
+    void createTemplate_rejectsLeadingTrailingWhitespace() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": " padded ",
+                  "TemplateContent": {"Subject": "s", "Text": "t"}
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(15)
+    void sendEmail_withInlineTemplate_substitutesVariables() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "inline-sender@example.com"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        String messageId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline-sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateContent": {
+                        "Subject": "Inline {{name}}",
+                        "Text": "Hello inline {{name}} on {{team}}",
+                        "Html": "<p>Hello inline <b>{{name}}</b></p>"
+                      },
+                      "TemplateData": "{\\"name\\":\\"Alice\\",\\"team\\":\\"floci\\"}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200)
+            .body("MessageId", notNullValue())
+            .extract().path("MessageId");
+
+        given()
+            .queryParam("id", messageId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Inline Alice"))
+            .body("messages[0].Body.text_part", equalTo("Hello inline Alice on floci"))
+            .body("messages[0].Body.html_part", equalTo("<p>Hello inline <b>Alice</b></p>"));
+    }
+
+    @Test
+    @Order(16)
+    void sendEmail_templateWithBothNameAndContent_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline-sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateName": "anything",
+                      "TemplateContent": {"Subject": "s", "Text": "t"},
+                      "TemplateData": "{}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(17)
+    void sendEmail_withTemplateArn_resolvesStoredTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "arn-welcome",
+                  "TemplateContent": {
+                    "Subject": "Hi {{name}}",
+                    "Text": "Hello {{name}}"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+
+        String messageId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline-sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateArn": "arn:aws:ses:us-east-1:000000000000:template/arn-welcome",
+                      "TemplateData": "{\\"name\\":\\"Alice\\"}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200)
+            .body("MessageId", notNullValue())
+            .extract().path("MessageId");
+
+        given()
+            .queryParam("id", messageId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Hi Alice"))
+            .body("messages[0].Body.text_part", equalTo("Hello Alice"));
+    }
+
+    @Test
+    @Order(18)
+    void sendEmail_templateWithMalformedArn_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline-sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateArn": "not-an-arn",
+                      "TemplateData": "{}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(19)
+    void sendEmail_templateWithNameAndArn_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline-sender@example.com",
+                  "Destination": {"ToAddresses": ["recipient@example.com"]},
+                  "Content": {
+                    "Template": {
+                      "TemplateName": "arn-welcome",
+                      "TemplateArn": "arn:aws:ses:us-east-1:000000000000:template/arn-welcome",
+                      "TemplateData": "{}"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -260,7 +260,6 @@ class SesV2IntegrationTest {
     @Test
     @Order(13)
     void sendEmail_template() {
-        // Re-create an identity for template test
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
@@ -269,6 +268,23 @@ class SesV2IntegrationTest {
                 """)
         .when()
             .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "TemplateName": "MyTemplate",
+                    "TemplateContent": {
+                        "Subject": "Hello {{name}}",
+                        "Text": "Hi {{name}}!"
+                    }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
         .then()
             .statusCode(200);
 


### PR DESCRIPTION
## Summary

- Implement Email Template CRUD for both SES V2 (REST JSON at `/v2/email/templates`) and V1 (Query: `CreateTemplate` / `GetTemplate` / `UpdateTemplate` / `DeleteTemplate` / `ListTemplates`).
- Resolve `Content.Template` on V2 `SendEmail` (previously a stub) and support V1 `SendTemplatedEmail`, with Mustache-style `{{var}}` substitution applied to subject / text / html parts using the caller's `TemplateData` JSON.
- Accept all three AWS template selectors: `TemplateName`, `TemplateArn`, and (V2 only) `TemplateContent` for inline sends. `TemplateArn` is resolved by extracting the name from the `template/<name>` segment (region/account not validated, matching how KMS and Secrets Manager handle ARNs in Floci).
- Region-scoped persistence via a new `templateStore` on `SesService`, wired through `StorageFactory` (new file `ses-templates.json`).
- Service layer throws V1-style codes (`TemplateDoesNotExist` / `AlreadyExists` / `InvalidTemplate` / `InvalidParameterValue`); `SesController` remaps to `NotFoundException` (404) / `AlreadyExistsException` (400) / `BadRequestException` (400) for V2.
- Out of scope: `SendBulkTemplatedEmail`, `CreateCustomVerificationEmailTemplate`, `TestRenderTemplate`, and pagination (`NextToken`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified against real AWS SDK clients:
- **boto3** 1.37.1 — `ses` (V1) and `sesv2` (V2) clients (`compatibility-tests/sdk-test-python/tests/test_ses_templates.py`)
- **AWS Java SDK v2** 2.42.24 — `SesClient` and `SesV2Client` (`compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java`)
- Native image (`Dockerfile.native` / Mandrel) verified locally — both Python and Java compat suites pass against the native binary

## Checklist

- [x] `./mvnw test` passes locally (full `Ses*` suite green)
- [x] New or updated integration test added (V1 + V2 REST, plus SDK compat for boto3 and Java SDK v2)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)