### PR TITLE
feat(cognito): add TagResource, UntagResource, ListTagsForResource for user pools

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/cognito.bats
+++ b/compatibility-tests/sdk-test-awscli/test/cognito.bats
@@ -187,3 +187,45 @@ teardown() {
     assert_failure
     [[ "$output" == *"ResourceConflictException"* ]]
 }
+
+@test "Cognito: tag-resource list-tags-for-resource and untag-resource manage user pool tags" {
+    out=$(aws_cmd cognito-idp create-user-pool --pool-name "bats-test-pool-$(unique_name)")
+    POOL_ID=$(json_get "$out" '.UserPool.Id')
+    RESOURCE_ARN=$(json_get "$out" '.UserPool.Arn')
+
+    run aws_cmd cognito-idp tag-resource \
+        --resource-arn "$RESOURCE_ARN" \
+        --tags env=test,team=platform
+    assert_success
+
+    run aws_cmd cognito-idp list-tags-for-resource --resource-arn "$RESOURCE_ARN"
+    assert_success
+    env_value=$(json_get "$output" '.Tags.env')
+    [ "$env_value" = "test" ]
+    team_value=$(json_get "$output" '.Tags.team')
+    [ "$team_value" = "platform" ]
+
+    run aws_cmd cognito-idp untag-resource \
+        --resource-arn "$RESOURCE_ARN" \
+        --tag-keys team
+    assert_success
+
+    run aws_cmd cognito-idp list-tags-for-resource --resource-arn "$RESOURCE_ARN"
+    assert_success
+    env_value=$(json_get "$output" '.Tags.env')
+    [ "$env_value" = "test" ]
+    has_team=$(echo "$output" | jq '.Tags | has("team")')
+    [ "$has_team" = "false" ]
+}
+
+@test "Cognito: standalone tag-resource rejects reserved floci tags" {
+    out=$(aws_cmd cognito-idp create-user-pool --pool-name "bats-test-pool-$(unique_name)")
+    POOL_ID=$(json_get "$out" '.UserPool.Id')
+    RESOURCE_ARN=$(json_get "$out" '.UserPool.Arn')
+
+    run aws_cmd cognito-idp tag-resource \
+        --resource-arn "$RESOURCE_ARN" \
+        --tags floci:override-id=late-id
+    assert_failure
+    [[ "$output" == *"ValidationException"* ]]
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoFeaturesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoFeaturesTest.java
@@ -48,6 +48,7 @@ class CognitoFeaturesTest {
     private static CognitoIdentityProviderClient cognito;
 
     private static String poolId;
+    private static String poolArn;
     private static String clientId;
     private static final String USERNAME = "compat-user-" + UUID.randomUUID() + "@example.com";
     private static final String PASSWORD = "CompatPass1!";
@@ -76,11 +77,37 @@ class CognitoFeaturesTest {
     void createPool() {
         CreateUserPoolResponse resp = cognito.createUserPool(b -> b.poolName("compat-test-pool"));
         poolId = resp.userPool().id();
+        poolArn = resp.userPool().arn();
         assertThat(poolId).isNotBlank();
+        assertThat(poolArn).isNotBlank();
     }
 
     @Test
     @Order(2)
+    void tagListAndUntagResourceRoundTrip() {
+        cognito.tagResource(b -> b.resourceArn(poolArn).tags(Map.of("env", "test", "team", "platform")));
+
+        ListTagsForResourceResponse tagged = cognito.listTagsForResource(b -> b.resourceArn(poolArn));
+        assertThat(tagged.tags()).containsEntry("env", "test").containsEntry("team", "platform");
+
+        cognito.untagResource(b -> b.resourceArn(poolArn).tagKeys("team"));
+
+        ListTagsForResourceResponse untagged = cognito.listTagsForResource(b -> b.resourceArn(poolArn));
+        assertThat(untagged.tags()).containsEntry("env", "test").doesNotContainKey("team");
+    }
+
+    @Test
+    @Order(3)
+    void tagResourceRejectsReservedKey() {
+        assertThatThrownBy(() -> cognito.tagResource(b -> b
+                .resourceArn(poolArn)
+                .tags(Map.of("floci:override-id", "late-id"))))
+                .isInstanceOf(CognitoIdentityProviderException.class)
+                .hasMessageContaining("Reserved tag keys with prefix floci:");
+    }
+
+    @Test
+    @Order(4)
     void createClient() {
         CreateUserPoolClientResponse resp = cognito.createUserPoolClient(b -> b
                 .userPoolId(poolId)
@@ -93,7 +120,7 @@ class CognitoFeaturesTest {
     }
 
     @Test
-    @Order(3)
+    @Order(5)
     void createUserWithPermPassword() {
         cognito.adminCreateUser(b -> b
                 .userPoolId(poolId)

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -7,11 +7,14 @@ Floci serves pool-specific discovery and JWKS endpoints, plus a relaxed OAuth to
 
 `CreateUserPool` accepts a reserved user-pool tag, `floci:override-id`, to pin the resulting `UserPool.Id` at creation time. Floci strips reserved `floci:*` tags from stored and returned `UserPoolTags` on both create and update paths, so the tag namespace acts as an input-only control channel and is never persisted as user-visible metadata.
 
+Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` and `UntagResource` operate on the persisted user-pool tag map.
+
 ## Supported Actions
 
 | Category | Actions |
 |---|---|
-| **User Pools** | CreateUserPool, DescribeUserPool, ListUserPools, DeleteUserPool |
+| **User Pools** | CreateUserPool, DescribeUserPool, ListUserPools, UpdateUserPool, DeleteUserPool |
+| **User Pool Tags** | TagResource, UntagResource, ListTagsForResource |
 | **User Pool Clients** | CreateUserPoolClient, DescribeUserPoolClient, ListUserPoolClients, DeleteUserPoolClient |
 | **Resource Servers** | CreateResourceServer, DescribeResourceServer, ListResourceServers, DeleteResourceServer |
 | **Admin User Management** | AdminCreateUser, AdminGetUser, AdminDeleteUser, AdminSetUserPassword, AdminUpdateUserAttributes |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -21,7 +21,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 21 |
 | [IAM](iam.md) | `POST /` with `Action=` param | Query | 68 |
 | [STS](sts.md) | `POST /` with `Action=` param | Query | 7 |
-| [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 40 |
+| [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 43 |
 | [KMS](kms.md) | `POST /` + `X-Amz-Target: TrentService.*` | JSON 1.1 | 23 |
 | [Kinesis](kinesis.md) | `POST /` + `X-Amz-Target: Kinesis_20131202.*` | JSON 1.1 | 24 |
 | [Secrets Manager](secrets-manager.md) | `POST /` + `X-Amz-Target: secretsmanager.*` | JSON 1.1 | 16 |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -266,7 +266,8 @@ public class AwsQueryController {
             "InitiateAuth", "AdminInitiateAuth", "RespondToAuthChallenge",
             "SignUp", "ConfirmSignUp", "ChangePassword", "ForgotPassword",
             "ConfirmForgotPassword", "GetUser", "UpdateUserAttributes",
-            "CreateUserPool", "DescribeUserPool", "ListUserPools", "DeleteUserPool",
+            "CreateUserPool", "DescribeUserPool", "ListUserPools", "UpdateUserPool", "DeleteUserPool",
+            "TagResource", "UntagResource", "ListTagsForResource",
             "CreateUserPoolClient", "DescribeUserPoolClient", "ListUserPoolClients", "DeleteUserPoolClient",
             "CreateGroup", "GetGroup", "ListGroups", "DeleteGroup",
             "AdminAddUserToGroup", "AdminRemoveUserFromGroup", "AdminListGroupsForUser"

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -38,6 +38,9 @@ public class CognitoJsonHandler {
             case "DescribeUserPool" -> handleDescribeUserPool(request);
             case "ListUserPools" -> handleListUserPools(request);
             case "UpdateUserPool" -> handleUpdateUserPool(request, region);
+            case "TagResource" -> handleTagResource(request);
+            case "UntagResource" -> handleUntagResource(request);
+            case "ListTagsForResource" -> handleListTagsForResource(request);
             case "GetUserPoolMfaConfig" -> handleGetUserPoolMfaConfig(request);
             case "DeleteUserPool" -> handleDeleteUserPool(request);
             case "CreateUserPoolClient" -> handleCreateUserPoolClient(request);
@@ -116,6 +119,24 @@ public class CognitoJsonHandler {
         UserPool pool = service.updateUserPool(reqMap, region);
         ObjectNode response = objectMapper.createObjectNode();
         response.set("UserPool", userPoolToFullNode(pool));
+        return Response.ok(response).build();
+    }
+
+    private Response handleTagResource(JsonNode request) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = objectMapper.convertValue(request.path("Tags"), Map.class);
+        service.tagResource(request.path("ResourceArn").asText(), tags);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleUntagResource(JsonNode request) {
+        service.untagResource(request.path("ResourceArn").asText(), readStringList(request.path("TagKeys")));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleListTagsForResource(JsonNode request) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("Tags", objectMapper.valueToTree(service.listTagsForResource(request.path("ResourceArn").asText())));
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -150,6 +150,61 @@ public class CognitoService {
         return poolStore.scan(k -> true);
     }
 
+    private UserPool describeUserPoolByArn(String resourceArn) {
+        String poolId = extractUserPoolIdFromArn(resourceArn);
+        return describeUserPool(poolId);
+    }
+
+    public void tagResource(String resourceArn, Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            throw new AwsException("InvalidParameterException", "Tags are required", 400);
+        }
+        ReservedTags.rejectReservedTagsOnUpdate(tags);
+        UserPool pool = describeUserPoolByArn(resourceArn);
+        synchronized (pool) {
+            pool.setUserPoolTags(mergeUserPoolTags(pool.getUserPoolTags(), tags));
+            pool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+            poolStore.put(pool.getId(), pool);
+        }
+    }
+
+    public void untagResource(String resourceArn, List<String> tagKeys) {
+        if (tagKeys == null || tagKeys.isEmpty()) {
+            throw new AwsException("InvalidParameterException", "TagKeys are required", 400);
+        }
+        UserPool pool = describeUserPoolByArn(resourceArn);
+        synchronized (pool) {
+            pool.setUserPoolTags(removeUserPoolTags(pool.getUserPoolTags(), tagKeys));
+            pool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+            poolStore.put(pool.getId(), pool);
+        }
+    }
+
+    public Map<String, String> listTagsForResource(String resourceArn) {
+        UserPool pool = describeUserPoolByArn(resourceArn);
+        return new HashMap<>(pool.getUserPoolTags() != null ? pool.getUserPoolTags() : Map.of());
+    }
+
+    private static String extractUserPoolIdFromArn(String resourceArn) {
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw new AwsException("InvalidParameterException", "ResourceArn is required", 400);
+        }
+        // arn:aws:cognito-idp:<region>:<account>:userpool/<pool-id>
+        String[] parts = resourceArn.split(":", 6);
+        if (parts.length < 6 || !"cognito-idp".equals(parts[2])) {
+            throw new AwsException("InvalidParameterException", "Invalid resource ARN: " + resourceArn, 400);
+        }
+        String resource = parts[5];
+        if (!resource.startsWith("userpool/")) {
+            throw new AwsException("InvalidParameterException", "Invalid resource ARN: " + resourceArn, 400);
+        }
+        String poolId = resource.substring("userpool/".length());
+        if (poolId.isBlank()) {
+            throw new AwsException("InvalidParameterException", "Invalid resource ARN: " + resourceArn, 400);
+        }
+        return poolId;
+    }
+
     public void deleteUserPool(String id) {
         String prefix = id + "::";
         groupStore.scan(k -> k.startsWith(prefix))
@@ -1461,6 +1516,18 @@ public class CognitoService {
     private String generateSecretValue() {
         return UUID.randomUUID().toString().replace("-", "")
                 + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private Map<String, String> mergeUserPoolTags(Map<String, String> existingTags, Map<String, String> tagsToAdd) {
+        Map<String, String> merged = new HashMap<>(existingTags != null ? existingTags : Map.of());
+        merged.putAll(tagsToAdd);
+        return merged;
+    }
+
+    private Map<String, String> removeUserPoolTags(Map<String, String> existingTags, List<String> tagKeys) {
+        Map<String, String> updated = new HashMap<>(existingTags != null ? existingTags : Map.of());
+        tagKeys.forEach(updated::remove);
+        return updated;
     }
 
     private String trimTrailingSlash(String value) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
@@ -150,5 +151,60 @@ class CognitoJsonHandlerTest {
         JsonNode describedPool = describeBody.get("UserPool");
         assertEquals("test", describedPool.get("UserPoolTags").get("env").asText());
         assertFalse(describedPool.get("UserPoolTags").has(ReservedTags.OVERRIDE_ID_KEY));
+    }
+
+    @Test
+    void tagListAndUntagResourceRoundTrip() {
+        ObjectNode createRequest = mapper.createObjectNode();
+        createRequest.put("PoolName", "tag-pool");
+        JsonNode createBody = (JsonNode) handler.handle("CreateUserPool", createRequest, "us-east-1").getEntity();
+        JsonNode createdPool = createBody.get("UserPool");
+        String resourceArn = createdPool.get("Arn").asText();
+
+        ObjectNode tagRequest = mapper.createObjectNode();
+        tagRequest.put("ResourceArn", resourceArn);
+        ObjectNode tags = tagRequest.putObject("Tags");
+        tags.put("env", "test");
+        tags.put("team", "platform");
+
+        Response tagResponse = handler.handle("TagResource", tagRequest, "us-east-1");
+        assertEquals(200, tagResponse.getStatus());
+
+        ObjectNode listRequest = mapper.createObjectNode();
+        listRequest.put("ResourceArn", resourceArn);
+        Response listResponse = handler.handle("ListTagsForResource", listRequest, "us-east-1");
+        assertEquals(200, listResponse.getStatus());
+        JsonNode listedTags = ((JsonNode) listResponse.getEntity()).get("Tags");
+        assertEquals("test", listedTags.get("env").asText());
+        assertEquals("platform", listedTags.get("team").asText());
+
+        ObjectNode untagRequest = mapper.createObjectNode();
+        untagRequest.put("ResourceArn", resourceArn);
+        untagRequest.putArray("TagKeys").add("team");
+
+        Response untagResponse = handler.handle("UntagResource", untagRequest, "us-east-1");
+        assertEquals(200, untagResponse.getStatus());
+
+        JsonNode afterUntag = ((JsonNode) handler.handle("ListTagsForResource", listRequest, "us-east-1").getEntity()).get("Tags");
+        assertEquals("test", afterUntag.get("env").asText());
+        assertFalse(afterUntag.has("team"));
+    }
+
+    @Test
+    void tagResourceRejectsReservedKey() {
+        ObjectNode createRequest = mapper.createObjectNode();
+        createRequest.put("PoolName", "tag-pool");
+        JsonNode createBody = (JsonNode) handler.handle("CreateUserPool", createRequest, "us-east-1").getEntity();
+        String resourceArn = createBody.get("UserPool").get("Arn").asText();
+
+        ObjectNode tagRequest = mapper.createObjectNode();
+        tagRequest.put("ResourceArn", resourceArn);
+        tagRequest.putObject("Tags").put(ReservedTags.OVERRIDE_ID_KEY, "late-id");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> handler.handle("TagResource", tagRequest, "us-east-1")
+        );
+        assertEquals("ValidationException", exception.getErrorCode());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -183,6 +183,90 @@ class CognitoServiceTest {
     }
 
     @Test
+    void tagResourceAddsAndOverwritesTags() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TaggedPool", "UserPoolTags", Map.of("env", "dev")),
+                "us-east-1"
+        );
+
+        service.tagResource(pool.getArn(), Map.of("team", "platform", "env", "test"));
+
+        assertEquals(Map.of("env", "test", "team", "platform"), service.listTagsForResource(pool.getArn()));
+    }
+
+    @Test
+    void tagResourceRejectsReservedKey() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TaggedPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.tagResource(pool.getArn(), Map.of(ReservedTags.OVERRIDE_ID_KEY, "late-id"))
+        );
+
+        assertEquals("ValidationException", exception.getErrorCode());
+    }
+
+    @Test
+    void tagResourceRejectsEmptyTags() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TaggedPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.tagResource(pool.getArn(), Map.of())
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void tagResourceWithUnknownArnThrowsNotFound() {
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.tagResource("arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_missing", Map.of("env", "test"))
+        );
+
+        assertEquals("ResourceNotFoundException", exception.getErrorCode());
+    }
+
+    @Test
+    void untagResourceRemovesRequestedKeysAndAllowsReservedRemoval() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TaggedPool", "UserPoolTags", Map.of("env", "test", "team", "platform")),
+                "us-east-1"
+        );
+
+        service.untagResource(pool.getArn(), List.of("team", ReservedTags.OVERRIDE_ID_KEY));
+
+        assertEquals(Map.of("env", "test"), service.listTagsForResource(pool.getArn()));
+    }
+
+    @Test
+    void listTagsForResourceReturnsCurrentTags() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TaggedPool", "UserPoolTags", Map.of("env", "test")),
+                "us-east-1"
+        );
+
+        assertEquals(Map.of("env", "test"), service.listTagsForResource(pool.getArn()));
+    }
+
+    @Test
+    void updateUserPoolAndTagResourceShareConsistentVisibleTagBehavior() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TaggedPool"), "us-east-1");
+
+        service.updateUserPool(
+                Map.of(
+                        "UserPoolId", pool.getId(),
+                        "UserPoolTags", Map.of(ReservedTags.OVERRIDE_ID_KEY, "late-id", "env", "test")
+                ),
+                "us-east-1"
+        );
+        service.tagResource(pool.getArn(), Map.of("team", "platform"));
+
+        assertEquals(Map.of("env", "test", "team", "platform"), service.listTagsForResource(pool.getArn()));
+    }
+
+    @Test
     void issuerUrlForPinnedPoolResolvesAsBaseUrlSlashPoolId() {
         UserPool pool = service.createUserPool(
                 Map.of("PoolName", "PinnedPool", "UserPoolTags", Map.of(ReservedTags.OVERRIDE_ID_KEY, "custompool")),


### PR DESCRIPTION
## Summary

- Add the three Cognito IDP tag APIs (`TagResource`, `UntagResource`, `ListTagsForResource`) for user pools, dispatched through `CognitoJsonHandler`.
- Resolve user pools by parsing the resource ARN directly (O(1) pool-store lookup, not a full scan). Malformed ARNs surface as `InvalidParameterException` instead of a swallowed `ResourceNotFoundException`.
- Reject reserved `floci:*` tag keys on standalone `TagResource` via `ReservedTags.rejectReservedTagsOnUpdate`, matching the existing strip-on-write behavior on `CreateUserPool` / `UpdateUserPool`.
- Reject missing / null `ResourceArn`, null or empty `Tags`, and null or empty `TagKeys` with `InvalidParameterException` at the service boundary.
- Synchronize tag mutations on the pool instance, matching the existing `ensureJwtSigningKeys` pattern.

## Notes

`UpdateUserPool` continues to silently strip reserved tags (needed for the existing `floci:override-id` control channel). Standalone `TagResource` rejects them, because there is no creation context to honor. The two behaviors are intentional and documented in `docs/services/cognito.md`.

Tag support is for user pools only. User pool client tagging was out of scope for this PR.

## Test plan

- [x] `./mvnw test -Dtest='CognitoServiceTest,CognitoJsonHandlerTest'`, 70/70 focused unit tests pass.
- [x] `FLOCI_ENDPOINT=http://localhost:4568 bats compatibility-tests/sdk-test-awscli/test/cognito.bats`, 13/13 pass, incl. two new `tag-resource`/`list-tags-for-resource`/`untag-resource` cases.
- [x] `FLOCI_ENDPOINT=http://localhost:4568 mvn -Dtest=CognitoFeaturesTest`, 20/20 pass, incl. round-trip and reserved-key rejection.