### PR TITLE
fix(s3-control): accept plain S3 ARN (arn:aws:s3:::bucket) in ListTagsForResource (#556)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3ControlTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3ControlTest.java
@@ -213,4 +213,31 @@ class S3ControlTest {
                 .isInstanceOf(S3ControlException.class)
                 .satisfies(e -> assertThat(((S3ControlException) e).statusCode()).isEqualTo(404));
     }
+
+    @Test
+    @Order(7)
+    @DisplayName("listTagsForResource: accepts plain S3 ARN (arn:aws:s3:::bucket) — Go SDK v2 / Terraform provider v6 (#556)")
+    void listTagsForResourceWithPlainS3Arn() {
+        s3.putBucketTagging(PutBucketTaggingRequest.builder()
+                .bucket(BUCKET)
+                .tagging(Tagging.builder()
+                        .tagSet(Tag.builder().key("PlainArn").value("works").build())
+                        .build())
+                .build());
+
+        // Plain ARN form used by Terraform provider v6 / Go SDK v2 for general-purpose buckets
+        String plainArn = "arn:aws:s3:::" + BUCKET;
+        ListTagsForResourceResponse response = s3control.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .accountId(ACCOUNT_ID)
+                        .resourceArn(plainArn)
+                        .build());
+
+        Map<String, String> tags = response.tags().stream()
+                .collect(Collectors.toMap(
+                        software.amazon.awssdk.services.s3control.model.Tag::key,
+                        software.amazon.awssdk.services.s3control.model.Tag::value));
+
+        assertThat(tags).containsEntry("PlainArn", "works");
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ControlController.java
@@ -134,6 +134,12 @@ public class S3ControlController {
      * literally. We decode defensively so both forms work, and so routing
      * frameworks that leave {@code %2F} encoded in path segments don't break
      * us.
+     *
+     * <p>Two valid ARN forms are accepted:
+     * <ul>
+     *   <li>S3 Control ARN: {@code arn:aws:s3:<region>:<account>:bucket/<name>}</li>
+     *   <li>Plain S3 ARN:   {@code arn:aws:s3:::<name>} — sent by Go SDK v2 / Terraform provider v6</li>
+     * </ul>
      */
     private String extractBucketName(String resourceArn) {
         String decoded;
@@ -143,13 +149,25 @@ public class S3ControlController {
             throw new AwsException("InvalidRequest",
                     "Malformed percent-encoding in resource ARN: " + e.getMessage(), 400);
         }
+
+        // Form 1: arn:<partition>:s3:<region>:<account>:bucket/<name>
         int idx = decoded.lastIndexOf(":bucket/");
-        if (idx < 0) {
-            throw new AwsException("InvalidRequest",
-                    "Unsupported resource type. Only S3 bucket ARNs are supported " +
-                    "(arn:aws:s3:<region>:<account>:bucket/<name>).", 400);
+        if (idx >= 0) {
+            return decoded.substring(idx + ":bucket/".length());
         }
-        return decoded.substring(idx + ":bucket/".length());
+
+        // Form 2: arn:<partition>:s3:::<name>  (plain S3 ARN — no region, no account)
+        // Go SDK v2 / Terraform provider v6 sends this form for general-purpose buckets.
+        String[] parts = decoded.split(":", 6);
+        if (parts.length == 6 && "s3".equals(parts[2])
+                && parts[3].isEmpty() && parts[4].isEmpty()
+                && !parts[5].isEmpty() && !parts[5].contains("/")) {
+            return parts[5];
+        }
+
+        throw new AwsException("InvalidRequest",
+                "Unsupported resource type. Only S3 bucket ARNs are supported " +
+                "(arn:aws:s3:<region>:<account>:bucket/<name> or arn:aws:s3:::<name>).", 400);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ControlUrlEncodedArnIntegrationTest.java
@@ -180,4 +180,36 @@ class S3ControlUrlEncodedArnIntegrationTest {
 
         assertS3ControlErrorResponse(response);
     }
+
+    @Test
+    @Order(8)
+    @DisplayName("ListTagsForResource accepts plain S3 ARN (arn:aws:s3:::bucket) from Go SDK v2 / Terraform (#556)")
+    void listTagsForResourceWithPlainS3Arn() {
+        // Terraform AWS provider v6 / Go SDK v2 sends arn:aws:s3:::<name> for general-purpose buckets
+        String plainArn = "arn:aws:s3:::" + BUCKET;
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + plainArn)
+        .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<ListTagsForResourceResult"));
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("ListTagsForResource accepts URL-encoded plain S3 ARN from Go SDK v2 / Terraform (#556)")
+    void listTagsForResourceWithUrlEncodedPlainS3Arn() {
+        // Go SDK v2 percent-encodes colons: arn%3Aaws%3As3%3A%3A%3A<bucket>
+        String encodedPlainArn = "arn%3Aaws%3As3%3A%3A%3A" + BUCKET;
+        given()
+            .header("x-amz-account-id", ACCOUNT)
+        .when()
+            .get("/v20180820/tags/" + encodedPlainArn)
+        .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<ListTagsForResourceResult"));
+    }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
 - Go SDK v2 and Terraform AWS provider v6 call ListTagsForResource with arn:aws:s3:::<name> for general-purpose buckets. This form carries no region and no account, so the previous lastIndexOf(":bucket/") check failed and returned 400 InvalidRequest.
- extractBucketName() in S3ControlController now tries Form 1 (arn:aws:s3:<region>:account>:bucket/<name>) first, then falls back to Form 2 (arn:aws:s3:::<name>) by splitting on : with a limit of 6 and validating that segments 3 and 4 are empty and segment 5 is a non-empty name without /.                                                  
- Both the literal and URL-encoded (arn%3Aaws%3As3%3A%3A%3A<bucket>) variants of Form 2 are handled through the existing URLDecoder.decode() path.

Closes #556 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Test plan                                                     
                                                                                                                                                                                
- S3ControlUrlEncodedArnIntegrationTest — 2 new unit tests (orders 8 & 9): plain ARN and URL-encoded plain ARN return 200 with <ListTagsForResourceResult>. All 9 tests pass. 
- S3ControlTest — 1 new SDK compat test (order 7): tags a bucket via PutBucketTagging, reads back via listTagsForResource with arn:aws:s3:::bucket, asserts tag is present. Passes against the rebuilt native image.                                                                                                                                      
- Full Java SDK compatibility suite: 626 tests, 0 new failures introduced.
