### PR TITLE
fix(eks): use named Docker volume for k3s data directory

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -171,6 +171,20 @@ public class ContainerLifecycleManager {
     }
 
     /**
+     * Removes a named Docker volume, ignoring errors if it does not exist or is still in use.
+     */
+    public void removeVolume(String volumeName) {
+        try {
+            dockerClient.removeVolumeCmd(volumeName).exec();
+            LOG.debugv("Removed volume {0}", volumeName);
+        } catch (NotFoundException e) {
+            // Already gone — nothing to do
+        } catch (Exception e) {
+            LOG.warnv("Error removing volume {0}: {1}", volumeName, e.getMessage());
+        }
+    }
+
+    /**
      * Finds an existing container by name.
      *
      * @param name the container name to search for

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
@@ -71,43 +71,27 @@ public class EksClusterManager {
                 config.services().eks().apiServerBasePort(),
                 config.services().eks().apiServerMaxPort());
 
-        // Ensure data directory exists
-        Path dataPath = Path.of(config.services().eks().dataPath(), cluster.getName());
-        try {
-            Files.createDirectories(dataPath);
-        } catch (IOException e) {
-            LOG.warnv("Could not create EKS data directory {0}: {1}", dataPath, e.getMessage());
-        }
-
         // Remove any stale container
         lifecycleManager.removeIfExists(containerName);
 
-        // Build container spec
-        String hostDataPath;
-        String hostPersistentPath = config.storage().hostPersistentPath();
-        boolean isAbsoluteHostPath = hostPersistentPath.startsWith("/");
-
-        if (isAbsoluteHostPath) {
-            String dataPathStr = dataPath.toAbsolutePath().normalize().toString();
-            String persistentPathStr = Path.of(config.storage().persistentPath()).toAbsolutePath().normalize().toString();
-            hostDataPath = dataPathStr.replace(persistentPathStr, hostPersistentPath);
-        } else {
-            // Relative or named-volume path: when running inside Docker (DinD), a relative path
-            // refers to a path inside this container that the host daemon cannot bind-mount.
-            // Use a named Docker volume per cluster instead — the host daemon manages it directly.
-            hostDataPath = "floci-eks-" + cluster.getName();
-        }
-
+        // k3s v1.34+ removed support for --kube-apiserver-arg=storage-backend and
+        // --kube-apiserver-arg=etcd-servers. k3s now manages kine (embedded SQLite)
+        // internally without those flags.
+        //
+        // A named Docker volume is used for the k3s data directory instead of a host
+        // bind mount. Bind-mounting to a macOS host path causes kine to create its Unix
+        // socket (kine.sock) on macOS APFS, which returns EINVAL on chmod — crashing
+        // k3s before it can start. Named volumes live in the Docker VM's Linux
+        // filesystem, so chmod works correctly and data persists across container restarts.
+        String volumeName = "floci-eks-" + cluster.getName();
         ContainerSpec spec = containerBuilder.newContainer(image)
                 .withName(containerName)
                 .withCmd(List.of("server",
                         "--disable=traefik",
-                        "--tls-san=localhost",
-                        "--kube-apiserver-arg=storage-backend=sqlite3",
-                        "--kube-apiserver-arg=etcd-servers=unix:///tmp/kine.sock"))
+                        "--tls-san=localhost"))
                 .withEnv("K3S_KUBECONFIG_MODE", "644")
                 .withPortBinding(K3S_API_SERVER_PORT, hostPort)
-                .withBind(hostDataPath, "/var/lib/rancher/k3s")
+                .withNamedVolume(volumeName, "/var/lib/rancher/k3s")
                 .withDockerNetwork(config.services().eks().dockerNetwork())
                 .withPrivileged(true)
                 .withLogRotation()
@@ -193,6 +177,7 @@ public class EksClusterManager {
             return;
         }
         lifecycleManager.stopAndRemove(cluster.getContainerId(), null);
+        lifecycleManager.removeVolume("floci-eks-" + cluster.getName());
         LOG.infov("Stopped k3s container for cluster {0}", cluster.getName());
     }
 


### PR DESCRIPTION
## Summary

k3s v1.34+ removed --kube-apiserver-arg=storage-backend and --kube-apiserver-arg=etcd-servers; drop both flags.                                                                                                                           
                                                                                                                                                                                
Replace the host bind mount with a named Docker volume (floci-eks-<cluster>) mounted at /var/lib/rancher/k3s. Named volumes live in the Docker VM's Linux filesystem, so kine can chmod its Unix socket without hitting the EINVAL error macOS APFS returns for that operation. Data now persists across container restarts. The volume is removed when the cluster is deleted.   

Closes #633

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
