### PR TITLE
feat(cognito): implement AdminRespondToAuthChallenge operation

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoFeaturesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoFeaturesTest.java
@@ -400,6 +400,46 @@ class CognitoFeaturesTest {
         assertThat(sub.mutable()).isFalse();
     }
 
+    // ── AdminRespondToAuthChallenge ─────────────────────────────────────────
+
+    @Test
+    @Order(60)
+    void adminRespondToAuthChallengeNewPasswordRequired() {
+        String tempUser = "admin-challenge-user-" + java.util.UUID.randomUUID();
+        String tempPassword = "TempPass1!";
+        String newPassword = "Permanent99!";
+
+        cognito.adminCreateUser(b -> b
+                .userPoolId(poolId)
+                .username(tempUser)
+                .temporaryPassword(tempPassword)
+                .userAttributes(AttributeType.builder().name("email").value(tempUser + "@example.com").build())
+                .messageAction(MessageActionType.SUPPRESS));
+
+        AdminInitiateAuthResponse initResp = cognito.adminInitiateAuth(b -> b
+                .userPoolId(poolId)
+                .clientId(clientId)
+                .authFlow(AuthFlowType.ADMIN_USER_PASSWORD_AUTH)
+                .authParameters(Map.of("USERNAME", tempUser, "PASSWORD", tempPassword)));
+
+        assertThat(initResp.challengeNameAsString()).isEqualTo("NEW_PASSWORD_REQUIRED");
+        assertThat(initResp.session()).isNotBlank();
+
+        AdminRespondToAuthChallengeResponse challengeResp = cognito.adminRespondToAuthChallenge(b -> b
+                .userPoolId(poolId)
+                .clientId(clientId)
+                .challengeName(ChallengeNameType.NEW_PASSWORD_REQUIRED)
+                .session(initResp.session())
+                .challengeResponses(Map.of("USERNAME", tempUser, "NEW_PASSWORD", newPassword)));
+
+        assertThat(challengeResp.authenticationResult()).isNotNull();
+        assertThat(challengeResp.authenticationResult().accessToken()).isNotBlank();
+        assertThat(challengeResp.authenticationResult().idToken()).isNotBlank();
+        assertThat(challengeResp.authenticationResult().refreshToken()).isNotBlank();
+
+        cognito.adminDeleteUser(b -> b.userPoolId(poolId).username(tempUser));
+    }
+
     // ── Issue #234 note ───────────────────────────────────────────────────────
     // GetTokensFromRefreshToken is tested in sdk-test-node/tests/cognito-features.test.ts
     // because GetTokensFromRefreshTokenCommand is not available in Java SDK 2.31.8.

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -287,7 +287,7 @@ public class AwsQueryController {
     private static final Set<String> COGNITO_ACTIONS = Set.of(
             "AdminCreateUser", "AdminGetUser", "AdminDeleteUser", "AdminSetUserPassword",
             "AdminUpdateUserAttributes", "AdminUserGlobalSignOut", "ListUsers",
-            "InitiateAuth", "AdminInitiateAuth", "RespondToAuthChallenge",
+            "InitiateAuth", "AdminInitiateAuth", "RespondToAuthChallenge", "AdminRespondToAuthChallenge",
             "SignUp", "ConfirmSignUp", "ChangePassword", "ForgotPassword",
             "ConfirmForgotPassword", "GetUser", "UpdateUserAttributes",
             "CreateUserPool", "DescribeUserPool", "ListUserPools", "UpdateUserPool", "DeleteUserPool",

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -137,7 +137,20 @@ final class CognitoAuthFlowHandler {
                                                 Map<String, String> responses, Map<String, String> clientMetadata) {
         UserPoolClient client = service.findClientById(clientId);
         UserPool pool = service.describeUserPool(client.getUserPoolId());
+        return processChallenge(pool, client, challengeName, session, responses, clientMetadata);
+    }
 
+    Map<String, Object> adminRespondToAuthChallenge(String userPoolId, String clientId, String challengeName,
+                                                      String session, Map<String, String> responses,
+                                                      Map<String, String> clientMetadata) {
+        UserPoolClient client = service.describeUserPoolClient(userPoolId, clientId);
+        UserPool pool = service.describeUserPool(userPoolId);
+        return processChallenge(pool, client, challengeName, session, responses, clientMetadata);
+    }
+
+    private Map<String, Object> processChallenge(UserPool pool, UserPoolClient client, String challengeName,
+                                                   String session, Map<String, String> responses,
+                                                   Map<String, String> clientMetadata) {
         if ("PASSWORD_VERIFIER".equals(challengeName)) {
             return handlePasswordVerifierChallenge(pool, client, session, responses, clientMetadata);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -66,6 +66,7 @@ public class CognitoJsonHandler {
             case "InitiateAuth" -> handleInitiateAuth(request);
             case "AdminInitiateAuth" -> handleAdminInitiateAuth(request);
             case "RespondToAuthChallenge" -> handleRespondToAuthChallenge(request);
+            case "AdminRespondToAuthChallenge" -> handleAdminRespondToAuthChallenge(request);
             case "SignUp" -> handleSignUp(request);
             case "ConfirmSignUp" -> handleConfirmSignUp(request);
             case "ChangePassword" -> handleChangePassword(request);
@@ -398,6 +399,23 @@ public class CognitoJsonHandler {
         request.path("ClientMetadata").fields().forEachRemaining(e -> clientMetadata.put(e.getKey(), e.getValue().asText()));
 
         Map<String, Object> result = service.respondToAuthChallenge(
+                request.path("ClientId").asText(),
+                request.path("ChallengeName").asText(),
+                request.path("Session").asText(null),
+                responses,
+                clientMetadata
+        );
+        return Response.ok(objectMapper.valueToTree(result)).build();
+    }
+
+    private Response handleAdminRespondToAuthChallenge(JsonNode request) {
+        Map<String, String> responses = new HashMap<>();
+        request.path("ChallengeResponses").fields().forEachRemaining(e -> responses.put(e.getKey(), e.getValue().asText()));
+        Map<String, String> clientMetadata = new HashMap<>();
+        request.path("ClientMetadata").fields().forEachRemaining(e -> clientMetadata.put(e.getKey(), e.getValue().asText()));
+
+        Map<String, Object> result = service.adminRespondToAuthChallenge(
+                request.path("UserPoolId").asText(),
                 request.path("ClientId").asText(),
                 request.path("ChallengeName").asText(),
                 request.path("Session").asText(null),

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -770,6 +770,19 @@ public class CognitoService {
         return authFlowHandler.respondToAuthChallenge(clientId, challengeName, session, responses, clientMetadata);
     }
 
+    public Map<String, Object> adminRespondToAuthChallenge(String userPoolId, String clientId,
+                                                             String challengeName, String session,
+                                                             Map<String, String> responses) {
+        return authFlowHandler.adminRespondToAuthChallenge(userPoolId, clientId, challengeName, session, responses, Map.of());
+    }
+
+    public Map<String, Object> adminRespondToAuthChallenge(String userPoolId, String clientId,
+                                                             String challengeName, String session,
+                                                             Map<String, String> responses,
+                                                             Map<String, String> clientMetadata) {
+        return authFlowHandler.adminRespondToAuthChallenge(userPoolId, clientId, challengeName, session, responses, clientMetadata);
+    }
+
     public void changePassword(String accessToken, String previousPassword, String proposedPassword) {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1196,4 +1196,76 @@ class CognitoServiceTest {
         assertNotNull(auth);
         assertNotNull(auth.get("AccessToken"));
     }
+
+    // =========================================================================
+    // AdminRespondToAuthChallenge
+    // =========================================================================
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void adminRespondToAuthChallengeNewPasswordRequired() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), "TempPass1!");
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(), "c", false, false, List.of(), List.of());
+
+        Map<String, Object> challengeResp = service.adminInitiateAuth(
+                pool.getId(), client.getClientId(), "ADMIN_USER_PASSWORD_AUTH",
+                Map.of("USERNAME", "bob", "PASSWORD", "TempPass1!"), Map.of());
+        assertEquals("NEW_PASSWORD_REQUIRED", challengeResp.get("ChallengeName"));
+        String session = (String) challengeResp.get("Session");
+
+        Map<String, Object> result = service.adminRespondToAuthChallenge(
+                pool.getId(), client.getClientId(), "NEW_PASSWORD_REQUIRED", session,
+                Map.of("USERNAME", "bob", "NEW_PASSWORD", "Permanent99!"));
+        Map<String, Object> auth = (Map<String, Object>) result.get("AuthenticationResult");
+        assertNotNull(auth, "AuthenticationResult should be present");
+        assertNotNull(auth.get("AccessToken"));
+        assertNotNull(auth.get("IdToken"));
+        assertNotNull(auth.get("RefreshToken"));
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "bob");
+        assertEquals("CONFIRMED", user.getUserStatus());
+    }
+
+    @Test
+    void adminRespondToAuthChallengeInvalidPool() {
+        UserPool pool1 = service.createUserPool(Map.of("PoolName", "Pool1"), "us-east-1");
+        UserPool pool2 = service.createUserPool(Map.of("PoolName", "Pool2"), "us-east-1");
+        service.adminCreateUser(pool1.getId(), "alice", Map.of("email", "a@example.com"), "TempPass1!");
+        UserPoolClient client = service.createUserPoolClient(
+                pool1.getId(), "c", false, false, List.of(), List.of());
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.adminRespondToAuthChallenge(
+                        pool2.getId(), client.getClientId(), "NEW_PASSWORD_REQUIRED", null,
+                        Map.of("USERNAME", "alice", "NEW_PASSWORD", "NewPass1!")));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void adminRespondToAuthChallengeWithUserAttributes() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        service.adminCreateUser(pool.getId(), "carol", Map.of("email", "carol@example.com"), "TempPass1!");
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(), "c", false, false, List.of(), List.of());
+
+        Map<String, Object> challengeResp = service.adminInitiateAuth(
+                pool.getId(), client.getClientId(), "ADMIN_USER_PASSWORD_AUTH",
+                Map.of("USERNAME", "carol", "PASSWORD", "TempPass1!"), Map.of());
+        String session = (String) challengeResp.get("Session");
+
+        Map<String, String> responses = new HashMap<>();
+        responses.put("USERNAME", "carol");
+        responses.put("NEW_PASSWORD", "Permanent99!");
+        responses.put("userAttributes.given_name", "Carolyn");
+
+        Map<String, Object> result = service.adminRespondToAuthChallenge(
+                pool.getId(), client.getClientId(), "NEW_PASSWORD_REQUIRED", session, responses);
+        assertNotNull(((Map<String, Object>) result.get("AuthenticationResult")).get("AccessToken"));
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "carol");
+        assertEquals("Carolyn", user.getAttributes().get("given_name"));
+    }
 }


### PR DESCRIPTION
## Summary

Implements the [AdminRespondToAuthChallenge of Cognito API](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminRespondToAuthChallenge.html), enabling server-side challenge response handling with explicit UserPoolId + ClientId validation.

- Adds `adminRespondToAuthChallenge` entry point in `CognitoAuthFlowHandler`, resolving the client via `describeUserPoolClient(userPoolId, clientId)` to validate the client belongs to the specified pool
- Extracts shared challenge logic (PASSWORD_VERIFIER, CUSTOM_CHALLENGE, NEW_PASSWORD_REQUIRED) into a private `processChallenge` method to avoid duplication with the existing `respondToAuthChallenge`
- Registers the action in `CognitoJsonHandler` switch and `COGNITO_ACTIONS` set
- Unit tests: NEW_PASSWORD_REQUIRED flow, cross-pool rejection, userAttributes propagation
- SDK compatibility test: AdminInitiateAuth → AdminRespondToAuthChallenge end-to-end flow

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS SDK for Java v2 (`AdminRespondToAuthChallengeRequest` / `AdminRespondToAuthChallengeResponse`). Wire format matches the existing `RespondToAuthChallenge` response shape — the only input difference is the additional required `UserPoolId` field.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
