### PR TITLE
fix(docker): replace bash /dev/tcp HEALTHCHECK with busybox wget for Alpine runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ VOLUME /app/data
 EXPOSE 4566 6379-6399
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD bash -c 'echo -e "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4566' || exit 1
+    CMD wget -q --spider http://localhost:4566/_floci/health || exit 1
 
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}


### PR DESCRIPTION
## Summary

`Dockerfile` is based on `eclipse-temurin:25-jre-alpine`, which does not ship bash. The HEALTHCHECK invoked `bash -c '... > /dev/tcp/localhost/4566'`, so containers built from this Dockerfile reported `unhealthy` with `/bin/sh: bash: not found`, breaking `depends_on: condition: service_healthy` in downstream Compose files.

This change switches the HEALTHCHECK to `wget -q --spider http://localhost:4566/_floci/health`, which matches the line already in use in `Dockerfile.jvm-package` and runs under plain `/bin/sh` using busybox `wget` — no extra package needed.

`Dockerfile.native` is left as-is: its `quarkus-micro-image:2.0` base ships bash, so the existing `/dev/tcp` healthcheck works there.

Closes #597

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A — affects only the container HEALTHCHECK.

## Checklist

- [x] `./mvnw test` passes locally (no Java code changed; HEALTHCHECK is a Docker-image concern only)
- [x] Locally verified by `docker build` + `docker run` — container converges to `healthy` (`ExitCode=0`, `FailingStreak=0`); `wget -q --spider http://localhost:4566/_floci/health` exits 0 from inside the container
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)