### PR TITLE
fix(sqs): inject QueueUrl into form body for query protocol path-based requests

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/SqsQueueUrlRouterFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/SqsQueueUrlRouterFilter.java
@@ -6,16 +6,25 @@ import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.Provider;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 /**
- * Pre-matching filter that rewrites SQS JSON 1.0 requests sent to the queue URL path
- * (/{accountId}/{queueName}) to POST / so they are handled by AwsJsonController.
+ * Pre-matching filter that rewrites SQS requests sent to the queue URL path
+ * (/{accountId}/{queueName}) to POST / so they are handled by the correct controller.
  * <p>
  * Newer AWS SDKs (e.g. aws-sdk-sqs Ruby gem >= 1.71) route operations to the queue URL
  * rather than POST /. Without this filter, those requests match S3Controller's
  * /{bucket}/{key:.+} handler and return NoSuchBucket errors.
+ * <p>
+ * For the query (form-encoded) protocol, AWS SDK v1 omits QueueUrl from the body and
+ * uses the queue URL as the HTTP path instead. This filter appends it back into the
+ * entity stream so SqsQueryHandler can look up the queue normally.
  */
 @Provider
 @PreMatching
@@ -53,10 +62,29 @@ public class SqsQueueUrlRouterFilter implements ContainerRequestFilter {
             return;
         }
 
-        URI rewritten = ctx.getUriInfo().getRequestUriBuilder()
+        // Reconstruct the queue URL from the original path.
+        URI reqUri = ctx.getUriInfo().getRequestUri();
+        String queueUrl = reqUri.getScheme() + "://" + reqUri.getAuthority() + path;
+
+        if (isSqsQuery) {
+            // AWS SDK v1 omits QueueUrl from the form body and uses the queue URL as the
+            // HTTP path instead. Append it to the entity stream so SqsQueryHandler gets it
+            // naturally from form params — no changes needed in AwsQueryController.
+            byte[] injection = ("&QueueUrl=" + URLEncoder.encode(queueUrl, StandardCharsets.UTF_8))
+                    .getBytes(StandardCharsets.UTF_8);
+            ctx.setEntityStream(new SequenceInputStream(ctx.getEntityStream(),
+                    new ByteArrayInputStream(injection)));
+            String cl = ctx.getHeaderString("Content-Length");
+            if (cl != null) {
+                ctx.getHeaders().putSingle("Content-Length",
+                        String.valueOf(Long.parseLong(cl) + injection.length));
+            }
+        }
+
+        // Rewrite the path to / so AwsQueryController / AwsJsonController handles the request.
+        ctx.setRequestUri(ctx.getUriInfo().getRequestUriBuilder()
                 .replacePath("/")
-                .build();
-        ctx.setRequestUri(rewritten);
+                .build());
     }
 
     private boolean isSqsTarget(String target) {


### PR DESCRIPTION
## Problem

#153 fixed path-based routing for newer SDKs, but left a gap for clients using the **form-encoded query protocol** (Java SDK v1, Python boto3 legacy, Go SDK v1, .NET SDK v1, etc.).

These clients send queue-specific operations with the queue URL as the HTTP path and **no `QueueUrl` in the body**:

```
POST /000000000000/my-queue HTTP/1.1
Content-Type: application/x-www-form-urlencoded

Action=GetQueueAttributes&AttributeName.1=QueueArn
```

After #153's path rewrite to `POST /`, `SqsQueryHandler` reads `QueueUrl` from the form body, gets null, and returns `QueueDoesNotExist` for every queue-specific operation.

## Fix

In `SqsQueueUrlRouterFilter`, before rewriting the path, reconstruct the queue URL from the original path components and **append it directly to the entity stream** as a form parameter:

```java
byte[] injection = ("&QueueUrl=" + URLEncoder.encode(queueUrl, StandardCharsets.UTF_8))
        .getBytes(StandardCharsets.UTF_8);
ctx.setEntityStream(new SequenceInputStream(ctx.getEntityStream(),
        new ByteArrayInputStream(injection)));
```

`Content-Length` is updated when present. `AwsQueryController` is unchanged.

## Result

- All queue-specific SQS operations now work with query protocol path-based clients
- No change for JSON protocol clients (SDK v2) or root-path clients — only the `isSqsQuery` branch is affected
- `SqsQueryHandler` reads `QueueUrl` from form params as before — no handler changes needed

## Related

Completes the fix started in #153.