### PR TITLE
fix(lambda): wire S3VirtualHostFilter to container-aware DNS suffix

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaDnsResolutionTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaDnsResolutionTest.java
@@ -1,0 +1,132 @@
+package com.floci.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.CreateFunctionRequest;
+import software.amazon.awssdk.services.lambda.model.DeleteFunctionRequest;
+import software.amazon.awssdk.services.lambda.model.FunctionCode;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies that a Lambda container can reach S3 via virtual-hosted URL using
+ * the embedded DNS server injected into the container's /etc/resolv.conf.
+ *
+ * Requires Docker dispatch (docker.sock mounted) — skipped automatically when
+ * Lambda invocation is unavailable (CI without Docker, host-only mode, etc.).
+ *
+ * <p>The endpoint used inside the Lambda must match Floci's FLOCI_HOSTNAME so
+ * that the embedded DNS resolves it and S3VirtualHostFilter recognises the
+ * virtual-host prefix. Override via the {@code FLOCI_DNS_HOSTNAME} env var
+ * (default: {@code floci}, matching the standard docker-compose.yml).
+ */
+@DisplayName("Lambda DNS — S3 virtual-host resolution from inside container")
+class LambdaDnsResolutionTest {
+
+    private static final String FUNCTION_NAME = "dns-probe-fn";
+    private static final String BUCKET = "dns-probe-bucket";
+    private static final String KEY = "hello.txt";
+    private static final String OBJECT_BODY = "dns-resolution-ok";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    // The hostname Floci is reachable at from *inside* a Lambda container.
+    // Must match FLOCI_HOSTNAME so the embedded DNS resolves *.{hostname} and
+    // S3VirtualHostFilter extracts the bucket from the virtual-hosted Host header.
+    private static final String FLOCI_DNS_ENDPOINT =
+            Optional.ofNullable(System.getenv("FLOCI_DNS_HOSTNAME"))
+                    .filter(h -> !h.isBlank())
+                    .map(h -> h + ":4566")
+                    .orElse("floci:4566");
+
+    private static LambdaClient lambda;
+    private static S3Client s3;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        assumeTrue(TestFixtures.isLambdaDispatchAvailable(),
+                "Lambda dispatch unavailable — skipping DNS resolution test");
+
+        lambda = TestFixtures.lambdaClient();
+        s3 = TestFixtures.s3Client();
+
+        s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+        s3.putObject(
+                PutObjectRequest.builder().bucket(BUCKET).key(KEY).build(),
+                RequestBody.fromString(OBJECT_BODY));
+
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .timeout(30)
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.s3VirtualHostFetchZip()))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda != null) {
+            try { lambda.deleteFunction(DeleteFunctionRequest.builder().functionName(FUNCTION_NAME).build()); } catch (Exception ignored) {}
+            lambda.close();
+        }
+        if (s3 != null) {
+            try { s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(KEY).build()); } catch (Exception ignored) {}
+            try { s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build()); } catch (Exception ignored) {}
+            s3.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Lambda fetches S3 object via virtual-hosted URL using embedded DNS")
+    void lambdaResolvesS3ViaVirtualHostedUrl() throws Exception {
+        String payload = MAPPER.writeValueAsString(
+                MAPPER.createObjectNode()
+                        .put("bucket", BUCKET)
+                        .put("key", KEY)
+                        .put("endpoint", FLOCI_DNS_ENDPOINT));
+
+        InvokeResponse response = lambda.invoke(InvokeRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .invocationType(InvocationType.REQUEST_RESPONSE)
+                .payload(SdkBytes.fromUtf8String(payload))
+                .overrideConfiguration(c -> c.apiCallTimeout(Duration.ofSeconds(30)))
+                .build());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.functionError()).isNullOrEmpty();
+
+        String responseBody = response.payload().asUtf8String();
+        JsonNode result = MAPPER.readTree(responseBody);
+
+        assertThat(result.path("statusCode").asInt())
+                .as("S3 virtual-host HTTP status from inside Lambda container")
+                .isEqualTo(200);
+        assertThat(result.path("body").asText())
+                .as("S3 object body fetched via virtual-hosted URL")
+                .contains(OBJECT_BODY);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
@@ -151,6 +151,33 @@ public final class LambdaUtils {
         }
     }
 
+    /**
+     * ZIP containing a Node.js handler that fetches an S3 object via virtual-hosted URL.
+     * Receives {@code {bucket, key, endpoint}} in the event (endpoint = "host:port").
+     * Used to verify embedded DNS injection into Lambda containers.
+     */
+    public static byte[] s3VirtualHostFetchZip() {
+        String code = """
+                const http = require('http');
+                exports.handler = async (event) => {
+                    const { bucket, key, endpoint } = event;
+                    const url = `http://${bucket}.${endpoint}/${key}`;
+                    console.log('[dns-probe] fetching', url);
+                    return new Promise((resolve, reject) => {
+                        http.get(url, (res) => {
+                            let data = '';
+                            res.on('data', chunk => data += chunk);
+                            res.on('end', () => {
+                                console.log('[dns-probe] status', res.statusCode, 'body', data);
+                                resolve({ statusCode: res.statusCode, body: data });
+                            });
+                        }).on('error', e => reject(new Error(e.message)));
+                    });
+                };
+                """;
+        return createZip("index.js", code);
+    }
+
     private static byte[] createZip(String filename, String content) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.core.common.dns;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.quarkus.runtime.Startup;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.datagram.DatagramSocket;
@@ -34,12 +35,14 @@ import java.util.Optional;
  * Only starts when Floci detects it is running inside Docker. No-op on the host.
  */
 @ApplicationScoped
+@Startup
 public class EmbeddedDnsServer {
 
     private static final Logger LOG = Logger.getLogger(EmbeddedDnsServer.class);
     private static final int DNS_PORT = 53;
     private static final int TTL = 60;
     private static final String FALLBACK_UPSTREAM = "127.0.0.11";
+    public static final String DEFAULT_SUFFIX = "localhost.floci.io";
 
     private volatile String serverIp;
     private final List<String> suffixes = new ArrayList<>();
@@ -58,7 +61,7 @@ public class EmbeddedDnsServer {
             String myIp = InetAddress.getLocalHost().getHostAddress();
             upstreamDns = readUpstreamDns();
 
-            config.hostname().ifPresent(suffixes::add);
+            suffixes.add(config.hostname().orElse(DEFAULT_SUFFIX));
             config.dns().extraSuffixes().ifPresent(suffixes::addAll);
 
             DatagramSocket socket = vertx.createDatagramSocket(new DatagramSocketOptions().setIpV6(false));

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -1,32 +1,35 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 import java.net.URI;
-import java.util.Optional;
 
 @Provider
 @PreMatching
+@ApplicationScoped
 public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     private final String baseHostname;
 
-    public S3VirtualHostFilter() {
-        var config = ConfigProvider.getConfig();
-        String baseUrl = config
-                .getOptionalValue("floci.base-url", String.class)
-                .orElse("http://localhost:4566");
-        Optional<String> hostname = config
-                .getOptionalValue("floci.hostname", String.class);
-        String effectiveUrl = hostname
-                .map(h -> baseUrl.replaceFirst("://[^:/]+(:\\d+)?", "://" + h + "$1"))
-                .orElse(baseUrl);
-        this.baseHostname = extractHostnameFromUrl(effectiveUrl);
+    @Inject
+    public S3VirtualHostFilter(EmulatorConfig config, ContainerDetector containerDetector) {
+        this.baseHostname = config.hostname()
+                .orElseGet(() -> containerDetector.isRunningInContainer()
+                        ? EmbeddedDnsServer.DEFAULT_SUFFIX
+                        : extractHostnameFromUrl(config.baseUrl()));
+    }
+
+    S3VirtualHostFilter() {
+        this.baseHostname = "localhost";
     }
 
     @Override


### PR DESCRIPTION
S3VirtualHostFilter was reading config via ConfigProvider at construction time, always deriving baseHostname from floci.base-url. When running inside Docker, Lambda containers resolve S3 via the embedded DNS suffix (e.g. bucket.floci:4566), not the external base-url hostname. The filter never matched those virtual-host headers, so S3 requests from Lambda containers were served as path-style misses.

Switch to CDI injection (EmulatorConfig + ContainerDetector) so that in Docker mode baseHostname is set to EmbeddedDnsServer.DEFAULT_SUFFIX (or FLOCI_HOSTNAME when configured), consistent with what the embedded DNS actually resolves.

Add @Startup to EmbeddedDnsServer for eager initialisation and export DEFAULT_SUFFIX as a shared constant. Add LambdaDnsResolutionTest to validate the full path: Lambda container → embedded DNS → virtual-host filter → S3 object.

Closes #432 

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
