### PR TITLE
fix(cloudformation): resolve changeset by ARN in DescribeChangeSet, ExecuteChangeSet, DeleteChangeSet

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/cloudformation.bats
+++ b/compatibility-tests/sdk-test-awscli/test/cloudformation.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# CloudFormation tests
+
+setup() {
+    load 'test_helper/common-setup'
+    STACK_NAME="bats-cfn-stack-$(unique_name)"
+    TEMPLATE_FILE=$(mktemp /tmp/cfn-bats-XXXXXX.yaml)
+}
+
+teardown() {
+    aws_cmd cloudformation delete-stack --stack-name "$STACK_NAME" >/dev/null 2>&1 || true
+    [ -n "$TEMPLATE_FILE" ] && rm -f "$TEMPLATE_FILE"
+}
+
+# ── CreateStack / DescribeStacks ──────────────────────────────────────────────
+
+@test "CloudFormation: create stack reaches CREATE_COMPLETE" {
+    cat > "$TEMPLATE_FILE" << 'EOF'
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: bats-cfn-basic-queue
+EOF
+    run aws_cmd cloudformation create-stack \
+        --stack-name "$STACK_NAME" \
+        --template-body "file://$TEMPLATE_FILE"
+    assert_success
+
+    run aws_cmd cloudformation describe-stacks --stack-name "$STACK_NAME"
+    assert_success
+    local stack_status
+    stack_status=$(json_get "$output" '.Stacks[0].StackStatus')
+    [ "$stack_status" = "CREATE_COMPLETE" ]
+}
+
+@test "CloudFormation: describe-stack-resources lists provisioned resources" {
+    cat > "$TEMPLATE_FILE" << 'EOF'
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: bats-cfn-resources-queue
+EOF
+    aws_cmd cloudformation create-stack \
+        --stack-name "$STACK_NAME" \
+        --template-body "file://$TEMPLATE_FILE" >/dev/null
+
+    run aws_cmd cloudformation describe-stack-resources --stack-name "$STACK_NAME"
+    assert_success
+    local count
+    count=$(json_get "$output" '.StackResources | length')
+    [ "$count" -gt 0 ]
+}
+
+@test "CloudFormation: delete stack removes resources" {
+    cat > "$TEMPLATE_FILE" << 'EOF'
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: bats-cfn-delete-queue
+EOF
+    aws_cmd cloudformation create-stack \
+        --stack-name "$STACK_NAME" \
+        --template-body "file://$TEMPLATE_FILE" >/dev/null
+
+    run aws_cmd cloudformation delete-stack --stack-name "$STACK_NAME"
+    assert_success
+
+    run aws_cmd cloudformation describe-stacks --stack-name "$STACK_NAME"
+    # Stack should no longer exist
+    [[ "$output" == *"does not exist"* ]]
+    STACK_NAME=""  # prevent teardown from trying again
+}
+
+# ── aws cloudformation deploy (CreateChangeSet + ExecuteChangeSet by ARN) ─────
+#
+# Regression: DescribeChangeSet / ExecuteChangeSet failed when called with the
+# changeset ARN (the AWS CLI always passes the ARN, not the short name).
+# See: https://github.com/floci-io/floci/issues/606
+
+@test "CloudFormation: deploy creates stack via changeset" {
+    cat > "$TEMPLATE_FILE" << 'EOF'
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: bats-cfn-deploy-queue
+EOF
+    run aws_cmd cloudformation deploy \
+        --stack-name "$STACK_NAME" \
+        --template-file "$TEMPLATE_FILE"
+    assert_success
+
+    run aws_cmd cloudformation describe-stacks --stack-name "$STACK_NAME"
+    assert_success
+    local stack_status
+    stack_status=$(json_get "$output" '.Stacks[0].StackStatus')
+    [ "$stack_status" = "CREATE_COMPLETE" ]
+}
+
+@test "CloudFormation: deploy provisions resources correctly" {
+    cat > "$TEMPLATE_FILE" << 'EOF'
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: bats-cfn-deploy-res-queue
+EOF
+    aws_cmd cloudformation deploy \
+        --stack-name "$STACK_NAME" \
+        --template-file "$TEMPLATE_FILE" >/dev/null
+
+    run aws_cmd cloudformation describe-stack-resources --stack-name "$STACK_NAME"
+    assert_success
+    local resource_status
+    resource_status=$(json_get "$output" '.StackResources[0].ResourceStatus')
+    [ "$resource_status" = "CREATE_COMPLETE" ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -100,7 +100,7 @@ public class CloudFormationService {
 
     public ChangeSet describeChangeSet(String stackName, String changeSetName, String region) {
         Stack stack = getStackOrThrow(stackName, region);
-        ChangeSet cs = stack.getChangeSets().get(changeSetName);
+        ChangeSet cs = stack.getChangeSets().get(resolveChangeSetName(changeSetName));
         if (cs == null) {
             throw new AwsException("ChangeSetNotFoundException",
                     "ChangeSet [" + changeSetName + "] does not exist", 400);
@@ -112,7 +112,7 @@ public class CloudFormationService {
 
     public Future<?> executeChangeSet(String stackName, String changeSetName, String region) {
         Stack stack = getStackOrThrow(stackName, region);
-        ChangeSet cs = stack.getChangeSets().get(changeSetName);
+        ChangeSet cs = stack.getChangeSets().get(resolveChangeSetName(changeSetName));
         if (cs == null) {
             throw new AwsException("ChangeSetNotFoundException",
                     "ChangeSet [" + changeSetName + "] does not exist", 400);
@@ -136,12 +136,13 @@ public class CloudFormationService {
 
     public void deleteChangeSet(String stackName, String changeSetName, String region) {
         Stack stack = getStackOrThrow(stackName, region);
-        ChangeSet cs = stack.getChangeSets().get(changeSetName);
+        String name = resolveChangeSetName(changeSetName);
+        ChangeSet cs = stack.getChangeSets().get(name);
         if (cs == null) {
             throw new AwsException("ChangeSetNotFoundException",
                     "ChangeSet [" + changeSetName + "] does not exist", 400);
         }
-        stack.getChangeSets().remove(changeSetName);
+        stack.getChangeSets().remove(name);
     }
 
     // ── DeleteStack ───────────────────────────────────────────────────────────
@@ -491,6 +492,22 @@ public class CloudFormationService {
                     "Stack with id " + stackNameOrArn + " does not exist", 400);
         }
         return stack;
+    }
+
+    /**
+     * Resolves a changeset name from either a short name or a full ARN.
+     * The AWS CLI passes the full ARN (arn:aws:cloudformation:…:changeSet/<name>/<uuid>)
+     * when referencing a changeset by the ID returned from CreateChangeSet.
+     */
+    private String resolveChangeSetName(String changeSetNameOrArn) {
+        if (changeSetNameOrArn != null && changeSetNameOrArn.startsWith("arn:")) {
+            // arn:aws:cloudformation:<region>:<account>:changeSet/<name>/<uuid>
+            String[] parts = changeSetNameOrArn.split("/");
+            if (parts.length >= 2) {
+                return parts[1];
+            }
+        }
+        return changeSetNameOrArn;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -2050,4 +2050,80 @@ class CloudFormationIntegrationTest {
         .then()
             .statusCode(404);
     }
+
+    @Test
+    void createChangeSet_describeAndExecuteByArn_succeeds() {
+        // Regression test for: DescribeChangeSet / ExecuteChangeSet fail when called
+        // with a changeset ARN instead of a short name.
+        // The AWS CLI's `aws cloudformation deploy` always passes the full ARN returned
+        // by CreateChangeSet back to DescribeChangeSet and ExecuteChangeSet, so this
+        // path must work for `deploy` to function at all.
+        String template = """
+            {
+              "Resources": {
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": { "QueueName": "cfn-cs-arn-queue" }
+                }
+              }
+            }
+            """;
+
+        // 1. CreateChangeSet — returns a changeset ARN in the response
+        String createXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateChangeSet")
+            .formParam("StackName", "cfn-cs-arn-stack")
+            .formParam("ChangeSetName", "my-changeset")
+            .formParam("ChangeSetType", "CREATE")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>"))
+            .extract().asString();
+
+        // Extract the full changeset ARN from the CreateChangeSet response
+        String changeSetArn = createXml
+            .split("<Id>")[1]
+            .split("</Id>")[0];
+
+        assertThat("CreateChangeSet should return a changeset ARN",
+            changeSetArn, startsWith("arn:aws:cloudformation:"));
+
+        // 2. DescribeChangeSet by ARN — must return Status, not 400
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeChangeSet")
+            .formParam("StackName", "cfn-cs-arn-stack")
+            .formParam("ChangeSetName", changeSetArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Status>CREATE_COMPLETE</Status>"));
+
+        // 3. ExecuteChangeSet by ARN — must succeed and provision the stack
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ExecuteChangeSet")
+            .formParam("StackName", "cfn-cs-arn-stack")
+            .formParam("ChangeSetName", changeSetArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // 4. Stack should reach CREATE_COMPLETE
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-cs-arn-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+    }
 }


### PR DESCRIPTION
## Summary

`aws cloudformation deploy` was completely broken — it crashed with `KeyError: 'Status'` immediately after creating the changeset.

The AWS CLI calls `CreateChangeSet`, receives a full changeset ARN in the response, then passes that ARN as `ChangeSetName` to `DescribeChangeSet` and `ExecuteChangeSet`. `CloudFormationService` was doing a direct map lookup using the raw parameter, which always missed because changesets are stored by short name — returning 400 `ChangeSetNotFoundException` on every `deploy` invocation.

Fix: add `resolveChangeSetName()` to extract the short name from the ARN path segment (`arn:aws:cloudformation:…:changeSet/<name>/<uuid>`) before the map lookup. Applied to `describeChangeSet`, `executeChangeSet`, and `deleteChangeSet`.

Closes #606

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

`aws cloudformation deploy` passes the changeset ARN (not the short name) to `DescribeChangeSet` and `ExecuteChangeSet` — this is standard AWS CLI v2 behavior. Verified with AWS CLI v2.22.22.

Before this fix: `deploy` always failed with `KeyError: 'Status'`.
After this fix: `deploy` completes successfully.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`createChangeSet_describeAndExecuteByArn_succeeds` in `CloudFormationIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)