### PR TITLE
fix(docker): make bind-mounted /var/run/docker.sock work on all hosts

### DIFF
--- a/Dockerfile.jvm-package
+++ b/Dockerfile.jvm-package
@@ -6,6 +6,24 @@ ARG INSTALL_AWS_CLI=false
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
+ENV GOSU_VERSION=1.17
+ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
+ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+RUN set -eux; \
+    apk add --no-cache shadow ca-certificates; \
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
+    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
 WORKDIR /app
 
 RUN mkdir -p /app/data \
@@ -20,11 +38,13 @@ VOLUME /app/data
 
 COPY --chown=1001:root target/quarkus-app quarkus-app/
 
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 4566 6379-6399
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
     CMD wget -q --spider http://localhost:4566/_floci/health || exit 1
 
-USER 1001
-
-ENTRYPOINT ["java", "-jar", "quarkus-app/quarkus-run.jar", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["java", "-jar", "/app/quarkus-app/quarkus-run.jar", "-Dquarkus.http.host=0.0.0.0"]

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -13,11 +13,42 @@ COPY src ./src
 
 RUN mvn clean package -Dnative -DskipTests -B
 
-# Stage 2: Minimal runtime
+# See: https://www.redhat.com/en/blog/build-ubi-micro-images
+FROM registry.access.redhat.com/ubi9:9.7 AS tools
+
+ENV GOSU_VERSION=1.17
+ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
+ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+
+RUN set -eux; \
+    mkdir -p /toolsroot; \
+    dnf install -y --installroot=/toolsroot --releasever=9 \
+        --setopt=install_weak_deps=0 --nodocs \
+        shadow-utils; \
+    dnf -y --installroot=/toolsroot clean all; \
+    rm -rf /toolsroot/var/cache/* /toolsroot/var/log/dnf* /toolsroot/var/log/yum* \
+           /toolsroot/var/lib/rpm /toolsroot/var/lib/dnf; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    mkdir -p /toolsroot/usr/local/bin; \
+    curl -fsSL -o /toolsroot/usr/local/bin/gosu \
+        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
+    echo "${gosuSha256}  /toolsroot/usr/local/bin/gosu" | sha256sum -c -; \
+    chmod +x /toolsroot/usr/local/bin/gosu
+
+# Stage 3: Minimal runtime
 FROM quay.io/quarkus/quarkus-micro-image:2.0
 
 USER root
 WORKDIR /app
+.
+COPY --from=tools /toolsroot/ /
+
+RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 
 RUN mkdir -p /app/data \
     && chown -R 1001:root /app \
@@ -37,5 +68,8 @@ COPY --from=build /app/target/*-runner /app/application
 
 RUN chmod +x /app/application
 
-USER 1001
-ENTRYPOINT ["/app/application"]
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application"]

--- a/Dockerfile.native-package
+++ b/Dockerfile.native-package
@@ -7,6 +7,25 @@ ARG TARGETARCH
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
+ENV GOSU_VERSION=1.17
+ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
+ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+RUN set -eux; \
+    microdnf install -y --nodocs shadow-utils; \
+    microdnf clean all; \
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
+    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
 WORKDIR /app
 
 RUN mkdir -p /app/data \
@@ -18,11 +37,13 @@ VOLUME /app/data
 COPY --chown=1001:root native/${TARGETARCH}/ /app/
 RUN mv /app/*-runner /app/application && chmod +x /app/application
 
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 4566
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
     CMD curl -f http://localhost:4566/_floci/health || exit 1
 
-USER 1001
-
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Starts as root, normalizes the bind-mounted Docker socket's group
+# ownership so the unprivileged `floci` user can reach it on any host,
+# then re-executes this script as `floci` via gosu. The second invocation
+# falls through to exec the user's command.
+#
+# Why: on native Linux Docker, /var/run/docker.sock is owned by
+# root:docker with mode 660 and the docker GID varies by distro. On
+# Docker Desktop (macOS/Windows) the socket is typically root:root (GID
+# 0). Without the group fix-up below, floci (uid 1001, group 0) can open
+# the socket on Docker Desktop but not on native Linux — which breaks
+# ECR, Lambda, and RDS service emulation there. Discovering the GID at
+# runtime handles every host transparently.
+
+set -eu
+
+if [ "$(id -u)" = '0' ]; then
+    if [ -S /var/run/docker.sock ]; then
+        sock_gid="$(stat -c '%g' /var/run/docker.sock)"
+        if [ "$sock_gid" != '0' ]; then
+            group_name="$(getent group "$sock_gid" | cut -d: -f1)" || group_name=''
+            if [ -z "$group_name" ]; then
+                groupadd -g "$sock_gid" docker-host
+                group_name='docker-host'
+            fi
+            usermod -aG "$group_name" floci
+        fi
+    fi
+
+    # Re-own state dir for the case where a host bind-mount arrives with
+    # ownership the floci user cannot write to. Ignore errors (read-only
+    # mounts, unusual filesystems) so the container still starts.
+    if [ -d /app/data ]; then
+        chown -R floci:root /app/data 2>/dev/null || true
+    fi
+
+    exec gosu floci "$0" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

Closes #592.

The published images run as `USER 1001` with primary group `root`. On Docker Desktop (macOS/Windows) `/var/run/docker.sock` is owned `root:root` inside containers so the floci process can open it via the `group-0` bit, but on native Linux Docker (and Rootless/Podman) the socket is owned by `root:<docker-group>` with mode `660` — and the floci user is not a member of that group. This silently breaks ECR, Lambda, and RDS service emulation on those hosts: floci's docker-java client gets `BindException` / `SocketException` and reports `CREATE_FAILED` on `AWS::ECR::Repository`.

Fix: ship a `docker/entrypoint.sh` modeled on the `docker-library/postgres` pattern. It starts as root, stats the bind-mounted socket to learn the host's docker GID, ensures a group with that GID exists, adds the floci user to it, then `exec gosu floci` re-execs the same script as uid 1001 with the supplementary group set. The 'if id -u == 0' guard means downstream `user:` overrides in compose files keep working unchanged.

Verified end-to-end on native Linux (Pop!_OS, docker GID 999) using a minimal CDK bootstrap repro: `AWS::ECR::Repository` goes from `CREATE_FAILED` to `CREATE_COMPLETE` and the `registry:2` sidecar comes up cleanly. pid 1 runs as Uid:1001 Gid:0 Groups:999.

Implementation notes:
- All three Dockerfiles keep their original base images (quarkus-micro-image, ubi9-minimal, eclipse-temurin alpine).
- `Dockerfile.native` gains a tools builder stage that uses the canonical Red Hat pattern (`dnf install --installroot`) to install `shadow-utils` into a stagable `/toolsroot`, which the runtime stage wholesale-copies into `quarkus-micro-image`. Image growth: ~42 MB (quarkus-micro has no package manager and lacks `groupadd`/`usermod` by itself).
- Dockerfile.native-package adds shadow-utils via microdnf (already had the package manager).
- Dockerfile.jvm-package adds shadow + ca-certificates via apk so the entrypoint can use the same useradd/groupadd/usermod syntax across all three image variants.
- gosu 1.17 is downloaded and SHA256-pinned (rather than GPG-verified as Postgres does) to avoid pulling gnupg2 into the runtime layers and to sidestep a gpgme dependency conflict in ubi9-minimal.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- `ecr:CreateRepository`
- `cloudformation:CreateChangeSet`
- `cloudformation:ExecuteChangeSet`
- `cloudformation:DescribeStackEvents`
- `cloudformation:DescribeStacks`

Verified with `cdk` using minimal reproducible example from https://github.com/floci-io/floci/issues/592. 

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
