### PR TITLE
fix(apigateway): support _custom_id_ tag on create-rest-api 

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1028,6 +1028,11 @@ public class ApiGatewayController {
         node.put("name", api.getName());
         if (api.getDescription() != null) node.put("description", api.getDescription());
         node.put("createdDate", api.getCreatedDate());
+        if (api.getTags() != null && !api.getTags().isEmpty()) {
+            ObjectNode tagsNode = objectMapper.createObjectNode();
+            api.getTags().forEach(tagsNode::put);
+            node.set("tags", tagsNode);
+        }
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -82,11 +82,19 @@ public class ApiGatewayService {
         String name = (String) request.get("name");
         String description = (String) request.get("description");
 
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = request.get("tags") instanceof Map<?, ?> m
+                ? (Map<String, String>) m : new HashMap<>();
+
+        String customId = tags.get("_custom_id_");
+        String apiId = (customId != null && !customId.isBlank()) ? customId : shortId(10);
+
         RestApi api = new RestApi();
-        api.setId(shortId(10));
+        api.setId(apiId);
         api.setName(name);
         api.setDescription(description);
         api.setCreatedDate(System.currentTimeMillis() / 1000L);
+        api.setTags(tags);
 
         apiStore.put(apiKey(region, api.getId()), api);
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -336,4 +336,39 @@ class ApiGatewayIntegrationTest {
                 .then()
                 .statusCode(404);
     }
+
+    // ──────────────────────────── _custom_id_ tag ────────────────────────────
+
+    @Test @Order(50)
+    void createRestApi_customIdTag_usesTagValueAsApiId() {
+        String body = """
+                {"name":"custom-id-api","tags":{"_custom_id_":"MYCUSTOMNAME"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo("MYCUSTOMNAME"))
+                .body("tags._custom_id_", equalTo("MYCUSTOMNAME"));
+    }
+
+    @Test @Order(51)
+    void getRestApi_customId_resolvesById() {
+        given()
+                .when().get("/restapis/MYCUSTOMNAME")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo("MYCUSTOMNAME"))
+                .body("name", equalTo("custom-id-api"));
+    }
+
+    @Test @Order(52)
+    void deleteRestApi_customId() {
+        given()
+                .when().delete("/restapis/MYCUSTOMNAME")
+                .then()
+                .statusCode(202);
+    }
 }


### PR DESCRIPTION
## Summary

- When `create-rest-api` receives `tags: {"_custom_id_": "ALIAS"}`, the tag value is now used as the REST API ID instead of a random 10-char ID — matching LocalStack behavior
- Tags are stored on the `RestApi` object and included in the `create-rest-api` / `get-rest-api` response
- No changes to the execute controller — since the custom value becomes the actual stored API ID, routing via `/execute-api/ALIAS/{stage}/{path}` works through the existing lookup path                                                                                                                                                                   
                                                                                                                                                                                
## Test plan                                                                                                                                                                  

- [x] `ApiGatewayIntegrationTest` — 3 new tests: create with `_custom_id_`, get by custom ID, delete by custom ID
- [x] All 37 existing + new API Gateway integration tests pass                                                                                                                
                                                                                                                                                                                
Closes #636                                                     

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
