### PR TITLE
fix(lambda): drop dead pooled containers in WarmPool.acquire() before reuse

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -246,6 +246,26 @@ public class ContainerLifecycleManager {
     }
 
     /**
+     * Returns whether the container is currently running. A missing container
+     * is treated as not-running; any other Docker error is treated as running
+     * so a transient daemon hiccup does not evict a healthy warm pool.
+     *
+     * @param containerId the container ID to inspect
+     * @return true if the container exists and is reported as running
+     */
+    public boolean isContainerRunning(String containerId) {
+        try {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+            return Boolean.TRUE.equals(inspect.getState().getRunning());
+        } catch (NotFoundException e) {
+            return false;
+        } catch (Exception e) {
+            LOG.warnv("Liveness check failed for container {0}: {1}", containerId, e.getMessage());
+            return true;
+        }
+    }
+
+    /**
      * Resolves the endpoint (host and port) to connect to a specific container port.
      *
      * @param containerId the container ID

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -103,8 +103,23 @@ public class WarmPool {
 
         if (!ephemeral) {
             ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(fn.getFunctionName(), k -> new ArrayDeque<>());
-            synchronized (queue) {
-                handle = queue.pollFirst();
+            // Skip pooled handles whose container died out-of-band — otherwise the
+            // caller would wait the full Lambda function timeout.
+            while (true) {
+                ContainerHandle candidate;
+                synchronized (queue) {
+                    candidate = queue.pollFirst();
+                }
+                if (candidate == null) {
+                    break;
+                }
+                if (containerLauncher.isAlive(candidate)) {
+                    handle = candidate;
+                    break;
+                }
+                LOG.infov("Discarding dead pooled container {0} for function {1}",
+                        candidate.getContainerId(), fn.getFunctionName());
+                stopQuietly(candidate);
             }
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -217,6 +217,16 @@ public class ContainerLauncher {
         lifecycleManager.stopAndRemove(handle.getContainerId(), handle.getLogStream());
     }
 
+    /**
+     * Probes whether the handle's underlying container is still running.
+     *
+     * @param handle the warm-pool handle to probe
+     * @return true if the container is still running
+     */
+    public boolean isAlive(ContainerHandle handle) {
+        return lifecycleManager.isContainerRunning(handle.getContainerId());
+    }
+
     private void copyDirToContainer(DockerClient dockerClient, String containerId,
                                     Path sourceDir, String remotePath, String functionName) {
         try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -103,6 +104,7 @@ class WarmPoolTest {
         ContainerHandle h2 = new ContainerHandle("cid-b", "multi-fn", null, ContainerState.WARM);
 
         when(containerLauncher.launch(any())).thenReturn(h1, h2);
+        when(containerLauncher.isAlive(any())).thenReturn(true);
 
         ContainerHandle acquired1 = pool.acquire(fn);
         pool.release(acquired1);
@@ -136,6 +138,7 @@ class WarmPoolTest {
 
         ContainerHandle handle = new ContainerHandle("cid-reuse", "reuse-fn", null, ContainerState.WARM);
         when(containerLauncher.launch(any())).thenReturn(handle);
+        when(containerLauncher.isAlive(any())).thenReturn(true);
 
         ContainerHandle first = pool.acquire(fn);
         assertEquals(ContainerState.BUSY, first.getState());
@@ -149,6 +152,72 @@ class WarmPoolTest {
 
         // containerLauncher.launch should only have been called once (cold start)
         verify(containerLauncher, times(1)).launch(any());
+
+        pool.shutdown();
+    }
+
+    @Test
+    void acquire_discardsDeadPooledHandleAndColdStarts() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("dead-fn");
+
+        ContainerHandle dead = new ContainerHandle("cid-dead", "dead-fn", null, ContainerState.WARM);
+        ContainerHandle fresh = new ContainerHandle("cid-fresh", "dead-fn", null, ContainerState.WARM);
+
+        // Seed the pool with the dead handle by acquiring + releasing it once.
+        // The seed acquire is a cold start (empty pool), so isAlive isn't called.
+        when(containerLauncher.launch(any())).thenReturn(dead, fresh);
+        ContainerHandle seeded = pool.acquire(fn);
+        assertSame(dead, seeded);
+        pool.release(seeded);
+
+        // Now the container "dies" out-of-band (docker rm -f, OOM, etc.).
+        when(containerLauncher.isAlive(dead)).thenReturn(false);
+
+        ContainerHandle acquired = pool.acquire(fn);
+        assertSame(fresh, acquired);
+        assertNotSame(dead, acquired);
+        verify(containerLauncher, times(1)).stop(dead);
+        verify(containerLauncher, times(2)).launch(any());
+
+        pool.shutdown();
+    }
+
+    @Test
+    void acquire_skipsDeadHandleAndReusesNextAlive() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("mixed-fn");
+
+        ContainerHandle dead = new ContainerHandle("cid-dead", "mixed-fn", null, ContainerState.WARM);
+        ContainerHandle alive = new ContainerHandle("cid-alive", "mixed-fn", null, ContainerState.WARM);
+
+        // Seed deque with [dead, alive]: release(alive) first, then release(dead),
+        // so dead ends up at the front (release uses addFirst). Both acquires
+        // here are cold starts (empty pool) so no isAlive stub is needed yet.
+        when(containerLauncher.launch(any())).thenReturn(alive, dead);
+        ContainerHandle a1 = pool.acquire(fn);
+        ContainerHandle a2 = pool.acquire(fn);
+        assertSame(alive, a1);
+        assertSame(dead, a2);
+        pool.release(a1);
+        pool.release(a2);
+
+        // dead dies out-of-band, alive is still up.
+        when(containerLauncher.isAlive(dead)).thenReturn(false);
+        when(containerLauncher.isAlive(alive)).thenReturn(true);
+
+        ContainerHandle acquired = pool.acquire(fn);
+        assertSame(alive, acquired);
+        verify(containerLauncher, times(1)).stop(dead);
+        verify(containerLauncher, never()).stop(alive);
+        // Only the original two cold starts; no extra launch was needed.
+        verify(containerLauncher, times(2)).launch(any());
 
         pool.shutdown();
     }


### PR DESCRIPTION
## Summary

Addresses: #609 

When a Floci-tracked Lambda container disappears out-of-band (`docker rm -f`,
OOM kill, daemon restart, Docker Desktop prune), the next invocation hangs
for the full configured `Timeout` and returns `Function.TimedOut`. Real AWS
Lambda always cold-starts on the post-eviction invocation; Floci does not.

Root cause: `WarmPool.acquire()` returned the head of the per-function deque
without verifying the underlying container was still alive, so the caller
enqueued an invocation onto a `RuntimeApiServer` that no runtime would ever
poll.

Fix: before returning a pooled handle, ask Docker whether the container is
still running via `inspectContainerCmd`. If not, fully destroy the handle
(stops the orphaned `RuntimeApiServer`, releases its port, closes the log
stream) and try the next handle in the deque, falling back to a cold start
if the deque drains. One synchronous inspect per pooled acquire (~1–5 ms);
no new threads, no event subscriptions.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior (before):** the first invocation after a pooled Lambda
container died out-of-band hung for the entire configured function `Timeout`
and returned

```json
{"errorMessage":"Task timed out after X seconds","errorType":"Function.TimedOut"}
```

The very next invocation succeeded only because the failed attempt's
`destroyHandle` had drained the pool, forcing a cold start. Real AWS Lambda
never exhibits this — it always cold-starts on a post-eviction invocation
and succeeds in <1 s.

**After fix:** the post-eviction invocation cold-starts and returns the
correct response, matching real AWS Lambda. The dead handle is detected and
discarded synchronously before the caller ever sees it.

## Changes

| File | Change |
|------|--------|
| [`src/main/java/.../docker/ContainerLifecycleManager.java`](../../src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java) | Add `isContainerRunning(String)`. Returns `inspect.getState().getRunning()`; treats `NotFoundException` as not-running; conservatively treats other Docker errors as running so a daemon hiccup never wipes a healthy pool. |
| [`src/main/java/.../launcher/ContainerLauncher.java`](../../src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java) | Add thin pass-through `isAlive(ContainerHandle)` so `WarmPool` can probe liveness without taking a direct dependency on Docker types. |
| [`src/main/java/.../lambda/WarmPool.java`](../../src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java) | Replace single `pollFirst()` in `acquire()` with a loop that drops dead handles via `containerLauncher.isAlive` + `stopQuietly`, falling through to a cold start when the deque drains. |
| [`src/test/java/.../lambda/WarmPoolTest.java`](../../src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java) | Two new regression tests (`acquire_discardsDeadPooledHandleAndColdStarts`, `acquire_skipsDeadHandleAndReusesNextAlive`); existing reuse tests stub `isAlive(any())` → `true` where needed. |

## Regression test matrix — wrong behavior → test

| Wrong behavior | Test |
|---|---|
| `acquire()` returns a dead pooled handle and the caller waits the full Lambda timeout | `acquire_discardsDeadPooledHandleAndColdStarts` |
| A dead handle in front of an alive one in the deque blocks reuse and forces a cold start | `acquire_skipsDeadHandleAndReusesNextAlive` |

Both tests fail on the pre-fix code (acquire returns the dead handle directly)
and pass after.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
