### PR TITLE
fix: normalize bare host:port Docker host values to prevent URI parse failure

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
@@ -27,10 +27,33 @@ public class DockerClientProducer {
         this.config = config;
     }
 
+    /**
+     * Normalizes a Docker host value by prepending {@code tcp://} when no recognized
+     * URI scheme ({@code tcp://}, {@code unix://}, {@code npipe://}) is present.
+     *
+     * @param dockerHost the raw Docker host configuration value
+     * @return the normalized Docker host value, or the original value if it already has a scheme
+     */
+    static String normalizeDockerHost(String dockerHost) {
+        if (dockerHost == null) {
+            return null;
+        }
+        if (dockerHost.isEmpty()) {
+            return dockerHost;
+        }
+        String lower = dockerHost.toLowerCase();
+        if (lower.startsWith("tcp://") || lower.startsWith("unix://") || lower.startsWith("npipe://")) {
+            return dockerHost;
+        }
+        String normalized = "tcp://" + dockerHost;
+        LOG.infov("Docker host value ''{0}'' has no URI scheme; normalizing to ''{1}''", dockerHost, normalized);
+        return normalized;
+    }
+
     @Produces
     @ApplicationScoped
     public DockerClient dockerClient() {
-        String dockerHost = config.docker().dockerHost();
+        String dockerHost = normalizeDockerHost(config.docker().dockerHost());
         LOG.infov("Creating DockerClient for host: {0}", dockerHost);
 
         DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder()

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
@@ -1,0 +1,123 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug condition exploration test for Docker host scheme normalization.
+ *
+ * Bug: When the Docker host configuration value is a bare host:port string
+ * without a URI scheme (e.g., "10.37.124.101:2375"), URI.create() throws
+ * IllegalArgumentException because the IP/hostname is parsed as an invalid
+ * scheme name. The normalizeDockerHost method should prepend "tcp://" to
+ * bare host:port values so they become valid URIs.
+ *
+ * EXPECTED OUTCOME on unfixed code: Test FAILS (compilation failure or
+ * assertion failure — normalizeDockerHost method does not exist yet,
+ * confirming the missing normalization logic).
+ */
+class DockerClientProducerTest {
+
+    /**
+     * Documents the bug: URI.create with bare host:port throws IllegalArgumentException.
+     *
+     * On unfixed code, URI.create("10.37.124.101:2375") throws:
+     *   IllegalArgumentException: Illegal character in scheme name at index 0
+     *
+     * This is because "10.37.124.101" is parsed as a URI scheme, and dots
+     * are illegal characters in scheme names per RFC 3986.
+     */
+    static Stream<String> bareHostPortInputs() {
+        return Stream.of(
+                "10.37.124.101:2375",
+                "docker-daemon:2375",
+                "192.168.1.100:2376",
+                "localhost:2375"
+        );
+    }
+
+    /**
+     * Bug Condition — Bare host:port values are normalized with tcp:// prefix.
+     *
+     * For each bare host:port input, normalizeDockerHost should return "tcp://" + input,
+     * and the result should be a valid URI (URI.create does not throw).
+     */
+    @ParameterizedTest
+    @MethodSource("bareHostPortInputs")
+    void bareHostPort_isNormalizedWithTcpScheme(String input) {
+        String result = DockerClientProducer.normalizeDockerHost(input);
+
+        assertEquals("tcp://" + input, result,
+                "Bare host:port '" + input + "' should be normalized with tcp:// prefix");
+
+        // The normalized value must be a valid URI — URI.create must not throw
+        URI uri = assertDoesNotThrow(() -> URI.create(result),
+                "Normalized value '" + result + "' should be a valid URI");
+        assertNotNull(uri.getScheme(), "Normalized URI should have a scheme");
+        assertEquals("tcp", uri.getScheme(), "Normalized URI scheme should be 'tcp'");
+    }
+
+    /**
+     * Provides Docker host values that already carry a recognized URI scheme.
+     * These values should pass through normalizeDockerHost unchanged.
+     */
+    static Stream<String> schemedUriInputs() {
+        return Stream.of(
+                "tcp://10.37.124.101:2375",
+                "tcp://localhost:2375",
+                "unix:///var/run/docker.sock",
+                "npipe:////./pipe/docker_engine"
+        );
+    }
+
+    /**
+     * Preservation — Schemed URIs are passed through unchanged.
+     *
+     * For any Docker host value that already contains a recognized URI scheme
+     * (tcp://, unix://, npipe://), normalizeDockerHost should return the value
+     * unchanged, preserving all existing Docker client initialization behavior.
+     */
+    @ParameterizedTest
+    @MethodSource("schemedUriInputs")
+    void schemedUri_passedThroughUnchanged(String input) {
+        String result = DockerClientProducer.normalizeDockerHost(input);
+
+        assertEquals(input, result,
+                "Schemed URI '" + input + "' should pass through unchanged");
+
+        // The value should remain a valid URI
+        URI uri = assertDoesNotThrow(() -> URI.create(result),
+                "Schemed URI '" + result + "' should still be a valid URI");
+        assertNotNull(uri.getScheme(), "Schemed URI should retain its scheme");
+    }
+
+    /**
+     * Edge case: null input handling.
+     *
+     * normalizeDockerHost should handle null gracefully — either return null
+     * or throw a clear exception, but not produce an invalid result.
+     */
+    @Test
+    void nullInput_handledGracefully() {
+        String result = DockerClientProducer.normalizeDockerHost(null);
+        assertNull(result, "null input should return null");
+    }
+
+    /**
+     * Edge case: empty string input handling.
+     *
+     * normalizeDockerHost should handle empty string gracefully — return it
+     * unchanged since there is no meaningful host to normalize.
+     */
+    @Test
+    void emptyInput_handledGracefully() {
+        String result = DockerClientProducer.normalizeDockerHost("");
+        assertEquals("", result, "Empty string input should return empty string");
+    }
+}


### PR DESCRIPTION
## Summary

When Floci runs in CI environments like Bitbucket Pipelines, the Docker daemon host is often exposed as a bare `host:port` string (e.g., `DOCKER_HOST=10.37.124.101:2375`) without a URI scheme prefix. `DockerClientProducer.dockerClient()` passes this value directly to `DefaultDockerClientConfig.withDockerHost()`, which internally calls `URI.create()`. Since a bare IP-and-port string is not a valid URI — the IP address portion is parsed as a scheme name, and dots are illegal in scheme names — this throws:

```
IllegalArgumentException: Illegal character in scheme name at index 0: 10.37.124.101:2375
```

This prevents Floci from starting in any CI environment where Docker is accessed over TCP without an explicit `tcp://` prefix.

This PR adds a `normalizeDockerHost()` method in `DockerClientProducer` that detects bare `host:port` values (no `tcp://`, `unix://`, or `npipe://` scheme) and prepends `tcp://` before passing them to the Docker Java client. Values that already carry a recognized scheme pass through unchanged.

Closes #663 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Floci crashes at startup with `IllegalArgumentException` when `floci.docker.docker-host` is set to a bare `host:port` value (e.g., `10.37.124.101:2375`), which is the default format in Bitbucket Pipelines and similar CI environments.

**Fixed behavior:** Bare `host:port` values are normalized to `tcp://host:port` before being passed to the Docker Java client. Existing schemed values (`tcp://`, `unix://`, `npipe://`) are unaffected.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)