### PR TITLE
fix(apigateway): propagate TOKEN authorizer context to AWS_PROXY Lambda

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.apigatewayv2.model.Route;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -44,6 +45,7 @@ import java.util.regex.Pattern;
 public class ApiGatewayExecuteController {
 
     private static final Logger LOG = Logger.getLogger(ApiGatewayExecuteController.class);
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
 
     private final ApiGatewayService apiGatewayService;
     private final ApiGatewayV2Service apiGatewayV2Service;
@@ -66,6 +68,8 @@ public class ApiGatewayExecuteController {
         this.vtlEngine = vtlEngine;
         this.serviceRouter = serviceRouter;
     }
+
+    private record AuthorizerResult(Response errorResponse, String principalId, Map<String, Object> context) {}
 
     @GET
     @Path("/{proxy: .*}")
@@ -163,8 +167,8 @@ public class ApiGatewayExecuteController {
         }
 
         // 1. Authorizer
-        Response authResponse = invokeAuthorizer(region, apiId, method, headers, uriInfo);
-        if (authResponse != null) return authResponse;
+        AuthorizerResult authorizerResult = invokeAuthorizer(region, apiId, stageName, httpMethod, path, method, headers, uriInfo);
+        if (authorizerResult.errorResponse() != null) return authorizerResult.errorResponse();
 
         // 2. Request validation
         Response validationResponse = validateRequest(region, apiId, method, headers, uriInfo, body);
@@ -182,7 +186,7 @@ public class ApiGatewayExecuteController {
 
         return switch (integration.getType().toUpperCase()) {
             case "AWS_PROXY" -> invokeProxy(region, httpMethod, path, proxy, stageName,
-                    matched, integration, headers, uriInfo, body);
+                    matched, integration, headers, uriInfo, body, authorizerResult);
             case "AWS" -> invokeAwsIntegration(region, httpMethod, path, proxy, stageName,
                     matched, integration, headers, uriInfo, body);
             case "MOCK" -> invokeMock(region, httpMethod, path, stageName, matched, integration, headers, uriInfo, body);
@@ -197,7 +201,8 @@ public class ApiGatewayExecuteController {
     private Response invokeProxy(String region, String httpMethod, String path, String proxy,
                                  String stageName, ApiGatewayResource resource,
                                  Integration integration, HttpHeaders headers,
-                                 UriInfo uriInfo, byte[] body) {
+                                 UriInfo uriInfo, byte[] body,
+                                 AuthorizerResult authorizerResult) {
         String functionName = functionNameFromUri(integration.getUri());
         if (functionName == null) {
             return Response.status(500)
@@ -207,7 +212,8 @@ public class ApiGatewayExecuteController {
 
         String requestId = UUID.randomUUID().toString();
         String eventJson = buildProxyEvent(httpMethod, path, proxy, resource.getPath(),
-                stageName, headers, uriInfo, body, requestId);
+                stageName, headers, uriInfo, body, requestId,
+                authorizerResult.principalId(), authorizerResult.context());
 
         try {
             InvokeResult result = lambdaService.invoke(region, functionName, eventJson.getBytes(),
@@ -223,38 +229,45 @@ public class ApiGatewayExecuteController {
         }
     }
 
-    private Response invokeAuthorizer(String region, String apiId, MethodConfig method,
-                                      HttpHeaders headers, UriInfo uriInfo) {
+    private AuthorizerResult invokeAuthorizer(String region, String apiId, String stageName,
+                                              String httpMethod, String requestPath, MethodConfig method,
+                                              HttpHeaders headers, UriInfo uriInfo) {
         if ("CUSTOM".equals(method.getAuthorizationType())) {
             String authorizerId = method.getAuthorizerId();
             if (authorizerId == null) {
-                return null;
+                return new AuthorizerResult(null, null, null);
             }
 
             io.github.hectorvent.floci.services.apigateway.model.Authorizer auth = apiGatewayService.getAuthorizer(region, apiId, authorizerId);
             String lambdaName = functionNameFromUri(auth.getAuthorizerUri());
             if (lambdaName == null) {
-                return null;
+                return new AuthorizerResult(null, null, null);
             }
 
-            String event = toAuthorizerEvent(auth, headers);
+            String event = toAuthorizerEvent(auth, headers, region, apiId, stageName, httpMethod, requestPath);
             try {
                 InvokeResult result = lambdaService.invoke(region, lambdaName, event.getBytes(), InvocationType.RequestResponse);
                 if (result.getFunctionError() != null) {
-                    return Response.status(403).build();
+                    return new AuthorizerResult(Response.status(403).build(), null, null);
                 }
                 
                 JsonNode policy = objectMapper.readTree(result.getPayload());
                 String effect = policy.path("policyDocument").path("Statement").get(0).path("Effect").asText("Deny");
                 if ("Deny".equalsIgnoreCase(effect)) {
-                    return Response.status(403).entity(jsonMessage("User is not authorized to access this resource")).build();
+                    return new AuthorizerResult(
+                            Response.status(403).entity(jsonMessage("User is not authorized to access this resource")).build(),
+                            null,
+                            null);
                 }
+                String principalId = policy.path("principalId").asText(null);
+                Map<String, Object> context = extractAuthorizerContext(policy.path("context"));
+                return new AuthorizerResult(null, principalId, context);
             } catch (Exception e) {
                 LOG.warnv("Authorizer failure: {0}", e.getMessage());
-                return Response.status(500).build();
+                return new AuthorizerResult(Response.status(500).build(), null, null);
             }
         }
-        return null;
+        return new AuthorizerResult(null, null, null);
     }
 
     private Response validateRequest(String region, String apiId, MethodConfig method,
@@ -348,16 +361,32 @@ public class ApiGatewayExecuteController {
         return null;
     }
 
-    private String toAuthorizerEvent(io.github.hectorvent.floci.services.apigateway.model.Authorizer auth, HttpHeaders headers) {
+    private Map<String, Object> extractAuthorizerContext(JsonNode contextNode) {
+        if (contextNode == null || contextNode.isMissingNode() || contextNode.isNull() || !contextNode.isObject()) {
+            return null;
+        }
+        return objectMapper.convertValue(contextNode, MAP_TYPE);
+    }
+
+    private String toAuthorizerEvent(io.github.hectorvent.floci.services.apigateway.model.Authorizer auth,
+                                     HttpHeaders headers, String region, String apiId, String stageName,
+                                     String httpMethod, String requestPath) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("type", auth.getType());
-        node.put("methodArn", "arn:aws:execute-api:" + regionResolver.getDefaultRegion()
-                + ":" + regionResolver.getAccountId() + ":api/stage/METHOD/path");
+        node.put("methodArn", buildMethodArn(region, apiId, stageName, httpMethod, requestPath));
         if ("TOKEN".equals(auth.getType())) {
             String headerName = auth.getIdentitySource().replace("method.request.header.", "");
             node.put("authorizationToken", headers.getHeaderString(headerName));
         }
         return node.toString();
+    }
+
+    private String buildMethodArn(String region, String apiId, String stageName, String httpMethod, String requestPath) {
+        String normalizedPath = requestPath == null ? "" : requestPath.replaceFirst("^/", "");
+        String arnRegion = region == null ? regionResolver.getDefaultRegion() : region;
+        return "arn:aws:execute-api:" + arnRegion
+                + ":" + regionResolver.getAccountId()
+                + ":" + apiId + "/" + stageName + "/" + httpMethod + "/" + normalizedPath;
     }
 
     /**
@@ -391,7 +420,8 @@ public class ApiGatewayExecuteController {
     private String buildProxyEvent(String httpMethod, String path, String proxy,
                                    String resourcePath, String stageName,
                                    HttpHeaders headers, UriInfo uriInfo,
-                                   byte[] body, String requestId) {
+                                   byte[] body, String requestId,
+                                   String principalId, Map<String, Object> authorizerContext) {
         ObjectNode event = objectMapper.createObjectNode();
         event.put("resource", resourcePath);
         event.put("path", path);
@@ -426,6 +456,19 @@ public class ApiGatewayExecuteController {
         ctx.put("requestId", requestId);
         ctx.put("requestTimeEpoch", System.currentTimeMillis());
         ctx.putObject("identity").put("sourceIp", "127.0.0.1");
+        if (principalId != null || (authorizerContext != null && !authorizerContext.isEmpty())) {
+            ObjectNode authorizerNode = ctx.putObject("authorizer");
+            if (principalId != null) {
+                authorizerNode.put("principalId", principalId);
+            }
+            if (authorizerContext != null) {
+                authorizerContext.forEach((key, value) -> {
+                    if (value != null) {
+                        authorizerNode.put(key, value.toString());
+                    }
+                });
+            }
+        }
 
         if (body != null && body.length > 0) {
             event.put("body", new String(body));

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAuthorizerContextIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAuthorizerContextIntegrationTest.java
@@ -1,0 +1,319 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayAuthorizerContextIntegrationTest {
+
+    private static final String LAMBDA_BASE_PATH = "/2015-03-31/functions";
+    private static final String AUTHORIZER_FUNCTION = "apigw-authorizer-context-auth";
+    private static final String PROXY_FUNCTION = "apigw-authorizer-context-proxy";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/lambda-role";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static String apiId;
+    private static String rootId;
+    private static String securedResourceId;
+    private static String plainResourceId;
+    private static String authorizerId;
+    private static String deploymentId;
+
+    @Test
+    @Order(1)
+    void createAuthorizerLambda() throws Exception {
+        createNodeLambda(AUTHORIZER_FUNCTION, """
+                exports.handler = async (event) => ({
+                  principalId: "test-user",
+                  policyDocument: {
+                    Version: "2012-10-17",
+                    Statement: [{
+                      Action: "execute-api:Invoke",
+                      Effect: event.authorizationToken === "Bearer deny" ? "Deny" : "Allow",
+                      Resource: event.methodArn
+                    }]
+                  },
+                  context: {
+                    org_id: "ORG001",
+                    sub: "test-user",
+                    client_id: "my-client",
+                    methodArn: event.methodArn
+                  }
+                });
+                """);
+    }
+
+    @Test
+    @Order(2)
+    void createProxyLambda() throws Exception {
+        createNodeLambda(PROXY_FUNCTION, """
+                exports.handler = async (event) => ({
+                  statusCode: 200,
+                  body: JSON.stringify({
+                    authorizer: event.requestContext?.authorizer ?? null,
+                    hasAuthorizer: Object.prototype.hasOwnProperty.call(event.requestContext ?? {}, "authorizer")
+                  })
+                });
+                """);
+    }
+
+    @Test
+    @Order(3)
+    void createRestApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"authorizer-context-api"}
+                        """)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+    }
+
+    @Test
+    @Order(4)
+    void getRootResource() {
+        rootId = given()
+                .when().get("/restapis/" + apiId + "/resources")
+                .then()
+                .statusCode(200)
+                .extract().path("item[0].id");
+    }
+
+    @Test
+    @Order(5)
+    void createResources() {
+        securedResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"secured\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        plainResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"plain\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+    }
+
+    @Test
+    @Order(6)
+    void createAuthorizer() {
+        String authorizerUri = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/"
+                + "arn:aws:lambda:us-east-1:000000000000:function:" + AUTHORIZER_FUNCTION + "/invocations";
+        authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "name":"ctx-authorizer",
+                          "type":"TOKEN",
+                          "authorizerUri":"%s",
+                          "identitySource":"method.request.header.Authorization",
+                          "authorizerResultTtlInSeconds":0
+                        }
+                        """.formatted(authorizerUri))
+                .when().post("/restapis/" + apiId + "/authorizers")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+    }
+
+    @Test
+    @Order(7)
+    void configureMethodsAndIntegrations() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizationType":"CUSTOM",
+                          "authorizerId":"%s",
+                          "requestParameters":{"method.request.header.Authorization":true}
+                        }
+                        """.formatted(authorizerId))
+                .when().put("/restapis/" + apiId + "/resources/" + securedResourceId + "/methods/PUT")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"authorizationType":"NONE"}
+                        """)
+                .when().put("/restapis/" + apiId + "/resources/" + plainResourceId + "/methods/PUT")
+                .then()
+                .statusCode(201);
+
+        String proxyUri = "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/"
+                + "arn:aws:lambda:us-east-1:000000000000:function:" + PROXY_FUNCTION + "/invocations";
+        String integrationBody = """
+                {
+                  "type":"AWS_PROXY",
+                  "httpMethod":"POST",
+                  "uri":"%s"
+                }
+                """.formatted(proxyUri);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(integrationBody)
+                .when().put("/restapis/" + apiId + "/resources/" + securedResourceId + "/methods/PUT/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(integrationBody)
+                .when().put("/restapis/" + apiId + "/resources/" + plainResourceId + "/methods/PUT/integration")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @Order(8)
+    void deployApi() {
+        deploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"description\":\"authorizer-context\"}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"stageName":"test","deploymentId":"%s"}
+                        """.formatted(deploymentId))
+                .when().post("/restapis/" + apiId + "/stages")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @Order(9)
+    void executeSecuredRoute_propagatesAuthorizerContextAndMethodArn() throws Exception {
+        String response = given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer allow")
+                .body("{\"ok\":true}")
+                .when().put("/execute-api/" + apiId + "/test/secured")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        JsonNode payload = OBJECT_MAPPER.readTree(response);
+        JsonNode authorizer = payload.path("authorizer");
+
+        assertTrue(payload.path("hasAuthorizer").asBoolean());
+        assertEquals("test-user", authorizer.path("principalId").asText());
+        assertEquals("ORG001", authorizer.path("org_id").asText());
+        assertEquals("test-user", authorizer.path("sub").asText());
+        assertEquals("my-client", authorizer.path("client_id").asText());
+        assertEquals(
+                "arn:aws:execute-api:us-east-1:000000000000:" + apiId + "/test/PUT/secured",
+                authorizer.path("methodArn").asText());
+    }
+
+    @Test
+    @Order(10)
+    void executePlainRoute_doesNotInjectAuthorizerContext() throws Exception {
+        String response = given()
+                .contentType(ContentType.JSON)
+                .body("{\"ok\":true}")
+                .when().put("/execute-api/" + apiId + "/test/plain")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        JsonNode payload = OBJECT_MAPPER.readTree(response);
+        assertFalse(payload.path("hasAuthorizer").asBoolean());
+        assertTrue(payload.path("authorizer").isNull());
+    }
+
+    @Test
+    @Order(11)
+    void executeSecuredRoute_denyStillReturns403() {
+        given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer deny")
+                .body("{\"ok\":true}")
+                .when().put("/execute-api/" + apiId + "/test/secured")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given().when().delete("/restapis/" + apiId).then().statusCode(202);
+        }
+        deleteFunction(AUTHORIZER_FUNCTION);
+        deleteFunction(PROXY_FUNCTION);
+    }
+
+    private static void createNodeLambda(String functionName, String handlerSource) throws Exception {
+        String zipBase64 = Base64.getEncoder().encodeToString(zipEntries(Map.of(
+                "index.js", handlerSource
+        )));
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "FunctionName":"%s",
+                          "Runtime":"nodejs20.x",
+                          "Role":"%s",
+                          "Handler":"index.handler",
+                          "Code":{"ZipFile":"%s"}
+                        }
+                        """.formatted(functionName, ROLE_ARN, zipBase64))
+                .when().post(LAMBDA_BASE_PATH)
+                .then()
+                .statusCode(201);
+    }
+
+    private static byte[] zipEntries(Map<String, String> entries) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                zos.putNextEntry(new ZipEntry(entry.getKey()));
+                zos.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static void deleteFunction(String functionName) {
+        int statusCode = given()
+                .when().delete(LAMBDA_BASE_PATH + "/" + functionName)
+                .then()
+                .extract().statusCode();
+        assertTrue(statusCode == 204 || statusCode == 404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAuthorizerContextIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAuthorizerContextIntegrationTest.java
@@ -289,6 +289,7 @@ class ApiGatewayAuthorizerContextIntegrationTest {
                           "Runtime":"nodejs20.x",
                           "Role":"%s",
                           "Handler":"index.handler",
+                          "Timeout":30,
                           "Code":{"ZipFile":"%s"}
                         }
                         """.formatted(functionName, ROLE_ARN, zipBase64))


### PR DESCRIPTION
Closes #574.

## What

REST API Gateway v1 TOKEN authorizers return a `principalId` + `context` map that floci silently dropped, so downstream `AWS_PROXY` Lambdas saw an empty `event.requestContext.authorizer`. LocalStack propagates both; this brings floci to parity.

Also fixes the `methodArn` in the authorizer event, previously a literal `"api/stage/METHOD/path"` string, now the real `arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>` built from the incoming request so policy-scoping authorizers can match.

## Changes

- Introduce a small `AuthorizerResult` record carrying `errorResponse`, `principalId`, and `context`. `invokeAuthorizer` now returns it; `dispatch` short-circuits on `errorResponse`, otherwise threads `principalId` + `context` into `invokeProxy` → `buildProxyEvent`.
- `buildProxyEvent` emits `requestContext.authorizer` only when a `CUSTOM` authorizer actually ran, matching AWS behavior (no injected empty map on unprotected routes).
- Context values are stringified at emit time to match AWS's flat-string wire contract. `null` values are omitted (not emitted as JSON `null`).
- Replace the placeholder `methodArn` with a real one built from the request-resolved region, API ID, stage, the raw request HTTP method, and the incoming path.

## Test coverage

New `ApiGatewayAuthorizerContextIntegrationTest` (`@QuarkusTest`) covers:

- **Happy path**: TOKEN authorizer returns `{principalId, context:{org_id, sub, client_id, methodArn}}` → proxy Lambda receives all fields at `event.requestContext.authorizer`, plus a real `methodArn` of the form `arn:aws:execute-api:<region>:<account>:<apiId>/<stage>/<METHOD>/<path>`.
- **Unprotected route** (`authorizationType: NONE`): proxy Lambda sees no `authorizer` key in `requestContext`.
- **Deny**: authorizer returns `Effect: Deny` → 403, proxy Lambda is not invoked.

`./mvnw -q -DskipTests test-compile` passes locally. The focused integration test is not runnable in my local harness due to an unrelated `ContainerDetector.hasMountInfoMarkers()` false-positive on Linux hosts with Docker installed; CI runs inside a container and should exercise the test. Happy to follow up with a separate PR for the detector if useful.

## Out of scope

- v2 HTTP API JWT authorizer context (different event shape, separate code path).
- REST `REQUEST` authorizer event-shape parity (needs a broader event builder, separate plan).
- `authorizerResultTtlInSeconds` caching.
- Threading authorizer context into `AWS` and `MOCK` integrations via VTL (`$context.authorizer.*`). Worth a follow-up; not needed to close #574.

## Backwards compatibility

No breaking changes. All signature changes are to private methods inside `ApiGatewayExecuteController`. Public behavior:

- Methods without a `CUSTOM` authorizer: unchanged (no `authorizer` key injected).
- Methods with a `CUSTOM` authorizer that returns `Allow`: previously received no `authorizer` context; now receive `principalId` + context fields. Existing consumers that didn't read these fields are unaffected.
- Deny / authorizer error: still return 403 / 500, same as before.