### PR TITLE
fix(lambda): replace blocking /next handler with reactive pattern

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -5,13 +5,13 @@ import io.github.hectorvent.floci.services.lambda.model.PendingInvocation;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
 import org.jboss.logging.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Per-container HTTP server implementing the AWS Lambda Runtime API.
@@ -35,14 +35,15 @@ public class RuntimeApiServer {
     private static final byte[] CONTAINER_STOPPED_PAYLOAD =
             "{\"errorMessage\":\"Container stopped\",\"errorType\":\"ContainerStopped\"}".getBytes();
 
-    // Sentinel used to wake a /next handler blocked in pendingQueue.poll() when stop() is called.
-    // Compared by identity (==), not equals.
-    private static final PendingInvocation SHUTDOWN_SENTINEL =
-            new PendingInvocation("<shutdown>", new byte[0], 0L, "", new CompletableFuture<>());
-
     private final Vertx vertx;
     private final int port;
-    private final LinkedBlockingQueue<PendingInvocation> pendingQueue = new LinkedBlockingQueue<>();
+
+    // Invocations queued before a /next poller arrived.
+    private final ConcurrentLinkedQueue<PendingInvocation> pendingQueue = new ConcurrentLinkedQueue<>();
+
+    // /next callers parked while the pending queue is empty.
+    private final ConcurrentLinkedQueue<RoutingContext> waitingContexts = new ConcurrentLinkedQueue<>();
+
     private final ConcurrentHashMap<String, PendingInvocation> inFlight = new ConcurrentHashMap<>();
 
     private volatile HttpServer httpServer;
@@ -63,46 +64,39 @@ public class RuntimeApiServer {
         Router router = Router.router(vertx);
         router.route().handler(BodyHandler.create());
 
-        // GET /runtime/invocation/next — poll for next invocation, one request per worker thread.
-        // Returns 204 when nothing arrives within 30 s so the runtime re-polls.
-        // This matches the real AWS Runtime API contract and caps each handler to one
-        // Vert.x worker thread for at most 30 seconds, preventing worker-pool exhaustion
-        // when multiple warm containers are polling concurrently.
-        router.get(NEXT_PATH).blockingHandler(ctx -> {
-            try {
+        // GET /runtime/invocation/next — AWS Runtime API contract: blocks until an invocation
+        // arrives, then returns 200 with the invocation payload and required headers.
+        // Uses a reactive pattern (no thread held while waiting) to avoid Vert.x worker pool
+        // exhaustion when many warm containers poll concurrently.
+        router.get(NEXT_PATH).handler(ctx -> {
+            if (stopped) {
+                ctx.response().setStatusCode(204).end();
+                return;
+            }
+            PendingInvocation invocation = pendingQueue.poll();
+            if (invocation != null) {
                 if (stopped) {
-                    ctx.response().setStatusCode(204).end();
-                    return;
-                }
-                PendingInvocation invocation = pendingQueue.poll(30, TimeUnit.SECONDS);
-                if (invocation == SHUTDOWN_SENTINEL) {
-                    invocation = null;
-                }
-                // If stop() ran after poll() returned a real invocation (narrow race before
-                // inFlight.put), complete it here so the caller doesn't hang.
-                if (invocation != null && stopped) {
                     invocation.getResultFuture().complete(
                             new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
-                    invocation = null;
-                }
-                if (invocation == null) {
                     ctx.response().setStatusCode(204).end();
                     return;
                 }
-                inFlight.put(invocation.getRequestId(), invocation);
-                ctx.response()
-                        .setStatusCode(200)
-                        .putHeader("Content-Type", "application/json")
-                        .putHeader("Lambda-Runtime-Aws-Request-Id", invocation.getRequestId())
-                        .putHeader("Lambda-Runtime-Invoked-Function-Arn", invocation.getFunctionArn())
-                        .putHeader("Lambda-Runtime-Deadline-Ms", String.valueOf(invocation.getDeadlineMs()))
-                        .end(invocation.getPayload() != null
-                                ? new String(invocation.getPayload())
-                                : "{}");
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                ctx.response().setStatusCode(204).end();
+                sendInvocation(ctx, invocation);
+                return;
             }
+            // No invocation queued yet — park this context until enqueue() wakes it.
+            waitingContexts.add(ctx);
+            // Re-check stop race: stop() may have drained waitingContexts before our add().
+            if (stopped && waitingContexts.remove(ctx)) {
+                ctx.response().setStatusCode(204).end();
+                return;
+            }
+            // Re-check enqueue race: an invocation may have arrived between our poll() and add().
+            PendingInvocation raced = pendingQueue.poll();
+            if (raced != null && waitingContexts.remove(ctx)) {
+                sendInvocation(ctx, raced);
+            }
+            // else: still parked — enqueue() will dispatch via vertx.runOnContext().
         });
 
         // POST /runtime/invocation/{requestId}/response — success
@@ -156,21 +150,23 @@ public class RuntimeApiServer {
             httpServer.close();
         }
 
-        // Drain queued invocations that were never consumed by /next, completing each future
-        // with ContainerStopped so callers (LambdaExecutorService) don't hang waiting for a result.
+        // Wake any parked /next pollers with 204 (container shutting down — runtime will exit).
+        RoutingContext waiting;
+        while ((waiting = waitingContexts.poll()) != null) {
+            final RoutingContext ctx = waiting;
+            vertx.runOnContext(v -> {
+                if (!ctx.response().ended()) {
+                    ctx.response().setStatusCode(204).end();
+                }
+            });
+        }
+
+        // Drain queued invocations that were never consumed by /next.
         PendingInvocation pending;
         while ((pending = pendingQueue.poll()) != null) {
-            if (pending == SHUTDOWN_SENTINEL) {
-                continue;
-            }
             pending.getResultFuture().complete(
                     new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, pending.getRequestId()));
         }
-
-        // Offer sentinel AFTER drain so it cannot be discarded. Wakes any /next handler
-        // currently blocked in poll(). N=1 today: a single RuntimeApiServer serves one container,
-        // so one sentinel suffices.
-        pendingQueue.offer(SHUTDOWN_SENTINEL);
 
         // Complete any in-flight invocations with error.
         inFlight.values().forEach(inv ->
@@ -181,9 +177,22 @@ public class RuntimeApiServer {
 
     public CompletableFuture<InvokeResult> enqueue(PendingInvocation invocation) {
         if (stopped) {
-            // stop() already ran; don't queue. Complete immediately so caller doesn't hang.
             invocation.getResultFuture().complete(
                     new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
+            return invocation.getResultFuture();
+        }
+        // If a /next poller is already parked, dispatch immediately on the event loop.
+        RoutingContext ctx = waitingContexts.poll();
+        if (ctx != null) {
+            final RoutingContext waitingCtx = ctx;
+            vertx.runOnContext(v -> {
+                if (!waitingCtx.response().ended()) {
+                    sendInvocation(waitingCtx, invocation);
+                } else {
+                    // Connection closed between park and dispatch — re-queue.
+                    pendingQueue.offer(invocation);
+                }
+            });
             return invocation.getResultFuture();
         }
         pendingQueue.offer(invocation);
@@ -194,5 +203,18 @@ public class RuntimeApiServer {
                     new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
         }
         return invocation.getResultFuture();
+    }
+
+    private void sendInvocation(RoutingContext ctx, PendingInvocation invocation) {
+        inFlight.put(invocation.getRequestId(), invocation);
+        ctx.response()
+                .setStatusCode(200)
+                .putHeader("Content-Type", "application/json")
+                .putHeader("Lambda-Runtime-Aws-Request-Id", invocation.getRequestId())
+                .putHeader("Lambda-Runtime-Invoked-Function-Arn", invocation.getFunctionArn())
+                .putHeader("Lambda-Runtime-Deadline-Ms", String.valueOf(invocation.getDeadlineMs()))
+                .end(invocation.getPayload() != null
+                        ? new String(invocation.getPayload())
+                        : "{}");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -77,32 +77,30 @@ class RuntimeApiServerTest {
     }
 
     @Test
-    @Timeout(45)
-    void nextEndpoint_returns204OnTimeout_thenReturns200OnRepoll() throws Exception {
-        // AWS Runtime API contract: GET /next returns 204 when no invocation arrives within
-        // the poll window. The runtime re-polls and picks up the next queued invocation.
+    @Timeout(10)
+    void nextEndpoint_parksWithNoResponse_thenReturns200WhenInvocationEnqueued() throws Exception {
+        // AWS Runtime API spec: GET /next must park (no response) until an invocation
+        // arrives — it must never return 204 during normal operation.
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:" + port + "/2018-06-01/runtime/invocation/next"))
                 .GET()
                 .build();
+        CompletableFuture<HttpResponse<String>> asyncResponse =
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
 
-        // First poll: nothing queued — should return 204 after ~30 s.
-        HttpResponse<String> emptyResponse = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals(204, emptyResponse.statusCode(),
-                "GET /next should return 204 when the queue is empty after the poll timeout");
+        Thread.sleep(300);
+        assertFalse(asyncResponse.isDone(), "GET /next should be parked, not returned");
 
-        // Enqueue an invocation and re-poll — should be returned immediately.
         PendingInvocation invocation = new PendingInvocation(
-                "req-after-timeout", "{\"repoll\":true}".getBytes(),
+                "req-parked", "{\"reactive\":true}".getBytes(),
                 System.currentTimeMillis() + 60_000,
                 "arn:aws:lambda:us-east-1:000000000000:function:test",
                 new CompletableFuture<>());
         server.enqueue(invocation);
 
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        assertEquals(200, response.statusCode());
-        assertEquals("req-after-timeout",
-                response.headers().firstValue("Lambda-Runtime-Aws-Request-Id").orElse(""));
+        HttpResponse<String> response = asyncResponse.get(2, TimeUnit.SECONDS);
+        assertEquals(200, response.statusCode(), "GET /next must return 200 when invocation arrives");
+        assertEquals("req-parked", response.headers().firstValue("Lambda-Runtime-Aws-Request-Id").orElse(""));
     }
 
     @Test
@@ -136,8 +134,8 @@ class RuntimeApiServerTest {
 
     @Test
     @Timeout(15)
-    void stopWakesBlockedPollerImmediately() throws Exception {
-        // GET /next on a background thread — blocks in pendingQueue.poll(30s).
+    void stopWakesParkedPollerImmediately() throws Exception {
+        // GET /next on a background thread — parks in waitingContexts (no thread held).
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:" + port + "/2018-06-01/runtime/invocation/next"))
                 .GET()
@@ -145,19 +143,18 @@ class RuntimeApiServerTest {
         CompletableFuture<HttpResponse<String>> asyncResponse =
                 httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
 
-        // Give the handler time to enter poll()
+        // Give the handler time to park
         Thread.sleep(500);
-        assertFalse(asyncResponse.isDone(), "handler should be blocked in poll");
+        assertFalse(asyncResponse.isDone(), "handler should be parked");
 
         long start = System.currentTimeMillis();
         server.stop();
         HttpResponse<String> response = asyncResponse.get(2, TimeUnit.SECONDS);
         long elapsed = System.currentTimeMillis() - start;
 
-        // 204 requires the handler to have: woken from poll, observed sentinel, exited loop,
-        // written the response. Proves the worker thread is released (not just the socket closed).
+        // 204 is only valid on shutdown — the container is being terminated.
         assertEquals(204, response.statusCode());
-        assertTrue(elapsed < 1000, "stop() should wake poller in <1s, took " + elapsed + "ms");
+        assertTrue(elapsed < 1000, "stop() should wake parked poller in <1s, took " + elapsed + "ms");
     }
 
     @Test


### PR DESCRIPTION
GET /runtime/invocation/next returned 204 after a 30-second poll timeout, violating the AWS Lambda Runtime API spec. The spec defines only 200 as a valid success response for this endpoint. The .NET Lambda RIC reads Lambda-Runtime-Aws-Request-Id unconditionally after every /next call and crashes with KeyNotFoundException on 204.

Replace blockingHandler + LinkedBlockingQueue.poll(30s) with a non-blocking handler that parks the RoutingContext in waitingContexts. enqueue() dispatches to a parked caller via vertx.runOnContext(), holding zero worker threads while idle. stop() drains waitingContexts with 204, which is valid only on shutdown when the container exits.

Fixes #462 

## Summary

- `GET /runtime/invocation/next` returned `204` after a 30-second
  poll timeout, violating the AWS Lambda Runtime API spec (only `200`
  is defined as a success response)
- The .NET Lambda RIC reads `Lambda-Runtime-Aws-Request-Id`
  unconditionally on every `/next` response and throws
  `KeyNotFoundException` on `204`, crashing the runtime at cold start
- Replace `blockingHandler` + `LinkedBlockingQueue.poll(30s)` with a
  reactive pattern: park `RoutingContext` in `waitingContexts`;
  `enqueue()` dispatches to parked callers via `vertx.runOnContext()`;
  zero Vert.x worker threads held while waiting

## Test plan

- [ ] `nextEndpoint_blocksUntilInvocationArrives` — parks and returns `200` when invocation enqueued after 2 s
- [ ] `nextEndpoint_parksWithNoResponse_thenReturns200WhenInvocationEnqueued`
  — connection stays open with no response until `enqueue()` is called
- [ ] `stopWakesParkedPollerImmediately` — `stop()` sends `204` in < 1 s (shutdown-only path, not normal operation)
- [ ] `stopCompletesInFlightWithContainerStopped` — in-flight future completed with `ContainerStopped` on stop
- [ ] `stopCompletesQueuedInvocationsWithContainerStopped` — queued but unconsumed invocations completed on stop
- [ ] `enqueueAfterStopCompletesImmediately` — `enqueue()` after `stop()` completes the future synchronously


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
