### PR TITLE
fix(athena): resolve s3_endpoint to a network-reachable host for floci-duck

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.athena.model.*;
@@ -39,6 +41,8 @@ public class AthenaService {
     private final GlueService glueService;
     private final S3Service s3Service;
     private final EmulatorConfig config;
+    private final DockerHostResolver dockerHostResolver;
+    private final EmbeddedDnsServer embeddedDnsServer;
     private final Vertx vertx;
     private final ObjectMapper mapper;
     private final HttpClient httpClient;
@@ -49,6 +53,8 @@ public class AthenaService {
                          GlueService glueService,
                          S3Service s3Service,
                          EmulatorConfig config,
+                         DockerHostResolver dockerHostResolver,
+                         EmbeddedDnsServer embeddedDnsServer,
                          Vertx vertx,
                          ObjectMapper mapper) {
         this.queryStore = storageFactory.create("athena", "queries.json",
@@ -57,6 +63,8 @@ public class AthenaService {
         this.glueService = glueService;
         this.s3Service = s3Service;
         this.config = config;
+        this.dockerHostResolver = dockerHostResolver;
+        this.embeddedDnsServer = embeddedDnsServer;
         this.vertx = vertx;
         this.mapper = mapper;
         this.httpClient = HttpClient.newHttpClient();
@@ -205,7 +213,11 @@ public class AthenaService {
             if (setupDdl != null && !setupDdl.isBlank()) {
                 body.put("setup_sql", setupDdl);
             }
-            body.put("s3_endpoint", config.baseUrl());
+            body.put("s3_endpoint", resolveS3EndpointForDuck(
+                    config.baseUrl(),
+                    embeddedDnsServer.getServerIp(),
+                    config.hostname(),
+                    dockerHostResolver.resolve()));
             body.put("s3_region", config.defaultRegion());
             body.put("s3_access_key", "test");
             body.put("s3_secret_key", "test");
@@ -231,6 +243,29 @@ public class AthenaService {
         } catch (Exception e) {
             throw new RuntimeException("Failed to call floci-duck for query " + queryId + ": " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Resolves the Floci S3 endpoint URL that floci-duck uses to read source data.
+     *
+     * <p>{@code config.baseUrl()} typically points to {@code http://localhost:4566}, which
+     * inside the floci-duck container resolves to the duck container itself, not Floci.
+     * We follow the same pattern as
+     * {@code services.lambda.launcher.ContainerLauncher}: prefer the DNS-resolvable
+     * Floci hostname when the embedded DNS is active, otherwise fall back to the
+     * Docker-host address (Floci's container IP, or {@code host.docker.internal}).
+     *
+     * <p>Visible for testing.
+     */
+    static String resolveS3EndpointForDuck(String configBaseUrl,
+                                            Optional<String> embeddedDnsServerIp,
+                                            Optional<String> configHostname,
+                                            String dockerHostAddress) {
+        int flociPort = URI.create(configBaseUrl).getPort();
+        String hostname = embeddedDnsServerIp.isPresent()
+                ? configHostname.orElse(EmbeddedDnsServer.DEFAULT_SUFFIX)
+                : dockerHostAddress;
+        return "http://" + hostname + ":" + flociPort;
     }
 
     private ResultSet readResultsFromS3(String outputLocation, String queryId) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaServiceTest.java
@@ -1,0 +1,85 @@
+package io.github.hectorvent.floci.services.athena;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AthenaServiceTest {
+
+    private static final String BASE_URL = "http://localhost:4566";
+
+    @Test
+    void resolveS3EndpointForDuck_usesDockerHostAddressWhenEmbeddedDnsInactive() {
+        // Floci runs in a container, embedded DNS is not active.
+        // The Floci container's IP (resolved by DockerHostResolver) is reachable
+        // from the floci-duck container on the same Docker network.
+        String endpoint = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL,
+                Optional.empty(),
+                Optional.empty(),
+                "172.30.0.2");
+
+        assertEquals("http://172.30.0.2:4566", endpoint);
+    }
+
+    @Test
+    void resolveS3EndpointForDuck_usesHostDockerInternalWhenFlociOnHost() {
+        // Floci runs natively on the host. DockerHostResolver returns
+        // host.docker.internal so containers can reach back.
+        String endpoint = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL,
+                Optional.empty(),
+                Optional.empty(),
+                "host.docker.internal");
+
+        assertEquals("http://host.docker.internal:4566", endpoint);
+    }
+
+    @Test
+    void resolveS3EndpointForDuck_usesDefaultSuffixWhenEmbeddedDnsActiveAndHostnameUnset() {
+        // Embedded DNS is active and no hostname is configured.
+        // Containers using the embedded DNS resolve the default suffix to Floci.
+        String endpoint = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL,
+                Optional.of("172.30.0.2"),
+                Optional.empty(),
+                "ignored-fallback");
+
+        assertEquals("http://localhost.floci.io:4566", endpoint);
+    }
+
+    @Test
+    void resolveS3EndpointForDuck_usesConfiguredHostnameWhenEmbeddedDnsActive() {
+        // Embedded DNS is active and a custom hostname is configured.
+        String endpoint = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL,
+                Optional.of("172.30.0.2"),
+                Optional.of("floci.local"),
+                "ignored-fallback");
+
+        assertEquals("http://floci.local:4566", endpoint);
+    }
+
+    @Test
+    void resolveS3EndpointForDuck_neverReturnsLocalhost() {
+        // Regression: previously the s3_endpoint was config.baseUrl() ("http://localhost:4566"),
+        // which inside the duck container points at duck itself, breaking S3 reads.
+        // Whichever branch fires, the hostname must not be "localhost".
+        String endpointOnHost = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL, Optional.empty(), Optional.empty(), "host.docker.internal");
+        String endpointInContainer = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL, Optional.empty(), Optional.empty(), "172.30.0.2");
+        String endpointWithDns = AthenaService.resolveS3EndpointForDuck(
+                BASE_URL, Optional.of("172.30.0.2"), Optional.empty(), "ignored");
+
+        assertEquals(false, endpointOnHost.contains("localhost"),
+                "expected non-localhost endpoint, got " + endpointOnHost);
+        assertEquals(false, endpointInContainer.contains("localhost"),
+                "expected non-localhost endpoint, got " + endpointInContainer);
+        // Note: the embedded-DNS branch's default suffix happens to start with "localhost." —
+        // that is a *resolvable* DNS name pointing to Floci's IP, not the loopback alias.
+        assertEquals("http://localhost.floci.io:4566", endpointWithDns);
+    }
+}


### PR DESCRIPTION
## Summary

Athena queries that touch S3 currently fail in the standard `docker compose` setup because the `s3_endpoint` sent to the `floci-duck` sidecar is `config.baseUrl()` — typically `http://localhost:4566`. Inside the duck container `localhost` resolves to duck itself (which listens on 3000, not 4566), so DuckDB cannot reach Floci's S3 endpoint and any S3-touching query fails.

Resolve the endpoint via the same pattern used by `services.lambda.launcher.ContainerLauncher` for Lambda containers: prefer the configured hostname when the embedded DNS is active, otherwise fall back to `DockerHostResolver` (Floci's container IP, or `host.docker.internal` when Floci runs on the host). Inter-container Lambda calls already use this pattern; Athena now matches.

### Reproduction (before)

```yaml
# docker-compose.yml
services:
  floci:
    image: floci/floci:1.5.10
    user: root
    container_name: floci
    ports: ["4566:4566"]
    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
    environment:
      FLOCI_STORAGE_MODE: memory
      FLOCI_SERVICES_DOCKER_NETWORK: <project>_default
```

```bash
aws s3 mb s3://athena-data
echo '{"user":"alice","amount":100,"region":"us-east-1"}
{"user":"bob","amount":250,"region":"us-east-1"}
{"user":"carol","amount":80,"region":"ap-northeast-1"}' | \
  aws s3 cp - s3://athena-data/sales/data.json

aws glue create-database --database-input '{"Name":"shop"}'
aws glue create-table --database-name shop --table-input '{
  "Name":"sales",
  "StorageDescriptor":{
    "Columns":[
      {"Name":"user","Type":"string"},
      {"Name":"amount","Type":"int"},
      {"Name":"region","Type":"string"}
    ],
    "Location":"s3://athena-data/sales/",
    "InputFormat":"org.apache.hadoop.mapred.TextInputFormat",
    "SerdeInfo":{"SerializationLibrary":"org.openx.data.jsonserde.JsonSerDe"}
  },
  "TableType":"EXTERNAL_TABLE"
}'

aws athena start-query-execution \
  --query-string "SELECT region, SUM(amount) AS total FROM sales GROUP BY region" \
  --query-execution-context Database=shop \
  --result-configuration OutputLocation=s3://athena-data/results/
```

`get-query-execution` returns `FAILED`:

```
floci-duck returned HTTP 500: {"status":"error","message":"IO Error:
Could not connect to server error for HTTP GET to
'http://localhost:4566/athena-data/?...&prefix=sales%2F'
LINE 1: CREATE OR REPLACE VIEW \"sales\" AS SELECT * FROM read_json_auto('s3://athena-data/sales/**');"}
```

`floci-duck` container log:

```
Configuring S3: endpoint=http://localhost:4566, region=us-east-1
```

Setting `FLOCI_BASE_URL=http://floci:4566` (so the in-network hostname is sent as `s3_endpoint`) makes the same query succeed and return `us-east-1=350`, `ap-northeast-1=80` — confirming the diagnosis. This PR achieves the same result without requiring users to override `FLOCI_BASE_URL` (which is meant for client-facing URLs like presigned URLs, not internal sidecar wiring).

### Fix

`AthenaService.callDuck()` now builds `s3_endpoint` from a small helper that mirrors `ContainerLauncher`'s logic:

```java
static String resolveS3EndpointForDuck(String configBaseUrl,
                                        Optional<String> embeddedDnsServerIp,
                                        Optional<String> configHostname,
                                        String dockerHostAddress) {
    int flociPort = URI.create(configBaseUrl).getPort();
    String hostname = embeddedDnsServerIp.isPresent()
            ? configHostname.orElse(EmbeddedDnsServer.DEFAULT_SUFFIX)
            : dockerHostAddress;
    return "http://" + hostname + ":" + flociPort;
}
```

### Scope

This PR is intentionally narrow — it fixes the reproducible default-config case (Floci-in-container + duck-in-container on the same Docker network). Edge cases not addressed here, possible follow-ups:

- Floci-on-host on Linux native Docker: `FlociDuckManager` does not currently call `withHostDockerInternalOnLinux()`, so duck cannot resolve `host.docker.internal`. Docker Desktop on macOS/Windows is unaffected.
- Embedded DNS branch: `FlociDuckManager` does not call `withEmbeddedDns()`, so duck never uses Floci's embedded resolver. The DNS branch in the helper is wired up so that, once `withEmbeddedDns()` is added, behavior is correct without further changes.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior fixed: `StartQueryExecution` against a Glue-registered table backed by S3 data fails with a `Could not connect to server` error from `floci-duck`, because `s3_endpoint` is the unreachable `http://localhost:4566`. After the fix, the same query executes against the actual S3 data and returns the expected result set.

No AWS protocol or SDK behavior changes — only the URL Floci uses for an internal sidecar call is corrected.

## Checklist

- [x] `./mvnw test` passes locally (Athena unit + integration tests, 10/10)
- [x] New or updated integration test added — added `AthenaServiceTest` regression test asserting the resolved endpoint never points at `localhost` plus coverage for each of the four resolution branches. The existing `AthenaIntegrationTest` only exercises `SELECT 1`, which is why CI did not surface this; an end-to-end test that runs DuckDB against S3 would require a live `floci-duck` container and is out of scope here.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
