### PR TITLE
fix(athena): Connect to floci-duck container via IP not via DNS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/FlociDuckManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/FlociDuckManager.java
@@ -4,6 +4,8 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.quarkus.runtime.ShutdownEvent;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -89,12 +91,11 @@ public class FlociDuckManager {
                 .withLogRotation()
                 .build();
 
-        containerId = lifecycleManager.createAndStart(spec).containerId();
+        ContainerInfo info = lifecycleManager.createAndStart(spec);
+        EndpointInfo endpoint = info.getEndpoint(DUCK_PORT);
+        containerId = info.containerId();
 
-        String url = containerDetector.isRunningInContainer()
-                ? "http://" + CONTAINER_NAME + ":" + DUCK_PORT
-                : "http://localhost:" + DUCK_PORT;
-
+        String url = "http://" + endpoint;
         LOG.infov("floci-duck container started, waiting for health check at {0}", url);
         waitForHealth(url);
 


### PR DESCRIPTION
## Summary

Resolving a container URL via DNS is not working reliably within different Docker runtimes and network setups. If we can avoid DNS resolution, we should avoid it. This PR switches the connection from Floci to floci-duck container from DNS-based URL to an IP-based one.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No AWS compatibility required for this PR

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
