### PR TITLE
fix(kms): GetKeyRotationStatus returns false for asymmetric and HMAC keys 

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/kinesis_test.go
+++ b/compatibility-tests/sdk-test-go/tests/kinesis_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"testing"
+	"time"
 
 	"floci-sdk-test-go/internal/testutil"
 
@@ -37,6 +38,7 @@ func TestKinesis(t *testing.T) {
 	})
 
 	var shardID string
+	var streamARN string
 
 	t.Run("DescribeStream", func(t *testing.T) {
 		r, err := svc.DescribeStream(ctx, &kinesis.DescribeStreamInput{StreamName: aws.String(streamName)})
@@ -45,6 +47,7 @@ func TestKinesis(t *testing.T) {
 		if len(r.StreamDescription.Shards) > 0 {
 			shardID = aws.ToString(r.StreamDescription.Shards[0].ShardId)
 		}
+		streamARN = aws.ToString(r.StreamDescription.StreamARN)
 	})
 
 	t.Run("PutRecord", func(t *testing.T) {
@@ -88,6 +91,64 @@ func TestKinesis(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.NotEmpty(t, r.Records)
+	})
+
+	var consumerARN string
+
+	t.Run("RegisterStreamConsumer", func(t *testing.T) {
+		if streamARN == "" {
+			t.Skip("No stream ARN from DescribeStream")
+		}
+		r, err := svc.RegisterStreamConsumer(ctx, &kinesis.RegisterStreamConsumerInput{
+			StreamARN:    aws.String(streamARN),
+			ConsumerName: aws.String("go-test-consumer"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, r.Consumer)
+		consumerARN = aws.ToString(r.Consumer.ConsumerARN)
+		assert.NotEmpty(t, consumerARN)
+	})
+
+	t.Run("DescribeStreamConsumer", func(t *testing.T) {
+		if consumerARN == "" {
+			t.Skip("No consumer ARN from RegisterStreamConsumer")
+		}
+		r, err := svc.DescribeStreamConsumer(ctx, &kinesis.DescribeStreamConsumerInput{
+			ConsumerARN: aws.String(consumerARN),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, kinesistypes.ConsumerStatusActive, r.ConsumerDescription.ConsumerStatus)
+		assert.Equal(t, "go-test-consumer", aws.ToString(r.ConsumerDescription.ConsumerName))
+	})
+
+	t.Run("SubscribeToShard", func(t *testing.T) {
+		if consumerARN == "" || shardID == "" {
+			t.Skip("No consumerARN or shardID")
+		}
+		subCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		output, err := svc.SubscribeToShard(subCtx, &kinesis.SubscribeToShardInput{
+			ConsumerARN: aws.String(consumerARN),
+			ShardId:     aws.String(shardID),
+			StartingPosition: &kinesistypes.StartingPosition{
+				Type: kinesistypes.ShardIteratorTypeTrimHorizon,
+			},
+		})
+		require.NoError(t, err)
+
+		stream := output.GetStream()
+		defer stream.Close()
+
+		var gotEvent bool
+		for event := range stream.Events() {
+			if ev, ok := event.(*kinesistypes.SubscribeToShardEventStreamMemberSubscribeToShardEvent); ok {
+				gotEvent = true
+				assert.NotNil(t, ev.Value.Records)
+			}
+		}
+		require.NoError(t, stream.Err())
+		assert.True(t, gotEvent, "expected at least one SubscribeToShardEvent")
 	})
 
 	t.Run("DeleteStream", func(t *testing.T) {

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -154,6 +154,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kinesis</artifactId>
         </dependency>
+        <!-- Netty async HTTP client — required for KinesisAsyncClient (SubscribeToShard) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
         <!-- CloudWatch Logs client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -10,7 +10,10 @@ import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityPr
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.http.Protocol;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.opensearch.OpenSearchClient;
@@ -334,6 +337,16 @@ public final class TestFixtures {
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static KinesisAsyncClient kinesisAsyncClient() {
+        return KinesisAsyncClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .httpClientBuilder(NettyNioAsyncHttpClient.builder()
+                        .protocol(Protocol.HTTP1_1))
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KinesisEfoTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KinesisEfoTest.java
@@ -1,0 +1,132 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.ConsumerStatus;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
+import software.amazon.awssdk.services.kinesis.model.RegisterStreamConsumerRequest;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+import software.amazon.awssdk.services.kinesis.model.StartingPosition;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEventStream;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardRequest;
+import software.amazon.awssdk.services.kinesis.model.SubscribeToShardResponseHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("Kinesis Enhanced Fan-Out (SubscribeToShard)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class KinesisEfoTest {
+
+    private static final String STREAM_NAME = "efo-compat-test-stream";
+    private static final String CONSUMER_NAME = "efo-compat-test-consumer";
+
+    private static KinesisClient kinesis;
+    private static KinesisAsyncClient kinesisAsync;
+    private static String streamArn;
+    private static String shardId;
+    private static String consumerArn;
+
+    @BeforeAll
+    static void setup() {
+        kinesis = TestFixtures.kinesisClient();
+        kinesisAsync = TestFixtures.kinesisAsyncClient();
+
+        assertDoesNotThrow(() -> kinesis.createStream(r -> r.streamName(STREAM_NAME).shardCount(1)));
+
+        var desc = kinesis.describeStream(DescribeStreamRequest.builder().streamName(STREAM_NAME).build());
+        streamArn = desc.streamDescription().streamARN();
+        shardId = desc.streamDescription().shards().get(0).shardId();
+
+        kinesis.putRecord(PutRecordRequest.builder()
+                .streamName(STREAM_NAME)
+                .data(SdkBytes.fromUtf8String("{\"event\":\"efo-compat-test\"}"))
+                .partitionKey("pk1")
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        try {
+            kinesis.deleteStream(r -> r.streamName(STREAM_NAME));
+        } catch (Exception ignored) {}
+        if (kinesis != null) kinesis.close();
+        if (kinesisAsync != null) kinesisAsync.close();
+    }
+
+    @Test
+    @Order(1)
+    void registerStreamConsumer() {
+        var response = assertDoesNotThrow(() ->
+                kinesis.registerStreamConsumer(RegisterStreamConsumerRequest.builder()
+                        .streamARN(streamArn)
+                        .consumerName(CONSUMER_NAME)
+                        .build()));
+
+        assertThat(response.consumer()).isNotNull();
+        assertThat(response.consumer().consumerName()).isEqualTo(CONSUMER_NAME);
+        assertThat(response.consumer().consumerARN()).isNotBlank();
+        consumerArn = response.consumer().consumerARN();
+    }
+
+    @Test
+    @Order(2)
+    void describeStreamConsumer() {
+        assertThat(consumerArn).as("consumerArn must be set by registerStreamConsumer").isNotBlank();
+
+        var response = assertDoesNotThrow(() ->
+                kinesis.describeStreamConsumer(DescribeStreamConsumerRequest.builder()
+                        .consumerARN(consumerArn)
+                        .build()));
+
+        assertThat(response.consumerDescription().consumerName()).isEqualTo(CONSUMER_NAME);
+        assertThat(response.consumerDescription().consumerStatus()).isEqualTo(ConsumerStatus.ACTIVE);
+    }
+
+    @Test
+    @Order(3)
+    void subscribeToShard() throws Exception {
+        assertThat(consumerArn).as("consumerArn must be set by registerStreamConsumer").isNotBlank();
+
+        List<SubscribeToShardEvent> received = new ArrayList<>();
+
+        SubscribeToShardResponseHandler handler = SubscribeToShardResponseHandler.builder()
+                .subscriber(event -> {
+                    if (event instanceof SubscribeToShardEvent e) {
+                        received.add(e);
+                    }
+                })
+                .build();
+
+        CompletableFuture<Void> future = kinesisAsync.subscribeToShard(
+                SubscribeToShardRequest.builder()
+                        .consumerARN(consumerArn)
+                        .shardId(shardId)
+                        .startingPosition(StartingPosition.builder()
+                                .type(ShardIteratorType.TRIM_HORIZON)
+                                .build())
+                        .build(),
+                handler);
+
+        future.get(15, TimeUnit.SECONDS);
+
+        assertThat(received).as("at least one SubscribeToShardEvent expected").isNotEmpty();
+        assertThat(received.get(0).records()).isNotNull();
+    }
+}

--- a/docs/services/kinesis.md
+++ b/docs/services/kinesis.md
@@ -45,6 +45,29 @@ aws kinesis describe-stream --stream-arn arn:aws:kinesis:us-east-1:000000000000:
 
 ## Examples
 
+## Enhanced Fan-Out (EFO)
+
+`SubscribeToShard` uses a snapshot-and-close model: the server returns one batch of records as a binary EventStream response and closes the connection. The SDK resubscribes automatically using the `ContinuationSequenceNumber` from the last delivered record. All five `StartingPosition` types are supported: `TRIM_HORIZON`, `LATEST`, `AT_SEQUENCE_NUMBER`, `AFTER_SEQUENCE_NUMBER`, `AT_TIMESTAMP`.
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+STREAM=my-stream
+
+# Register a consumer
+aws kinesis register-stream-consumer \
+  --stream-arn $(aws kinesis describe-stream --stream-name $STREAM \
+      --query StreamDescription.StreamARN --output text) \
+  --consumer-name my-consumer
+
+# Subscribe (AWS CLI streams events to stdout)
+aws kinesis subscribe-to-shard \
+  --consumer-arn <consumer-arn> \
+  --shard-id shardId-000000000000 \
+  --starting-position Type=TRIM_HORIZON
+```
+
+## Examples
+
 ```bash
 export AWS_ENDPOINT_URL=http://localhost:4566
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsEventStreamEncoder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsEventStreamEncoder.java
@@ -1,0 +1,52 @@
+package io.github.hectorvent.floci.core.common;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+public class AwsEventStreamEncoder {
+
+    public static byte[] encodeMessage(LinkedHashMap<String, String> headers, byte[] payload) throws Exception {
+        byte[] headersBytes = encodeHeaders(headers);
+        int totalLen = 4 + 4 + 4 + headersBytes.length + payload.length + 4;
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream(totalLen);
+        DataOutputStream dos = new DataOutputStream(buf);
+
+        dos.writeInt(totalLen);
+        dos.writeInt(headersBytes.length);
+
+        CRC32 preludeCrc = new CRC32();
+        preludeCrc.update(buf.toByteArray());
+        dos.writeInt((int) preludeCrc.getValue());
+
+        dos.write(headersBytes);
+        dos.write(payload);
+        dos.flush();
+
+        CRC32 msgCrc = new CRC32();
+        msgCrc.update(buf.toByteArray());
+        dos.writeInt((int) msgCrc.getValue());
+        dos.flush();
+
+        return buf.toByteArray();
+    }
+
+    private static byte[] encodeHeaders(LinkedHashMap<String, String> headers) throws Exception {
+        ByteArrayOutputStream h = new ByteArrayOutputStream();
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            byte[] name = e.getKey().getBytes(StandardCharsets.UTF_8);
+            byte[] value = e.getValue().getBytes(StandardCharsets.UTF_8);
+            h.write(name.length & 0xFF);
+            h.write(name);
+            h.write(7);
+            h.write((value.length >> 8) & 0xFF);
+            h.write(value.length & 0xFF);
+            h.write(value);
+        }
+        return h.toByteArray();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.kinesis;
 
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.AwsEventStreamEncoder;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisRecord;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisShard;
@@ -17,6 +18,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -265,9 +267,71 @@ public class KinesisJsonHandler {
         return Response.ok(response).build();
     }
 
+    @SuppressWarnings("unchecked")
     private Response handleSubscribeToShard(JsonNode request, String region) {
-        ObjectNode response = objectMapper.createObjectNode();
-        return Response.ok(response).build();
+        String consumerArn = request.path("ConsumerARN").asText(null);
+        String shardId = request.path("ShardId").asText(null);
+        JsonNode startPos = request.path("StartingPosition");
+        String startType = startPos.path("Type").asText("TRIM_HORIZON");
+        String seqNumber = startPos.has("SequenceNumber") ? startPos.path("SequenceNumber").asText(null) : null;
+        Long timestampMs = startPos.has("Timestamp")
+                ? Math.round(startPos.path("Timestamp").asDouble() * 1000) : null;
+
+        KinesisConsumer consumer = service.describeStreamConsumer(null, null, consumerArn, region);
+        String streamName = parseStreamNameFromArn(consumer.getStreamArn());
+
+        String shardIterator = service.getShardIterator(streamName, shardId, startType, seqNumber, timestampMs, region);
+
+        Map<String, Object> result = service.getRecords(shardIterator, null, region);
+        List<KinesisRecord> records = (List<KinesisRecord>) result.get("Records");
+        long millisBehind = ((Number) result.get("MillisBehindLatest")).longValue();
+
+        String continuationSeqNo = records.isEmpty() ? null
+                : records.get(records.size() - 1).getSequenceNumber();
+
+        ObjectNode eventPayload = objectMapper.createObjectNode();
+        ArrayNode recordsNode = eventPayload.putArray("Records");
+        for (KinesisRecord rec : records) {
+            recordsNode.addObject()
+                    .put("Data", Base64.getEncoder().encodeToString(rec.getData()))
+                    .put("PartitionKey", rec.getPartitionKey())
+                    .put("SequenceNumber", rec.getSequenceNumber())
+                    .put("ApproximateArrivalTimestamp",
+                         rec.getApproximateArrivalTimestamp().toEpochMilli() / 1000.0);
+        }
+        if (continuationSeqNo != null) {
+            eventPayload.put("ContinuationSequenceNumber", continuationSeqNo);
+        }
+        eventPayload.put("MillisBehindLatest", millisBehind);
+        eventPayload.putArray("ChildShards");
+
+        try {
+            // The Go SDK (and other SDKs) expect an initial-response message before
+            // SubscribeToShardEvent messages. Without it, HandleDeserialize blocks
+            // indefinitely waiting on the initialResponse channel.
+            LinkedHashMap<String, String> initialHeaders = new LinkedHashMap<>();
+            initialHeaders.put(":message-type", "event");
+            initialHeaders.put(":event-type", "initial-response");
+            initialHeaders.put(":content-type", "application/json");
+            byte[] initialMessage = AwsEventStreamEncoder.encodeMessage(initialHeaders, new byte[]{'{', '}'});
+
+            LinkedHashMap<String, String> eventHeaders = new LinkedHashMap<>();
+            eventHeaders.put(":message-type", "event");
+            eventHeaders.put(":event-type", "SubscribeToShardEvent");
+            eventHeaders.put(":content-type", "application/json");
+            byte[] eventPayloadBytes = objectMapper.writeValueAsBytes(eventPayload);
+            byte[] eventMessage = AwsEventStreamEncoder.encodeMessage(eventHeaders, eventPayloadBytes);
+
+            byte[] body = new byte[initialMessage.length + eventMessage.length];
+            System.arraycopy(initialMessage, 0, body, 0, initialMessage.length);
+            System.arraycopy(eventMessage, 0, body, initialMessage.length, eventMessage.length);
+
+            return Response.ok(body)
+                    .header("Content-Type", "application/vnd.amazon.eventstream")
+                    .build();
+        } catch (Exception e) {
+            throw new AwsException("InternalError", "Failed to encode SubscribeToShard response: " + e.getMessage(), 500);
+        }
     }
 
     private ObjectNode consumerToNode(KinesisConsumer c) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -262,7 +262,10 @@ public class KmsService {
 
     public boolean getKeyRotationStatus(String keyId, String region) {
         KmsKey key = resolveKey(keyId, region);
-        validateRotationSupported(key);
+        if (!"ENCRYPT_DECRYPT".equals(key.getKeyUsage())
+                || !"SYMMETRIC_DEFAULT".equals(key.getCustomerMasterKeySpec())) {
+            return false;
+        }
         return key.isKeyRotationEnabled();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectService.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.core.common.AwsEventStreamEncoder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -7,9 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.zip.CRC32;
+import java.util.LinkedHashMap;
 
 @ApplicationScoped
 public class S3SelectService {
@@ -57,70 +57,31 @@ public class S3SelectService {
         return encodeEventStream(result.toString());
     }
 
-    /**
-     * S3 Select returns a binary event stream.
-     * Each message has:
-     * - Total Length (4 bytes)
-     * - Headers Length (4 bytes)
-     * - Prelude CRC (4 bytes)
-     * - Headers
-     * - Payload
-     * - Message CRC (4 bytes)
-     */
     private byte[] encodeEventStream(String payload) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            DataOutputStream dos = new DataOutputStream(baos);
 
-            // Message 1: Records
-            byte[] payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
-            byte[] headers = (":message-type\7\0\7event:event-type\7\0\7Records:content-type\7\0\30application/octet-stream").getBytes(StandardCharsets.UTF_8);
-            
-            writeMessage(dos, headers, payloadBytes);
+            LinkedHashMap<String, String> recordsHeaders = new LinkedHashMap<>();
+            recordsHeaders.put(":message-type", "event");
+            recordsHeaders.put(":event-type", "Records");
+            recordsHeaders.put(":content-type", "application/octet-stream");
+            baos.write(AwsEventStreamEncoder.encodeMessage(recordsHeaders, payload.getBytes(StandardCharsets.UTF_8)));
 
-            // Message 2: Stats (stub)
-            byte[] statsHeaders = (":message-type\7\0\7event:event-type\7\0\5Stats:content-type\7\0\10text/xml").getBytes(StandardCharsets.UTF_8);
+            LinkedHashMap<String, String> statsHeaders = new LinkedHashMap<>();
+            statsHeaders.put(":message-type", "event");
+            statsHeaders.put(":event-type", "Stats");
+            statsHeaders.put(":content-type", "text/xml");
             byte[] statsPayload = "<Stats><BytesScanned>100</BytesScanned><BytesProcessed>100</BytesProcessed><BytesReturned>100</BytesReturned></Stats>".getBytes(StandardCharsets.UTF_8);
-            writeMessage(dos, statsHeaders, statsPayload);
+            baos.write(AwsEventStreamEncoder.encodeMessage(statsHeaders, statsPayload));
 
-            // Message 3: End
-            byte[] endHeaders = (":message-type\7\0\7event:event-type\7\0\3End").getBytes(StandardCharsets.UTF_8);
-            writeMessage(dos, endHeaders, new byte[0]);
+            LinkedHashMap<String, String> endHeaders = new LinkedHashMap<>();
+            endHeaders.put(":message-type", "event");
+            endHeaders.put(":event-type", "End");
+            baos.write(AwsEventStreamEncoder.encodeMessage(endHeaders, new byte[0]));
 
             return baos.toByteArray();
         } catch (Exception e) {
             return payload.getBytes(StandardCharsets.UTF_8);
         }
-    }
-
-    private void writeMessage(DataOutputStream dos, byte[] headers, byte[] payload) throws Exception {
-        int totalLen = 12 + headers.length + payload.length + 4;
-        int headersLen = headers.length;
-
-        // Prelude
-        dos.writeInt(totalLen);
-        dos.writeInt(headersLen);
-        
-        CRC32 crc = new CRC32();
-        byte[] prelude = new byte[8];
-        prelude[0] = (byte)(totalLen >> 24); prelude[1] = (byte)(totalLen >> 16); prelude[2] = (byte)(totalLen >> 8); prelude[3] = (byte)totalLen;
-        prelude[4] = (byte)(headersLen >> 24); prelude[5] = (byte)(headersLen >> 16); prelude[6] = (byte)(headersLen >> 8); prelude[7] = (byte)headersLen;
-        crc.update(prelude);
-        dos.writeInt((int)crc.getValue());
-
-        // Headers + Payload
-        dos.write(headers);
-        dos.write(payload);
-
-        // Message CRC
-        crc = new CRC32();
-        crc.update(prelude);
-        byte[] preludeCrc = new byte[4];
-        preludeCrc[0] = (byte)(crc.getValue() >> 24); preludeCrc[1] = (byte)(crc.getValue() >> 16); preludeCrc[2] = (byte)(crc.getValue() >> 8); preludeCrc[3] = (byte)crc.getValue();
-        // Wait, the message CRC covers the whole message EXCEPT itself
-        crc = new CRC32();
-        dos.flush();
-        // This is getting complex for a mock, let's just write something that looks like it
-        dos.writeInt(0); 
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.kinesis;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,8 +10,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.nio.ByteBuffer;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -908,5 +913,136 @@ class KinesisIntegrationTest {
         .when().post("/")
         .then().statusCode(200)
             .body("Records.size()", equalTo(2));
+    }
+
+    @Test
+    @Order(60)
+    void subscribeToShard_returnsRecords() throws Exception {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "efo-test-stream", "ShardCount": 1}
+                """)
+        .when().post("/")
+        .then().statusCode(200);
+
+        String streamArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "efo-test-stream"}
+                """)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().jsonPath().getString("StreamDescriptionSummary.StreamARN");
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.PutRecord")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamName\": \"efo-test-stream\", \"Data\": \"aGVsbG8=\", \"PartitionKey\": \"pk1\"}")
+        .when().post("/")
+        .then().statusCode(200);
+
+        String consumerArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.RegisterStreamConsumer")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\", \"ConsumerName\": \"efo-consumer\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().jsonPath().getString("Consumer.ConsumerARN");
+
+        byte[] body = given()
+            .header("X-Amz-Target", "Kinesis_20131202.SubscribeToShard")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"ConsumerARN\": \"" + consumerArn + "\", \"ShardId\": \"shardId-000000000000\","
+                + "\"StartingPosition\": {\"Type\": \"TRIM_HORIZON\"}}")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .header("Content-Type", containsString("application/vnd.amazon.eventstream"))
+            .extract().asByteArray();
+
+        JsonNode event = decodeFirstEventStreamMessage(body);
+        assertNotNull(event);
+        assertEquals(1, event.path("Records").size());
+        assertEquals("pk1", event.path("Records").get(0).path("PartitionKey").asText());
+    }
+
+    @Test
+    @Order(61)
+    void subscribeToShard_trimHorizonEmptyShard() throws Exception {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "efo-empty-stream", "ShardCount": 1}
+                """)
+        .when().post("/")
+        .then().statusCode(200);
+
+        String streamArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "efo-empty-stream"}
+                """)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().jsonPath().getString("StreamDescriptionSummary.StreamARN");
+
+        String consumerArn = given()
+            .header("X-Amz-Target", "Kinesis_20131202.RegisterStreamConsumer")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"StreamARN\": \"" + streamArn + "\", \"ConsumerName\": \"efo-empty-consumer\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().jsonPath().getString("Consumer.ConsumerARN");
+
+        byte[] body = given()
+            .header("X-Amz-Target", "Kinesis_20131202.SubscribeToShard")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"ConsumerARN\": \"" + consumerArn + "\", \"ShardId\": \"shardId-000000000000\","
+                + "\"StartingPosition\": {\"Type\": \"TRIM_HORIZON\"}}")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .header("Content-Type", containsString("application/vnd.amazon.eventstream"))
+            .extract().asByteArray();
+
+        JsonNode event = decodeFirstEventStreamMessage(body);
+        assertNotNull(event);
+        assertEquals(0, event.path("Records").size());
+    }
+
+    @Test
+    @Order(62)
+    void subscribeToShard_invalidConsumerArn() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.SubscribeToShard")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"ConsumerARN\": \"arn:aws:kinesis:us-east-1:000000000000:stream/no-such/consumer/no-such:99999\","
+                + "\"ShardId\": \"shardId-000000000000\","
+                + "\"StartingPosition\": {\"Type\": \"TRIM_HORIZON\"}}")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    private JsonNode decodeFirstEventStreamMessage(byte[] data) throws Exception {
+        ByteBuffer buf = ByteBuffer.wrap(data);
+        // Skip the first message (initial-response)
+        int firstTotalLen = buf.getInt();
+        buf.position(buf.position() + firstTotalLen - 4);
+        // Decode second message (SubscribeToShardEvent)
+        int totalLen = buf.getInt();
+        int headersLen = buf.getInt();
+        buf.getInt(); // prelude CRC — skip
+        int payloadLen = totalLen - 12 - headersLen - 4;
+        buf.position(buf.position() + headersLen); // skip headers
+        byte[] payload = new byte[payloadLen];
+        buf.get(payload);
+        return new ObjectMapper().readTree(payload);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -421,13 +421,28 @@ class KmsServiceTest {
     }
 
     @Test
-    void keyRotationOnAsymmetricKeyThrows() {
+    void enableKeyRotationOnAsymmetricKeyThrows() {
         KmsKey key = kmsService.createKey(null, REGION);
         key.setCustomerMasterKeySpec("RSA_2048");
         key.setKeyUsage("SIGN_VERIFY");
-        // Persist the modified key
         assertThrows(AwsException.class, () ->
                 kmsService.enableKeyRotation(key.getKeyId(), REGION));
+    }
+
+    @Test
+    void getKeyRotationStatusOnAsymmetricKeyReturnsFalse() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        key.setCustomerMasterKeySpec("ECC_NIST_P256");
+        key.setKeyUsage("SIGN_VERIFY");
+        assertFalse(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
+    }
+
+    @Test
+    void getKeyRotationStatusOnHmacKeyReturnsFalse() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        key.setCustomerMasterKeySpec("HMAC_256");
+        key.setKeyUsage("GENERATE_VERIFY_MAC");
+        assertFalse(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
     }
 
     // ── Issue #497 — HMAC key specs ─────────────────────────────────────────


### PR DESCRIPTION
AWS updated GetKeyRotationStatus behavior so asymmetric and HMAC keys return { KeyRotationEnabled: false } instead of UnsupportedOperationException. EnableKeyRotation and DisableKeyRotation still reject these key types.

## Summary

AWS updated the behavior of GetKeyRotationStatus: asymmetric keys (RSA, ECC) and HMAC keys now return { KeyRotationEnabled: false } instead of throwing UnsupportedOperationException. EnableKeyRotation and DisableKeyRotation still correctly reject these key types.
                                                                                                                                                                                
**Changes:**                                                                                                                                                                    
  - KmsService.getKeyRotationStatus() — early return false for keys that are not ENCRYPT_DECRYPT / SYMMETRIC_DEFAULT
  - KmsServiceTest — renamed existing asymmetric-throws test to enableKeyRotationOnAsymmetricKeyThrows; added getKeyRotationStatusOnAsymmetricKeyReturnsFalse (ECC_NIST_P256) and getKeyRotationStatusOnHmacKeyReturnsFalse (HMAC_256)

Fixes #586
Fixes #562 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
