### PR TITLE
fix: resolve IAM Action from form-encoded body for Query-protocol services

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamActionRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamActionRegistry.java
@@ -2,8 +2,15 @@ package io.github.hectorvent.floci.services.iam;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
 import org.jboss.logging.Logger;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -92,8 +99,14 @@ public class IamActionRegistry {
      * Returns {@code null} when the action is unknown (caller treats this as ALLOW).
      */
     public String resolve(String credentialScope, ContainerRequestContext ctx) {
-        // Query-protocol: Action form param → service:Action
+        // Query-protocol: Action param → service:Action.
+        // AWS SDKs send Query-protocol calls (IAM, STS, EC2, SQS, SNS, ...) as
+        // POST with Action=... in the application/x-www-form-urlencoded body,
+        // not the URL query string — so we look in both places.
         String queryAction = ctx.getUriInfo().getQueryParameters().getFirst("Action");
+        if (queryAction == null || queryAction.isBlank()) {
+            queryAction = readFormAction(ctx);
+        }
         if (queryAction != null && !queryAction.isBlank()) {
             return credentialScope + ":" + queryAction;
         }
@@ -120,5 +133,59 @@ public class IamActionRegistry {
 
         LOG.debugv("No action mapping for {0} {1} {2} — defaulting to ALLOW", credentialScope, method, path);
         return null;
+    }
+
+    /**
+     * Reads {@code Action} from a {@code application/x-www-form-urlencoded}
+     * request body and restores the entity stream so downstream consumers
+     * (e.g. {@code AwsQueryController}'s {@code MultivaluedMap} injection)
+     * can still parse the form themselves. Returns {@code null} if the
+     * request is not form-encoded or the body has no {@code Action} field.
+     */
+    private static String readFormAction(ContainerRequestContext ctx) {
+        MediaType mt = ctx.getMediaType();
+        if (mt == null
+                || !"application".equalsIgnoreCase(mt.getType())
+                || !"x-www-form-urlencoded".equalsIgnoreCase(mt.getSubtype())) {
+            return null;
+        }
+        InputStream in = ctx.getEntityStream();
+        if (in == null) {
+            return null;
+        }
+        byte[] body;
+        try {
+            body = in.readAllBytes();
+        } catch (IOException e) {
+            LOG.debugv(e, "Failed to buffer form body for IAM action resolution");
+            return null;
+        }
+        ctx.setEntityStream(new ByteArrayInputStream(body));
+        if (body.length == 0) {
+            return null;
+        }
+        Charset charset = resolveCharset(mt);
+        String form = new String(body, charset);
+        for (String pair : form.split("&")) {
+            int eq = pair.indexOf('=');
+            String key = eq < 0 ? pair : pair.substring(0, eq);
+            if (!"Action".equals(URLDecoder.decode(key, charset))) {
+                continue;
+            }
+            return eq < 0 ? "" : URLDecoder.decode(pair.substring(eq + 1), charset);
+        }
+        return null;
+    }
+
+    private static Charset resolveCharset(MediaType mt) {
+        String name = mt.getParameters().get("charset");
+        if (name == null || name.isBlank()) {
+            return StandardCharsets.UTF_8;
+        }
+        try {
+            return Charset.forName(name);
+        } catch (RuntimeException e) {
+            return StandardCharsets.UTF_8;
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamActionRegistryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamActionRegistryTest.java
@@ -1,0 +1,136 @@
+package io.github.hectorvent.floci.services.iam;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IamActionRegistry}, focused on the protocol-aware
+ * {@code Action} extraction. The HTTP filter path is covered by SDK
+ * compatibility tests; these tests pin the resolver behavior directly.
+ */
+class IamActionRegistryTest {
+
+    private final IamActionRegistry registry = new IamActionRegistry();
+
+    @Test
+    void resolvesActionFromFormEncodedBody() {
+        // AWS SDKs send Query-protocol calls as POST with
+        // application/x-www-form-urlencoded body — Action=ListUsers&Version=...
+        ContainerRequestContext ctx = mockCtx(
+                "POST", "/",
+                new MultivaluedHashMap<>(),
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+                "Action=ListUsers&Version=2010-05-08&UserName=alice");
+        assertEquals("iam:ListUsers", registry.resolve("iam", ctx));
+    }
+
+    @Test
+    void resolvesUrlEncodedActionValueFromFormBody() {
+        ContainerRequestContext ctx = mockCtx(
+                "POST", "/",
+                new MultivaluedHashMap<>(),
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+                "Action=Get%2BCallerIdentity");
+        assertEquals("sts:Get+CallerIdentity", registry.resolve("sts", ctx));
+    }
+
+    @Test
+    void prefersUrlQueryActionOverFormBody() {
+        // Some clients (older AWS CLI, curl) send Query-protocol requests with
+        // Action in the URL query string; that path must keep working.
+        MultivaluedMap<String, String> query = new MultivaluedHashMap<>();
+        query.add("Action", "ListUsers");
+        ContainerRequestContext ctx = mockCtx(
+                "POST", "/",
+                query,
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+                "Action=DeleteUser");
+        assertEquals("iam:ListUsers", registry.resolve("iam", ctx));
+    }
+
+    @Test
+    void formBodyIsRestoredForDownstreamConsumers() throws Exception {
+        String body = "Action=ListUsers&Version=2010-05-08";
+        AtomicReference<InputStream> streamRef = new AtomicReference<>(
+                new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        ContainerRequestContext ctx = mockCtxWithStream(
+                "POST", "/",
+                new MultivaluedHashMap<>(),
+                MediaType.APPLICATION_FORM_URLENCODED_TYPE,
+                streamRef);
+
+        registry.resolve("iam", ctx);
+
+        // Downstream resource method must still see the full form body.
+        byte[] remaining = streamRef.get().readAllBytes();
+        assertEquals(body, new String(remaining, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void resolvesJson11ActionFromXAmzTarget() {
+        ContainerRequestContext ctx = Mockito.mock(ContainerRequestContext.class);
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(uriInfo.getPath()).thenReturn("/");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getMediaType()).thenReturn(MediaType.valueOf("application/x-amz-json-1.0"));
+        when(ctx.getMethod()).thenReturn("POST");
+        when(ctx.getHeaderString("X-Amz-Target")).thenReturn("DynamoDB_20120810.PutItem");
+        assertEquals("dynamodb:PutItem", registry.resolve("dynamodb", ctx));
+    }
+
+    @Test
+    void returnsNullForUnknownRestJsonRoute() {
+        ContainerRequestContext ctx = mockCtx(
+                "POST", "/some/unknown/path",
+                new MultivaluedHashMap<>(),
+                MediaType.APPLICATION_JSON_TYPE,
+                "");
+        assertNull(registry.resolve("kms", ctx));
+    }
+
+    // -------------------------------------------------------------------------
+
+    private static ContainerRequestContext mockCtx(String method, String path,
+                                                   MultivaluedMap<String, String> queryParams,
+                                                   MediaType mediaType, String body) {
+        AtomicReference<InputStream> streamRef = new AtomicReference<>(
+                new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        return mockCtxWithStream(method, path, queryParams, mediaType, streamRef);
+    }
+
+    private static ContainerRequestContext mockCtxWithStream(String method, String path,
+                                                             MultivaluedMap<String, String> queryParams,
+                                                             MediaType mediaType,
+                                                             AtomicReference<InputStream> streamRef) {
+        ContainerRequestContext ctx = Mockito.mock(ContainerRequestContext.class);
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(queryParams);
+        when(uriInfo.getPath()).thenReturn(path);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getMediaType()).thenReturn(mediaType);
+        when(ctx.getMethod()).thenReturn(method);
+        when(ctx.getEntityStream()).thenAnswer(inv -> streamRef.get());
+        doAnswer(inv -> {
+            streamRef.set(inv.getArgument(0));
+            return null;
+        }).when(ctx).setEntityStream(any(InputStream.class));
+        return ctx;
+    }
+}


### PR DESCRIPTION
## Summary

`IamActionRegistry.resolve()` reads `Action` from the URL query string only:

```java
String queryAction = ctx.getUriInfo().getQueryParameters().getFirst("Action");
```

AWS SDKs send Query-protocol calls (IAM, STS, EC2, SQS, SNS, RDS, ELBv2, CloudFormation, CloudWatch, ...) as `POST` with `Action=...` in an `application/x-www-form-urlencoded` body, so this lookup always returns `null` for those services. Combined with the permissive `action == null → ALLOW` fallback in `IamEnforcementFilter` and the absence of any `iam`/`sts`/`ec2`/`sqs`/`sns` rules in the REST-JSON rule table, IAM enforcement is silently bypassed for every Query-protocol service — exactly the protocol the resolver's Javadoc claims to handle.

## Repro

With `floci.iam.enforcement-enabled=true` and an IAM user whose attached policy denies `iam:*`, the SDK call still succeeds:

```python
iam = boto3.client("iam", endpoint_url="http://localhost:4566",
                   aws_access_key_id=AKID, aws_secret_access_key=SECRET)
iam.list_users()   # expected: AccessDeniedException; actual: 200 OK
```

## Fix

`resolve()` now also reads `Action` from the form-encoded body when it isn't in the query string. The entity stream is buffered into memory and reset (`ContainerRequestContext.setEntityStream(new ByteArrayInputStream(...))`) so `AwsQueryController`'s `MultivaluedMap<String,String>` form-param injection still sees the original body. URL-encoded values (e.g. `%2B`) are decoded; `charset` from the `Content-Type` is honored when present.

The behavior order is:
1. URL query `Action=` (preserves the existing path)
2. Form body `Action=` *(new)*
3. `X-Amz-Target` header (JSON 1.x)
4. REST-JSON path rule table

## Test plan
- [x] `./mvnw test -Dtest=IamActionRegistryTest` — 6 new unit tests, all pass
  - resolves Action from form-encoded body
  - URL-decoding of Action value
  - URL query takes precedence over form body
  - entity stream is restored for downstream consumers
  - JSON 1.x path still resolves from `X-Amz-Target`
  - unknown REST-JSON route still returns `null`
- [x] `./mvnw test -Dtest=IamEnforcementIntegrationTest` — 14 existing tests still pass

## Follow-up (out of scope)

Once this lands, `IamEnforcementFilter.accessDeniedResponse()` returns a JSON `AccessDeniedException` body for *all* services. That's correct for JSON-protocol services but breaks SDK error parsing for Query-protocol services, which expect `<ErrorResponse><Error>...</Error></ErrorResponse>`. I'll file a separate issue with a per-protocol response shape proposal.