### PR TITLE
fix(pipes): read EventBridgeEventBusParameters for Source and DetailType

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
@@ -67,7 +67,7 @@ public class PipesTargetInvoker {
         } else if (targetArn.contains(":sns:")) {
             invokeSns(targetArn, payload, region);
         } else if (targetArn.contains(":events:")) {
-            invokeEventBridge(targetArn, payload, region);
+            invokeEventBridge(targetArn, payload, region, tp);
         } else if (targetArn.contains(":states:")) {
             invokeStepFunctions(targetArn, payload, region);
         } else {
@@ -94,13 +94,24 @@ public class PipesTargetInvoker {
         LOG.debugv("Pipe delivered to SNS: {0}", arn);
     }
 
-    private void invokeEventBridge(String arn, String payload, String region) {
+    private void invokeEventBridge(String arn, String payload, String region, JsonNode tp) {
         String busName = arn.substring(arn.lastIndexOf('/') + 1);
         String ebRegion = extractRegionFromArn(arn, region);
+        String source = "aws.pipes";
+        String detailType = "PipeForwarded";
+        if (tp != null) {
+            JsonNode ebParams = tp.path("EventBridgeEventBusParameters");
+            if (ebParams.has("Source")) {
+                source = ebParams.get("Source").asText();
+            }
+            if (ebParams.has("DetailType")) {
+                detailType = ebParams.get("DetailType").asText();
+            }
+        }
         Map<String, Object> entry = Map.of(
                 "EventBusName", busName,
-                "Source", "aws.pipes",
-                "DetailType", "PipeForwarded",
+                "Source", source,
+                "DetailType", detailType,
                 "Detail", payload
         );
         eventBridgeService.putEvents(List.of(entry), ebRegion);

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
@@ -18,6 +18,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -153,6 +156,40 @@ class PipesTargetInvokerTest {
     @Test
     void extractJsonPath_booleanValue() {
         assertEquals("true", invoker.extractJsonPath("$.active", "{\"active\": true}"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void eventBridge_usesEventBridgeEventBusParameters() {
+        ObjectNode tp = MAPPER.createObjectNode();
+        ObjectNode ebParams = tp.putObject("EventBridgeEventBusParameters");
+        ebParams.put("Source", "registration-service");
+        ebParams.put("DetailType", "USER_REGISTRATION_COMPLETED");
+
+        Pipe pipe = createPipe("arn:aws:events:us-east-1:000000000000:event-bus/my-bus", tp);
+        invoker.invoke(pipe, "{\"user\": \"123\"}", "us-east-1");
+
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(eventBridgeService).putEvents(captor.capture(), eq("us-east-1"));
+        Map<String, Object> entry = captor.getValue().get(0);
+        assertEquals("my-bus", entry.get("EventBusName"));
+        assertEquals("registration-service", entry.get("Source"));
+        assertEquals("USER_REGISTRATION_COMPLETED", entry.get("DetailType"));
+        assertEquals("{\"user\": \"123\"}", entry.get("Detail"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void eventBridge_fallsBackToDefaults() {
+        Pipe pipe = createPipe("arn:aws:events:us-east-1:000000000000:event-bus/default", null);
+        invoker.invoke(pipe, "{}", "us-east-1");
+
+        ArgumentCaptor<List<Map<String, Object>>> captor = ArgumentCaptor.forClass(List.class);
+        verify(eventBridgeService).putEvents(captor.capture(), eq("us-east-1"));
+        Map<String, Object> entry = captor.getValue().get(0);
+        assertEquals("default", entry.get("EventBusName"));
+        assertEquals("aws.pipes", entry.get("Source"));
+        assertEquals("PipeForwarded", entry.get("DetailType"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Read `Source` and `DetailType` from `TargetParameters.EventBridgeEventBusParameters` when delivering to an EventBridge event bus target
- Fall back to `aws.pipes` / `PipeForwarded` when not configured
- Previously these values were hardcoded, so downstream EventBridge rules matching on Source or DetailType would never trigger

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`EventBridgeEventBusParameters` is part of the AWS Pipes `TargetParameters` for event bus targets. When a Pipe targets an EventBridge event bus, the `Source` and `DetailType` fields control how the event appears on the bus. Without reading these, any EventBridge rule matching on those fields silently fails to trigger.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)