### PR TITLE
docs: update Docker image references to floci/floci

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -4,7 +4,7 @@ name: Edge
 # Runs on a weekly schedule (every Monday 00:00 UTC) and can be triggered manually.
 # Uses JVM-only build to keep runtime cost low (~2-3 min vs ~15 min for native).
 #
-# Published tag: hectorvent/floci:edge
+# Published tag: floci/floci:edge
 #
 # Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ git push origin release/1.1.x
 
 ### Edge builds
 
-The `edge.yml` workflow publishes a JVM-only `hectorvent/floci:edge` image from `main` every Monday at 00:00 UTC. It can also be triggered manually from the Actions tab.
+The `edge.yml` workflow publishes a JVM-only `floci/floci:edge` image from `main` every Monday at 00:00 UTC. It can also be triggered manually from the Actions tab.
 
 ## Testing Policy for Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p align="center">
   <a href="https://github.com/floci-io/floci/releases/latest"><img src="https://img.shields.io/github/v/release/floci-io/floci?label=latest%20release&color=blue" alt="Latest Release"></a>
   <a href="https://github.com/floci-io/floci/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/floci-io/floci/release.yml?label=build" alt="Build Status"></a>
-  <a href="https://hub.docker.com/r/floci/floci"><img src="https://img.shields.io/docker/pulls/floci/floci?label=docker%20pulls" alt="Docker Pulls"></a>
-  <a href="https://hub.docker.com/r/floci/floci"><img src="https://img.shields.io/docker/image-size/floci/floci/latest?label=image%20size" alt="Docker Image Size"></a>
+  <a href="https://hub.docker.com/r/hectorvent/floci"><img src="https://img.shields.io/docker/pulls/hectorvent/floci?label=docker%20pulls" alt="Docker Pulls"></a>
+  <a href="https://hub.docker.com/r/hectorvent/floci"><img src="https://img.shields.io/docker/image-size/hectorvent/floci/latest?label=image%20size" alt="Docker Image Size"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
   <a href="https://github.com/floci-io/floci/stargazers"><img src="https://img.shields.io/github/stars/floci-io/floci?style=flat" alt="GitHub Stars"></a>
   <a href="https://github.com/floci-io/floci/graphs/contributors"><img src="https://img.shields.io/github/contributors/floci-io/floci" alt="GitHub Contributors"></a>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <p align="center">
   <a href="https://github.com/floci-io/floci/releases/latest"><img src="https://img.shields.io/github/v/release/floci-io/floci?label=latest%20release&color=blue" alt="Latest Release"></a>
   <a href="https://github.com/floci-io/floci/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/floci-io/floci/release.yml?label=build" alt="Build Status"></a>
-  <a href="https://hub.docker.com/r/hectorvent/floci"><img src="https://img.shields.io/docker/pulls/hectorvent/floci?label=docker%20pulls" alt="Docker Pulls"></a>
-  <a href="https://hub.docker.com/r/hectorvent/floci"><img src="https://img.shields.io/docker/image-size/hectorvent/floci/latest?label=image%20size" alt="Docker Image Size"></a>
+  <a href="https://hub.docker.com/r/floci/floci"><img src="https://img.shields.io/docker/pulls/floci/floci?label=docker%20pulls" alt="Docker Pulls"></a>
+  <a href="https://hub.docker.com/r/floci/floci"><img src="https://img.shields.io/docker/image-size/floci/floci/latest?label=image%20size" alt="Docker Image Size"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
   <a href="https://github.com/floci-io/floci/stargazers"><img src="https://img.shields.io/github/stars/floci-io/floci?style=flat" alt="GitHub Stars"></a>
   <a href="https://github.com/floci-io/floci/graphs/contributors"><img src="https://img.shields.io/github/contributors/floci-io/floci" alt="GitHub Contributors"></a>

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -7,7 +7,7 @@ For most services (SSM, SQS, SNS, S3, DynamoDB, Lambda, API Gateway, Cognito, KM
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     volumes:
@@ -23,7 +23,7 @@ ElastiCache and RDS work by proxying TCP connections to real Docker containers (
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"         # All AWS API calls
       - "6379-6399:6379-6399"  # ElastiCache / Redis proxy ports
@@ -56,7 +56,7 @@ in every URL it generates:
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     environment:
@@ -94,7 +94,7 @@ Hook scripts can be mounted into the container to run custom setup and teardown 
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     volumes:
@@ -111,7 +111,7 @@ By default Floci stores all data in memory — data is lost on restart. To persi
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     volumes:
@@ -128,7 +128,7 @@ Instead of bind-mounting a local directory, you can use Docker named volumes to 
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     volumes:
@@ -183,7 +183,7 @@ All `application.yml` options can be overridden via environment variables using 
 ```yaml title=".github/workflows/test.yml"
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
 

--- a/docs/configuration/initialization-hooks.md
+++ b/docs/configuration/initialization-hooks.md
@@ -26,30 +26,30 @@ Hooks can call Floci service endpoints directly from inside the container (e.g. 
 
 The published Docker images are available on Docker Hub:
 
-- `hectorvent/floci:latest` — native image (minimal, no apk)
-- `hectorvent/floci:latest-jvm` — JVM image (Alpine-based, has apk)
-- `hectorvent/floci:latest-aws` — JVM image with AWS CLI pre-installed
+- `floci/floci:latest` — native image (minimal, no apk)
+- `floci/floci:latest-jvm` — JVM image (Alpine-based, has apk)
+- `floci/floci:latest-aws` — JVM image with AWS CLI pre-installed
 
 If your hooks require the AWS CLI, use one of these options:
 
 **Option 1: Use the pre-built AWS CLI image**
 
 ```dockerfile
-FROM hectorvent/floci:latest-aws
+FROM floci/floci:latest-aws
 # AWS CLI is already installed
 ```
 
 **Option 2: Extend the JVM image (Alpine-based)**
 
 ```dockerfile
-FROM hectorvent/floci:latest-jvm
+FROM floci/floci:latest-jvm
 RUN apk add --no-cache aws-cli
 ```
 
 **Option 3: Extend the JVM image with additional tools**
 
 ```dockerfile
-FROM hectorvent/floci:latest-jvm
+FROM floci/floci:latest-jvm
 RUN apk add --no-cache aws-cli jq curl
 ```
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -150,7 +150,7 @@ Only the proxy-based services (ElastiCache and RDS) need port mappings in `docke
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"           # All AWS API calls
       - "6379-6399:6379-6399" # ElastiCache / Redis proxy (proxy in Floci)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,7 +7,7 @@ Floci can be run three ways: as a Docker image, as a pre-built native binary, or
 No installation required beyond Docker itself.
 
 ```bash
-docker pull hectorvent/floci:latest
+docker pull floci/floci:latest
 ```
 
 | Tag | Description |
@@ -29,7 +29,7 @@ The `latest` tag is the native image — a self-contained executable with no JVM
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest   # native — recommended
+    image: floci/floci:latest   # native — recommended
     ports:
       - "4566:4566"
 ```
@@ -39,7 +39,7 @@ Use the JVM image if you need broader platform compatibility or encounter native
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest-jvm
+    image: floci/floci:latest-jvm
     ports:
       - "4566:4566"
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ This guide gets Floci running and verifies that AWS CLI commands work against it
     ```yaml
     services:
       floci:
-        image: hectorvent/floci:latest
+        image: floci/floci:latest
         ports:
           - "4566:4566"
         volumes:
@@ -36,7 +36,7 @@ This guide gets Floci running and verifies that AWS CLI commands work against it
     ```yaml
     services:
       floci:
-        image: hectorvent/floci:latest-jvm
+        image: floci/floci:latest-jvm
         ports:
           - "4566:4566"
         volumes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ Floci emulates 31 AWS services. See the [Services Overview](services/index.md) f
 ```yaml title="docker-compose.yml"
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
     volumes:

--- a/docs/services/ecr.md
+++ b/docs/services/ecr.md
@@ -75,7 +75,7 @@ The ECR registry sidecar container binds its host port directly — do **not** a
 # Correct — no ECR port range on the floci service
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
       - "6379-6399:6379-6399"   # ElastiCache

--- a/docs/services/ecs.md
+++ b/docs/services/ecs.md
@@ -151,7 +151,7 @@ Set `FLOCI_SERVICES_ECS_MOCK=true` to run without Docker. In this mode tasks ski
 # docker-compose.yml — CI / test environment
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     environment:
       FLOCI_SERVICES_ECS_MOCK: "true"
 ```
@@ -160,7 +160,7 @@ services:
 # docker-compose.yml — local development (real containers)
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
@@ -175,7 +175,7 @@ When `mock: false` (the default), ECS launches real Docker containers and requir
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/docs/services/eks.md
+++ b/docs/services/eks.md
@@ -33,7 +33,7 @@ Floci starts a **k3s** (`rancher/k3s`) container for each cluster. The k3s API s
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -83,7 +83,7 @@ Use `FLOCI_SERVICES_EKS_MOCK=true` when you only need the API shape:
 # docker-compose.yml — CI / test environment
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     environment:
       FLOCI_SERVICES_EKS_MOCK: "true"
 ```

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -38,7 +38,7 @@ ElastiCache requires the Docker socket and port range exposure. For private regi
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
       - "6379-6399:6379-6399"   # ElastiCache proxy ports

--- a/docs/services/opensearch.md
+++ b/docs/services/opensearch.md
@@ -22,7 +22,7 @@ Floci starts an **OpenSearch** (`opensearchproject/opensearch:2`) Docker contain
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -119,7 +119,7 @@ Use `FLOCI_SERVICES_OPENSEARCH_MOCK=true` when you only need the API shape:
 # docker-compose.yml — CI / test environment
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     environment:
       FLOCI_SERVICES_OPENSEARCH_MOCK: "true"
 ```

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -46,7 +46,7 @@ RDS requires the Docker socket and port range exposure. For private registry aut
 ```yaml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports:
       - "4566:4566"
       - "7001-7099:7001-7099"   # RDS proxy ports

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -68,7 +68,7 @@ like [Mailpit](https://mailpit.axllent.org/) or any standard SMTP server.
 # docker-compose.yml
 services:
   floci:
-    image: hectorvent/floci:latest
+    image: floci/floci:latest
     ports: ["4566:4566"]
     environment:
       FLOCI_SERVICES_SES_SMTP_HOST: mailpit


### PR DESCRIPTION
## Summary

Update stale `hectorvent/floci` Docker image references to `floci/floci` across documentation and one workflow comment.

Affected files:
- `README.md` — Docker Hub badges
- `CONTRIBUTING.md` — edge build note
- `.github/workflows/edge.yml` — comment only (`tags:` was already `floci/floci:edge`)
- 13 `docs/**/*.md` files — `image: floci/floci:latest` in compose snippets and `docker pull`

Intentionally left as-is:
- `README.md` migration notice (`[!IMPORTANT]` block) — must reference the old name to inform users of the move
- `CHANGELOG.md` — historical GitHub URLs (auto-generated)
- `.coderabbit.yaml` — Java package paths (`io.github.hectorvent.floci`), not image references
- `.github/CODEOWNERS`, `.github/FUNDING.yml` — GitHub username `@hectorvent`

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — documentation-only change.

## Checklist

- [x] `./mvnw test` passes locally — N/A (docs only, no code changes)
- [x] New or updated integration test added — N/A (docs only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)