### PR TITLE
fix(pipes): return parameters in mutation responses, warn on stream record loss

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesController.java
@@ -215,6 +215,18 @@ public class PipesController {
         node.put("CurrentState", pipe.getCurrentState().name());
         if (pipe.getDescription() != null) node.put("Description", pipe.getDescription());
         if (pipe.getEnrichment() != null) node.put("Enrichment", pipe.getEnrichment());
+        if (pipe.getSourceParameters() != null) {
+            node.set("SourceParameters", pipe.getSourceParameters());
+        }
+        if (pipe.getTargetParameters() != null) {
+            node.set("TargetParameters", pipe.getTargetParameters());
+        }
+        if (pipe.getEnrichmentParameters() != null) {
+            node.set("EnrichmentParameters", pipe.getEnrichmentParameters());
+        }
+        if (pipe.getTags() != null && !pipe.getTags().isEmpty()) {
+            node.set("Tags", objectMapper.valueToTree(pipe.getTags()));
+        }
         if (pipe.getCreationTime() != null) node.put("CreationTime", pipe.getCreationTime().getEpochSecond());
         if (pipe.getLastModifiedTime() != null) node.put("LastModifiedTime", pipe.getLastModifiedTime().getEpochSecond());
         if (pipe.getStateReason() != null) node.put("StateReason", pipe.getStateReason());

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
@@ -219,7 +219,10 @@ public class PipesPoller {
                 return;
             }
             String eventJson = wrapRecords(filtered);
-            invokeWithDlq(pipe, eventJson, region);
+            if (!invokeWithDlq(pipe, eventJson, region)) {
+                LOG.warnv("Pipe {0}: {1} Kinesis record(s) dropped — delivery and DLQ both failed",
+                        pipe.getName(), filtered.size());
+            }
         } catch (AwsException e) {
             if ("ExpiredIteratorException".equals(e.getErrorCode())) {
                 kinesisIterators.remove(pipeKey);
@@ -267,7 +270,10 @@ public class PipesPoller {
                 return;
             }
             String eventJson = wrapRecords(filtered);
-            invokeWithDlq(pipe, eventJson, region);
+            if (!invokeWithDlq(pipe, eventJson, region)) {
+                LOG.warnv("Pipe {0}: {1} DynamoDB Stream record(s) dropped — delivery and DLQ both failed",
+                        pipe.getName(), filtered.size());
+            }
         } catch (AwsException e) {
             if ("ExpiredIteratorException".equals(e.getErrorCode()) ||
                 "TrimmedDataAccessException".equals(e.getErrorCode())) {

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesIntegrationTest.java
@@ -198,6 +198,46 @@ class PipesIntegrationTest {
 
     @Test
     @Order(12)
+    void createPipeReturnsParametersInResponse() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:params-source",
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:params-target",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+                    "SourceParameters": {
+                        "FilterCriteria": {
+                            "Filters": [{"Pattern": "{\\"body\\":{\\"status\\":[\\"active\\"]}}"}]
+                        }
+                    },
+                    "TargetParameters": {
+                        "InputTemplate": "{\\"id\\": <$.messageId>}"
+                    },
+                    "Tags": {"env": "test", "team": "platform"}
+                }
+                """)
+        .when()
+            .post("/v1/pipes/params-pipe")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("params-pipe"))
+            .body("SourceParameters.FilterCriteria.Filters[0].Pattern",
+                    equalTo("{\"body\":{\"status\":[\"active\"]}}"))
+            .body("TargetParameters.InputTemplate", equalTo("{\"id\": <$.messageId>}"))
+            .body("Tags.env", equalTo("test"))
+            .body("Tags.team", equalTo("platform"));
+
+        given()
+            .contentType("application/json")
+        .when()
+            .delete("/v1/pipes/params-pipe")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(13)
     void createPipeMissingSourceReturns400() {
         given()
             .contentType("application/json")


### PR DESCRIPTION
## Summary

- Return `SourceParameters`, `TargetParameters`, `EnrichmentParameters`, and `Tags` in create/update/start/stop responses (`buildPipeResponse` was missing them; `describePipe` already returned them via direct Pipe serialization)
- Log a warning when Kinesis or DynamoDB Stream records are dropped because both target delivery and DLQ routing failed (SQS path already handled this correctly by gating message deletion on the return value)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`CreatePipe`, `UpdatePipe`, `StartPipe`, and `StopPipe` responses were missing `SourceParameters`, `TargetParameters`, `EnrichmentParameters`, and `Tags` fields that AWS returns. `DescribePipe` was already correct. Stream sources now warn on record loss instead of silently dropping, matching the observability expected when retry exhaustion occurs.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)