### PR TITLE
 fix(lambda): inject log group/stream and Floci endpoint env vars into Lambda containers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaEventInvokeController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaEventInvokeController.java
@@ -1,0 +1,125 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.lambda.model.FunctionEventInvokeConfig;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lambda function event invoke configuration endpoints.
+ *
+ * PutFunctionEventInvokeConfig:    PUT    /2019-09-25/functions/{FunctionName}/event-invoke-config
+ * UpdateFunctionEventInvokeConfig: POST   /2019-09-25/functions/{FunctionName}/event-invoke-config
+ * GetFunctionEventInvokeConfig:    GET    /2019-09-25/functions/{FunctionName}/event-invoke-config
+ * DeleteFunctionEventInvokeConfig: DELETE /2019-09-25/functions/{FunctionName}/event-invoke-config
+ * ListFunctionEventInvokeConfigs:  GET    /2019-09-25/functions/{FunctionName}/event-invoke-config/list
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class LambdaEventInvokeController {
+
+    private final LambdaService lambdaService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public LambdaEventInvokeController(LambdaService lambdaService,
+                                       RegionResolver regionResolver,
+                                       ObjectMapper objectMapper) {
+        this.lambdaService = lambdaService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @PUT
+    @Path("/2019-09-25/functions/{functionName}/event-invoke-config")
+    public Response putFunctionEventInvokeConfig(@Context HttpHeaders headers,
+                                                 @PathParam("functionName") String functionName,
+                                                 @QueryParam("Qualifier") String qualifier,
+                                                 String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            FunctionEventInvokeConfig cfg = lambdaService.putEventInvokeConfig(region, functionName, qualifier, request);
+            return Response.ok(cfg).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("InvalidParameterValueException", e.getMessage(), 400);
+        }
+    }
+
+    @POST
+    @Path("/2019-09-25/functions/{functionName}/event-invoke-config")
+    public Response updateFunctionEventInvokeConfig(@Context HttpHeaders headers,
+                                                    @PathParam("functionName") String functionName,
+                                                    @QueryParam("Qualifier") String qualifier,
+                                                    String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            FunctionEventInvokeConfig cfg = lambdaService.updateEventInvokeConfig(region, functionName, qualifier, request);
+            return Response.ok(cfg).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("InvalidParameterValueException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/2019-09-25/functions/{functionName}/event-invoke-config")
+    public Response getFunctionEventInvokeConfig(@Context HttpHeaders headers,
+                                                 @PathParam("functionName") String functionName,
+                                                 @QueryParam("Qualifier") String qualifier) {
+        String region = regionResolver.resolveRegion(headers);
+        FunctionEventInvokeConfig cfg = lambdaService.getEventInvokeConfig(region, functionName, qualifier);
+        return Response.ok(cfg).build();
+    }
+
+    @DELETE
+    @Path("/2019-09-25/functions/{functionName}/event-invoke-config")
+    public Response deleteFunctionEventInvokeConfig(@Context HttpHeaders headers,
+                                                    @PathParam("functionName") String functionName,
+                                                    @QueryParam("Qualifier") String qualifier) {
+        String region = regionResolver.resolveRegion(headers);
+        lambdaService.deleteEventInvokeConfig(region, functionName, qualifier);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/2019-09-25/functions/{functionName}/event-invoke-config/list")
+    public Response listFunctionEventInvokeConfigs(@Context HttpHeaders headers,
+                                                   @PathParam("functionName") String functionName) {
+        String region = regionResolver.resolveRegion(headers);
+        List<FunctionEventInvokeConfig> configs = lambdaService.listEventInvokeConfigs(region, functionName);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("FunctionEventInvokeConfigs");
+        for (FunctionEventInvokeConfig cfg : configs) {
+            items.addPOJO(cfg);
+        }
+        return Response.ok(root).build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.lambda.model.EventSourceMapping;
+import io.github.hectorvent.floci.services.lambda.model.FunctionEventInvokeConfig;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaAlias;
@@ -61,6 +62,7 @@ public class LambdaService {
     private final KinesisEventSourcePoller kinesisPoller;
     private final DynamoDbStreamsEventSourcePoller dynamodbStreamsPoller;
     private final ConcurrentHashMap<String, Integer> versionCounters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, FunctionEventInvokeConfig> eventInvokeConfigs = new ConcurrentHashMap<>();
     /**
      * Per-function locks covering PutFunctionConcurrency,
      * DeleteFunctionConcurrency, and deleteFunction itself. Serializing the
@@ -1287,6 +1289,108 @@ public class LambdaService {
             return Integer.parseInt(value.toString());
         } catch (NumberFormatException e) {
             return defaultValue;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // EventInvokeConfig
+    // -------------------------------------------------------------------------
+
+    public FunctionEventInvokeConfig putEventInvokeConfig(String region, String functionName,
+                                                          String qualifier, Map<String, Object> request) {
+        LambdaFunction fn = getFunction(region, functionName);
+        String key = eventInvokeKey(region, fn.getFunctionArn(), qualifier);
+        FunctionEventInvokeConfig cfg = new FunctionEventInvokeConfig();
+        cfg.setFunctionArn(qualifiedArn(fn.getFunctionArn(), qualifier));
+        cfg.setLastModified(System.currentTimeMillis());
+        applyEventInvokeRequest(cfg, request, true);
+        eventInvokeConfigs.put(key, cfg);
+        return cfg;
+    }
+
+    public FunctionEventInvokeConfig updateEventInvokeConfig(String region, String functionName,
+                                                             String qualifier, Map<String, Object> request) {
+        LambdaFunction fn = getFunction(region, functionName);
+        String key = eventInvokeKey(region, fn.getFunctionArn(), qualifier);
+        FunctionEventInvokeConfig existing = eventInvokeConfigs.get(key);
+        if (existing == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The function " + fn.getFunctionArn() + " doesn't have an EventInvokeConfig", 404);
+        }
+        applyEventInvokeRequest(existing, request, false);
+        existing.setLastModified(System.currentTimeMillis());
+        return existing;
+    }
+
+    public FunctionEventInvokeConfig getEventInvokeConfig(String region, String functionName, String qualifier) {
+        LambdaFunction fn = getFunction(region, functionName);
+        String key = eventInvokeKey(region, fn.getFunctionArn(), qualifier);
+        FunctionEventInvokeConfig cfg = eventInvokeConfigs.get(key);
+        if (cfg == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The function " + fn.getFunctionArn() + " doesn't have an EventInvokeConfig", 404);
+        }
+        return cfg;
+    }
+
+    public void deleteEventInvokeConfig(String region, String functionName, String qualifier) {
+        LambdaFunction fn = getFunction(region, functionName);
+        String key = eventInvokeKey(region, fn.getFunctionArn(), qualifier);
+        if (eventInvokeConfigs.remove(key) == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The function " + fn.getFunctionArn() + " doesn't have an EventInvokeConfig", 404);
+        }
+    }
+
+    public List<FunctionEventInvokeConfig> listEventInvokeConfigs(String region, String functionName) {
+        LambdaFunction fn = getFunction(region, functionName);
+        String prefix = region + ":" + fn.getFunctionArn() + ":";
+        List<FunctionEventInvokeConfig> result = new ArrayList<>();
+        for (Map.Entry<String, FunctionEventInvokeConfig> entry : eventInvokeConfigs.entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                result.add(entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    private String eventInvokeKey(String region, String functionArn, String qualifier) {
+        return region + ":" + functionArn + ":" + (qualifier != null ? qualifier : "$LATEST");
+    }
+
+    private String qualifiedArn(String functionArn, String qualifier) {
+        if (qualifier == null || qualifier.isBlank() || "$LATEST".equals(qualifier)) {
+            return functionArn + ":$LATEST";
+        }
+        return functionArn + ":" + qualifier;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void applyEventInvokeRequest(FunctionEventInvokeConfig cfg, Map<String, Object> request, boolean replace) {
+        if (replace || request.containsKey("MaximumRetryAttempts")) {
+            Object raw = request.get("MaximumRetryAttempts");
+            cfg.setMaximumRetryAttempts(raw instanceof Number ? ((Number) raw).intValue() : null);
+        }
+        if (replace || request.containsKey("MaximumEventAgeInSeconds")) {
+            Object raw = request.get("MaximumEventAgeInSeconds");
+            cfg.setMaximumEventAgeInSeconds(raw instanceof Number ? ((Number) raw).intValue() : null);
+        }
+        if (replace || request.containsKey("DestinationConfig")) {
+            Map<String, Object> destMap = (Map<String, Object>) request.get("DestinationConfig");
+            if (destMap != null) {
+                FunctionEventInvokeConfig.DestinationConfig dest = new FunctionEventInvokeConfig.DestinationConfig();
+                Map<String, Object> onSuccess = (Map<String, Object>) destMap.get("OnSuccess");
+                if (onSuccess != null) {
+                    dest.setOnSuccess(new FunctionEventInvokeConfig.Destination((String) onSuccess.get("Destination")));
+                }
+                Map<String, Object> onFailure = (Map<String, Object>) destMap.get("OnFailure");
+                if (onFailure != null) {
+                    dest.setOnFailure(new FunctionEventInvokeConfig.Destination((String) onFailure.get("Destination")));
+                }
+                cfg.setDestinationConfig(dest);
+            } else if (replace) {
+                cfg.setDestinationConfig(null);
+            }
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.lambda.launcher;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
@@ -54,6 +55,7 @@ public class ContainerLauncher {
     private final DockerHostResolver dockerHostResolver;
     private final EmulatorConfig config;
     private final EcrRegistryManager ecrRegistryManager;
+    private final EmbeddedDnsServer embeddedDnsServer;
 
     /** Matches an AWS-shaped ECR image URI: {@code <account>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag]}. */
     private static final java.util.regex.Pattern AWS_ECR_URI =
@@ -67,7 +69,8 @@ public class ContainerLauncher {
                              RuntimeApiServerFactory runtimeApiServerFactory,
                              DockerHostResolver dockerHostResolver,
                              EmulatorConfig config,
-                             EcrRegistryManager ecrRegistryManager) {
+                             EcrRegistryManager ecrRegistryManager,
+                             EmbeddedDnsServer embeddedDnsServer) {
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
         this.logStreamer = logStreamer;
@@ -76,6 +79,7 @@ public class ContainerLauncher {
         this.dockerHostResolver = dockerHostResolver;
         this.config = config;
         this.ecrRegistryManager = ecrRegistryManager;
+        this.embeddedDnsServer = embeddedDnsServer;
     }
 
     /**
@@ -132,6 +136,24 @@ public class ContainerLauncher {
         String hostAddress = dockerHostResolver.resolve();
         String runtimeApiEndpoint = hostAddress + ":" + runtimeApiServer.getPort();
 
+        // Give the container a human-readable name (needed for log stream name below)
+        String shortId = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String containerName = "floci-" + fn.getFunctionName() + "-" + shortId;
+
+        // CloudWatch log coordinates — computed here so they can be injected as env vars
+        String cwLogGroup  = "/aws/lambda/" + fn.getFunctionName();
+        String cwLogStream = LOG_STREAM_DATE_FMT.format(LocalDate.now()) + "/[$LATEST]" + shortId;
+
+        // Floci endpoint reachable from inside the container.
+        // When the embedded DNS server is active, Lambda containers already have it wired as their
+        // resolver and can reach Floci by the configured hostname (or the default DNS suffix).
+        // Fall back to the raw Docker host IP when the embedded DNS is not running (local dev mode).
+        int flociPort = java.net.URI.create(config.baseUrl()).getPort();
+        String flociHostname = embeddedDnsServer.getServerIp().isPresent()
+                ? config.hostname().orElse(EmbeddedDnsServer.DEFAULT_SUFFIX)
+                : hostAddress;
+        String flociEndpoint = "http://" + flociHostname + ":" + flociPort;
+
         // Build env vars
         List<String> env = new ArrayList<>();
         env.add("AWS_LAMBDA_RUNTIME_API=" + runtimeApiEndpoint);
@@ -139,6 +161,8 @@ public class ContainerLauncher {
         env.add("AWS_LAMBDA_FUNCTION_MEMORY_SIZE=" + fn.getMemorySize());
         env.add("AWS_LAMBDA_FUNCTION_TIMEOUT=" + fn.getTimeout());
         env.add("AWS_LAMBDA_FUNCTION_VERSION=$LATEST");
+        env.add("AWS_LAMBDA_LOG_GROUP_NAME=" + cwLogGroup);
+        env.add("AWS_LAMBDA_LOG_STREAM_NAME=" + cwLogStream);
         if (fn.getHandler() != null && !fn.getHandler().isBlank()) {
             env.add("_HANDLER=" + fn.getHandler());
         }
@@ -147,13 +171,12 @@ public class ContainerLauncher {
         env.add("AWS_ACCESS_KEY_ID=test");
         env.add("AWS_SECRET_ACCESS_KEY=test");
         env.add("AWS_SESSION_TOKEN=test");
+        env.add("FLOCI_HOSTNAME=" + flociHostname);
+        env.add("FLOCI_ENDPOINT=" + flociEndpoint);
+        env.add("AWS_ENDPOINT_URL=" + flociEndpoint);
         if (fn.getEnvironment() != null) {
             fn.getEnvironment().forEach((k, v) -> env.add(k + "=" + v));
         }
-
-        // Give the container a human-readable name
-        String shortId = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-        String containerName = "floci-" + fn.getFunctionName() + "-" + shortId;
 
         ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
                 .withName(containerName)
@@ -214,12 +237,8 @@ public class ContainerLauncher {
 
         ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), runtimeApiServer, ContainerState.WARM, fn.isHotReload());
 
-        // Determine CloudWatch Logs destination for this container instance
-        String cwLogGroup = "/aws/lambda/" + fn.getFunctionName();
-        String region = extractRegionFromArn(fn.getFunctionArn());
-        String cwLogStream = LOG_STREAM_DATE_FMT.format(LocalDate.now()) + "/[$LATEST]" + shortId;
-
         // Attach log streaming
+        String region = extractRegionFromArn(fn.getFunctionArn());
         Closeable logHandle = logStreamer.attach(
                 containerId, cwLogGroup, cwLogStream, region, "lambda:" + fn.getFunctionName());
         handle.setLogStream(logHandle);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/FunctionEventInvokeConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/FunctionEventInvokeConfig.java
@@ -1,0 +1,84 @@
+package io.github.hectorvent.floci.services.lambda.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FunctionEventInvokeConfig {
+
+    @JsonProperty("FunctionArn")
+    private String functionArn;
+
+    @JsonIgnore
+    private long lastModifiedMillis;
+
+    @JsonProperty("MaximumRetryAttempts")
+    private Integer maximumRetryAttempts;
+
+    @JsonProperty("MaximumEventAgeInSeconds")
+    private Integer maximumEventAgeInSeconds;
+
+    @JsonProperty("DestinationConfig")
+    private DestinationConfig destinationConfig;
+
+    public FunctionEventInvokeConfig() {}
+
+    @JsonProperty("LastModified")
+    public double getLastModifiedSeconds() {
+        return lastModifiedMillis / 1000.0;
+    }
+
+    public String getFunctionArn() { return functionArn; }
+    public void setFunctionArn(String functionArn) { this.functionArn = functionArn; }
+
+    @JsonIgnore
+    public long getLastModified() { return lastModifiedMillis; }
+    public void setLastModified(long lastModifiedMillis) { this.lastModifiedMillis = lastModifiedMillis; }
+
+    public Integer getMaximumRetryAttempts() { return maximumRetryAttempts; }
+    public void setMaximumRetryAttempts(Integer maximumRetryAttempts) { this.maximumRetryAttempts = maximumRetryAttempts; }
+
+    public Integer getMaximumEventAgeInSeconds() { return maximumEventAgeInSeconds; }
+    public void setMaximumEventAgeInSeconds(Integer maximumEventAgeInSeconds) { this.maximumEventAgeInSeconds = maximumEventAgeInSeconds; }
+
+    public DestinationConfig getDestinationConfig() { return destinationConfig; }
+    public void setDestinationConfig(DestinationConfig destinationConfig) { this.destinationConfig = destinationConfig; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class DestinationConfig {
+        @JsonProperty("OnSuccess")
+        private Destination onSuccess;
+
+        @JsonProperty("OnFailure")
+        private Destination onFailure;
+
+        public DestinationConfig() {}
+
+        public Destination getOnSuccess() { return onSuccess; }
+        public void setOnSuccess(Destination onSuccess) { this.onSuccess = onSuccess; }
+
+        public Destination getOnFailure() { return onFailure; }
+        public void setOnFailure(Destination onFailure) { this.onFailure = onFailure; }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Destination {
+        @JsonProperty("Destination")
+        private String destination;
+
+        public Destination() {}
+        public Destination(String destination) { this.destination = destination; }
+
+        public String getDestination() { return destination; }
+        public void setDestination(String destination) { this.destination = destination; }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaEventInvokeConfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaEventInvokeConfigTest.java
@@ -1,0 +1,148 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.lambda.model.FunctionEventInvokeConfig;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.lambda.zip.CodeStore;
+import io.github.hectorvent.floci.services.lambda.zip.ZipExtractor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LambdaEventInvokeConfigTest {
+
+    private static final String REGION = "us-east-1";
+
+    private LambdaService service;
+
+    @BeforeEach
+    void setUp() {
+        LambdaFunctionStore store = new LambdaFunctionStore(new InMemoryStorage<String, LambdaFunction>());
+        WarmPool warmPool = new WarmPool();
+        CodeStore codeStore = new CodeStore(Path.of("target/test-data/lambda-code"));
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        service = new LambdaService(store, warmPool, codeStore, new ZipExtractor(), regionResolver);
+
+        service.createFunction(REGION, Map.of(
+                "FunctionName", "test-fn",
+                "PackageType", "Image",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Code", Map.of("ImageUri", "public.ecr.aws/lambda/nodejs:20")
+        ));
+    }
+
+    @Test
+    void putCreatesConfig() {
+        Map<String, Object> req = new HashMap<>();
+        req.put("MaximumRetryAttempts", 1);
+        req.put("MaximumEventAgeInSeconds", 3600);
+
+        FunctionEventInvokeConfig cfg = service.putEventInvokeConfig(REGION, "test-fn", null, req);
+
+        assertEquals(1, cfg.getMaximumRetryAttempts());
+        assertEquals(3600, cfg.getMaximumEventAgeInSeconds());
+        assertTrue(cfg.getFunctionArn().endsWith(":$LATEST"));
+        assertTrue(cfg.getLastModifiedSeconds() > 0);
+    }
+
+    @Test
+    void putReplacesExistingConfig() {
+        service.putEventInvokeConfig(REGION, "test-fn", null, Map.of("MaximumRetryAttempts", 2));
+
+        Map<String, Object> req2 = new HashMap<>();
+        req2.put("MaximumRetryAttempts", 0);
+        FunctionEventInvokeConfig cfg = service.putEventInvokeConfig(REGION, "test-fn", null, req2);
+
+        assertEquals(0, cfg.getMaximumRetryAttempts());
+        assertNull(cfg.getMaximumEventAgeInSeconds());
+    }
+
+    @Test
+    void getReturnsStoredConfig() {
+        service.putEventInvokeConfig(REGION, "test-fn", null, Map.of("MaximumRetryAttempts", 1));
+
+        FunctionEventInvokeConfig cfg = service.getEventInvokeConfig(REGION, "test-fn", null);
+
+        assertEquals(1, cfg.getMaximumRetryAttempts());
+    }
+
+    @Test
+    void getThrows404WhenNotFound() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.getEventInvokeConfig(REGION, "test-fn", null));
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void updateMergesPartialFields() {
+        service.putEventInvokeConfig(REGION, "test-fn", null, Map.of(
+                "MaximumRetryAttempts", 2,
+                "MaximumEventAgeInSeconds", 7200));
+
+        Map<String, Object> partial = new HashMap<>();
+        partial.put("MaximumRetryAttempts", 0);
+        service.updateEventInvokeConfig(REGION, "test-fn", null, partial);
+
+        FunctionEventInvokeConfig cfg = service.getEventInvokeConfig(REGION, "test-fn", null);
+        assertEquals(0, cfg.getMaximumRetryAttempts());
+        assertEquals(7200, cfg.getMaximumEventAgeInSeconds());
+    }
+
+    @Test
+    void updateThrows404WhenNotFound() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.updateEventInvokeConfig(REGION, "test-fn", null, Map.of()));
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void deleteRemovesConfig() {
+        service.putEventInvokeConfig(REGION, "test-fn", null, Map.of("MaximumRetryAttempts", 1));
+        service.deleteEventInvokeConfig(REGION, "test-fn", null);
+
+        assertThrows(AwsException.class,
+                () -> service.getEventInvokeConfig(REGION, "test-fn", null));
+    }
+
+    @Test
+    void deleteThrows404WhenNotFound() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.deleteEventInvokeConfig(REGION, "test-fn", null));
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void listReturnsAllConfigsForFunction() {
+        service.putEventInvokeConfig(REGION, "test-fn", null, Map.of("MaximumRetryAttempts", 1));
+        service.putEventInvokeConfig(REGION, "test-fn", "1", Map.of("MaximumRetryAttempts", 0));
+
+        List<FunctionEventInvokeConfig> configs = service.listEventInvokeConfigs(REGION, "test-fn");
+
+        assertEquals(2, configs.size());
+    }
+
+    @Test
+    void putWithDestinationConfig() {
+        Map<String, Object> req = new HashMap<>();
+        req.put("DestinationConfig", Map.of(
+                "OnSuccess", Map.of("Destination", "arn:aws:sqs:us-east-1:000000000000:my-queue"),
+                "OnFailure", Map.of("Destination", "arn:aws:sqs:us-east-1:000000000000:dlq")
+        ));
+
+        FunctionEventInvokeConfig cfg = service.putEventInvokeConfig(REGION, "test-fn", null, req);
+
+        assertNotNull(cfg.getDestinationConfig());
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:my-queue",
+                cfg.getDestinationConfig().getOnSuccess().getDestination());
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq",
+                cfg.getDestinationConfig().getOnFailure().getDestination());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
@@ -181,6 +181,8 @@ class LambdaImageConfigTest {
             when(config.docker()).thenReturn(docker);
             when(docker.logMaxSize()).thenReturn("10m");
             when(docker.logMaxFile()).thenReturn("3");
+            when(config.baseUrl()).thenReturn("http://localhost:4566");
+            lenient().when(config.hostname()).thenReturn(Optional.empty());
             when(embeddedDnsServer.getServerIp()).thenReturn(Optional.empty());
 
             ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
@@ -185,7 +185,7 @@ class LambdaImageConfigTest {
 
             ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);
             launcher = new ContainerLauncher(containerBuilder, lifecycleManager, logStreamer, imageResolver,
-                    runtimeApiServerFactory, dockerHostResolver, config, ecrRegistryManager);
+                    runtimeApiServerFactory, dockerHostResolver, config, ecrRegistryManager, embeddedDnsServer);
 
             when(runtimeApiServerFactory.create()).thenReturn(runtimeApiServer);
             when(runtimeApiServer.getPort()).thenReturn(9000);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -72,7 +72,7 @@ class ContainerLauncherTest {
 
         ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);
         launcher = new ContainerLauncher(containerBuilder, lifecycleManager, logStreamer, imageResolver,
-                runtimeApiServerFactory, dockerHostResolver, config, ecrRegistryManager);
+                runtimeApiServerFactory, dockerHostResolver, config, ecrRegistryManager, embeddedDnsServer);
 
         when(runtimeApiServerFactory.create()).thenReturn(runtimeApiServer);
         when(runtimeApiServer.getPort()).thenReturn(9000);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -67,6 +67,8 @@ class ContainerLauncherTest {
         when(config.docker()).thenReturn(docker);
         when(docker.logMaxSize()).thenReturn("10m");
         when(docker.logMaxFile()).thenReturn("3");
+        when(config.baseUrl()).thenReturn("http://localhost:4566");
+        lenient().when(config.hostname()).thenReturn(Optional.empty());
 
         when(embeddedDnsServer.getServerIp()).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## Summary

Two separate issues both traced back to missing environment variables in Lambda containers.
                                                                                                                                                                                
**- Missing required environment variables: AWS_LAMBDA_LOG_GROUP_NAME, AWS_LAMBDA_LOG_STREAM_NAME** Node.js 24 (and other recent runtimes) validate these vars at startup and throw a hard `PlatformError` before any handler code runs. Floci computed both values but only passed them to the log streamer — they were never added to the                                                                                                       
container's env list.                                                                                                                                                         
                                                                                                                                                                              
**- process.env.FLOCI_HOSTNAME is undefined** Lambda functions running inside Docker containers had no way to discover the Floci endpoint. LocalStack injects `LOCALSTACK_HOSTNAME` + `AWS_ENDPOINT_URL` for the same purpose. Floci had no equivalent, so any function that called back into Floci (e.g. to read from S3 or DynamoDB) had to hardcode the endpoint. 

## Validation                                                                                                                                                                 
                                                            
Smoke test against docker-compose deployment confirmed:                                                                                                                       
                                                                                                                                                                                
```json
{                                                                                                                                                                             
  "FLOCI_HOSTNAME":   "floci",                            
  "FLOCI_ENDPOINT":   "http://floci:4566",
  "AWS_ENDPOINT_URL": "http://floci:4566",
  "LOG_GROUP":        "/aws/lambda/dns-check",                                                                                                                                
  "LOG_STREAM":       "2026/04/29/[$LATEST]46973cb2"
}
```                                                                                                                                                                          
                                                                                                                                                                                
FLOCI_HOSTNAME is the DNS name (floci), not a raw IP — consistent with how the rest of the system (S3 virtual hosting, RDS/ElastiCache proxies) uses the embedded DNS. All 56 Lambda compatibility tests pass.                                                                                                                         
                                                                                                                                                                              
Closes #628                                                                                                                                                                   
Closes #629  
Closes #632           

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
