### PR TITLE
fix(cloudformation): resolve CDK path-style S3 TemplateURL against local S3 

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -427,36 +427,44 @@ public class CloudFormationService {
     }
 
     private String fetchTemplateFromS3(String url) {
+        // Parse S3 URL — three forms:
+        //   Virtual-hosted AWS:   https://bucket.s3[.region].amazonaws.com/key
+        //   Virtual-hosted local: http://bucket.localhost:4566/key  (or configured hostname)
+        //   Path-style (both):    https://s3[.region].amazonaws.com/bucket/key
+        //                         http://host:port/bucket/key
+        //
+        // The old condition matched host.endsWith(".amazonaws.com") for virtual-hosted, which
+        // incorrectly caught path-style AWS URLs like s3.us-east-1.amazonaws.com and extracted
+        // "s3" as the bucket name. Virtual-hosted URLs always have a bucket label before ".s3.".
+        String bucket;
+        String key;
+
+        URI uri = URI.create(url);
+        String host = uri.getHost();
+        String path = uri.getRawPath();
+
+        boolean isVirtualHosted = host != null && (
+                host.contains(".s3.")
+                || (config.hostname().isPresent() && host.endsWith("." + config.hostname().get()))
+                || host.endsWith(".localhost"));
+
+        if (isVirtualHosted) {
+            bucket = host.split("\\.")[0];
+            key = path.startsWith("/") ? path.substring(1) : path;
+        } else {
+            // Path-style: /bucket/key
+            String rawPath = path.startsWith("/") ? path.substring(1) : path;
+            int slash = rawPath.indexOf('/');
+            bucket = slash > 0 ? rawPath.substring(0, slash) : rawPath;
+            key = slash > 0 ? rawPath.substring(slash + 1) : "";
+        }
+
         try {
-            // Parse S3 URL:
-            // Virtual-hosted local: http://bucket.localhost:4566/key
-            // Virtual-hosted AWS:   https://bucket.s3.region.amazonaws.com/key
-            // Path-style:           http://host:port/bucket/key
-            String bucket;
-            String key;
-
-            URI uri = URI.create(url);
-            String host = uri.getHost();
-            String path = uri.getRawPath();
-
-            if (host != null && (host.contains(".s3.") || host.endsWith(".amazonaws.com") ||
-                    (config.hostname().isPresent() && host.endsWith("." + config.hostname().get())) ||
-                    (host.endsWith(".localhost")))) {
-                // Virtual-hosted style
-                bucket = host.split("\\.")[0];
-                key = path.startsWith("/") ? path.substring(1) : path;
-            } else {
-                // Path-style: /bucket/key
-                String rawPath = path.startsWith("/") ? path.substring(1) : path;
-                int slash = rawPath.indexOf('/');
-                bucket = slash > 0 ? rawPath.substring(0, slash) : rawPath;
-                key = slash > 0 ? rawPath.substring(slash + 1) : "";
-            }
             var obj = s3Service.getObject(bucket, key);
             return new String(obj.getData());
         } catch (Exception e) {
-            LOG.warnv("Failed to fetch template from {0}: {1}", url, e.getMessage());
-            return "{}";
+            LOG.errorv("Failed to fetch CloudFormation template from {0}: {1}", url, e.getMessage());
+            throw new RuntimeException("Failed to fetch CloudFormation template from " + url + ": " + e.getMessage(), e);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -2268,4 +2268,126 @@ class CloudFormationIntegrationTest {
         .then()
             .statusCode(404);
     }
+
+    // ── TemplateURL (path-style AWS S3) ──────────────────────────────────────
+
+    @Test
+    void createStack_templateUrlPathStyle_resolvesLocalS3() {
+        String bucket = "cfn-template-url-bucket";
+        String key = "template.json";
+        String template = """
+            {
+              "Resources": {
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-template-url-queue"
+                  }
+                }
+              }
+            }
+            """;
+
+        // Create S3 bucket and upload template
+        given().when().put("/" + bucket).then().statusCode(200);
+        given()
+            .contentType("application/json")
+            .body(template)
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        // CreateStack using a CDK-style path-style AWS S3 TemplateURL
+        String templateUrl = "https://s3.us-east-1.amazonaws.com/" + bucket + "/" + key;
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-template-url-stack")
+            .formParam("TemplateURL", templateUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // Verify stack and its resource were provisioned from the S3 template
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-template-url-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CREATE_COMPLETE"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", "cfn-template-url-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void createStack_templateUrlVirtualHosted_resolvesLocalS3() {
+        String bucket = "cfn-vhost-template-bucket";
+        String key = "template.json";
+        String template = """
+            {
+              "Resources": {
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-vhost-template-queue"
+                  }
+                }
+              }
+            }
+            """;
+
+        given().when().put("/" + bucket).then().statusCode(200);
+        given()
+            .contentType("application/json")
+            .body(template)
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        // Virtual-hosted style: bucket.s3.region.amazonaws.com/key
+        String templateUrl = "https://" + bucket + ".s3.us-east-1.amazonaws.com/" + key;
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-vhost-template-stack")
+            .formParam("TemplateURL", templateUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-vhost-template-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CREATE_COMPLETE"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", "cfn-vhost-template-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
 }


### PR DESCRIPTION
## Summary

CDK uploads CloudFormation templates to local S3 and then calls CreateStack with:
TemplateURL: https://s3.us-east-1.amazonaws.com/{bucket}/{hash}.json cdklocal only rewrites AWS SDK endpoint calls — not the TemplateURL string value inside the request body. Floci's fetchTemplateFromS3 must rewrite it internally.             
                                                                                                                                                                                
**Root Cause**                                                                                                                                                                    
                                                                                                                                                                                Two bugs in fetchTemplateFromS3:

1. Wrong URL parsing — the condition host.endsWith(".amazonaws.com") matched path-style AWS S3 URLs (s3.us-east-1.amazonaws.com) and took the virtual-hosted branch, extracting "s3" as the bucket name instead of the actual bucket. Virtual-hosted URLs always have a bucket label before .s3. (e.g. bucket.s3.region.amazonaws.com).

2. Silent failure — a failed fetch caught the exception, logged a warning, and returned "{}". The stack then provisioned nothing and reported CREATE_COMPLETE with zero resources.

**Fix**                                                                                                                                                                           
                                                            
- Changed the virtual-hosted detection to host.contains(".s3.") only, leaving path-style URLs to fall through to the existing path-parsing branch                             
- Rethrow on fetch failure so the error propagates and the stack correctly reaches CREATE_FAILED

Closes #627 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
