### PR TITLE
fix(dynamodb): enforce DeletionProtectionEnabled on create, update, and delete

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -139,8 +139,12 @@ public class DynamoDbJsonHandler {
         String billingMode = request.has("BillingMode")
                 ? request.get("BillingMode").asText() : null;
 
+        boolean deletionProtection = request.path("DeletionProtectionEnabled").asBoolean(false);
+
         TableDefinition table = dynamoDbService.createTable(tableName, keySchema, attrDefs,
                 readCapacity, writeCapacity, gsis, lsis, region);
+
+        table.setDeletionProtectionEnabled(deletionProtection);
 
         if ("PAY_PER_REQUEST".equals(billingMode)) {
             table.setBillingMode("PAY_PER_REQUEST");
@@ -176,6 +180,10 @@ public class DynamoDbJsonHandler {
     private Response handleDeleteTable(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
+        if (table.isDeletionProtectionEnabled()) {
+            throw new AwsException("ResourceInUseException",
+                    "Table " + tableName + " can't be deleted while DeletionProtectionEnabled is set to true", 400);
+        }
         dynamoDbService.deleteTable(tableName, region);
 
         table.setTableStatus("DELETING");
@@ -506,6 +514,11 @@ public class DynamoDbJsonHandler {
 
         TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity,
                 gsiCreates, gsiDeletes, newAttrDefs, region);
+
+        JsonNode deletionProtectionNode = request.path("DeletionProtectionEnabled");
+        if (!deletionProtectionNode.isMissingNode()) {
+            table.setDeletionProtectionEnabled(deletionProtectionNode.asBoolean());
+        }
 
         String billingMode = request.has("BillingMode")
                 ? request.get("BillingMode").asText() : null;
@@ -849,7 +862,7 @@ public class DynamoDbJsonHandler {
         node.put("CreationDateTime", table.getCreationDateTime().getEpochSecond());
         node.put("ItemCount", table.getItemCount());
         node.put("TableSizeBytes", table.getTableSizeBytes());
-        node.put("DeletionProtectionEnabled", false);
+        node.put("DeletionProtectionEnabled", table.isDeletionProtectionEnabled());
 
         if ("PAY_PER_REQUEST".equals(table.getBillingMode())) {
             ObjectNode billing = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -34,6 +34,7 @@ public class TableDefinition {
     private boolean ttlEnabled;
     private boolean pointInTimeRecoveryEnabled;
     private int pointInTimeRecoveryRecoveryPeriodInDays;
+    private boolean deletionProtectionEnabled;
     private boolean streamEnabled;
     private String streamArn;
     private String streamViewType;
@@ -133,6 +134,9 @@ public class TableDefinition {
     public void setPointInTimeRecoveryRecoveryPeriodInDays(int pointInTimeRecoveryRecoveryPeriodInDays) {
         this.pointInTimeRecoveryRecoveryPeriodInDays = pointInTimeRecoveryRecoveryPeriodInDays;
     }
+
+    public boolean isDeletionProtectionEnabled() { return deletionProtectionEnabled; }
+    public void setDeletionProtectionEnabled(boolean deletionProtectionEnabled) { this.deletionProtectionEnabled = deletionProtectionEnabled; }
 
     public boolean isStreamEnabled() { return streamEnabled; }
     public void setStreamEnabled(boolean streamEnabled) { this.streamEnabled = streamEnabled; }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1682,6 +1682,87 @@ given()
         .then().statusCode(200);
     }
 
+    @Test
+    @Order(32)
+    void deletionProtectionEnabled() {
+        String tableName = "deletion-protection-test";
+
+        // Create table with DeletionProtectionEnabled = true
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST",
+                    "DeletionProtectionEnabled": true
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        // DescribeTable returns DeletionProtectionEnabled = true
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.DeletionProtectionEnabled", equalTo(true));
+
+        // DeleteTable is blocked
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ResourceInUseException"));
+
+        // UpdateTable to disable deletion protection
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "DeletionProtectionEnabled": false
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        // DescribeTable returns DeletionProtectionEnabled = false
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.DeletionProtectionEnabled", equalTo(false));
+
+        // DeleteTable now succeeds
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
     private static long crc32Of(byte[] bytes) {
         CRC32 crc = new CRC32();
         crc.update(bytes);


### PR DESCRIPTION
## Summary

Persist and enforce `DeletionProtectionEnabled` on DynamoDB tables. Previously the flag was silently ignored on `CreateTable`/`UpdateTable` and hardcoded to `false` in `DescribeTable` responses.

- Read `DeletionProtectionEnabled` from `CreateTable` and `UpdateTable` requests and persist on the table model
- Block `DeleteTable` with `ResourceInUseException` when deletion protection is enabled
- Return the actual flag value in `DescribeTable` (was hardcoded to `false`)

Closes #540

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`DescribeTable` was returning `DeletionProtectionEnabled: false` regardless of actual state. `DeleteTable` was succeeding even when protection was enabled. Both now match real AWS behavior: `DeleteTable` returns `ResourceInUseException` (HTTP 400) when the flag is true.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)