### PR TITLE
feat(pipes): populate SQS message attributes in pipe source records

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.pipes.model.DesiredState;
 import io.github.hectorvent.floci.services.pipes.model.Pipe;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import io.github.hectorvent.floci.services.sqs.model.Message;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import io.vertx.core.Vertx;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -19,6 +20,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -403,7 +405,18 @@ public class PipesPoller {
             ObjectNode attrs = record.putObject("attributes");
             attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
             attrs.put("SentTimestamp", String.valueOf(System.currentTimeMillis()));
-            record.putObject("messageAttributes");
+            ObjectNode msgAttrs = record.putObject("messageAttributes");
+            for (Map.Entry<String, MessageAttributeValue> entry : msg.getMessageAttributes().entrySet()) {
+                ObjectNode attrNode = msgAttrs.putObject(entry.getKey());
+                MessageAttributeValue val = entry.getValue();
+                attrNode.put("stringValue", val.getStringValue());
+                if (val.getBinaryValue() != null) {
+                    attrNode.put("binaryValue", Base64.getEncoder().encodeToString(val.getBinaryValue()));
+                }
+                attrNode.putArray("stringListValues");
+                attrNode.putArray("binaryListValues");
+                attrNode.put("dataType", val.getDataType());
+            }
             record.put("md5OfBody", msg.getMd5OfBody() != null ? msg.getMd5OfBody() : "");
             record.put("eventSource", "aws:sqs");
             record.put("eventSourceARN", pipe.getSource());

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesPollerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesPollerIntegrationTest.java
@@ -621,4 +621,113 @@ class PipesPollerIntegrationTest {
         .then()
             .statusCode(200);
     }
+
+    // ──────────────────────────── Message Attributes Tests ────────────────────────────
+
+    @Test
+    @Order(50)
+    void createMsgAttrSourceQueue() {
+        given()
+            .contentType(SQS_CONTENT_TYPE)
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "pipe-msgattr-source")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(51)
+    void createMsgAttrTargetQueue() {
+        given()
+            .contentType(SQS_CONTENT_TYPE)
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "pipe-msgattr-target")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(52)
+    void createMsgAttrPipeWithInputTemplate() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:pipe-msgattr-source",
+                    "Target": "arn:aws:sqs:us-east-1:000000000000:pipe-msgattr-target",
+                    "RoleArn": "arn:aws:iam::000000000000:role/pipe-role",
+                    "DesiredState": "RUNNING",
+                    "TargetParameters": {
+                        "InputTemplate": "{\\"body\\": <$.body>, \\"traceId\\": <$.messageAttributes.traceId.stringValue>}"
+                    }
+                }
+                """)
+        .when()
+            .post("/v1/pipes/msgattr-pipe")
+        .then()
+            .statusCode(200)
+            .body("CurrentState", equalTo("RUNNING"));
+    }
+
+    @Test
+    @Order(53)
+    void sendMessageWithAttributes() {
+        given()
+            .contentType(SQS_CONTENT_TYPE)
+            .formParam("Action", "SendMessage")
+            .formParam("QueueUrl", "http://localhost:4566/000000000000/pipe-msgattr-source")
+            .formParam("MessageBody", "{\"event\": \"test\"}")
+            .formParam("MessageAttribute.1.Name", "traceId")
+            .formParam("MessageAttribute.1.Value.DataType", "String")
+            .formParam("MessageAttribute.1.Value.StringValue", "trace-abc-123")
+            .formParam("MessageAttribute.2.Name", "priority")
+            .formParam("MessageAttribute.2.Value.DataType", "Number")
+            .formParam("MessageAttribute.2.Value.StringValue", "5")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(54)
+    void messageAttributesForwardedAndAccessibleViaInputTemplate() throws Exception {
+        String body = null;
+        for (int i = 0; i < 10; i++) {
+            Thread.sleep(500);
+            body = given()
+                .contentType(SQS_CONTENT_TYPE)
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", "http://localhost:4566/000000000000/pipe-msgattr-target")
+                .formParam("MaxNumberOfMessages", "1")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+            if (body.contains("trace-abc-123")) {
+                break;
+            }
+        }
+        assertTrue(body.contains("trace-abc-123"),
+                "Target should contain traceId extracted from message attributes but got: " + body);
+        assertTrue(body.contains("&quot;body&quot;") || body.contains("\"body\""),
+                "Target should contain body field from InputTemplate but got: " + body);
+    }
+
+    @Test
+    @Order(55)
+    void cleanupMsgAttrPipe() {
+        given()
+            .contentType("application/json")
+        .when()
+            .delete("/v1/pipes/msgattr-pipe")
+        .then()
+            .statusCode(200);
+    }
 }


### PR DESCRIPTION
## Summary

Populates `messageAttributes` in the SQS source record envelope when EventBridge Pipes polls from an SQS queue. Previously this field was hardcoded as an empty object, which meant message attributes set by producers were silently dropped.

Each attribute now includes `stringValue`, `binaryValue` (base64-encoded when present), `stringListValues`, `binaryListValues`, and `dataType`, matching the real AWS Lambda SQS event record format.

⚠️ Looks like the failing test is a flakey test, not related to my changes.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The `messageAttributes` field in the SQS record envelope now matches the format produced by real AWS Pipes and Lambda SQS event source mappings:

```json
{
  "attributeName": {
    "stringValue": "value",
    "binaryValue": null,
    "stringListValues": [],
    "binaryListValues": [],
    "dataType": "String"
  }
}
```

The `stringListValues` and `binaryListValues` fields are always empty arrays per AWS behavior (reserved, never populated).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)