### PR TITLE
feat(iam): add 23 AWS managed ExecutionRole policies (#614)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -22,6 +22,7 @@ final class AwsManagedPolicies {
     }
 
     static final List<ManagedPolicyDef> POLICIES = List.of(
+        // General access policies
         new ManagedPolicyDef("AdministratorAccess", "/",
                 "Provides full access to AWS services and resources."),
         new ManagedPolicyDef("PowerUserAccess", "/",
@@ -46,10 +47,80 @@ final class AwsManagedPolicies {
                 "Provides full access to Amazon VPC via the AWS Management Console."),
         new ManagedPolicyDef("CloudWatchFullAccess", "/",
                 "Provides full access to CloudWatch."),
+        new ManagedPolicyDef("AWSLambdaFullAccess", "/",
+                "Provides full access to Lambda, S3, DynamoDB, CloudWatch Metrics and Logs."),
+
+        // Lambda execution role policies
         new ManagedPolicyDef("AWSLambdaBasicExecutionRole", "/service-role/",
                 "Provides write permissions to CloudWatch Logs."),
-        new ManagedPolicyDef("AWSLambdaFullAccess", "/",
-                "Provides full access to Lambda, S3, DynamoDB, CloudWatch Metrics and Logs.")
+        new ManagedPolicyDef("AWSLambdaBasicDurableExecutionRolePolicy", "/service-role/",
+                "Provides write permissions to CloudWatch Logs and read/write permissions to durable execution APIs for Lambda durable functions."),
+        new ManagedPolicyDef("AWSLambdaDynamoDBExecutionRole", "/service-role/",
+                "Provides list and read access to DynamoDB streams and write permissions to CloudWatch Logs."),
+        new ManagedPolicyDef("AWSLambdaKinesisExecutionRole", "/service-role/",
+                "Provides list and read access to Kinesis streams and write permissions to CloudWatch Logs."),
+        new ManagedPolicyDef("AWSLambdaMSKExecutionRole", "/service-role/",
+                "Provides permissions required to access an MSK cluster within a VPC, manage network interfaces, and write to CloudWatch Logs."),
+        new ManagedPolicyDef("AWSLambdaSQSQueueExecutionRole", "/service-role/",
+                "Provides receive message, delete message, and read attribute access to SQS queues, and write permissions to CloudWatch Logs."),
+        new ManagedPolicyDef("AWSLambdaVPCAccessExecutionRole", "/service-role/",
+                "Provides minimum permissions for a Lambda function to execute while accessing a resource within a VPC."),
+
+        // ECS / EKS execution role policies
+        new ManagedPolicyDef("AmazonECSTaskExecutionRolePolicy", "/service-role/",
+                "Provides the Amazon ECS container agent and Fargate agent permissions to make AWS API calls on your behalf."),
+        new ManagedPolicyDef("AmazonEKSFargatePodExecutionRolePolicy", "/",
+                "Provides access to other AWS service resources required to run Amazon EKS pods on AWS Fargate."),
+
+        // S3 Object Lambda execution role policy
+        new ManagedPolicyDef("AmazonS3ObjectLambdaExecutionRolePolicy", "/service-role/",
+                "Provides write permissions to CloudWatch Logs for S3 Object Lambda access points."),
+
+        // CloudWatch Lambda execution role policies
+        new ManagedPolicyDef("CloudWatchLambdaInsightsExecutionRolePolicy", "/",
+                "Allows Lambda Insights to create and write to CloudWatch Logs log groups for Lambda Insights monitoring."),
+        new ManagedPolicyDef("CloudWatchLambdaApplicationSignalsExecutionRolePolicy", "/",
+                "Provides write access to X-Ray and CloudWatch Application Signals log group."),
+
+        // Config execution role policy
+        new ManagedPolicyDef("AWSConfigRulesExecutionRole", "/service-role/",
+                "Allows AWS Config Rules Lambda functions to call AWS services and read the configuration of AWS resources."),
+
+        // MSK replicator execution role policy
+        new ManagedPolicyDef("AWSMSKReplicatorExecutionRole", "/service-role/",
+                "Grants permissions to Amazon MSK Replicator to replicate data between MSK Clusters."),
+
+        // SSM Automation execution role policies
+        new ManagedPolicyDef("AWS-SSM-DiagnosisAutomation-ExecutionRolePolicy", "/",
+                "Provides permissions for AWS Systems Manager diagnosis automation execution."),
+        new ManagedPolicyDef("AWS-SSM-RemediationAutomation-ExecutionRolePolicy", "/",
+                "Provides permissions for AWS Systems Manager remediation automation execution."),
+
+        // SageMaker execution role policies
+        new ManagedPolicyDef("AmazonSageMakerGeospatialExecutionRole", "/service-role/",
+                "Provides full access to Amazon SageMaker Geospatial capabilities and related services."),
+        new ManagedPolicyDef("AmazonSageMakerCanvasEMRServerlessExecutionRolePolicy", "/",
+                "Provides access for Amazon SageMaker Canvas to manage EMR Serverless resources."),
+
+        // SageMaker Studio execution role policies
+        new ManagedPolicyDef("SageMakerStudioBedrockFunctionExecutionRolePolicy", "/service-role/",
+                "Provides permissions for SageMaker Studio Bedrock function execution role."),
+        new ManagedPolicyDef("SageMakerStudioDomainExecutionRolePolicy", "/service-role/",
+                "Provides permissions for the SageMaker Studio domain execution role."),
+        new ManagedPolicyDef("SageMakerStudioQueryExecutionRolePolicy", "/service-role/",
+                "Provides permissions for SageMaker Studio query execution role."),
+
+        // Amazon DataZone execution role policy
+        new ManagedPolicyDef("AmazonDataZoneDomainExecutionRolePolicy", "/service-role/",
+                "Provides permissions for the Amazon DataZone domain execution role."),
+
+        // Amazon Bedrock execution role policy
+        new ManagedPolicyDef("AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy", "/",
+                "Provides Bedrock Model inference permissions to Bedrock agent core memory."),
+
+        // AWS Partner Central execution role policy
+        new ManagedPolicyDef("AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy", "/",
+                "Provides permissions for AWS Partner Central resource snapshot job execution role.")
     );
 
     private AwsManagedPolicies() {}


### PR DESCRIPTION
## Summary

- Adds 23 AWS managed `*ExecutionRole*` policies to the seeded catalog in `AwsManagedPolicies`                                                                                
- All ARN paths verified against the [AWS managed policy reference documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/)
- Policies are available immediately via `ListPolicies` (scope `AWS`) and attachable via `AttachRolePolicy` / `AttachUserPolicy`                                              
 
Closes #614 
## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
