### PR TITLE
Feat/lambda image config working directory

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/lambda.bats
+++ b/compatibility-tests/sdk-test-awscli/test/lambda.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# Lambda tests
+
+setup() {
+    load 'test_helper/common-setup'
+    FUNC_NAME=""
+}
+
+teardown() {
+    if [ -n "$FUNC_NAME" ]; then
+        aws_cmd lambda delete-function --function-name "$FUNC_NAME" >/dev/null 2>&1 || true
+    fi
+}
+
+_role="arn:aws:iam::000000000000:role/lambda-role"
+_image_uri="000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest"
+
+@test "Lambda: ImageConfig.WorkingDirectory is returned in CreateFunction response" {
+    FUNC_NAME="bats-imgwd-create-$(unique_name)"
+
+    run aws_cmd lambda create-function \
+        --function-name "$FUNC_NAME" \
+        --package-type Image \
+        --role "$_role" \
+        --code "ImageUri=$_image_uri" \
+        --image-config 'WorkingDirectory=/app'
+    assert_success
+
+    wd=$(json_get "$output" '.ImageConfigResponse.ImageConfig.WorkingDirectory')
+    [ "$wd" = "/app" ] || { echo "expected WorkingDirectory=/app, got: $wd"; return 1; }
+}
+
+@test "Lambda: ImageConfig.WorkingDirectory is persisted and returned by get-function-configuration" {
+    FUNC_NAME="bats-imgwd-get-$(unique_name)"
+
+    aws_cmd lambda create-function \
+        --function-name "$FUNC_NAME" \
+        --package-type Image \
+        --role "$_role" \
+        --code "ImageUri=$_image_uri" \
+        --image-config 'WorkingDirectory=/workspace' >/dev/null
+
+    run aws_cmd lambda get-function-configuration --function-name "$FUNC_NAME"
+    assert_success
+
+    wd=$(json_get "$output" '.ImageConfigResponse.ImageConfig.WorkingDirectory')
+    [ "$wd" = "/workspace" ] || { echo "expected WorkingDirectory=/workspace, got: $wd"; return 1; }
+}
+
+@test "Lambda: ImageConfig.WorkingDirectory is updated by update-function-configuration" {
+    FUNC_NAME="bats-imgwd-upd-$(unique_name)"
+
+    aws_cmd lambda create-function \
+        --function-name "$FUNC_NAME" \
+        --package-type Image \
+        --role "$_role" \
+        --code "ImageUri=$_image_uri" \
+        --image-config 'WorkingDirectory=/initial' >/dev/null
+
+    run aws_cmd lambda update-function-configuration \
+        --function-name "$FUNC_NAME" \
+        --image-config 'WorkingDirectory=/updated'
+    assert_success
+
+    wd=$(json_get "$output" '.ImageConfigResponse.ImageConfig.WorkingDirectory')
+    [ "$wd" = "/updated" ] || { echo "expected WorkingDirectory=/updated, got: $wd"; return 1; }
+}

--- a/compatibility-tests/sdk-test-go/tests/lambda_test.go
+++ b/compatibility-tests/sdk-test-go/tests/lambda_test.go
@@ -73,3 +73,58 @@ func TestLambda(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestLambdaImageConfigWorkingDirectory(t *testing.T) {
+	ctx := context.Background()
+	svc := testutil.LambdaClient()
+	roleARN := "arn:aws:iam::000000000000:role/test-role"
+	imageURI := "000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest"
+
+	t.Run("RoundTripsWorkingDirectoryOnCreate", func(t *testing.T) {
+		fnName := "go-test-imgwd-create"
+		t.Cleanup(func() {
+			svc.DeleteFunction(ctx, &lambda.DeleteFunctionInput{FunctionName: aws.String(fnName)})
+		})
+
+		createResp, err := svc.CreateFunction(ctx, &lambda.CreateFunctionInput{
+			FunctionName: aws.String(fnName),
+			PackageType:  lambdatypes.PackageTypeImage,
+			Role:         aws.String(roleARN),
+			Code:         &lambdatypes.FunctionCode{ImageUri: aws.String(imageURI)},
+			ImageConfig:  &lambdatypes.ImageConfig{WorkingDirectory: aws.String("/app")},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, createResp.ImageConfigResponse)
+		require.NotNil(t, createResp.ImageConfigResponse.ImageConfig)
+		assert.Equal(t, "/app", aws.ToString(createResp.ImageConfigResponse.ImageConfig.WorkingDirectory))
+
+		getResp, err := svc.GetFunctionConfiguration(ctx, &lambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String(fnName),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "/app", aws.ToString(getResp.ImageConfigResponse.ImageConfig.WorkingDirectory))
+	})
+
+	t.Run("UpdatesWorkingDirectory", func(t *testing.T) {
+		fnName := "go-test-imgwd-update"
+		t.Cleanup(func() {
+			svc.DeleteFunction(ctx, &lambda.DeleteFunctionInput{FunctionName: aws.String(fnName)})
+		})
+
+		_, err := svc.CreateFunction(ctx, &lambda.CreateFunctionInput{
+			FunctionName: aws.String(fnName),
+			PackageType:  lambdatypes.PackageTypeImage,
+			Role:         aws.String(roleARN),
+			Code:         &lambdatypes.FunctionCode{ImageUri: aws.String(imageURI)},
+			ImageConfig:  &lambdatypes.ImageConfig{WorkingDirectory: aws.String("/initial")},
+		})
+		require.NoError(t, err)
+
+		updateResp, err := svc.UpdateFunctionConfiguration(ctx, &lambda.UpdateFunctionConfigurationInput{
+			FunctionName: aws.String(fnName),
+			ImageConfig:  &lambdatypes.ImageConfig{WorkingDirectory: aws.String("/updated")},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "/updated", aws.ToString(updateResp.ImageConfigResponse.ImageConfig.WorkingDirectory))
+	})
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionConfigTest.java
@@ -218,4 +218,51 @@ class LambdaFunctionConfigTest {
                 .as("Environment block must be present even after clearing variables")
                 .isNotNull();
     }
+
+    @Test
+    @Order(6)
+    @DisplayName("ImageConfig.WorkingDirectory round-trips via create and get")
+    void imageConfigWorkingDirectoryRoundTrips() {
+        String imageFn = TestFixtures.uniqueName("fn-image-wd");
+        try {
+            CreateFunctionResponse createResp = lambda.createFunction(CreateFunctionRequest.builder()
+                    .functionName(imageFn)
+                    .packageType(software.amazon.awssdk.services.lambda.model.PackageType.IMAGE)
+                    .role(ROLE)
+                    .code(FunctionCode.builder()
+                            .imageUri("000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest")
+                            .build())
+                    .imageConfig(software.amazon.awssdk.services.lambda.model.ImageConfig.builder()
+                            .workingDirectory("/app")
+                            .build())
+                    .build());
+
+            assertThat(createResp.imageConfigResponse().imageConfig().workingDirectory())
+                    .as("CreateFunction response must include ImageConfig.WorkingDirectory")
+                    .isEqualTo("/app");
+
+            GetFunctionConfigurationResponse getResp = lambda.getFunctionConfiguration(
+                    GetFunctionConfigurationRequest.builder().functionName(imageFn).build());
+
+            assertThat(getResp.imageConfigResponse().imageConfig().workingDirectory())
+                    .as("GetFunctionConfiguration must persist ImageConfig.WorkingDirectory")
+                    .isEqualTo("/app");
+
+            UpdateFunctionConfigurationResponse updateResp = lambda.updateFunctionConfiguration(
+                    UpdateFunctionConfigurationRequest.builder()
+                            .functionName(imageFn)
+                            .imageConfig(software.amazon.awssdk.services.lambda.model.ImageConfig.builder()
+                                    .workingDirectory("/updated")
+                                    .build())
+                            .build());
+
+            assertThat(updateResp.imageConfigResponse().imageConfig().workingDirectory())
+                    .as("UpdateFunctionConfiguration must update ImageConfig.WorkingDirectory")
+                    .isEqualTo("/updated");
+        } finally {
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder().functionName(imageFn).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/compatibility-tests/sdk-test-node/tests/lambda.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/lambda.test.ts
@@ -7,6 +7,8 @@ import {
   LambdaClient,
   CreateFunctionCommand,
   GetFunctionCommand,
+  GetFunctionConfigurationCommand,
+  UpdateFunctionConfigurationCommand,
   ListFunctionsCommand,
   DeleteFunctionCommand,
   CreateAliasCommand,
@@ -126,5 +128,60 @@ describe('Lambda', () => {
     await expect(
       lambda.send(new GetFunctionCommand({ FunctionName: `test-fn-${uniqueName()}` }))
     ).rejects.toThrow();
+  });
+});
+
+describe('Lambda ImageConfig.WorkingDirectory', () => {
+  let lambda: LambdaClient;
+  const IMAGE_URI = '000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest';
+  const ROLE = 'arn:aws:iam::000000000000:role/lambda-role';
+
+  beforeAll(() => {
+    lambda = makeClient(LambdaClient);
+  });
+
+  it('round-trips WorkingDirectory through create and get', async () => {
+    const fnName = `test-imgwd-${uniqueName()}`;
+    try {
+      const createResp = await lambda.send(new CreateFunctionCommand({
+        FunctionName: fnName,
+        PackageType: 'Image',
+        Role: ROLE,
+        Code: { ImageUri: IMAGE_URI },
+        ImageConfig: { WorkingDirectory: '/app' },
+      }));
+
+      expect(createResp.ImageConfigResponse?.ImageConfig?.WorkingDirectory).toBe('/app');
+
+      const getResp = await lambda.send(new GetFunctionConfigurationCommand({
+        FunctionName: fnName,
+      }));
+
+      expect(getResp.ImageConfigResponse?.ImageConfig?.WorkingDirectory).toBe('/app');
+    } finally {
+      await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName })).catch(() => {});
+    }
+  });
+
+  it('updates WorkingDirectory via updateFunctionConfiguration', async () => {
+    const fnName = `test-imgwd-upd-${uniqueName()}`;
+    try {
+      await lambda.send(new CreateFunctionCommand({
+        FunctionName: fnName,
+        PackageType: 'Image',
+        Role: ROLE,
+        Code: { ImageUri: IMAGE_URI },
+        ImageConfig: { WorkingDirectory: '/initial' },
+      }));
+
+      const updateResp = await lambda.send(new UpdateFunctionConfigurationCommand({
+        FunctionName: fnName,
+        ImageConfig: { WorkingDirectory: '/updated' },
+      }));
+
+      expect(updateResp.ImageConfigResponse?.ImageConfig?.WorkingDirectory).toBe('/updated');
+    } finally {
+      await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName })).catch(() => {});
+    }
   });
 });

--- a/compatibility-tests/sdk-test-python/tests/test_lambda_function_config.py
+++ b/compatibility-tests/sdk-test-python/tests/test_lambda_function_config.py
@@ -280,3 +280,83 @@ class TestUpdateFunctionConfiguration:
             )
         finally:
             lambda_client.delete_function(FunctionName=fn)
+
+
+class TestImageConfigWorkingDirectory:
+    """ImageConfig.WorkingDirectory is persisted and returned correctly."""
+
+    IMAGE_URI = "000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest"
+
+    def test_create_image_function_with_working_directory(
+        self, lambda_client, unique_name
+    ):
+        fn = f"pytest-imgwd-{unique_name}"
+        try:
+            resp = lambda_client.create_function(
+                FunctionName=fn,
+                PackageType="Image",
+                Role=ROLE,
+                Code={"ImageUri": self.IMAGE_URI},
+                ImageConfig={"WorkingDirectory": "/app"},
+            )
+            wd = (
+                resp.get("ImageConfigResponse", {})
+                    .get("ImageConfig", {})
+                    .get("WorkingDirectory")
+            )
+            assert wd == "/app", (
+                f"CreateFunction response must include ImageConfig.WorkingDirectory='/app', got: {wd!r}"
+            )
+        finally:
+            lambda_client.delete_function(FunctionName=fn)
+
+    def test_get_function_configuration_persists_working_directory(
+        self, lambda_client, unique_name
+    ):
+        fn = f"pytest-imgwd-get-{unique_name}"
+        try:
+            lambda_client.create_function(
+                FunctionName=fn,
+                PackageType="Image",
+                Role=ROLE,
+                Code={"ImageUri": self.IMAGE_URI},
+                ImageConfig={"WorkingDirectory": "/workspace"},
+            )
+            resp = lambda_client.get_function_configuration(FunctionName=fn)
+            wd = (
+                resp.get("ImageConfigResponse", {})
+                    .get("ImageConfig", {})
+                    .get("WorkingDirectory")
+            )
+            assert wd == "/workspace", (
+                f"GetFunctionConfiguration must persist WorkingDirectory='/workspace', got: {wd!r}"
+            )
+        finally:
+            lambda_client.delete_function(FunctionName=fn)
+
+    def test_update_function_configuration_updates_working_directory(
+        self, lambda_client, unique_name
+    ):
+        fn = f"pytest-imgwd-upd-{unique_name}"
+        try:
+            lambda_client.create_function(
+                FunctionName=fn,
+                PackageType="Image",
+                Role=ROLE,
+                Code={"ImageUri": self.IMAGE_URI},
+                ImageConfig={"WorkingDirectory": "/initial"},
+            )
+            resp = lambda_client.update_function_configuration(
+                FunctionName=fn,
+                ImageConfig={"WorkingDirectory": "/updated"},
+            )
+            wd = (
+                resp.get("ImageConfigResponse", {})
+                    .get("ImageConfig", {})
+                    .get("WorkingDirectory")
+            )
+            assert wd == "/updated", (
+                f"UpdateFunctionConfiguration must update WorkingDirectory to '/updated', got: {wd!r}"
+            )
+        finally:
+            lambda_client.delete_function(FunctionName=fn)

--- a/compatibility-tests/sdk-test-rust/tests/lambda_test.rs
+++ b/compatibility-tests/sdk-test-rust/tests/lambda_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use aws_sdk_lambda::types::Runtime;
+use aws_sdk_lambda::types::{ImageConfig, PackageType, Runtime};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_lambda_create_function() {
@@ -175,4 +175,75 @@ async fn test_lambda_delete_function() {
 
     let result = lambda.delete_function().function_name(func_name).send().await;
     assert!(result.is_ok(), "DeleteFunction failed: {:?}", result.err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_lambda_image_config_working_directory_round_trip() {
+    let lambda = common::lambda_client().await;
+    let func_name = "rust-test-imgwd-fn";
+    let role_arn = "arn:aws:iam::000000000000:role/test-role";
+    let image_uri = "000000000000.dkr.ecr.us-east-1.amazonaws.com/fake-repo:latest";
+
+    let _guard = common::CleanupGuard::new({
+        let lambda = lambda.clone();
+        async move {
+            let _ = lambda.delete_function().function_name(func_name).send().await;
+        }
+    });
+
+    let create_resp = lambda
+        .create_function()
+        .function_name(func_name)
+        .package_type(PackageType::Image)
+        .role(role_arn)
+        .code(
+            aws_sdk_lambda::types::FunctionCode::builder()
+                .image_uri(image_uri)
+                .build(),
+        )
+        .image_config(
+            ImageConfig::builder()
+                .working_directory("/app")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("CreateFunction with ImageConfig.WorkingDirectory failed");
+
+    let wd = create_resp
+        .image_config_response()
+        .and_then(|r| r.image_config())
+        .and_then(|c| c.working_directory());
+    assert_eq!(wd, Some("/app"), "CreateFunction response must include WorkingDirectory");
+
+    let get_resp = lambda
+        .get_function_configuration()
+        .function_name(func_name)
+        .send()
+        .await
+        .expect("GetFunctionConfiguration failed");
+
+    let wd = get_resp
+        .image_config_response()
+        .and_then(|r| r.image_config())
+        .and_then(|c| c.working_directory());
+    assert_eq!(wd, Some("/app"), "GetFunctionConfiguration must persist WorkingDirectory");
+
+    let update_resp = lambda
+        .update_function_configuration()
+        .function_name(func_name)
+        .image_config(
+            ImageConfig::builder()
+                .working_directory("/updated")
+                .build(),
+        )
+        .send()
+        .await
+        .expect("UpdateFunctionConfiguration failed");
+
+    let wd = update_resp
+        .image_config_response()
+        .and_then(|r| r.image_config())
+        .and_then(|c| c.working_directory());
+    assert_eq!(wd, Some("/updated"), "UpdateFunctionConfiguration must update WorkingDirectory");
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -69,6 +69,7 @@ public class ContainerBuilder {
         private final List<String> env = new ArrayList<>();
         private List<String> cmd;
         private List<String> entrypoint;
+        private String workingDir;
         private Long memoryBytes;
         private final Map<Integer, Integer> portBindings = new HashMap<>();
         private final List<Integer> exposedPorts = new ArrayList<>();
@@ -133,6 +134,14 @@ public class ContainerBuilder {
          */
         public Builder withEntrypoint(List<String> entrypoint) {
             this.entrypoint = entrypoint;
+            return this;
+        }
+
+        /**
+         * Sets the working directory inside the container (overrides image WORKDIR).
+         */
+        public Builder withWorkingDir(String workingDir) {
+            this.workingDir = workingDir;
             return this;
         }
 
@@ -315,7 +324,8 @@ public class ContainerBuilder {
                     List.copyOf(extraHosts),
                     logConfig,
                     privileged,
-                    List.copyOf(dnsServers)
+                    List.copyOf(dnsServers),
+                    workingDir
             );
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -90,6 +90,9 @@ public class ContainerLifecycleManager {
         if (spec.entrypoint() != null && !spec.entrypoint().isEmpty()) {
             createCmd.withEntrypoint(spec.entrypoint());
         }
+        if (spec.workingDir() != null && !spec.workingDir().isBlank()) {
+            createCmd.withWorkingDir(spec.workingDir());
+        }
         if (spec.exposedPorts() != null && !spec.exposedPorts().isEmpty()) {
             ExposedPort[] exposed = spec.exposedPorts().stream()
                     .map(ExposedPort::tcp)

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
@@ -26,6 +26,7 @@ import java.util.Map;
  * @param logConfig Docker log driver configuration (null = daemon default)
  * @param privileged Whether to run the container in privileged mode (required for k3s)
  * @param dnsServers DNS server IPs to inject into the container (e.g. Floci's embedded DNS)
+ * @param workingDir Working directory inside the container (overrides image WORKDIR)
  */
 public record ContainerSpec(
         String image,
@@ -42,14 +43,15 @@ public record ContainerSpec(
         List<String> extraHosts,
         LogConfig logConfig,
         boolean privileged,
-        List<String> dnsServers
+        List<String> dnsServers,
+        String workingDir
 ) {
     /**
      * Creates a minimal spec with just the image name.
      * All other fields will be null or empty lists.
      */
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), null, false, List.of());
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), null, false, List.of(), null);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -539,6 +539,9 @@ public class LambdaController {
                 ArrayNode epNode = imageConfig.putArray("EntryPoint");
                 fn.getImageConfigEntryPoint().forEach(epNode::add);
             }
+            if (fn.getImageConfigWorkingDirectory() != null && !fn.getImageConfigWorkingDirectory().isBlank()) {
+                imageConfig.put("WorkingDirectory", fn.getImageConfigWorkingDirectory());
+            }
         }
         node.put("LastModified", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
                 .format(Instant.ofEpochMilli(fn.getLastModified()).atOffset(ZoneOffset.UTC)));

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -296,6 +296,9 @@ public class LambdaService {
             if (imageConfig.get("EntryPoint") instanceof List<?> ep) {
                 fn.setImageConfigEntryPoint(ep.stream().map(Object::toString).toList());
             }
+            if (imageConfig.get("WorkingDirectory") instanceof String wd) {
+                fn.setImageConfigWorkingDirectory(wd);
+            }
         }
 
         // Handle code deployment
@@ -508,6 +511,10 @@ public class LambdaService {
                     List<String> ep = imageConfig.get("EntryPoint") instanceof List<?>
                             ? ((List<?>) imageConfig.get("EntryPoint")).stream().map(Object::toString).toList() : null;
                     fn.setImageConfigEntryPoint(ep);
+                }
+                if (imageConfig.containsKey("WorkingDirectory")) {
+                    fn.setImageConfigWorkingDirectory(
+                            imageConfig.get("WorkingDirectory") instanceof String wd ? wd : null);
                 }
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -192,13 +192,16 @@ public class ContainerLauncher {
             specBuilder.withBind(fn.getHotReloadHostPath(), TASK_DIR);
         }
 
-        // For Image package type use ImageConfig.Command if set, otherwise fall back to Handler (Zip-style)
+        // For Image package type use ImageConfig.Command/EntryPoint/WorkingDirectory if set, otherwise fall back to Handler (Zip-style)
         if ("Image".equals(fn.getPackageType())) {
             if (fn.getImageConfigEntryPoint() != null && !fn.getImageConfigEntryPoint().isEmpty()) {
                 specBuilder.withEntrypoint(fn.getImageConfigEntryPoint());
             }
             if (fn.getImageConfigCommand() != null && !fn.getImageConfigCommand().isEmpty()) {
                 specBuilder.withCmd(fn.getImageConfigCommand());
+            }
+            if (fn.getImageConfigWorkingDirectory() != null && !fn.getImageConfigWorkingDirectory().isBlank()) {
+                specBuilder.withWorkingDir(fn.getImageConfigWorkingDirectory());
             }
         } else if (fn.getHandler() != null && !fn.getHandler().isBlank()) {
             specBuilder.withCmd(fn.getHandler());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
@@ -29,6 +29,7 @@ public class LambdaFunction {
     private String imageUri;
     private List<String> imageConfigCommand;
     private List<String> imageConfigEntryPoint;
+    private String imageConfigWorkingDirectory;
     private String codeLocalPath;
     private String s3Bucket;
     private String s3Key;
@@ -105,6 +106,9 @@ public class LambdaFunction {
 
     public List<String> getImageConfigEntryPoint() { return imageConfigEntryPoint; }
     public void setImageConfigEntryPoint(List<String> imageConfigEntryPoint) { this.imageConfigEntryPoint = imageConfigEntryPoint; }
+
+    public String getImageConfigWorkingDirectory() { return imageConfigWorkingDirectory; }
+    public void setImageConfigWorkingDirectory(String imageConfigWorkingDirectory) { this.imageConfigWorkingDirectory = imageConfigWorkingDirectory; }
 
     public String getCodeLocalPath() { return codeLocalPath; }
     public void setCodeLocalPath(String codeLocalPath) { this.codeLocalPath = codeLocalPath; }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaImageConfigTest.java
@@ -97,11 +97,40 @@ class LambdaImageConfigTest {
         }
 
         @Test
+        void storesImageConfigWorkingDirectory() {
+            Map<String, Object> req = imageRequest("fn-wd");
+            req.put("ImageConfig", Map.of("WorkingDirectory", "/app"));
+
+            LambdaFunction fn = service.createFunction(REGION, req);
+
+            assertEquals("/app", fn.getImageConfigWorkingDirectory());
+            assertNull(fn.getImageConfigCommand());
+            assertNull(fn.getImageConfigEntryPoint());
+        }
+
+        @Test
+        void storesAllThreeImageConfigFields() {
+            Map<String, Object> req = imageRequest("fn-all");
+            req.put("ImageConfig", Map.of(
+                    "Command", List.of("app.handler"),
+                    "EntryPoint", List.of("/entry.sh"),
+                    "WorkingDirectory", "/workspace"
+            ));
+
+            LambdaFunction fn = service.createFunction(REGION, req);
+
+            assertEquals(List.of("app.handler"), fn.getImageConfigCommand());
+            assertEquals(List.of("/entry.sh"), fn.getImageConfigEntryPoint());
+            assertEquals("/workspace", fn.getImageConfigWorkingDirectory());
+        }
+
+        @Test
         void noImageConfigLeavesFieldsNull() {
             LambdaFunction fn = service.createFunction(REGION, imageRequest("fn-none"));
 
             assertNull(fn.getImageConfigCommand());
             assertNull(fn.getImageConfigEntryPoint());
+            assertNull(fn.getImageConfigWorkingDirectory());
         }
     }
 
@@ -145,6 +174,32 @@ class LambdaImageConfigTest {
             LambdaFunction fn = service.updateFunctionConfiguration(REGION, "fn-clear-cmd", update);
 
             assertTrue(fn.getImageConfigCommand() == null || fn.getImageConfigCommand().isEmpty());
+        }
+
+        @Test
+        void updatesImageConfigWorkingDirectory() {
+            service.createFunction(REGION, imageRequest("fn-upd-wd"));
+
+            Map<String, Object> update = new HashMap<>();
+            update.put("ImageConfig", Map.of("WorkingDirectory", "/updated"));
+            LambdaFunction fn = service.updateFunctionConfiguration(REGION, "fn-upd-wd", update);
+
+            assertEquals("/updated", fn.getImageConfigWorkingDirectory());
+        }
+
+        @Test
+        void clearsWorkingDirectoryWhenNullValueProvided() {
+            Map<String, Object> req = imageRequest("fn-clear-wd");
+            req.put("ImageConfig", Map.of("WorkingDirectory", "/initial"));
+            service.createFunction(REGION, req);
+
+            Map<String, Object> update = new HashMap<>();
+            Map<String, Object> imageConfig = new HashMap<>();
+            imageConfig.put("WorkingDirectory", null);
+            update.put("ImageConfig", imageConfig);
+            LambdaFunction fn = service.updateFunctionConfiguration(REGION, "fn-clear-wd", update);
+
+            assertNull(fn.getImageConfigWorkingDirectory());
         }
     }
 
@@ -257,6 +312,31 @@ class LambdaImageConfigTest {
             ContainerSpec spec = specCaptor.getValue();
             assertNull(spec.cmd(), "CMD should not be set when ImageConfig.Command is absent");
             assertNull(spec.entrypoint());
+        }
+
+        @Test
+        void usesImageConfigWorkingDirectoryForImageFunction() {
+            LambdaFunction fn = imageFn("img-wd-fn");
+            fn.setImageConfigWorkingDirectory("/app");
+
+            launcher.launch(fn);
+
+            ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+            verify(lifecycleManager).create(specCaptor.capture());
+
+            assertEquals("/app", specCaptor.getValue().workingDir());
+        }
+
+        @Test
+        void doesNotSetWorkingDirWhenNotConfigured() {
+            LambdaFunction fn = imageFn("img-no-wd-fn");
+
+            launcher.launch(fn);
+
+            ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+            verify(lifecycleManager).create(specCaptor.capture());
+
+            assertNull(specCaptor.getValue().workingDir(), "workingDir must be null when not configured");
         }
 
         @Test


### PR DESCRIPTION
## Summary

Implements support for ImageConfig.WorkingDirectory on Lambda Image-type functions, matching the https://docs.aws.amazon.com/lambda/latest/api/API_ImageConfig.html.

  When a function is created or updated with ImageConfig.WorkingDirectory, Floci now:
  - Persists the value on the function model
  - Applies it as the Docker container's working directory at launch time (overriding the image's WORKDIR)
  - Returns it under ImageConfigResponse.ImageConfig.WorkingDirectory in create, get, and update responses

  This completes ImageConfig support alongside the existing Command and EntryPoint fields.
  
## Type of change
- [X] New feature (`feat:`)

## AWS Compatibility

Verified against AWS CLI v2 and AWS SDK v2 (Java, Python, Node, Go, Rust). The wire protocol — ImageConfig.WorkingDirectory on the request and ImageConfigResponse.ImageConfig.WorkingDirectory on the response — matches the real AWS Lambda API.

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
