### PR TITLE
fix(test): handle SDK retry race in OpenSearch createDomain test

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OpenSearchTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/OpenSearchTest.java
@@ -56,19 +56,24 @@ class OpenSearchTest {
     @Test
     @Order(1)
     void createDomain() {
-        CreateDomainResponse response = opensearch.createDomain(CreateDomainRequest.builder()
-                .domainName(DOMAIN_NAME)
-                .engineVersion("OpenSearch_2.11")
-                .clusterConfig(ClusterConfig.builder()
-                        .instanceType(OpenSearchPartitionInstanceType.T3_SMALL_SEARCH)
-                        .instanceCount(1)
-                        .build())
-                .tagList(Tag.builder().key("env").value("test").build())
-                .build());
+        try {
+            CreateDomainResponse response = opensearch.createDomain(CreateDomainRequest.builder()
+                    .domainName(DOMAIN_NAME)
+                    .engineVersion("OpenSearch_2.11")
+                    .clusterConfig(ClusterConfig.builder()
+                            .instanceType(OpenSearchPartitionInstanceType.T3_SMALL_SEARCH)
+                            .instanceCount(1)
+                            .build())
+                    .tagList(Tag.builder().key("env").value("test").build())
+                    .build());
 
-        assertThat(response.domainStatus()).isNotNull();
-        assertThat(response.domainStatus().domainName()).isEqualTo(DOMAIN_NAME);
-        assertThat(response.domainStatus().arn()).isNotBlank();
+            assertThat(response.domainStatus()).isNotNull();
+            assertThat(response.domainStatus().domainName()).isEqualTo(DOMAIN_NAME);
+            assertThat(response.domainStatus().arn()).isNotBlank();
+        } catch (ResourceAlreadyExistsException e) {
+            // The SDK may timeout on the first attempt while the server still creates the domain.
+            // On retry the 409 surfaces here. Subsequent ordered tests validate the domain state.
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes flaky `OpenSearchTest.createDomain` compatibility test. When the first `createDomain` SDK attempt times out, the server still creates the domain. The SDK retries and gets a 409 `ResourceAlreadyExistsException`, failing the test.

The fix catches `ResourceAlreadyExistsException` and treats it as success, since the subsequent ordered tests (`describeDomain`, `addTags`, etc.) validate the domain was created correctly.

Observed failing on multiple unrelated PRs:
- floci-io/floci#667
- `fix/docker-host-scheme-normalization` (run 25170601541)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No behavioral change. Test-only fix for SDK timeout/retry race condition.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)