### PR TITLE
fix(cloudformation): wrap ZipFile inline source in zip archive before passing to Lambda

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationLambdaInlineZipTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationLambdaInlineZipTest.java
@@ -1,0 +1,171 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.*;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.GetFunctionResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Verifies that CloudFormation AWS::Lambda::Function with inline ZipFile source code
+ * reaches CREATE_COMPLETE instead of failing with "Illegal base64 character".
+ * Reproduces https://github.com/floci-io/floci/issues/607
+ */
+@DisplayName("CloudFormation Lambda inline ZipFile")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CloudFormationLambdaInlineZipTest {
+
+    private static final String STACK_NAME  = "compat-cfn-inline-zip-stack";
+    private static final String FUNC_NAME   = "compat-cfn-inline-zip-fn";
+    private static final String ROLE        = "arn:aws:iam::000000000000:role/cfn-lambda-role";
+
+    private static CloudFormationClient cfn;
+    private static LambdaClient         lambda;
+
+    @BeforeAll
+    static void setup() {
+        cfn    = TestFixtures.cloudFormationClient();
+        lambda = TestFixtures.lambdaClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (cfn != null) {
+            try {
+                cfn.deleteStack(DeleteStackRequest.builder().stackName(STACK_NAME).build());
+            } catch (Exception ignored) {}
+            cfn.close();
+        }
+        if (lambda != null) {
+            lambda.close();
+        }
+    }
+
+    // ── Node.js inline source ──────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    @DisplayName("CreateStack with Node.js ZipFile source reaches CREATE_COMPLETE")
+    void createStack_nodejsInlineZipFile() throws InterruptedException {
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "%s",
+                    "Code": {
+                      "ZipFile": "exports.handler = async (e) => ({ statusCode: 200, body: 'ok' });"
+                    }
+                  }
+                }
+              }
+            }
+            """.formatted(FUNC_NAME, ROLE);
+
+        cfn.createStack(CreateStackRequest.builder()
+                .stackName(STACK_NAME)
+                .templateBody(template)
+                .build());
+
+        String status = waitForTerminal(STACK_NAME, 30);
+        assertThat(status)
+                .as("Stack must reach CREATE_COMPLETE, not fail with base64 error")
+                .isEqualTo("CREATE_COMPLETE");
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Lambda function created by inline ZipFile stack is discoverable")
+    void lambdaFunctionExists() {
+        GetFunctionResponse fn = lambda.getFunction(r -> r.functionName(FUNC_NAME));
+        assertThat(fn.configuration().functionName()).isEqualTo(FUNC_NAME);
+        assertThat(fn.configuration().runtimeAsString()).isEqualTo("nodejs20.x");
+        assertThat(fn.configuration().handler()).isEqualTo("index.handler");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("DescribeStackResources shows Lambda in CREATE_COMPLETE")
+    void stackResourceIsComplete() {
+        List<StackResource> resources = cfn.describeStackResources(
+                DescribeStackResourcesRequest.builder().stackName(STACK_NAME).build()
+        ).stackResources();
+
+        assertThat(resources).hasSize(1);
+        StackResource r = resources.get(0);
+        assertThat(r.resourceType()).isEqualTo("AWS::Lambda::Function");
+        assertThat(r.resourceStatusAsString()).isEqualTo("CREATE_COMPLETE");
+    }
+
+    // ── Python inline source ───────────────────────────────────────────────────
+
+    @Test
+    @Order(4)
+    @DisplayName("CreateStack with Python ZipFile source reaches CREATE_COMPLETE")
+    void createStack_pythonInlineZipFile() throws InterruptedException {
+        String pythonStack = STACK_NAME + "-py";
+        String pythonFunc  = FUNC_NAME  + "-py";
+
+        String template = """
+            {
+              "Resources": {
+                "PyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "%s",
+                    "Runtime": "python3.12",
+                    "Handler": "lambda_function.lambda_handler",
+                    "Role": "%s",
+                    "Code": {
+                      "ZipFile": "def lambda_handler(event, context):\\n    return {'statusCode': 200}"
+                    }
+                  }
+                }
+              }
+            }
+            """.formatted(pythonFunc, ROLE);
+
+        cfn.createStack(CreateStackRequest.builder()
+                .stackName(pythonStack)
+                .templateBody(template)
+                .build());
+
+        String status = waitForTerminal(pythonStack, 30);
+        assertThat(status)
+                .as("Python inline ZipFile stack must reach CREATE_COMPLETE")
+                .isEqualTo("CREATE_COMPLETE");
+
+        GetFunctionResponse fn = lambda.getFunction(r -> r.functionName(pythonFunc));
+        assertThat(fn.configuration().runtimeAsString()).isEqualTo("python3.12");
+        assertThat(fn.configuration().handler()).isEqualTo("lambda_function.lambda_handler");
+
+        cfn.deleteStack(DeleteStackRequest.builder().stackName(pythonStack).build());
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private String waitForTerminal(String stackName, int maxSeconds) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + maxSeconds * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            List<Stack> stacks = cfn.describeStacks(
+                    DescribeStacksRequest.builder().stackName(stackName).build()
+            ).stacks();
+            if (!stacks.isEmpty()) {
+                String status = stacks.get(0).stackStatusAsString();
+                if (!status.endsWith("_IN_PROGRESS")) {
+                    return status;
+                }
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError("Stack " + stackName + " did not reach a terminal state within " + maxSeconds + "s");
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -409,7 +409,9 @@ public class CloudFormationResourceProvisioner {
 
             String zipFile = codeNode.path("ZipFile").asText(null);
             if (zipFile != null) {
-                return Map.of("ZipFile", zipFile);
+                String handler = resolveOrDefault(props, "Handler", engine, "index.handler");
+                String runtime = resolveOrDefault(props, "Runtime", engine, "nodejs18.x");
+                return Map.of("ZipFile", sourceToZipBase64(zipFile, handler, runtime));
             }
 
             String imageUri = codeNode.path("ImageUri").asText(null);
@@ -418,6 +420,22 @@ public class CloudFormationResourceProvisioner {
             }
         }
         return Map.of("ZipFile", defaultHandlerZipBase64());
+    }
+
+    private static String sourceToZipBase64(String source, String handler, String runtime) {
+        String module = handler.contains(".") ? handler.substring(0, handler.lastIndexOf('.')) : "index";
+        String ext = runtime.startsWith("python") ? ".py" : ".js";
+        try {
+            var baos = new ByteArrayOutputStream();
+            try (var zos = new ZipOutputStream(baos)) {
+                zos.putNextEntry(new ZipEntry(module + ext));
+                zos.write(source.getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+            return Base64.getEncoder().encodeToString(baos.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create zip from ZipFile source", e);
+        }
     }
 
     private static String defaultHandlerZipBase64() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -453,6 +453,56 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_lambdaWithInlineZipFile() {
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "cfn-inline-zipfile-func",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Code": {
+                      "ZipFile": "exports.handler = async (e) => ({ statusCode: 200 });"
+                    },
+                    "Role": "arn:aws:iam::000000000000:role/cfn-test-lambda-role"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-inline-zipfile-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-inline-zipfile-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/cfn-inline-zipfile-func")
+        .then()
+            .statusCode(200)
+            .body("Configuration.FunctionName", equalTo("cfn-inline-zipfile-func"));
+    }
+
+    @Test
     void createStack_withDynamoDbGsiAndLsi() {
         String template = """
             {


### PR DESCRIPTION
## Summary

CloudFormation's ZipFile property contains raw source code (JS, Python, etc.), but LambdaService expects Code.ZipFile to be a base64-encoded zip archive per the Lambda REST API contract. Passing raw source directly caused every inline Lambda to land in CREATE_FAILED with "Illegal base64 character".

Fix: added sourceToZipBase64() that wraps the raw source in a ZipEntry (filename derived from the Handler property and runtime extension — .js for Node, .py for Python) and base64-encodes the archive before forwarding to LambdaService.

Closes #607
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
