### PR TITLE
fix(lambda): inject default AWS credentials into Lambda containers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -144,6 +144,9 @@ public class ContainerLauncher {
         }
         env.add("AWS_DEFAULT_REGION=us-east-1");
         env.add("AWS_REGION=us-east-1");
+        env.add("AWS_ACCESS_KEY_ID=test");
+        env.add("AWS_SECRET_ACCESS_KEY=test");
+        env.add("AWS_SESSION_TOKEN=test");
         if (fn.getEnvironment() != null) {
             fn.getEnvironment().forEach((k, v) -> env.add(k + "=" + v));
         }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -24,9 +24,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -150,6 +152,68 @@ class ContainerLauncherTest {
 
         // createAndStart must NOT be called — Lambda uses the split path
         verify(lifecycleManager, never()).createAndStart(any());
+    }
+
+    @Test
+    void launchFunction_injectsDefaultAwsCredentials() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("creds-defaults"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("creds-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+
+        List<String> env = specCaptor.getValue().env();
+        assertTrue(env.contains("AWS_ACCESS_KEY_ID=test"),
+                "default AWS_ACCESS_KEY_ID should be injected");
+        assertTrue(env.contains("AWS_SECRET_ACCESS_KEY=test"),
+                "default AWS_SECRET_ACCESS_KEY should be injected");
+        assertTrue(env.contains("AWS_SESSION_TOKEN=test"),
+                "default AWS_SESSION_TOKEN should be injected");
+    }
+
+    @Test
+    void launchFunction_userEnvironmentOverridesDefaultCredentials() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("creds-override"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("override-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setEnvironment(Map.of(
+                "AWS_ACCESS_KEY_ID", "user-key",
+                "AWS_SECRET_ACCESS_KEY", "user-secret"));
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+
+        List<String> env = specCaptor.getValue().env();
+        // Docker honours the last occurrence of a duplicate Env entry, so user
+        // overrides must appear after the Floci defaults.
+        int defaultKeyIdx = env.indexOf("AWS_ACCESS_KEY_ID=test");
+        int userKeyIdx = env.indexOf("AWS_ACCESS_KEY_ID=user-key");
+        assertTrue(defaultKeyIdx >= 0, "default AWS_ACCESS_KEY_ID still present");
+        assertTrue(userKeyIdx > defaultKeyIdx,
+                "user AWS_ACCESS_KEY_ID must appear after the default");
+
+        int defaultSecretIdx = env.indexOf("AWS_SECRET_ACCESS_KEY=test");
+        int userSecretIdx = env.indexOf("AWS_SECRET_ACCESS_KEY=user-secret");
+        assertTrue(defaultSecretIdx >= 0, "default AWS_SECRET_ACCESS_KEY still present");
+        assertTrue(userSecretIdx > defaultSecretIdx,
+                "user AWS_SECRET_ACCESS_KEY must appear after the default");
+
+        // AWS_SESSION_TOKEN was not overridden so the default remains.
+        assertEquals(1, env.stream().filter(e -> e.startsWith("AWS_SESSION_TOKEN=")).count(),
+                "AWS_SESSION_TOKEN should retain its default exactly once");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Lambda containers launched by Floci received no AWS credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`), so AWS SDK calls from inside the function fell through to the EC2 instance-metadata service, which Floci does not emulate. The credential chain eventually timed out (e.g. `Scheduler.CreateSchedule` → `no EC2 IMDS role found, request canceled, context deadline exceeded`).

This change injects placeholder credentials (`test` / `test` / `test`) into every Lambda container before the user-supplied `--environment` is appended. Because Docker honours the last occurrence of a duplicate `Env` entry, user-supplied credential overrides still win.

Closes #611

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real AWS Lambda always provides the function's IAM-role credentials to the execution environment via `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`, so SDKs inside the function sign requests without extra setup. Floci was not mirroring this, forcing users to add `AWS_ACCESS_KEY_ID=test` / `AWS_SECRET_ACCESS_KEY=test` to every `--environment` payload manually. SDK behaviour now matches AWS for the common case while preserving the existing override path.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)