### PR TITLE
Fix/lambda incorrect size limit

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaPayloadSizeLimitTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaPayloadSizeLimitTest.java
@@ -17,9 +17,12 @@ class LambdaPayloadSizeLimitTest {
     private static final int _1_MB = 1 * 1024 * 1024;
     private static final int _6_MB = 6 * 1024 * 1024;
 
-    private static final String FN         = "sdk-size-limit-fn";
-    private static final String FN_LARGE   = "sdk-size-limit-large-response-fn";
-    private static final String ROLE       = "arn:aws:iam::000000000000:role/lambda-role";
+    private static final int _5_MB = 5 * 1024 * 1024;
+
+    private static final String FN          = "sdk-size-limit-fn";
+    private static final String FN_LARGE    = "sdk-size-limit-large-response-fn";
+    private static final String FN_5MB      = "sdk-size-limit-5mb-response-fn";
+    private static final String ROLE        = "arn:aws:iam::000000000000:role/lambda-role";
 
     private static LambdaClient lambda;
 
@@ -40,7 +43,7 @@ class LambdaPayloadSizeLimitTest {
     @AfterAll
     static void cleanup() {
         if (lambda == null) return;
-        for (String name : new String[]{FN, FN_LARGE}) {
+        for (String name : new String[]{FN, FN_LARGE, FN_5MB}) {
             try { lambda.deleteFunction(DeleteFunctionRequest.builder().functionName(name).build()); }
             catch (Exception ignored) {}
         }
@@ -124,5 +127,36 @@ class LambdaPayloadSizeLimitTest {
                 .build()))
                 .isInstanceOf(RequestTooLargeException.class)
                 .satisfies(ex -> assertThat(((RequestTooLargeException) ex).statusCode()).isEqualTo(413));
+    }
+
+    @Test
+    @DisplayName("sync invoke returning a 5 MB response succeeds (regression: RuntimeApiServer crashed on bodies > 8 KB via form-limit bug)")
+    void syncInvoke_5MBResponse_isReturnedSuccessfully() {
+        Assumptions.assumeTrue(TestFixtures.isLambdaDispatchAvailable(),
+                "skipping: Lambda dispatch (Docker) not available in this environment");
+
+        // 5 MB is within the 6 MB AWS limit but well above the 8 KB Netty form-attribute
+        // cap that previously caused "Size exceed allowed maximum capacity" when the Lambda
+        // runtime POSTed a large response body back to the RuntimeApiServer.
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FN_5MB)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.largeResponseZip(_5_MB)))
+                        .build())
+                .build());
+
+        InvokeResponse resp = lambda.invoke(InvokeRequest.builder()
+                .functionName(FN_5MB)
+                .invocationType(InvocationType.REQUEST_RESPONSE)
+                .payload(SdkBytes.fromUtf8String("{}"))
+                .overrideConfiguration(c -> c.apiCallTimeout(Duration.ofSeconds(60)))
+                .build());
+
+        assertThat(resp.statusCode()).isEqualTo(200);
+        assertThat(resp.functionError()).isNull();
+        assertThat(resp.payload().asByteArray().length).isGreaterThan(_5_MB - 100);
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaPayloadSizeLimitTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaPayloadSizeLimitTest.java
@@ -1,0 +1,128 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Lambda - Invoke payload size limits")
+class LambdaPayloadSizeLimitTest {
+
+    private static final int _1_MB = 1 * 1024 * 1024;
+    private static final int _6_MB = 6 * 1024 * 1024;
+
+    private static final String FN         = "sdk-size-limit-fn";
+    private static final String FN_LARGE   = "sdk-size-limit-large-response-fn";
+    private static final String ROLE       = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static LambdaClient lambda;
+
+    @BeforeAll
+    static void setup() {
+        lambda = TestFixtures.lambdaClient();
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FN)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.minimalZip()))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda == null) return;
+        for (String name : new String[]{FN, FN_LARGE}) {
+            try { lambda.deleteFunction(DeleteFunctionRequest.builder().functionName(name).build()); }
+            catch (Exception ignored) {}
+        }
+        lambda.close();
+    }
+
+    // ── Request payload limits ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("sync invoke with payload > 6 MB returns 413 RequestTooLargeException")
+    void syncInvoke_payloadExceeds6MB_throwsRequestTooLargeException() {
+        assertThatThrownBy(() -> lambda.invoke(InvokeRequest.builder()
+                .functionName(FN)
+                .invocationType(InvocationType.REQUEST_RESPONSE)
+                .payload(SdkBytes.fromByteArray(new byte[_6_MB + 1]))
+                .build()))
+                .isInstanceOf(RequestTooLargeException.class)
+                .satisfies(ex -> assertThat(((RequestTooLargeException) ex).statusCode()).isEqualTo(413));
+    }
+
+    @Test
+    @DisplayName("sync invoke with payload exactly 6 MB is not rejected by size check")
+    void syncInvoke_payloadExactly6MB_isNotRejected() {
+        // DryRun avoids waiting for Lambda dispatch; verifies no 413 from size check
+        InvokeResponse resp = lambda.invoke(InvokeRequest.builder()
+                .functionName(FN)
+                .invocationType(InvocationType.DRY_RUN)
+                .payload(SdkBytes.fromByteArray(new byte[_6_MB]))
+                .build());
+
+        assertThat(resp.statusCode()).isEqualTo(204);
+    }
+
+    @Test
+    @DisplayName("async invoke with payload > 1 MB returns 413 RequestTooLargeException")
+    void asyncInvoke_payloadExceeds1MB_throwsRequestTooLargeException() {
+        assertThatThrownBy(() -> lambda.invoke(InvokeRequest.builder()
+                .functionName(FN)
+                .invocationType(InvocationType.EVENT)
+                .payload(SdkBytes.fromByteArray(new byte[_1_MB + 1]))
+                .build()))
+                .isInstanceOf(RequestTooLargeException.class)
+                .satisfies(ex -> assertThat(((RequestTooLargeException) ex).statusCode()).isEqualTo(413));
+    }
+
+    @Test
+    @DisplayName("async invoke with payload exactly 1 MB is accepted (202)")
+    void asyncInvoke_payloadExactly1MB_isAccepted() {
+        InvokeResponse resp = lambda.invoke(InvokeRequest.builder()
+                .functionName(FN)
+                .invocationType(InvocationType.EVENT)
+                .payload(SdkBytes.fromByteArray(new byte[_1_MB]))
+                .build());
+
+        assertThat(resp.statusCode()).isEqualTo(202);
+    }
+
+    // ── Response payload limit ──────────────────────────────────────────────
+
+    @Test
+    @DisplayName("sync invoke returning > 6 MB response returns 413 RequestTooLargeException")
+    void syncInvoke_responseExceeds6MB_throwsRequestTooLargeException() {
+        Assumptions.assumeTrue(TestFixtures.isLambdaDispatchAvailable(),
+                "skipping: Lambda dispatch (Docker) not available in this environment");
+
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FN_LARGE)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.largeResponseZip(_6_MB + 1)))
+                        .build())
+                .build());
+
+        assertThatThrownBy(() -> lambda.invoke(InvokeRequest.builder()
+                .functionName(FN_LARGE)
+                .invocationType(InvocationType.REQUEST_RESPONSE)
+                .payload(SdkBytes.fromUtf8String("{}"))
+                .overrideConfiguration(c -> c.apiCallTimeout(Duration.ofSeconds(60)))
+                .build()))
+                .isInstanceOf(RequestTooLargeException.class)
+                .satisfies(ex -> assertThat(((RequestTooLargeException) ex).statusCode()).isEqualTo(413));
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaUtils.java
@@ -178,6 +178,17 @@ public final class LambdaUtils {
         return createZip("index.js", code);
     }
 
+    /**
+     * ZIP containing a Node.js handler that returns a payload of {@code bytes} 'x' characters.
+     * Used to test response payload size limit enforcement.
+     */
+    public static byte[] largeResponseZip(int bytes) {
+        String code = """
+                exports.handler = async () => 'x'.repeat(%d);
+                """.formatted(bytes);
+        return createZip("index.js", code);
+    }
+
     private static byte[] createZip(String filename, String content) {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.config;
+
+import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
+import io.vertx.core.http.HttpServerOptions;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Removes the 8 KB per-attribute limit imposed by Vert.x's default
+ * {@code HttpServerOptions.maxFormAttributeSize}.
+ *
+ * Without this, any request that arrives with
+ * {@code Content-Type: application/x-www-form-urlencoded} and a single
+ * attribute value larger than ~8 KB is rejected by Netty's form decoder
+ * with "Size exceed allowed maximum capacity". This hits real AWS APIs
+ * that use the Query Protocol: CloudFormation templates, EC2 UserData
+ * (base64-encoded), large IAM policies, etc.
+ *
+ * The overall request body size is still bounded by
+ * {@code quarkus.http.limits.max-body-size} (default 512 MB), so raising
+ * the per-attribute limit to unlimited is safe.
+ */
+@ApplicationScoped
+public class HttpOptionsCustomizer implements HttpServerOptionsCustomizer {
+
+    @Override
+    public void customizeHttpServer(HttpServerOptions options) {
+        options.setMaxFormAttributeSize(-1);
+    }
+
+    @Override
+    public void customizeHttpsServer(HttpServerOptions options) {
+        options.setMaxFormAttributeSize(-1);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -195,6 +195,10 @@ public class LambdaController {
 
     // ──────────────────────────── Invoke ────────────────────────────
 
+    private static final int SYNC_REQUEST_LIMIT  = 6 * 1024 * 1024;
+    private static final int ASYNC_REQUEST_LIMIT = 1 * 1024 * 1024;
+    private static final int SYNC_RESPONSE_LIMIT = 6 * 1024 * 1024;
+
     @POST
     @Path("/functions/{functionName}/invocations")
     @Consumes(MediaType.WILDCARD)
@@ -205,7 +209,30 @@ public class LambdaController {
         String invocationTypeHeader = headers.getHeaderString("X-Amz-Invocation-Type");
         InvocationType type = InvocationType.parse(invocationTypeHeader);
 
+        int payloadSize = payload != null ? payload.length : 0;
+        if (type == InvocationType.Event && payloadSize > ASYNC_REQUEST_LIMIT) {
+            return Response.status(413)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity("{\"__type\":\"RequestTooLargeException\",\"message\":\"The request payload exceeded the Invoke request body JSON input quota.\"}")
+                    .build();
+        }
+        if (type != InvocationType.Event && payloadSize > SYNC_REQUEST_LIMIT) {
+            return Response.status(413)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity("{\"__type\":\"RequestTooLargeException\",\"message\":\"The request payload exceeded the Invoke request body JSON input quota.\"}")
+                    .build();
+        }
+
         InvokeResult result = lambdaService.invoke(region, functionName, payload, type);
+
+        if (type != InvocationType.Event
+                && result.getPayload() != null
+                && result.getPayload().length > SYNC_RESPONSE_LIMIT) {
+            return Response.status(413)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity("{\"__type\":\"RequestTooLargeException\",\"message\":\"The response payload exceeded the maximum allowed payload size (6 MB).\"}")
+                    .build();
+        }
 
         Response.ResponseBuilder builder = Response.status(result.getStatusCode());
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.PendingInvocation;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -131,7 +132,8 @@ public class RuntimeApiServer {
             ctx.response().setStatusCode(202).end();
         });
 
-        httpServer = vertx.createHttpServer();
+        httpServer = vertx.createHttpServer(new HttpServerOptions()
+                .setMaxFormAttributeSize(-1));
         httpServer.requestHandler(router).listen(port, "0.0.0.0", result -> {
             if (result.succeeded()) {
                 LOG.debugv("RuntimeApiServer started on port {0}", port);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -352,4 +352,67 @@ class LambdaIntegrationTest {
         .then()
             .statusCode(204);
     }
+
+    // ──────────────────────────── Invoke payload size limits ────────────────────────────
+
+    @Test
+    @Order(30)
+    void syncInvoke_payloadExceeds6MB_returns413() {
+        byte[] oversized = new byte[6 * 1024 * 1024 + 1];
+
+        given()
+            .contentType("application/octet-stream")
+            .body(oversized)
+        .when()
+            .post(BASE_PATH + "/functions/hello-world/invocations")
+        .then()
+            .statusCode(413)
+            .body("__type", equalTo("RequestTooLargeException"));
+    }
+
+    @Test
+    @Order(31)
+    void syncInvoke_payloadExactly6MB_isNotRejected() {
+        byte[] exactLimit = new byte[6 * 1024 * 1024];
+
+        given()
+            .header("X-Amz-Invocation-Type", "DryRun")
+            .contentType("application/octet-stream")
+            .body(exactLimit)
+        .when()
+            .post(BASE_PATH + "/functions/hello-world/invocations")
+        .then()
+            .statusCode(not(413));
+    }
+
+    @Test
+    @Order(32)
+    void asyncInvoke_payloadExceeds1MB_returns413() {
+        byte[] oversized = new byte[1 * 1024 * 1024 + 1];
+
+        given()
+            .header("X-Amz-Invocation-Type", "Event")
+            .contentType("application/octet-stream")
+            .body(oversized)
+        .when()
+            .post(BASE_PATH + "/functions/hello-world/invocations")
+        .then()
+            .statusCode(413)
+            .body("__type", equalTo("RequestTooLargeException"));
+    }
+
+    @Test
+    @Order(33)
+    void asyncInvoke_payloadExactly1MB_isNotRejected() {
+        byte[] exactLimit = new byte[1 * 1024 * 1024];
+
+        given()
+            .header("X-Amz-Invocation-Type", "Event")
+            .contentType("application/octet-stream")
+            .body(exactLimit)
+        .when()
+            .post(BASE_PATH + "/functions/hello-world/invocations")
+        .then()
+            .statusCode(not(413));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two related issues caused by missing body-size configuration in Vert.x/Netty.

  1. 8 KB form-attribute cap causing crashes on large bodies

  Vert.x 4's default maxFormAttributeSize is ~8 KB. Any request body larger than that was throwing java.io.IOException: Size exceed allowed maximum capacity in Netty's HttpPostStandardRequestDecoder. This manifested in two places:

  - RuntimeApiServer — when a Lambda function returned a large response (e.g. a 5 MB PDF), the Lambda runtime's POST /runtime/invocation/{id}/response was rejected, crashing the entire invocation.
  - Main Quarkus HTTP server — any large AWS Query Protocol payload (CloudFormation templates, EC2 UserData, etc.) sent as a form field would be silently dropped with a 500.

  Fixed by setting maxFormAttributeSize(-1) (unlimited) on both the per-container RuntimeApiServer and the main server via a HttpServerOptionsCustomizer CDI bean.

  2. Missing AWS invoke payload size enforcement

  The emulator was not enforcing the AWS-documented invocation limits, so clients could send arbitrarily large payloads. Added server-side checks that return HTTP 413 RequestTooLargeException before dispatching:

  - Synchronous (RequestResponse): request payload > 6 MB
  - Asynchronous (Event): request payload > 1 MB
  - Synchronous response: response payload > 6 MB
  
## Type of change
- [X] Bug fix (`fix:`)

## AWS Compatibility

  AWS Lambda returns HTTP 413 RequestTooLargeException when the invoke payload exceeds the documented limits (sync 6 MB / async 1 MB). The emulator now matches this behavior.

  The root cause of the crash (Vert.x 8 KB form-attribute cap) is an emulator-internal issue with no AWS equivalent — real Lambda has no such restriction.
  
  https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added (unit tests in LambdaIntegrationTest covering request size boundaries; Java SDK compat tests in LambdaPayloadSizeLimitTest including a Docker-gated regression test for the 5 MB response crash)
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
