### PR TITLE
 fix(ec2): persist VPC DNS attributes and add Terraform/OpenTofu compat tests

### DIFF
--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -129,3 +129,19 @@ output "table_name" {
 output "secret_arn" {
   value = aws_secretsmanager_secret.db_creds.arn
 }
+
+# ── VPC (issue #468: ModifyVpcAttribute / DescribeVpcAttribute) ────────────
+resource "aws_vpc" "compat" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = false
+  enable_dns_hostnames = false
+
+  tags = {
+    Name        = "floci-compat-vpc"
+    Environment = "compat-test"
+  }
+}
+
+output "vpc_id" {
+  value = aws_vpc.compat.id
+}

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -34,5 +34,6 @@ provider "aws" {
     sts            = var.endpoint
     ssm            = var.endpoint
     secretsmanager = var.endpoint
+    ec2            = var.endpoint
   }
 }

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -95,3 +95,31 @@ setup() {
     assert_success
     assert_output --partial "floci-compat"
 }
+
+@test "OpenTofu: VPC created with custom DNS settings" {
+    run aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc"
+    assert_success
+    assert_output --partial "floci-compat-vpc"
+    assert_output --partial "10.0.0.0/16"
+}
+
+@test "OpenTofu: VPC enableDnsSupport persisted as false" {
+    VPC_ID=$(aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc" \
+        --query 'Vpcs[0].VpcId' --output text)
+    run aws_cmd ec2 describe-vpc-attribute \
+        --vpc-id "$VPC_ID" --attribute enableDnsSupport
+    assert_success
+    assert_output --partial '"Value": false'
+}
+
+@test "OpenTofu: VPC enableDnsHostnames persisted as false" {
+    VPC_ID=$(aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc" \
+        --query 'Vpcs[0].VpcId' --output text)
+    run aws_cmd ec2 describe-vpc-attribute \
+        --vpc-id "$VPC_ID" --attribute enableDnsHostnames
+    assert_success
+    assert_output --partial '"Value": false'
+}

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -207,3 +207,19 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
 output "alarm_arn" {
   value = aws_cloudwatch_metric_alarm.cpu.arn
 }
+
+# -- VPC (issue #468: ModifyVpcAttribute / DescribeVpcAttribute) ---------------
+resource "aws_vpc" "compat" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = false
+  enable_dns_hostnames = false
+
+  tags = {
+    Name        = "floci-compat-vpc"
+    Environment = "compat-test"
+  }
+}
+
+output "vpc_id" {
+  value = aws_vpc.compat.id
+}

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -37,5 +37,6 @@ provider "aws" {
     cognitoidp     = var.endpoint
     rds            = var.endpoint
     cloudwatch     = var.endpoint
+    ec2            = var.endpoint
   }
 }

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -114,3 +114,31 @@ setup() {
     assert_success
     assert_output --partial "compat-test"
 }
+
+@test "Terraform: VPC created with custom DNS settings" {
+    run aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc"
+    assert_success
+    assert_output --partial "floci-compat-vpc"
+    assert_output --partial "10.0.0.0/16"
+}
+
+@test "Terraform: VPC enableDnsSupport persisted as false" {
+    VPC_ID=$(aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc" \
+        --query 'Vpcs[0].VpcId' --output text)
+    run aws_cmd ec2 describe-vpc-attribute \
+        --vpc-id "$VPC_ID" --attribute enableDnsSupport
+    assert_success
+    assert_output --partial '"Value": false'
+}
+
+@test "Terraform: VPC enableDnsHostnames persisted as false" {
+    VPC_ID=$(aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-compat-vpc" \
+        --query 'Vpcs[0].VpcId' --output text)
+    run aws_cmd ec2 describe-vpc-attribute \
+        --vpc-id "$VPC_ID" --attribute enableDnsHostnames
+    assert_success
+    assert_output --partial '"Value": false'
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -613,6 +613,37 @@ class Ec2Tests {
 
     @Test
     @Order(47)
+    @DisplayName("ModifyVpcAttribute - set enableDnsSupport=false")
+    void modifyVpcAttributeDnsSupport() {
+        ec2.modifyVpcAttribute(r -> r.vpcId(vpcId)
+                .enableDnsSupport(a -> a.value(false)));
+    }
+
+    @Test
+    @Order(48)
+    @DisplayName("DescribeVpcAttribute - enableDnsSupport round-trip")
+    void describeVpcAttributeDnsSupport() {
+        DescribeVpcAttributeResponse resp = ec2.describeVpcAttribute(r -> r
+                .vpcId(vpcId)
+                .attribute(VpcAttributeName.ENABLE_DNS_SUPPORT));
+
+        assertThat(resp.vpcId()).isEqualTo(vpcId);
+        assertThat(resp.enableDnsSupport().value()).isFalse();
+    }
+
+    @Test
+    @Order(49)
+    @DisplayName("DescribeVpcEndpointServices - returns empty list")
+    void describeVpcEndpointServices() {
+        DescribeVpcEndpointServicesResponse resp = ec2.describeVpcEndpointServices(
+                DescribeVpcEndpointServicesRequest.builder().build());
+
+        assertThat(resp.serviceNames()).isEmpty();
+        assertThat(resp.serviceDetails()).isEmpty();
+    }
+
+    @Test
+    @Order(50)
     @DisplayName("DeleteVpc - delete VPC")
     void deleteVpc() {
         ec2.deleteVpc(DeleteVpcRequest.builder().vpcId(vpcId).build());

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -106,6 +106,7 @@ public class AwsQueryController {
             "RunInstances", "DescribeInstances", "TerminateInstances", "StartInstances", "StopInstances",
             "RebootInstances", "DescribeInstanceStatus", "DescribeInstanceAttribute", "ModifyInstanceAttribute",
             "CreateVpc", "DescribeVpcs", "DeleteVpc", "ModifyVpcAttribute", "DescribeVpcAttribute",
+            "DescribeVpcEndpointServices",
             "CreateDefaultVpc", "AssociateVpcCidrBlock", "DisassociateVpcCidrBlock",
             "CreateSubnet", "DescribeSubnets", "DeleteSubnet", "ModifySubnetAttribute",
             "CreateSecurityGroup", "DescribeSecurityGroups", "DeleteSecurityGroup",

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -50,6 +50,7 @@ public class Ec2QueryHandler {
                 case "DeleteVpc" -> handleDeleteVpc(params, region);
                 case "ModifyVpcAttribute" -> handleModifyVpcAttribute(params, region);
                 case "DescribeVpcAttribute" -> handleDescribeVpcAttribute(params, region);
+                case "DescribeVpcEndpointServices" -> handleDescribeVpcEndpointServices(params, region);
                 case "CreateDefaultVpc" -> handleCreateDefaultVpc(params, region);
                 case "AssociateVpcCidrBlock" -> handleAssociateVpcCidrBlock(params, region);
                 case "DisassociateVpcCidrBlock" -> handleDisassociateVpcCidrBlock(params, region);
@@ -423,6 +424,22 @@ public class Ec2QueryHandler {
     private Response handleCreateVpc(MultivaluedMap<String, String> p, String region) {
         String cidrBlock = p.getFirst("CidrBlock");
         Vpc vpc = service.createVpc(region, cidrBlock, false);
+        List<Tag> vpcTags = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String resType = p.getFirst("TagSpecification." + i + ".ResourceType");
+            if (resType == null) break;
+            if ("vpc".equals(resType)) {
+                for (int j = 1; ; j++) {
+                    String k = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Key");
+                    if (k == null) break;
+                    String v = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Value");
+                    vpcTags.add(new Tag(k, v));
+                }
+            }
+        }
+        if (!vpcTags.isEmpty()) {
+            service.createTags(region, List.of(vpc.getVpcId()), vpcTags);
+        }
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateVpcResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -453,7 +470,13 @@ public class Ec2QueryHandler {
 
     private Response handleModifyVpcAttribute(MultivaluedMap<String, String> p, String region) {
         String vpcId = p.getFirst("VpcId");
-        service.modifyVpcAttribute(region, vpcId, "attribute", "value");
+        if (p.containsKey("EnableDnsSupport.Value")) {
+            service.modifyVpcAttribute(region, vpcId, "enableDnsSupport", p.getFirst("EnableDnsSupport.Value"));
+        } else if (p.containsKey("EnableDnsHostnames.Value")) {
+            service.modifyVpcAttribute(region, vpcId, "enableDnsHostnames", p.getFirst("EnableDnsHostnames.Value"));
+        } else if (p.containsKey("EnableNetworkAddressUsageMetrics.Value")) {
+            service.modifyVpcAttribute(region, vpcId, "enableNetworkAddressUsageMetrics", p.getFirst("EnableNetworkAddressUsageMetrics.Value"));
+        }
         return booleanResponse("ModifyVpcAttribute");
     }
 
@@ -466,11 +489,23 @@ public class Ec2QueryHandler {
                 .elem("requestId", UUID.randomUUID().toString())
                 .elem("vpcId", vpcId);
         if ("enableDnsSupport".equals(attribute)) {
-            xml.start("enableDnsSupport").elem("value", "true").end("enableDnsSupport");
+            xml.start("enableDnsSupport").elem("value", String.valueOf(vpc.isEnableDnsSupport())).end("enableDnsSupport");
         } else if ("enableDnsHostnames".equals(attribute)) {
-            xml.start("enableDnsHostnames").elem("value", "true").end("enableDnsHostnames");
+            xml.start("enableDnsHostnames").elem("value", String.valueOf(vpc.isEnableDnsHostnames())).end("enableDnsHostnames");
+        } else if ("enableNetworkAddressUsageMetrics".equals(attribute)) {
+            xml.start("enableNetworkAddressUsageMetrics").elem("value", String.valueOf(vpc.isEnableNetworkAddressUsageMetrics())).end("enableNetworkAddressUsageMetrics");
         }
         xml.end("DescribeVpcAttributeResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeVpcEndpointServices(MultivaluedMap<String, String> p, String region) {
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeVpcEndpointServicesResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("serviceNameSet").end("serviceNameSet")
+                .start("serviceDetailSet").end("serviceDetailSet")
+                .end("DescribeVpcEndpointServicesResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -436,7 +436,12 @@ public class Ec2Service {
         if (vpc == null) {
             throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
         }
-        // no-op for mock
+        switch (attribute) {
+            case "enableDnsSupport"                    -> vpc.setEnableDnsSupport(Boolean.parseBoolean(value));
+            case "enableDnsHostnames"                  -> vpc.setEnableDnsHostnames(Boolean.parseBoolean(value));
+            case "enableNetworkAddressUsageMetrics"    -> vpc.setEnableNetworkAddressUsageMetrics(Boolean.parseBoolean(value));
+        }
+        vpcs.put(key(region, vpcId), vpc);
     }
 
     public Vpc describeVpcAttribute(String region, String vpcId, String attribute) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Vpc.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Vpc.java
@@ -19,6 +19,9 @@ public class Vpc {
     private String ownerId;
     private String region;
     private List<VpcCidrBlockAssociation> cidrBlockAssociationSet = new ArrayList<>();
+    private boolean enableDnsSupport = true;
+    private boolean enableDnsHostnames = false;
+    private boolean enableNetworkAddressUsageMetrics = false;
     private List<Tag> tags = new ArrayList<>();
 
     public Vpc() {}
@@ -49,6 +52,15 @@ public class Vpc {
 
     public List<VpcCidrBlockAssociation> getCidrBlockAssociationSet() { return cidrBlockAssociationSet; }
     public void setCidrBlockAssociationSet(List<VpcCidrBlockAssociation> cidrBlockAssociationSet) { this.cidrBlockAssociationSet = cidrBlockAssociationSet; }
+
+    public boolean isEnableDnsSupport() { return enableDnsSupport; }
+    public void setEnableDnsSupport(boolean enableDnsSupport) { this.enableDnsSupport = enableDnsSupport; }
+
+    public boolean isEnableDnsHostnames() { return enableDnsHostnames; }
+    public void setEnableDnsHostnames(boolean enableDnsHostnames) { this.enableDnsHostnames = enableDnsHostnames; }
+
+    public boolean isEnableNetworkAddressUsageMetrics() { return enableNetworkAddressUsageMetrics; }
+    public void setEnableNetworkAddressUsageMetrics(boolean enableNetworkAddressUsageMetrics) { this.enableNetworkAddressUsageMetrics = enableNetworkAddressUsageMetrics; }
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -205,7 +205,7 @@ class Ec2IntegrationTest {
         given()
             .formParam("Action", "ModifyVpcAttribute")
             .formParam("VpcId", vpcId)
-            .formParam("EnableDnsSupport.Value", "true")
+            .formParam("EnableDnsSupport.Value", "false")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -225,7 +225,20 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DescribeVpcAttributeResponse.vpcId", equalTo(vpcId));
+            .body("DescribeVpcAttributeResponse.vpcId", equalTo(vpcId))
+            .body("DescribeVpcAttributeResponse.enableDnsSupport.value", equalTo("false"));
+    }
+
+    @Test
+    @Order(14)
+    void describeVpcEndpointServices() {
+        given()
+            .formParam("Action", "DescribeVpcEndpointServices")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

- ModifyVpcAttribute was a no-op — DNS attribute values were never stored. Now enableDnsSupport, enableDnsHostnames, and enableNetworkAddressUsageMetrics are persisted on the Vpc model and round-trip correctly through DescribeVpcAttribute.
- DescribeVpcAttribute returned a hardcoded "true" for enableDnsSupport regardless of the stored value. Fixed to return the actual persisted value.                           
- DescribeVpcEndpointServices was unregistered and unimplemented — added as an empty-list response to unblock Terraform VPC endpoint workflows.                               
- CreateVpc did not process TagSpecification parameters — tags sent inline at VPC creation time (as modern Terraform AWS provider does) were silently dropped, breaking tag-based filtering in DescribeVpcs. Fixed by parsing TagSpecification.N.Tag.* during create.

Closes #468 
 
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
