### PR TITLE
fix(apigateway): implement GET deployment

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -442,6 +442,16 @@ public class ApiGatewayController {
         return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
     }
 
+    @GET
+    @Path("/restapis/{apiId}/deployments/{deploymentId}")
+    public Response getDeployment(@Context HttpHeaders headers,
+                                   @PathParam("apiId") String apiId,
+                                   @PathParam("deploymentId") String deploymentId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toDeploymentNode(service.getDeployment(region, apiId, deploymentId)).toString())
+                .type(MediaType.APPLICATION_JSON).build();
+    }
+
     @POST
     @Path("/restapis/{apiId}/stages")
     public Response createStage(@Context HttpHeaders headers,

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -218,9 +218,19 @@ class ApiGatewayIntegrationTest {
                 .body("item.id", hasItem(deploymentId));
     }
 
+    @Test @Order(18)
+    void getDeployment() {
+        given()
+                .when().get("/restapis/" + apiId + "/deployments/" + deploymentId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(deploymentId))
+                .body("description", equalTo("v1"));
+    }
+
     // ──────────────────────────── Stages ────────────────────────────
 
-    @Test @Order(18)
+    @Test @Order(19)
     void createStage() {
         given()
                 .contentType(ContentType.JSON)
@@ -232,7 +242,7 @@ class ApiGatewayIntegrationTest {
                 .body("deploymentId", equalTo(deploymentId));
     }
 
-    @Test @Order(19)
+    @Test @Order(20)
     void getStage() {
         given()
                 .when().get("/restapis/" + apiId + "/stages/prod")
@@ -241,7 +251,7 @@ class ApiGatewayIntegrationTest {
                 .body("stageName", equalTo("prod"));
     }
 
-    @Test @Order(20)
+    @Test @Order(21)
     void listStages() {
         given()
                 .when().get("/restapis/" + apiId + "/stages")
@@ -250,7 +260,7 @@ class ApiGatewayIntegrationTest {
                 .body("item.stageName", hasItem("prod"));
     }
 
-    @Test @Order(21)
+    @Test @Order(22)
     void updateStage() {
         String patch = """
                 {"patchOperations":[{"op":"replace","path":"/description","value":"Production"}]}
@@ -266,7 +276,7 @@ class ApiGatewayIntegrationTest {
 
     // ──────────────────────────── Tags ────────────────────────────
 
-    @Test @Order(22)
+    @Test @Order(23)
     void tagResource() {
         String arn = "arn:aws:apigateway:us-east-1::/restapis/" + apiId;
         given()
@@ -277,7 +287,7 @@ class ApiGatewayIntegrationTest {
                 .statusCode(204);
     }
 
-    @Test @Order(23)
+    @Test @Order(24)
     void getTags() {
         String arn = "arn:aws:apigateway:us-east-1::/restapis/" + apiId;
         given()
@@ -287,7 +297,7 @@ class ApiGatewayIntegrationTest {
                 .body("tags.env", equalTo("test"));
     }
 
-    @Test @Order(24)
+    @Test @Order(25)
     void untagResource() {
         String arn = "arn:aws:apigateway:us-east-1::/restapis/" + apiId;
         given()
@@ -305,7 +315,7 @@ class ApiGatewayIntegrationTest {
 
     // ──────────────────────────── Cleanup ────────────────────────────
 
-    @Test @Order(25)
+    @Test @Order(26)
     void deleteStage() {
         given()
                 .when().delete("/restapis/" + apiId + "/stages/prod")
@@ -313,7 +323,7 @@ class ApiGatewayIntegrationTest {
                 .statusCode(202);
     }
 
-    @Test @Order(26)
+    @Test @Order(27)
     void deleteResource() {
         given()
                 .when().delete("/restapis/" + apiId + "/resources/" + resourceId)
@@ -321,7 +331,7 @@ class ApiGatewayIntegrationTest {
                 .statusCode(204);
     }
 
-    @Test @Order(27)
+    @Test @Order(28)
     void deleteRestApi() {
         given()
                 .when().delete("/restapis/" + apiId)
@@ -329,7 +339,7 @@ class ApiGatewayIntegrationTest {
                 .statusCode(202);
     }
 
-    @Test @Order(28)
+    @Test @Order(29)
     void getDeletedRestApiReturns404() {
         given()
                 .when().get("/restapis/" + apiId)


### PR DESCRIPTION
## Summary

Addresses: #651

Adds the missing v1 REST `GetDeployment` route so that Terraform (and any other AWS SDK
client) can read a single deployment after creating it.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

The `GET /restapis/{restApiId}/deployments/{deploymentId}` path was entirely unhandled.
Quarkus fell through to its default 404 HTML page, which the AWS SDK could not
deserialise as JSON, producing:

```
invalid character '<' looking for beginning of value
```

The fix delegates to the already-implemented `ApiGatewayService.getDeployment` method
and returns the same JSON shape (`id`, `description`, `createdDate`) that
`CreateDeployment` and `GetDeployments` already produce.

## Changes

| File | What changed |
|------|--------------|
| `src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java` | Added `@GET @Path("/restapis/{apiId}/deployments/{deploymentId}")` handler after the existing `getDeployments` method |
| `src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java` | Added `getDeployment` test at `@Order(18)`; renumbered former orders 18–28 to 19–29 |
| `docs/issues/get-deployment-missing-bug.md` | New issue document |
| `docs/prs/get-deployment-missing-bug.md` | This PR document |

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
