### PR TITLE
fix(dynamodb): accept full ARN for TableName across operations (#575)

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
+++ b/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
@@ -36,6 +36,23 @@ teardown() {
     [ "$name" = "$TABLE_NAME" ]
 }
 
+@test "DynamoDB: describe table by ARN" {
+    aws_cmd dynamodb create-table \
+        --table-name "$TABLE_NAME" \
+        --attribute-definitions AttributeName=pk,AttributeType=S \
+        --key-schema AttributeName=pk,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST >/dev/null
+
+    ddb_wait_table "$TABLE_NAME"
+
+    table_arn="arn:aws:dynamodb:${AWS_REGION:-us-east-1}:000000000000:table/$TABLE_NAME"
+
+    run aws_cmd dynamodb describe-table --table-name "$table_arn"
+    assert_success
+    name=$(json_get "$output" '.Table.TableName')
+    [ "$name" = "$TABLE_NAME" ]
+}
+
 @test "DynamoDB: list tables" {
     aws_cmd dynamodb create-table \
         --table-name "$TABLE_NAME" \

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -71,7 +71,7 @@ public class DynamoDbJsonHandler {
     }
 
     private Response handleCreateTable(JsonNode request, String region) {
-        String tableName = request.path("TableName").asText();
+        String tableName = DynamoDbTableNames.requireShortName(request.path("TableName").asText());
 
         List<KeySchemaElement> keySchema = new ArrayList<>();
         request.path("KeySchema").forEach(ks ->
@@ -523,12 +523,12 @@ public class DynamoDbJsonHandler {
             if (streamEnabled) {
                 String viewType = streamSpec.path("StreamViewType").asText("NEW_AND_OLD_IMAGES");
                 StreamDescription sd = dynamoDbStreamService.enableStream(
-                        tableName, table.getTableArn(), viewType, region);
+                        table.getTableName(), table.getTableArn(), viewType, region);
                 table.setStreamEnabled(true);
                 table.setStreamArn(sd.getStreamArn());
                 table.setStreamViewType(viewType);
             } else {
-                dynamoDbStreamService.disableStream(tableName, region);
+                dynamoDbStreamService.disableStream(table.getTableName(), region);
                 table.setStreamEnabled(false);
             }
         }
@@ -693,6 +693,7 @@ public class DynamoDbJsonHandler {
         String streamArn = request.path("StreamArn").asText();
 
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
+        String resolvedTableName = table.getTableName();
 
         String streamName = streamArn.substring(streamArn.lastIndexOf('/') + 1);
         try {
@@ -717,16 +718,16 @@ public class DynamoDbJsonHandler {
 
         if (!table.isStreamEnabled()) {
             StreamDescription sd = dynamoDbStreamService.enableStream(
-                    tableName, table.getTableArn(), "NEW_AND_OLD_IMAGES", region);
+                    resolvedTableName, table.getTableArn(), "NEW_AND_OLD_IMAGES", region);
             table.setStreamEnabled(true);
             table.setStreamArn(sd.getStreamArn());
             table.setStreamViewType("NEW_AND_OLD_IMAGES");
         }
 
-        dynamoDbService.persistTable(tableName, table, region);
+        dynamoDbService.persistTable(resolvedTableName, table, region);
 
         ObjectNode response = objectMapper.createObjectNode();
-        response.put("TableName", tableName);
+        response.put("TableName", resolvedTableName);
         response.put("StreamArn", streamArn);
         response.put("DestinationStatus", "ACTIVE");
         response.put("DestinationStatusDescription", "Kinesis streaming is enabled for this table");
@@ -738,6 +739,7 @@ public class DynamoDbJsonHandler {
         String streamArn = request.path("StreamArn").asText();
 
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
+        String resolvedTableName = table.getTableName();
 
         Optional<KinesisStreamingDestination> existing = table.findKinesisStreamingDestination(streamArn);
         if (existing.isEmpty()) {
@@ -752,10 +754,10 @@ public class DynamoDbJsonHandler {
 
         existing.get().setDestinationStatus("DISABLED");
         existing.get().setDestinationStatusDescription("Kinesis streaming is disabled for this table");
-        dynamoDbService.persistTable(tableName, table, region);
+        dynamoDbService.persistTable(resolvedTableName, table, region);
 
         ObjectNode response = objectMapper.createObjectNode();
-        response.put("TableName", tableName);
+        response.put("TableName", resolvedTableName);
         response.put("StreamArn", streamArn);
         response.put("DestinationStatus", "DISABLED");
         response.put("DestinationStatusDescription", "Kinesis streaming is disabled for this table");
@@ -767,7 +769,7 @@ public class DynamoDbJsonHandler {
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
 
         ObjectNode response = objectMapper.createObjectNode();
-        response.put("TableName", tableName);
+        response.put("TableName", table.getTableName());
 
         ArrayNode destinations = objectMapper.createArrayNode();
         for (KinesisStreamingDestination dest : table.getKinesisStreamingDestinations()) {
@@ -795,7 +797,7 @@ public class DynamoDbJsonHandler {
         double cu = isWrite ? Math.max(1.0, itemCount) : Math.max(0.5, itemCount * 0.5);
 
         ObjectNode cc = objectMapper.createObjectNode();
-        cc.put("TableName", tableName);
+        cc.put("TableName", DynamoDbTableNames.resolve(tableName));
         cc.put("CapacityUnits", cu);
 
         if ("INDEXES".equals(returnCC)) {
@@ -829,7 +831,7 @@ public class DynamoDbJsonHandler {
         ArrayNode ccArray = objectMapper.createArrayNode();
         for (String tableName : tableItems.keySet()) {
             ObjectNode cc = objectMapper.createObjectNode();
-            cc.put("TableName", tableName);
+            cc.put("TableName", DynamoDbTableNames.resolve(tableName));
             cc.put("CapacityUnits", isWrite ? 1.0 : 0.5);
             if ("INDEXES".equals(returnCC)) {
                 ObjectNode tableCap = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -130,6 +130,11 @@ public class DynamoDbService {
                                         List<GlobalSecondaryIndex> gsis,
                                         List<LocalSecondaryIndex> lsis,
                                         String region) {
+        // Enforce at the service boundary: CreateTable persists its input as the
+        // canonical table name and derives TableArn from it. An ARN-form input
+        // would produce ARN-on-ARN TableArn values. Handler-layer rejection alone
+        // would leave non-HTTP callers able to bypass the guard.
+        DynamoDbTableNames.requireShortName(tableName);
         String storageKey = regionKey(region, tableName);
         if (tableStore.get(storageKey).isPresent()) {
             throw new AwsException("ResourceInUseException",
@@ -174,9 +179,10 @@ public class DynamoDbService {
     }
 
     public TableDefinition describeTable(String tableName, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         // Update dynamic counts
         var items = itemsByTable.get(storageKey);
@@ -187,7 +193,8 @@ public class DynamoDbService {
     }
 
     public void persistTable(String tableName, TableDefinition table, String region) {
-        tableStore.put(regionKey(region, tableName), table);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        tableStore.put(regionKey(region, canonicalTableName), table);
     }
 
     public void deleteTable(String tableName) {
@@ -195,9 +202,10 @@ public class DynamoDbService {
     }
 
     public void deleteTable(String tableName, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         if (tableStore.get(storageKey).isEmpty()) {
-            throw resourceNotFoundException(tableName);
+            throw resourceNotFoundException(canonicalTableName);
         }
         tableStore.delete(storageKey);
         itemsByTable.remove(storageKey);
@@ -205,9 +213,9 @@ public class DynamoDbService {
             itemStore.delete(storageKey);
         }
         if (streamService != null) {
-            streamService.deleteStream(tableName, region);
+            streamService.deleteStream(canonicalTableName, region);
         }
-        LOG.infov("Deleted table: {0}", tableName);
+        LOG.infov("Deleted table: {0}", canonicalTableName);
     }
 
     public List<String> listTables() {
@@ -233,9 +241,10 @@ public class DynamoDbService {
                          String conditionExpression,
                          JsonNode exprAttrNames, JsonNode exprAttrValues,
                          String region, String returnValuesOnConditionCheckFailure) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, item);
         var tableItems = itemsByTable.computeIfAbsent(storageKey, k -> new ConcurrentSkipListMap<>());
@@ -248,11 +257,11 @@ public class DynamoDbService {
 
         tableItems.put(itemKey, item);
         persistItems(storageKey);
-        LOG.debugv("Put item in {0}: key={1}", tableName, itemKey);
+        LOG.debugv("Put item in {0}: key={1}", canonicalTableName, itemKey);
 
         String eventName = existing == null ? "INSERT" : "MODIFY";
         if (streamService != null) {
-            streamService.captureEvent(tableName, eventName, existing, item, table, region);
+            streamService.captureEvent(canonicalTableName, eventName, existing, item, table, region);
         }
         if (kinesisForwarder != null) {
             kinesisForwarder.forward(eventName, existing, item, table, region);
@@ -264,9 +273,10 @@ public class DynamoDbService {
     }
 
     public JsonNode getItem(String tableName, JsonNode key, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key);
         var items = itemsByTable.get(storageKey);
@@ -288,9 +298,10 @@ public class DynamoDbService {
                                 String conditionExpression,
                                 JsonNode exprAttrNames, JsonNode exprAttrValues,
                                 String region, String returnValuesOnConditionCheckFailure) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key);
         var items = itemsByTable.get(storageKey);
@@ -303,11 +314,11 @@ public class DynamoDbService {
 
         JsonNode removed = items.remove(itemKey);
         persistItems(storageKey);
-        LOG.debugv("Deleted item from {0}: key={1}", tableName, itemKey);
+        LOG.debugv("Deleted item from {0}: key={1}", canonicalTableName, itemKey);
 
         if (removed != null) {
             if (streamService != null) {
-                streamService.captureEvent(tableName, "REMOVE", removed, null, table, region);
+                streamService.captureEvent(canonicalTableName, "REMOVE", removed, null, table, region);
             }
             if (kinesisForwarder != null) {
                 kinesisForwarder.forward("REMOVE", removed, null, table, region);
@@ -338,9 +349,10 @@ public class DynamoDbService {
                                     JsonNode expressionAttrNames, JsonNode expressionAttrValues,
                                     String returnValues, String conditionExpression, String region, 
                                     String returnValuesOnConditionCheckFailure) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key);
         var items = itemsByTable.computeIfAbsent(storageKey, k -> new ConcurrentSkipListMap<>());
@@ -388,7 +400,7 @@ public class DynamoDbService {
         persistItems(storageKey);
 
         if (streamService != null) {
-            streamService.captureEvent(tableName, "MODIFY", existing, item, table, region);
+            streamService.captureEvent(canonicalTableName, "MODIFY", existing, item, table, region);
         }
         if (kinesisForwarder != null) {
             kinesisForwarder.forward("MODIFY", existing, item, table, region);
@@ -415,9 +427,10 @@ public class DynamoDbService {
                               JsonNode expressionAttrValues, String keyConditionExpression,
                               String filterExpression, Integer limit, Boolean scanIndexForward, String indexName,
                               JsonNode exclusiveStartKey, JsonNode exprAttrNames, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         var items = itemsByTable.get(storageKey);
         if (items == null) return new QueryResult(List.of(), 0, null);
@@ -547,9 +560,10 @@ public class DynamoDbService {
     public ScanResult scan(String tableName, String filterExpression,
                             JsonNode expressionAttrNames, JsonNode expressionAttrValues,
                             JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         var items = itemsByTable.get(storageKey);
         if (items == null) return new ScanResult(List.of(), 0, null);
@@ -610,7 +624,7 @@ public class DynamoDbService {
 
     public BatchWriteResult batchWriteItem(Map<String, List<JsonNode>> requestItems, String region) {
         for (Map.Entry<String, List<JsonNode>> entry : requestItems.entrySet()) {
-            String tableName = entry.getKey();
+            String tableName = canonicalTableName(region, entry.getKey());
             for (JsonNode writeRequest : entry.getValue()) {
                 if (writeRequest.has("PutRequest")) {
                     JsonNode item = writeRequest.get("PutRequest").get("Item");
@@ -629,7 +643,8 @@ public class DynamoDbService {
     public BatchGetResult batchGetItem(Map<String, JsonNode> requestItems, String region) {
         Map<String, List<JsonNode>> responses = new HashMap<>();
         for (Map.Entry<String, JsonNode> entry : requestItems.entrySet()) {
-            String tableName = entry.getKey();
+            String tableNameOrArn = entry.getKey();
+            String tableName = canonicalTableName(region, tableNameOrArn);
             JsonNode tableRequest = entry.getValue();
             JsonNode keys = tableRequest.get("Keys");
             List<JsonNode> tableItems = new ArrayList<>();
@@ -641,7 +656,7 @@ public class DynamoDbService {
                     }
                 }
             }
-            responses.put(tableName, tableItems);
+            responses.put(tableNameOrArn, tableItems);
         }
         return new BatchGetResult(responses, Map.of());
     }
@@ -717,13 +732,14 @@ public class DynamoDbService {
                 ? target.get("ReturnValuesOnConditionCheckFailure").asText() : null;
 
         String tableName = target.path("TableName").asText();
+        String canonicalTableName = canonicalTableName(region, tableName);
         JsonNode key = transactItem.has("Put") ? target.get("Item") : target.get("Key");
         JsonNode exprAttrNames = target.has("ExpressionAttributeNames") ? target.get("ExpressionAttributeNames") : null;
         JsonNode exprAttrValues = target.has("ExpressionAttributeValues") ? target.get("ExpressionAttributeValues") : null;
 
-        String storageKey = regionKey(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key);
         var tableItems = itemsByTable.get(storageKey);
@@ -761,9 +777,10 @@ public class DynamoDbService {
     public TableDefinition updateTable(String tableName, Long readCapacity, Long writeCapacity,
                                         List<GlobalSecondaryIndex> gsiCreates, List<String> gsiDeletes,
                                         List<AttributeDefinition> newAttrDefs, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         if (readCapacity != null) {
             table.getProvisionedThroughput().setReadCapacityUnits(readCapacity);
@@ -793,33 +810,35 @@ public class DynamoDbService {
         }
 
         tableStore.put(storageKey, table);
-        LOG.infov("Updated table: {0} in region {1}", tableName, region);
+        LOG.infov("Updated table: {0} in region {1}", canonicalTableName, region);
         return table;
     }
 
     // --- TTL ---
 
     public void updateTimeToLive(String tableName, String ttlAttributeName, boolean enabled, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
         table.setTtlAttributeName(ttlAttributeName);
         table.setTtlEnabled(enabled);
         tableStore.put(storageKey, table);
-        LOG.infov("Updated TTL for table {0}: enabled={1}, attr={2}", tableName, enabled, ttlAttributeName);
+        LOG.infov("Updated TTL for table {0}: enabled={1}, attr={2}", canonicalTableName, enabled, ttlAttributeName);
     }
 
     public TableDefinition updateContinuousBackups(String tableName, boolean enabled,
                                                    Integer recoveryPeriodInDays, String region) {
-        String storageKey = regionKey(region, tableName);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(tableName));
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
         table.setPointInTimeRecoveryEnabled(enabled);
         table.setPointInTimeRecoveryRecoveryPeriodInDays(
                 recoveryPeriodInDays != null ? recoveryPeriodInDays : table.getPointInTimeRecoveryRecoveryPeriodInDays());
         tableStore.put(storageKey, table);
         LOG.infov("Updated PITR for table {0}: enabled={1}, recoveryPeriodInDays={2}",
-                tableName, enabled, table.getPointInTimeRecoveryRecoveryPeriodInDays());
+                canonicalTableName, enabled, table.getPointInTimeRecoveryRecoveryPeriodInDays());
         return table;
     }
 
@@ -908,6 +927,10 @@ public class DynamoDbService {
                 .findFirst()
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Requested resource not found: " + arn, 400));
+    }
+
+    private String canonicalTableName(String region, String tableName) {
+        return DynamoDbTableNames.resolveWithRegion(tableName, region).name();
     }
 
     // --- Condition expression evaluation ---

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNames.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNames.java
@@ -1,0 +1,107 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.regex.Pattern;
+
+/**
+ * Resolves DynamoDB {@code TableName} inputs that may be either a short table
+ * name or a full table ARN.
+ */
+public final class DynamoDbTableNames {
+
+    private static final Pattern TABLE_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]{3,255}");
+    private static final Pattern ACCOUNT_PATTERN = Pattern.compile("\\d{12}");
+
+    private DynamoDbTableNames() {}
+
+    public record ResolvedTableRef(String name, String region) {}
+
+    public static String resolve(String input) {
+        return resolveInternal(input).name();
+    }
+
+    /**
+     * Validates a short table name. Rejects ARN-form input: callers (e.g. CreateTable)
+     * must persist a canonical short name, not an ARN that would produce ARN-on-ARN
+     * values when derived into {@code TableArn}.
+     */
+    public static String requireShortName(String input) {
+        if (input == null || input.isBlank()) {
+            throw invalid("TableName must not be blank");
+        }
+        if (input.startsWith("arn:")) {
+            throw invalid("TableName must be a short name, not an ARN: " + input);
+        }
+        validateTableName(input);
+        return input;
+    }
+
+    public static ResolvedTableRef resolveWithRegion(String input, String requestRegion) {
+        ResolvedTableRef ref = resolveInternal(input);
+        if (ref.region() != null && !ref.region().equals(requestRegion)) {
+            throw invalid("Region '" + ref.region() + "' in ARN does not match request region '" + requestRegion + "'");
+        }
+        return ref;
+    }
+
+    private static ResolvedTableRef resolveInternal(String input) {
+        if (input == null || input.isBlank()) {
+            throw invalid("TableName must not be blank");
+        }
+        if (input.startsWith("arn:")) {
+            return parseArn(input);
+        }
+        validateTableName(input);
+        return new ResolvedTableRef(input, null);
+    }
+
+    private static ResolvedTableRef parseArn(String input) {
+        String[] parts = input.split(":", 6);
+        if (parts.length != 6) {
+            throw invalid("Invalid table ARN: " + input);
+        }
+        if (!"arn".equals(parts[0]) || !"aws".equals(parts[1]) || !"dynamodb".equals(parts[2])) {
+            throw invalid("Invalid table ARN: " + input);
+        }
+        String region = parts[3];
+        String account = parts[4];
+        String resource = parts[5];
+        if (region.isBlank()) {
+            throw invalid("Table ARN missing region: " + input);
+        }
+        if (!ACCOUNT_PATTERN.matcher(account).matches()) {
+            throw invalid("Table ARN has invalid account id: " + input);
+        }
+        if (!resource.startsWith("table/")) {
+            throw invalid("Table ARN resource must start with 'table/': " + input);
+        }
+
+        String tableResource = resource.substring("table/".length());
+        int slash = tableResource.indexOf('/');
+        String tableName = slash >= 0 ? tableResource.substring(0, slash) : tableResource;
+        if (tableName.isEmpty()) {
+            throw invalid("Table ARN is missing table name: " + input);
+        }
+        if (slash >= 0) {
+            String suffix = tableResource.substring(slash + 1);
+            if (suffix.startsWith("index/") || suffix.startsWith("stream/")) {
+                throw invalid("TableName does not accept index or stream ARNs: " + input);
+            }
+            throw invalid("Invalid table ARN: " + input);
+        }
+
+        validateTableName(tableName);
+        return new ResolvedTableRef(tableName, region);
+    }
+
+    private static void validateTableName(String tableName) {
+        if (!TABLE_NAME_PATTERN.matcher(tableName).matches()) {
+            throw invalid("Invalid TableName: " + tableName);
+        }
+    }
+
+    private static AwsException invalid(String message) {
+        return new AwsException("InvalidParameterValue", message, 400);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -35,6 +35,10 @@ class DynamoDbServiceTest {
                 5L, 5L);
     }
 
+    private static String tableArn(String region, String tableName) {
+        return "arn:aws:dynamodb:" + region + ":000000000000:table/" + tableName;
+    }
+
     private TableDefinition createOrdersTable() {
         return service.createTable("Orders",
                 List.of(
@@ -84,9 +88,27 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void createTableRejectsArnInput() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.createTable("arn:aws:dynamodb:us-east-1:000000000000:table/Users",
+                        List.of(new KeySchemaElement("userId", "HASH")),
+                        List.of(new AttributeDefinition("userId", "S")),
+                        5L, 5L));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
     void describeTable() {
         createUsersTable();
         TableDefinition table = service.describeTable("Users");
+        assertEquals("Users", table.getTableName());
+    }
+
+    @Test
+    void describeTableAcceptsArn() {
+        createUsersTable();
+        TableDefinition table = service.describeTable(tableArn("us-east-1", "Users"));
         assertEquals("Users", table.getTableName());
     }
 
@@ -122,6 +144,67 @@ class DynamoDbServiceTest {
         JsonNode retrieved = service.getItem("Users", key);
         assertNotNull(retrieved);
         assertEquals("Alice", retrieved.get("name").get("S").asText());
+    }
+
+    @Test
+    void putAndGetItemAcceptArnTableName() {
+        createUsersTable();
+        ObjectNode userItem = item("userId", "user-1", "name", "Alice");
+        String usersArn = tableArn("us-east-1", "Users");
+
+        service.putItem(usersArn, userItem);
+
+        JsonNode retrieved = service.getItem(usersArn, item("userId", "user-1"));
+        assertNotNull(retrieved);
+        assertEquals("Alice", retrieved.get("name").get("S").asText());
+    }
+
+    @Test
+    void batchGetPreservesRequestKeyButResolvesArn() {
+        createUsersTable();
+        service.putItem("Users", item("userId", "user-1", "name", "Alice"));
+
+        ObjectNode request = mapper.createObjectNode();
+        request.set("Keys", mapper.createArrayNode().add(item("userId", "user-1")));
+        String usersArn = tableArn("us-east-1", "Users");
+
+        DynamoDbService.BatchGetResult result = service.batchGetItem(java.util.Map.of(usersArn, request), "us-east-1");
+
+        assertTrue(result.responses().containsKey(usersArn));
+        assertEquals("Alice", result.responses().get(usersArn).getFirst().get("name").get("S").asText());
+    }
+
+    @Test
+    void transactWriteConditionChecksAcceptArnTableName() {
+        createUsersTable();
+        service.putItem("Users", item("userId", "user-1", "name", "Alice"));
+        String usersArn = tableArn("us-east-1", "Users");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":name", attributeValue("S", "Alice"));
+
+        ObjectNode update = mapper.createObjectNode();
+        update.put("TableName", usersArn);
+        update.set("Key", item("userId", "user-1"));
+        update.put("ConditionExpression", "name = :name");
+        update.put("UpdateExpression", "SET email = :name");
+        update.set("ExpressionAttributeValues", exprValues);
+
+        ObjectNode transactItem = mapper.createObjectNode();
+        transactItem.set("Update", update);
+
+        assertDoesNotThrow(() -> service.transactWriteItems(List.of(transactItem), "us-east-1"));
+        assertEquals("Alice", service.getItem("Users", item("userId", "user-1")).get("email").get("S").asText());
+    }
+
+    @Test
+    void describeTableRejectsRegionMismatchArn() {
+        createUsersTable();
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.describeTable(tableArn("eu-west-1", "Users")));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
@@ -1,0 +1,460 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+@QuarkusTest
+class DynamoDbTableArnIntegrationTest {
+
+    private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String KINESIS_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void describeAndGetItemAcceptTableArn() {
+        String tableName = tableName("describe-get");
+        String tableArn = createTable(tableName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {
+                        "pk": {"S": "user-1"},
+                        "name": {"S": "Alice"}
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.TableName", equalTo(tableName))
+            .body("Table.TableArn", equalTo(tableArn));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "user-1"}}
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.name.S", equalTo("Alice"));
+    }
+
+    @Test
+    void batchAndTransactOperationsAcceptTableArn() {
+        String tableName = tableName("batch-transact");
+        String tableArn = createTable(tableName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [
+                            {"PutRequest": {"Item": {"pk": {"S": "user-1"}, "name": {"S": "Alice"}}}}
+                        ]
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchGetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": {
+                            "Keys": [{"pk": {"S": "user-1"}}]
+                        }
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Responses.'%s'".formatted(tableArn), hasSize(1))
+            .body("Responses.'%s'[0].name.S".formatted(tableArn), equalTo("Alice"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.TransactWriteItems")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TransactItems": [
+                        {
+                            "Update": {
+                                "TableName": "%s",
+                                "Key": {"pk": {"S": "user-1"}},
+                                "ConditionExpression": "name = :expected",
+                                "UpdateExpression": "SET email = :email",
+                                "ExpressionAttributeValues": {
+                                    ":expected": {"S": "Alice"},
+                                    ":email": {"S": "alice@example.com"}
+                                }
+                            }
+                        }
+                    ]
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.TransactGetItems")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TransactItems": [
+                        {
+                            "Get": {
+                                "TableName": "%s",
+                                "Key": {"pk": {"S": "user-1"}}
+                            }
+                        }
+                    ]
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Responses[0].Item.email.S", equalTo("alice@example.com"));
+    }
+
+    @Test
+    void ttlAndContinuousBackupsAcceptTableArn() {
+        String tableName = tableName("ttl-backups");
+        String tableArn = createTable(tableName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTimeToLive")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "TimeToLiveSpecification": {
+                        "AttributeName": "expiresAt",
+                        "Enabled": true
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TimeToLiveSpecification.AttributeName", equalTo("expiresAt"))
+            .body("TimeToLiveSpecification.Enabled", equalTo(true));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTimeToLive")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TimeToLiveDescription.TimeToLiveStatus", equalTo("ENABLED"))
+            .body("TimeToLiveDescription.AttributeName", equalTo("expiresAt"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "PointInTimeRecoverySpecification": {
+                        "PointInTimeRecoveryEnabled": true
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
+                    equalTo("ENABLED"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeContinuousBackups")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus",
+                    equalTo("ENABLED"));
+    }
+
+    @Test
+    void describeTableRejectsRegionMismatchAndIndexArn() {
+        String tableArn = createTable(tableName("invalid-arn"));
+
+        String mismatchedRegionArn = tableArn.replace(":us-east-1:", ":eu-west-1:");
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(mismatchedRegionArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValue"))
+            .body("message", containsString("does not match request region"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s/index/by-status"}
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValue"))
+            .body("message", containsString("does not accept index or stream ARNs"));
+    }
+
+    @Test
+    void kinesisStreamingDestinationAcceptsTableArn() {
+        String streamName = tableName("ddb-kinesis-stream");
+        String tableName = tableName("ddb-kinesis-table");
+        String tableArn = createTable(tableName);
+        String streamArn = createKinesisStream(streamName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.EnableKinesisStreamingDestination")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "StreamArn": "%s"
+                }
+                """.formatted(tableArn, streamArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableName", equalTo(tableName))
+            .body("StreamArn", equalTo(streamArn))
+            .body("DestinationStatus", equalTo("ACTIVE"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeKinesisStreamingDestination")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableName", equalTo(tableName))
+            .body("KinesisDataStreamDestinations", hasSize(1))
+            .body("KinesisDataStreamDestinations[0].StreamArn", equalTo(streamArn));
+    }
+
+    @Test
+    void consumedCapacityReturnsCanonicalTableName() {
+        String tableName = tableName("consumed-cap");
+        String tableArn = createTable(tableName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "user-1"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.TableName", equalTo(tableName));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [
+                            {"PutRequest": {"Item": {"pk": {"S": "user-2"}}}}
+                        ]
+                    },
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity[0].TableName", equalTo(tableName));
+    }
+
+    @Test
+    void createTableRejectsArnInput() {
+        String bogusArn = "arn:aws:dynamodb:us-east-1:000000000000:table/bogus-" + UUID.randomUUID().toString().substring(0, 8);
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(bogusArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValue"))
+            .body("message", containsString("must be a short name, not an ARN"));
+    }
+
+    @Test
+    void updateTableStreamToggleUsesCanonicalNameWhenCalledViaArn() {
+        String tableName = tableName("update-stream");
+        String tableArn = createTable(tableName);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "StreamSpecification": {
+                        "StreamEnabled": true,
+                        "StreamViewType": "NEW_AND_OLD_IMAGES"
+                    }
+                }
+                """.formatted(tableArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableName", equalTo(tableName))
+            .body("TableDescription.StreamSpecification.StreamEnabled", equalTo(true));
+
+        // Describe via short name must still see the stream state (i.e. state was
+        // keyed under the canonical name, not the ARN used on UpdateTable).
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.StreamSpecification.StreamEnabled", equalTo(true))
+            .body("Table.LatestStreamArn", containsString(":table/" + tableName + "/stream/"));
+    }
+
+    private static String createTable(String tableName) {
+        return given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getString("TableDescription.TableArn");
+    }
+
+    private static String createKinesisStream(String streamName) {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "%s", "ShardCount": 1}
+                """.formatted(streamName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        return given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "%s"}
+                """.formatted(streamName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract()
+            .jsonPath()
+            .getString("StreamDescriptionSummary.StreamARN");
+    }
+
+    private static String tableName(String prefix) {
+        return prefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNamesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNamesTest.java
@@ -1,0 +1,103 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DynamoDbTableNamesTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "Orders, Orders, ",
+            "orders_v2, orders_v2, ",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders, Orders, us-east-1",
+            "arn:aws:dynamodb:eu-west-1:123456789012:table/orders_v2, orders_v2, eu-west-1"
+    })
+    void resolveAcceptsShortNamesAndArns(String input, String expectedName, String expectedRegion) {
+        DynamoDbTableNames.ResolvedTableRef ref = DynamoDbTableNames.resolveWithRegion(
+                input,
+                expectedRegion == null || expectedRegion.isEmpty() ? "us-east-1" : expectedRegion
+        );
+
+        assertEquals(expectedName, ref.name());
+        assertEquals(emptyToNull(expectedRegion), ref.region());
+    }
+
+    @Test
+    void resolveReturnsCanonicalShortName() {
+        assertEquals("Orders",
+                DynamoDbTableNames.resolve("arn:aws:dynamodb:us-east-1:000000000000:table/Orders"));
+    }
+
+    @Test
+    void resolveWithRegionRejectsRegionMismatch() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                DynamoDbTableNames.resolveWithRegion(
+                        "arn:aws:dynamodb:eu-west-1:000000000000:table/Orders",
+                        "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            " ",
+            "ab",
+            "name with spaces",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/",
+            "arn:aws:dynamodb::000000000000:table/Orders",
+            "arn:aws:dynamodb:us-east-1:abc:table/Orders",
+            "arn:aws:dynamodb:us-east-1:000000000000:index/Orders",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders/index/by-status",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders/stream/2026-04-24T00:00:00.000",
+            "arn:aws:s3:us-east-1:000000000000:table/Orders",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders/extra"
+    })
+    void resolveRejectsMalformedInputs(String input) {
+        AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.resolve(input));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void resolveAcceptsShortNameWithoutRegion() {
+        DynamoDbTableNames.ResolvedTableRef ref = DynamoDbTableNames.resolveWithRegion("Orders", "us-east-1");
+        assertEquals("Orders", ref.name());
+        assertNull(ref.region());
+    }
+
+    @Test
+    void requireShortNameAcceptsValidShortName() {
+        assertEquals("Orders", DynamoDbTableNames.requireShortName("Orders"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders",
+            "arn:aws:dynamodb:us-east-1:000000000000:table/Orders/stream/2026-04-24T00:00:00.000"
+    })
+    void requireShortNameRejectsArnInput(String arn) {
+        AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.requireShortName(arn));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "ab", "name with spaces"})
+    void requireShortNameRejectsMalformedInput(String input) {
+        AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.requireShortName(input));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #575.

DynamoDB `TableName` inputs now accept both short names (e.g. `Orders`) and full table ARNs (e.g. `arn:aws:dynamodb:us-east-1:000000000000:table/Orders`) across all operations that target existing tables. This matches real AWS behaviour and unblocks OpenSearch Data Prepper's dynamodb source plugin (which requires `table_arn`) plus Terraform flows that feed `aws_dynamodb_table.x.arn` into the SDK.

Same pattern as #450 (Lambda `FunctionName` ARN).

## Changes

- **New `DynamoDbTableNames` resolver**:
  - `resolve(input)`  canonical short name from either input form.
  - `resolveWithRegion(input, region)`  same, with 400 `InvalidParameterValue` on region mismatch.
  - `requireShortName(input)`  strict short-name validation (rejects ARN forms).
  - Rejects malformed inputs loudly (missing `:table/` segment, empty name, bad account id) and explicitly rejects `/index/...` and `/stream/...` ARNs for `TableName` fields.
- **`DynamoDbService`**: canonicalises at every request-facing lookup boundary, including transaction condition paths and batch `RequestItems` map keys, so non-handler callers cannot bypass the resolver. `createTable()` also rejects ARN input at the service boundary so it can never be persisted as the canonical table identity.
- **`DynamoDbJsonHandler`**:
  - `CreateTable` rejects ARN input via `requireShortName`.
  - `UpdateTable` stream enable/disable now pass `table.getTableName()` so stream state is keyed under the canonical name when the caller used an ARN.
  - `ConsumedCapacity.TableName` response fields normalise to the canonical name (previously echoed the raw ARN).

## Ops covered

`DescribeTable`, `UpdateTable`, `DeleteTable`, `Scan`, `Query`, `GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `BatchGetItem`, `BatchWriteItem`, `TransactGetItems`, `TransactWriteItems`, `DescribeTimeToLive`, `UpdateTimeToLive`, `DescribeContinuousBackups`, `UpdateContinuousBackups`, `EnableKinesisStreamingDestination`, `DisableKinesisStreamingDestination`, `DescribeKinesisStreamingDestination`.

## Out of scope

- **`CreateTable` accepting ARN input**: intentionally rejected. `CreateTable` persists the input as the canonical table name and derives `TableArn` from it; accepting ARN form there would produce ARN-on-ARN `TableArn` values.
- **GSI/LSI `IndexName` ARN forms**: not handled. If a `TableName` field contains a DynamoDB ARN with `/index/...` or `/stream/...`, the resolver rejects it with a descriptive error rather than silently stripping.
- **Cross-region ARNs**: ARN region mismatching the request region returns 400 `InvalidParameterValue` (matches the #450 Lambda ARN decision).
- **`StreamArn` surfaces** (`DynamoDBStreams`): different code path, out of scope.

## Test plan

- [x] `DynamoDbTableNamesTest` (29 cases): accept short/ARN, reject malformed/index/stream/region-mismatch, `requireShortName` ARN rejection.
- [x] `DynamoDbServiceTest`: service-layer `createTable` ARN rejection.
- [x] `DynamoDbTableArnIntegrationTest` (8 cases): describe, put/get, batch get/write, transact write/get, TTL, continuous backups, Kinesis streaming destination, region-mismatch rejection, index-ARN rejection, `CreateTable` rejection, `UpdateTable` stream toggle canonicalisation, `ConsumedCapacity` canonicalisation.
- [x] awscli compat: `describe-table --table-name <arn>`.
- [x] Full `DynamoDb*` suite: 211 green.