### PR TITLE
fix(test): disable bats within-file parallelism in awscli compat suite

### DIFF
--- a/compatibility-tests/sdk-test-awscli/run-bats-in-container.sh
+++ b/compatibility-tests/sdk-test-awscli/run-bats-in-container.sh
@@ -5,7 +5,13 @@ report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
 trap 'rm -rf "$report_dir"' EXIT
 
 set +e
-/opt/bats-core/bin/bats --jobs 4 --report-formatter junit -o "$report_dir" test/
+# --no-parallelize-within-files: bats-core defaults to running tests in parallel
+# both across files and within a file when --jobs > 1. Several tests in this
+# suite share state across tests in the same file via setup_file/teardown_file
+# (e.g. ses.bats, s3-notifications.bats), which races ordering-dependent tests.
+# Cross-file parallelism is preserved.
+/opt/bats-core/bin/bats --jobs 4 --no-parallelize-within-files \
+    --report-formatter junit -o "$report_dir" test/
 status=$?
 set -e
 


### PR DESCRIPTION
## Summary

- The awscli compat runner passes \`--jobs 4\` to bats-core, which **also parallelises tests within a file** by default.
- \`test/ses.bats\` shares state across tests via \`setup_file\` / \`teardown_file\` (\`TEST_EMAIL\`, \`TEST_DOMAIN\`). When bats schedules test 16 (\"verify identities deleted\") before tests 14/15 finish their delete calls, the list-identities response still contains the current run's identity and the assertion fails.
- Adds \`--no-parallelize-within-files\` to keep cross-file \`--jobs 4\` parallelism while serialising within each file.

## Why this fix, not the alternatives

- **Not a per-file opt-out** (\`export BATS_NO_PARALLELIZE_WITHIN_FILE=true\` in \`setup_file()\` of \`ses.bats\`): would leave \`s3-notifications.bats\` and any future \`setup_file\`-using test exposed to the same pattern.
- **Not a runtime refactor of ses.bats**: the \"verify → use → delete → verify-absent\" flow is the natural AWS sequence; breaking it into per-test self-contained scenarios would be a larger change with less coverage clarity.
- **Performance**: the \`--jobs 4\` speedup is driven by test-count / jobs, not by within-file scheduling. Cross-file parallelism continues to keep 4 \`.bats\` files running at once.

## Blocked PRs that share this failure

Same \`SES: verify identities deleted\` failure observed on recent unrelated PRs:
- #570 (Lambda: nested handler module paths)
- #576 (Pipes: filtering / input templates / batch sizes), \`@ctnnguyen\` noted \"I've had that exact one go off before\"
- #580 (DynamoDB: full ARN for TableName)

Other \`run-bats-in-container.sh\` scripts (cdk, terraform, opentofu) don't pass \`--jobs\`, so they run sequentially by default and don't need this flag.

## Test plan

- [x] 20 runs of \`bats --jobs 4 --no-parallelize-within-files test/ses.bats\` locally against \`hectorvent/floci:1.5.4\`: **20 pass / 0 fail**.
- [x] Baseline 10 runs of \`bats --jobs 4 test/ses.bats\` (unchanged): **4 pass / 6 fail** (~60% flake rate, failures on tests 3, 4, and 16 depending on the scheduling race).
- [x] Verified bats-core in the compat Dockerfile pulls \`master\` (\`git clone --depth 1\`), which is well past v1.10.0 (when \`--no-parallelize-within-files\` was introduced).

## Root-cause evidence

Log sequence for one failing run (timestamps trimmed):

\`\`\`
Verified domain: test-X.example.com
Verified email: test-X@example.com
SES email sent
SES raw email sent
Deleted identity: test-X.example.com ← test 15
Deleted identity: test-X@example.com ← test 14
Deleted identity: test-X@example.com ← teardown_file
Deleted identity: test-X.example.com ← teardown_file
\`\`\`

The log order already shows test 15 running before test 14, confirming bats scheduled them in parallel rather than serially. Test 16's failure is a direct consequence of that same scheduling racing against test 14 or 15.

Relevant bats-core gating at \`lib/bats-core/libexec/bats-core/bats-exec-file\`:
\`\`\`bash
if [[ "\$num_jobs"!= 1 && "\${BATS_NO_PARALLELIZE_WITHIN_FILE-False}" == False ]]; then
 # run tests within file in parallel
fi
\`\`\`

Docs guidance at \`lib/bats-core/docs/source/usage.md:108\`:
> If you have files where tests within the file would interfere with each other, you can use \`--no-parallelize-within-files\` to disable parallelization within all files.