### PR TITLE
fix(pipes): resolve InputTemplate paths through JSON-encoded string fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
@@ -15,6 +15,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -26,6 +27,7 @@ public class PipesTargetInvoker {
 
     private static final Logger LOG = Logger.getLogger(PipesTargetInvoker.class);
     private static final Pattern TEMPLATE_PLACEHOLDER = Pattern.compile("<(\\$[^>]+)>");
+    private static final Pattern ARRAY_INDEX = Pattern.compile("^(.+?)\\[(\\d+)]$");
 
     private final LambdaService lambdaService;
     private final SqsService sqsService;
@@ -142,18 +144,46 @@ public class PipesTargetInvoker {
             return null;
         }
         try {
-            String path = jsonPath.startsWith("$") ? jsonPath.substring(1) : jsonPath;
-            // Translate array indices [N] to /N for Jackson JSON Pointer
-            path = path.replaceAll("\\[(\\d+)]", "/$1");
-            String pointer = path.replace('.', '/');
-            JsonNode node = objectMapper.readTree(json).at(pointer);
-            if (node.isMissingNode() || node.isNull()) {
-                return null;
+            String path = jsonPath.startsWith("$.") ? jsonPath.substring(2)
+                    : jsonPath.startsWith("$") ? jsonPath.substring(1)
+                    : jsonPath;
+            // Split into segments on dots, but expand array indices into separate segments
+            // e.g. "Records[0].body" -> ["Records", "0", "body"]
+            String[] rawSegments = path.split("\\.");
+            List<String> segments = new ArrayList<>();
+            for (String seg : rawSegments) {
+                Matcher am = ARRAY_INDEX.matcher(seg);
+                if (am.matches()) {
+                    segments.add(am.group(1));
+                    segments.add(am.group(2));
+                } else if (!seg.isEmpty()) {
+                    segments.add(seg);
+                }
             }
-            if (node.isValueNode()) {
-                return objectMapper.writeValueAsString(node);
+
+            JsonNode current = objectMapper.readTree(json);
+            for (String segment : segments) {
+                // AWS Pipes auto-parses string fields containing valid JSON
+                if (current.isTextual()) {
+                    try {
+                        current = objectMapper.readTree(current.asText());
+                    } catch (Exception ignored) {
+                        return null;
+                    }
+                }
+                if (current.isArray()) {
+                    current = current.path(Integer.parseInt(segment));
+                } else {
+                    current = current.path(segment);
+                }
+                if (current.isMissingNode() || current.isNull()) {
+                    return null;
+                }
             }
-            return node.toString();
+            if (current.isValueNode()) {
+                return objectMapper.writeValueAsString(current);
+            }
+            return current.toString();
         } catch (Exception e) {
             LOG.warnv("Failed to extract JSONPath {0}: {1}", jsonPath, e.getMessage());
             return null;

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
@@ -197,4 +197,49 @@ class PipesTargetInvokerTest {
         String result = invoker.applyInputTemplate("{\"count\": <$.count>}", "{\"count\": 42}");
         assertEquals("{\"count\": 42}", result);
     }
+
+    // ──────────────────────────── nested JSON string resolution ────────────────────────────
+
+    @Test
+    void extractJsonPath_nestedJsonString_resolvesField() {
+        String json = "{\"body\": \"{\\\"message\\\": \\\"hello\\\", \\\"type\\\": \\\"greeting\\\"}\"}";
+        assertEquals("\"hello\"", invoker.extractJsonPath("$.body.message", json));
+        assertEquals("\"greeting\"", invoker.extractJsonPath("$.body.type", json));
+    }
+
+    @Test
+    void extractJsonPath_nestedJsonString_missingNestedField() {
+        String json = "{\"body\": \"{\\\"message\\\": \\\"hello\\\"}\"}";
+        assertNull(invoker.extractJsonPath("$.body.nonexistent", json));
+    }
+
+    @Test
+    void extractJsonPath_nestedJsonString_nonJsonStringReturnsNull() {
+        String json = "{\"body\": \"plain text\"}";
+        assertNull(invoker.extractJsonPath("$.body.message", json));
+    }
+
+    @Test
+    void extractJsonPath_nestedJsonString_objectValue() {
+        String json = "{\"body\": \"{\\\"data\\\": {\\\"id\\\": 1}}\"}";
+        assertEquals("{\"id\":1}", invoker.extractJsonPath("$.body.data", json));
+    }
+
+    @Test
+    void inputTemplate_nestedJsonString_endToEnd() {
+        ObjectNode tp = MAPPER.createObjectNode();
+        tp.put("InputTemplate",
+                "{\"message\": <$.body.message>, \"messageType\": <$.body.messageType>}");
+
+        Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", tp);
+        String payload = "{\"body\": \"{\\\"message\\\": \\\"user registered\\\", \\\"messageType\\\": \\\"REGISTRATION\\\"}\"}";
+
+        invoker.invoke(pipe, payload, "us-east-1");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0));
+        assertEquals(
+                "{\"message\": \"user registered\", \"messageType\": \"REGISTRATION\"}",
+                captor.getValue());
+    }
 }


### PR DESCRIPTION
## Summary

Fix `extractJsonPath` in `PipesTargetInvoker` to auto-parse string fields containing valid JSON when resolving nested paths. This matches AWS Pipes behavior where SQS message `body` is a JSON-encoded string, and InputTemplate paths like `<$.body.message>` need to traverse into it.

Previously, `$.body.message` returned null when `body` was a string like `"{\"message\": \"hello\"}"` because Jackson's JSON Pointer treated the text node as a leaf. Now the resolver detects when a path segment lands on a string node with remaining segments, attempts to parse the string as JSON, and continues resolution.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS Pipes InputTemplate resolves `<$.body.message>` against SQS event records where `body` is a JSON-encoded string. This is documented in the [AWS Pipes InputTemplate reference](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-input-transformation.html). The previous implementation only supported paths into native JSON objects, not string-encoded JSON fields.

Verified against the registration-service CloudFormation template which uses:
```
InputTemplate: '{"message": <$.body.message>, "messageType": <$.body.messageType>, "type": <$.body.type>}'
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)