### PR TITLE
feat(autoscaling): EC2 Auto Scaling stored-state API + capacity reconciler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 | EC2 (real Docker instances, IMDS, SSH, UserData) | ✅ | ❌ |
 | CodeBuild (real Docker build execution, S3 artifacts, CloudWatch logs) | ✅ | ❌ |
 | CodeDeploy (Lambda traffic shifting, lifecycle hooks, auto-rollback) | ✅ | ❌ |
+| Auto Scaling (groups, launch configs, reconciler, ELB v2 integration) | ✅ | ❌ |
 | Native binary | ✅ ~40 MB | ❌ |
 
 **Broad AWS coverage. Free forever.**
@@ -85,7 +86,7 @@ flowchart LR
         Router["HTTP Router\n(JAX-RS / Vert.x)"]
 
         subgraph Stateless ["Stateless Services"]
-            A["SSM · SQS · SNS\nIAM · STS · KMS\nSecrets Manager · SES\nCognito · Kinesis\nEventBridge · Scheduler · AppConfig\nCloudWatch · Step Functions\nCloudFormation · ACM\nAPI Gateway · ELB v2\nCodeDeploy · Bedrock Runtime"]
+            A["SSM · SQS · SNS\nIAM · STS · KMS\nSecrets Manager · SES\nCognito · Kinesis\nEventBridge · Scheduler · AppConfig\nCloudWatch · Step Functions\nCloudFormation · ACM\nAPI Gateway · ELB v2 · Auto Scaling\nCodeDeploy · Bedrock Runtime"]
         end
 
         subgraph Stateful ["Stateful Services"]
@@ -218,12 +219,13 @@ All default images are configurable via environment variables, useful for pinnin
 | **ELB v2** | In-process | Application and Network Load Balancers, target groups, listeners, path/host-based routing rules, tags |
 | **CodeBuild** | In-process + **real Docker containers** | Projects, report groups, source credentials; `StartBuild` runs real Docker containers, streams logs to CloudWatch, uploads artifacts to S3 via `docker cp` (works in Docker-in-Docker) |
 | **CodeDeploy** | In-process + **Lambda traffic shifting** | Applications, deployment groups, deployment configs; 17 `CodeDeployDefault.*` built-ins pre-seeded; `CreateDeployment` shifts Lambda alias `RoutingConfig` weights, invokes lifecycle hooks, auto-rolls back on failure |
+| **Auto Scaling** | In-process + **background reconciler** | Launch configurations, auto scaling groups with min/max/desired capacity; background loop (10 s) calls `RunInstances` / `TerminateInstances` to meet desired capacity; lifecycle hooks, scaling policies, ELB v2 target group auto-registration |
 
 > **Lambda, ElastiCache, RDS, MSK, ECS, EC2, EKS, OpenSearch, and CodeBuild** spin up real Docker containers and support IAM authentication and SigV4 request signing — the same auth flow as production AWS. **ECR** runs a shared `registry:2` container so the stock `docker` client can push and pull image bytes against repositories returned by the AWS-shaped control plane.
 >
 > For per-service operation counts and endpoint protocols, see the [Services Overview](https://floci.io/floci/services/) in the documentation site.
 
-**41 AWS services supported.**
+**42 AWS services supported.**
 
 ## Persistence & Storage Modes
 

--- a/docs/services/autoscaling.md
+++ b/docs/services/autoscaling.md
@@ -1,0 +1,126 @@
+# Auto Scaling
+
+Floci implements the EC2 Auto Scaling API — stored-state management for launch configurations, auto scaling groups, lifecycle hooks, and scaling policies, plus a real capacity reconciler that launches and terminates EC2 instances to maintain desired capacity.
+
+**Protocol:** Query — `POST /` with `Action=` form parameter, credential scope `autoscaling`
+
+**ARN formats:**
+
+- `arn:aws:autoscaling:<region>:<account>:autoScalingGroup:<uuid>:autoScalingGroupName/<name>`
+- `arn:aws:autoscaling:<region>:<account>:launchConfiguration:<uuid>:launchConfigurationName/<name>`
+- `arn:aws:autoscaling:<region>:<account>:scalingPolicy:<uuid>:autoScalingGroupName/<group>/policyName/<name>`
+
+## Supported Operations (30 total)
+
+### Launch Configurations
+
+| Operation | Notes |
+|---|---|
+| `CreateLaunchConfiguration` | Stores template: `ImageId`, `InstanceType`, `KeyName`, `SecurityGroups`, `UserData`, `IamInstanceProfile` |
+| `DescribeLaunchConfigurations` | Filtered by name list; returns all if no filter |
+| `DeleteLaunchConfiguration` | Removes the named launch configuration |
+
+### Auto Scaling Groups
+
+| Operation | Notes |
+|---|---|
+| `CreateAutoScalingGroup` | Creates a group with min/max/desired capacity, AZs, tags; starts capacity reconciliation loop |
+| `DescribeAutoScalingGroups` | Filtered by name list; returns all if no filter; includes current instance list with lifecycle state |
+| `UpdateAutoScalingGroup` | Updates capacity bounds, cooldown, launch configuration, AZs |
+| `DeleteAutoScalingGroup` | `ForceDelete=true` terminates all instances before deletion |
+
+### Instance Management
+
+| Operation | Notes |
+|---|---|
+| `DescribeAutoScalingInstances` | Returns all ASG-tracked instances with lifecycle state and health status |
+| `SetDesiredCapacity` | Updates desired count; reconciler handles scale-out / scale-in within 10 s |
+| `TerminateInstanceInAutoScalingGroup` | Terminates a specific instance; optionally decrements desired capacity |
+| `SetInstanceProtection` | Marks instances as protected from scale-in |
+
+### Load Balancer Attachment
+
+| Operation | Notes |
+|---|---|
+| `AttachLoadBalancerTargetGroups` | Attaches ELB v2 target group ARNs; new instances auto-registered on InService |
+| `DetachLoadBalancerTargetGroups` | Detaches target groups; instances deregistered |
+| `DescribeLoadBalancerTargetGroups` | Lists target groups attached to a group |
+| `AttachLoadBalancers` | Classic ELB attachment (stored; no ELB v1 routing) |
+| `DetachLoadBalancers` | Classic ELB detachment |
+| `DescribeLoadBalancers` | Lists classic ELBs attached to a group |
+
+### Lifecycle Hooks
+
+| Operation | Notes |
+|---|---|
+| `PutLifecycleHook` | Creates or updates a hook: `LifecycleTransition`, `DefaultResult`, `HeartbeatTimeout` |
+| `DescribeLifecycleHooks` | Lists hooks for a group |
+| `DeleteLifecycleHook` | Removes a hook |
+
+### Scaling Policies
+
+| Operation | Notes |
+|---|---|
+| `PutScalingPolicy` | Creates or updates a policy: `SimpleScaling`, `AdjustmentType`, `ScalingAdjustment`, `Cooldown` |
+| `DescribePolicies` | Lists policies filtered by group or policy name |
+| `DeletePolicy` | Removes a scaling policy |
+
+### Activities
+
+| Operation | Notes |
+|---|---|
+| `DescribeScalingActivities` | Returns the activity log for a group; activities recorded on scale-out and scale-in events |
+
+### Metadata
+
+| Operation | Notes |
+|---|---|
+| `DescribeTerminationPolicyTypes` | Returns the standard termination policy names |
+| `DescribeAccountLimits` | Returns max group / config / instance limits |
+| `DescribeLifecycleHookTypes` | Returns `autoscaling:EC2_INSTANCE_LAUNCHING` and `autoscaling:EC2_INSTANCE_TERMINATING` |
+| `DescribeAdjustmentTypes` | Returns the four standard adjustment types |
+| `DescribeMetricCollectionTypes` | Returns standard metric and granularity names |
+| `DescribeAutoScalingNotificationTypes` | Returns all notification type names |
+| `DescribeScalingProcessTypes` | Returns all scaling process names |
+| `DescribeTags` | Lists tags across all groups |
+
+## Capacity Reconciler (Phase 2)
+
+Floci runs a background reconciler (10 s fixed rate) that keeps each group's InService instance count aligned with `DesiredCapacity`:
+
+- **Scale-out**: calls `RunInstances` with the group's launch configuration; new instances are tracked as `Pending` until the EC2 state transitions to `running`, at which point they move to `InService` and are registered with all attached ELB v2 target groups.
+- **Scale-in**: selects InService instances not protected from scale-in, deregisters them from target groups, then calls `TerminateInstances`.
+- Activity records are written on each scale-out and scale-in event.
+
+## Usage Example
+
+```bash
+# Create a launch configuration
+aws autoscaling create-launch-configuration \
+  --launch-configuration-name my-lc \
+  --image-id ami-12345678 \
+  --instance-type t3.micro
+
+# Create a group targeting desired=2
+aws autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name my-asg \
+  --launch-configuration-name my-lc \
+  --min-size 1 \
+  --max-size 5 \
+  --desired-capacity 2 \
+  --availability-zones us-east-1a
+
+# Attach an ELB v2 target group
+aws autoscaling attach-load-balancer-target-groups \
+  --auto-scaling-group-name my-asg \
+  --target-group-arns arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/abc123
+
+# Watch instances appear
+aws autoscaling describe-auto-scaling-groups \
+  --auto-scaling-group-names my-asg
+
+# Scale out
+aws autoscaling set-desired-capacity \
+  --auto-scaling-group-name my-asg \
+  --desired-capacity 3
+```

--- a/docs/services/autoscaling.md
+++ b/docs/services/autoscaling.md
@@ -10,7 +10,7 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 - `arn:aws:autoscaling:<region>:<account>:launchConfiguration:<uuid>:launchConfigurationName/<name>`
 - `arn:aws:autoscaling:<region>:<account>:scalingPolicy:<uuid>:autoScalingGroupName/<group>/policyName/<name>`
 
-## Supported Operations (30 total)
+## Supported Operations (33 total)
 
 ### Launch Configurations
 
@@ -35,8 +35,9 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 |---|---|
 | `DescribeAutoScalingInstances` | Returns all ASG-tracked instances with lifecycle state and health status |
 | `SetDesiredCapacity` | Updates desired count; reconciler handles scale-out / scale-in within 10 s |
+| `AttachInstances` | Attaches existing EC2 instances to a group; sets lifecycle state to `InService` |
+| `DetachInstances` | Detaches instances from a group; optionally decrements desired capacity |
 | `TerminateInstanceInAutoScalingGroup` | Terminates a specific instance; optionally decrements desired capacity |
-| `SetInstanceProtection` | Marks instances as protected from scale-in |
 
 ### Load Balancer Attachment
 
@@ -56,6 +57,8 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 | `PutLifecycleHook` | Creates or updates a hook: `LifecycleTransition`, `DefaultResult`, `HeartbeatTimeout` |
 | `DescribeLifecycleHooks` | Lists hooks for a group |
 | `DeleteLifecycleHook` | Removes a hook |
+| `CompleteLifecycleAction` | Signals `CONTINUE` or `ABANDON` for a pending lifecycle action |
+| `RecordLifecycleActionHeartbeat` | Extends the heartbeat timeout for an in-progress lifecycle action |
 
 ### Scaling Policies
 
@@ -81,8 +84,6 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 | `DescribeAdjustmentTypes` | Returns the four standard adjustment types |
 | `DescribeMetricCollectionTypes` | Returns standard metric and granularity names |
 | `DescribeAutoScalingNotificationTypes` | Returns all notification type names |
-| `DescribeScalingProcessTypes` | Returns all scaling process names |
-| `DescribeTags` | Lists tags across all groups |
 
 ## Capacity Reconciler (Phase 2)
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 41 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 42 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service counts and operation counts. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -45,6 +45,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 | [EKS](eks.md) | `/clusters`, `/clusters/{name}`, `/tags/{resourceArn}` | REST JSON | 7 |
 | [ELB v2](elb.md) | `POST /` with `Action=` param | Query | 34 |
+| [Auto Scaling](autoscaling.md) | `POST /` with `Action=` param | Query | 30 |
 | [MSK](msk.md) | `/v1/clusters/...`, `/api/v2/clusters/...` | REST JSON | 8 |
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 8 |
 | [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 15 |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -45,7 +45,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 | [EKS](eks.md) | `/clusters`, `/clusters/{name}`, `/tags/{resourceArn}` | REST JSON | 7 |
 | [ELB v2](elb.md) | `POST /` with `Action=` param | Query | 34 |
-| [Auto Scaling](autoscaling.md) | `POST /` with `Action=` param | Query | 30 |
+| [Auto Scaling](autoscaling.md) | `POST /` with `Action=` param | Query | 33 |
 | [MSK](msk.md) | `/v1/clusters/...`, `/api/v2/clusters/...` | REST JSON | 8 |
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 8 |
 | [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 15 |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -272,6 +272,12 @@ public interface EmulatorConfig {
         ElbV2ServiceConfig elbv2();
         CodeBuildServiceConfig codebuild();
         CodeDeployServiceConfig codedeploy();
+        AutoScalingServiceConfig autoscaling();
+    }
+
+    interface AutoScalingServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface CodeBuildServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsNamespaces.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsNamespaces.java
@@ -17,7 +17,8 @@ public final class AwsNamespaces {
     public static final String S3_CONTROL = "http://awss3control.amazonaws.com/doc/2018-08-20/";
     public static final String SES = "http://ses.amazonaws.com/doc/2010-12-01/";
     public static final String EC2    = "http://ec2.amazonaws.com/doc/2016-11-15/";
-    public static final String ELB_V2 = "https://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
+    public static final String ELB_V2      = "https://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
+    public static final String AUTOSCALING = "https://autoscaling.amazonaws.com/doc/2011-01-01/";
 
     private AwsNamespaces() {}
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.services.autoscaling.AutoScalingQueryHandler;
 import io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler;
 import io.github.hectorvent.floci.services.ec2.Ec2QueryHandler;
 import io.github.hectorvent.floci.services.elbv2.ElbV2QueryHandler;
@@ -103,6 +104,23 @@ public class AwsQueryController {
             "GetAccountSummary", "GetAccountAuthorizationDetails"
     );
 
+    private static final Set<String> AUTOSCALING_ACTIONS = Set.of(
+            "CreateLaunchConfiguration", "DescribeLaunchConfigurations", "DeleteLaunchConfiguration",
+            "CreateAutoScalingGroup", "UpdateAutoScalingGroup", "DeleteAutoScalingGroup",
+            "DescribeAutoScalingGroups", "SetDesiredCapacity",
+            "DescribeAutoScalingInstances", "AttachInstances", "DetachInstances",
+            "TerminateInstanceInAutoScalingGroup",
+            "AttachLoadBalancerTargetGroups", "DetachLoadBalancerTargetGroups",
+            "DescribeLoadBalancerTargetGroups", "AttachLoadBalancers", "DetachLoadBalancers",
+            "PutLifecycleHook", "DeleteLifecycleHook", "DescribeLifecycleHooks",
+            "CompleteLifecycleAction", "RecordLifecycleActionHeartbeat",
+            "PutScalingPolicy", "DeletePolicy", "DescribePolicies",
+            "DescribeScalingActivities",
+            "DescribeAutoScalingNotificationTypes", "DescribeTerminationPolicyTypes",
+            "DescribeAdjustmentTypes", "DescribeAccountLimits",
+            "DescribeLifecycleHookTypes", "DescribeMetricCollectionTypes"
+    );
+
     private static final Set<String> ELB_V2_ACTIONS = Set.of(
             "CreateLoadBalancer", "DescribeLoadBalancers", "DeleteLoadBalancer",
             "ModifyLoadBalancerAttributes", "DescribeLoadBalancerAttributes",
@@ -153,6 +171,7 @@ public class AwsQueryController {
     private final CognitoJsonHandler cognitoJsonHandler;
     private final Ec2QueryHandler ec2QueryHandler;
     private final ElbV2QueryHandler elbV2QueryHandler;
+    private final AutoScalingQueryHandler autoScalingQueryHandler;
     private final ResolvedServiceCatalog catalog;
     private final RegionResolver regionResolver;
 
@@ -167,6 +186,7 @@ public class AwsQueryController {
                               CognitoJsonHandler cognitoJsonHandler,
                               Ec2QueryHandler ec2QueryHandler,
                               ElbV2QueryHandler elbV2QueryHandler,
+                              AutoScalingQueryHandler autoScalingQueryHandler,
                               ResolvedServiceCatalog catalog,
                               RegionResolver regionResolver) {
         this.cloudFormationQueryHandler = cloudFormationQueryHandler;
@@ -181,6 +201,7 @@ public class AwsQueryController {
         this.cognitoJsonHandler = cognitoJsonHandler;
         this.ec2QueryHandler = ec2QueryHandler;
         this.elbV2QueryHandler = elbV2QueryHandler;
+        this.autoScalingQueryHandler = autoScalingQueryHandler;
         this.catalog = catalog;
         this.regionResolver = regionResolver;
     }
@@ -216,6 +237,7 @@ public class AwsQueryController {
             case "cognito-idp" -> handleCognitoQuery(action, formParams, region);
             case "ec2" -> ec2QueryHandler.handle(action, formParams, region);
             case "elasticloadbalancing" -> elbV2QueryHandler.handle(action, formParams, region);
+            case "autoscaling" -> autoScalingQueryHandler.handle(action, formParams, region);
             default -> xmlErrorResponse("UnknownService",
                     "Unknown or unsupported service: " + service, 400);
         };
@@ -344,6 +366,9 @@ public class AwsQueryController {
         }
         if (ELB_V2_ACTIONS.contains(action)) {
             return "elasticloadbalancing";
+        }
+        if (AUTOSCALING_ACTIONS.contains(action)) {
+            return "autoscaling";
         }
         // SQS actions are numerous and not enumerated — fall back to sqs only for
         // requests that arrived without an Authorization header (raw/test clients)

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -216,7 +216,11 @@ public class ResolvedServiceCatalog {
                 descriptor("codedeploy", "codedeploy", config.services().codedeploy().enabled(), true,
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
-                        Set.of("CodeDeploy_20141006."), Set.of("codedeploy"), Set.of(), Set.of())
+                        Set.of("CodeDeploy_20141006."), Set.of("codedeploy"), Set.of(), Set.of()),
+                descriptor("autoscaling", "autoscaling", config.services().autoscaling().enabled(), true,
+                        "autoscaling", config.storage().mode(), 5000L, AwsNamespaces.AUTOSCALING, ServiceProtocol.QUERY,
+                        protocols(ServiceProtocol.QUERY),
+                        Set.of(), Set.of("autoscaling"), Set.of(), Set.of())
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -1,0 +1,746 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.AwsNamespaces;
+import io.github.hectorvent.floci.core.common.AwsQueryResponse;
+import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.autoscaling.model.*;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@ApplicationScoped
+public class AutoScalingQueryHandler {
+
+    private static final Logger LOG = Logger.getLogger(AutoScalingQueryHandler.class);
+    private static final String NS = AwsNamespaces.AUTOSCALING;
+    private static final DateTimeFormatter ISO_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+    private final AutoScalingService service;
+
+    @Inject
+    AutoScalingQueryHandler(AutoScalingService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, MultivaluedMap<String, String> p, String region) {
+        LOG.debugv("AutoScaling action: {0}", action);
+        try {
+            return switch (action) {
+                // Launch Configuration
+                case "CreateLaunchConfiguration"    -> handleCreateLaunchConfiguration(p, region);
+                case "DescribeLaunchConfigurations" -> handleDescribeLaunchConfigurations(p, region);
+                case "DeleteLaunchConfiguration"    -> handleDeleteLaunchConfiguration(p, region);
+                // ASG
+                case "CreateAutoScalingGroup"       -> handleCreateAutoScalingGroup(p, region);
+                case "UpdateAutoScalingGroup"       -> handleUpdateAutoScalingGroup(p, region);
+                case "DeleteAutoScalingGroup"       -> handleDeleteAutoScalingGroup(p, region);
+                case "DescribeAutoScalingGroups"    -> handleDescribeAutoScalingGroups(p, region);
+                case "SetDesiredCapacity"           -> handleSetDesiredCapacity(p, region);
+                // Instances
+                case "DescribeAutoScalingInstances" -> handleDescribeAutoScalingInstances(p, region);
+                case "AttachInstances"              -> handleAttachInstances(p, region);
+                case "DetachInstances"              -> handleDetachInstances(p, region);
+                case "TerminateInstanceInAutoScalingGroup" -> handleTerminateInstance(p, region);
+                // Load balancer attachment
+                case "AttachLoadBalancerTargetGroups"    -> handleAttachLoadBalancerTargetGroups(p, region);
+                case "DetachLoadBalancerTargetGroups"    -> handleDetachLoadBalancerTargetGroups(p, region);
+                case "DescribeLoadBalancerTargetGroups"  -> handleDescribeLoadBalancerTargetGroups(p, region);
+                case "AttachLoadBalancers"               -> handleAttachLoadBalancers(p, region);
+                case "DetachLoadBalancers"               -> handleDetachLoadBalancers(p, region);
+                case "DescribeLoadBalancers"             -> handleDescribeLoadBalancers(p, region);
+                // Lifecycle hooks
+                case "PutLifecycleHook"             -> handlePutLifecycleHook(p, region);
+                case "DeleteLifecycleHook"          -> handleDeleteLifecycleHook(p, region);
+                case "DescribeLifecycleHooks"       -> handleDescribeLifecycleHooks(p, region);
+                case "CompleteLifecycleAction"      -> handleCompleteLifecycleAction(p, region);
+                case "RecordLifecycleActionHeartbeat" -> handleRecordLifecycleActionHeartbeat();
+                // Scaling policies
+                case "PutScalingPolicy"             -> handlePutScalingPolicy(p, region);
+                case "DeletePolicy"                 -> handleDeletePolicy(p, region);
+                case "DescribePolicies"             -> handleDescribePolicies(p, region);
+                // Activities
+                case "DescribeScalingActivities"    -> handleDescribeScalingActivities(p, region);
+                // Metadata
+                case "DescribeAutoScalingNotificationTypes" -> handleDescribeNotificationTypes();
+                case "DescribeTerminationPolicyTypes"       -> handleDescribeTerminationPolicyTypes();
+                case "DescribeAdjustmentTypes"              -> handleDescribeAdjustmentTypes();
+                case "DescribeAccountLimits"                -> handleDescribeAccountLimits();
+                case "DescribeLifecycleHookTypes"           -> handleDescribeLifecycleHookTypes();
+                case "DescribeMetricCollectionTypes"        -> handleDescribeMetricCollectionTypes();
+                default -> xmlError("UnsupportedOperation",
+                        "Operation " + action + " is not supported.", 400);
+            };
+        } catch (AwsException e) {
+            return xmlError(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
+        } catch (Exception e) {
+            LOG.warnv("Unexpected error in AutoScaling action {0}: {1}", action, e.getMessage());
+            return xmlError("InternalFailure", e.getMessage(), 500);
+        }
+    }
+
+    // ── Launch Configuration ──────────────────────────────────────────────────
+
+    private Response handleCreateLaunchConfiguration(MultivaluedMap<String, String> p, String region) {
+        service.createLaunchConfiguration(region,
+                p.getFirst("LaunchConfigurationName"),
+                p.getFirst("ImageId"),
+                p.getFirst("InstanceType"),
+                p.getFirst("KeyName"),
+                memberList(p, "SecurityGroups"),
+                p.getFirst("UserData"),
+                p.getFirst("IamInstanceProfile"),
+                "true".equalsIgnoreCase(p.getFirst("AssociatePublicIpAddress")));
+        String xml = new XmlBuilder()
+                .start("CreateLaunchConfigurationResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("CreateLaunchConfigurationResponse")
+                .build();
+        return ok(xml);
+    }
+
+    private Response handleDescribeLaunchConfigurations(MultivaluedMap<String, String> p, String region) {
+        List<LaunchConfiguration> lcs = service.describeLaunchConfigurations(
+                region, memberList(p, "LaunchConfigurationNames"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeLaunchConfigurationsResponse", NS)
+                  .start("DescribeLaunchConfigurationsResult")
+                    .start("LaunchConfigurations");
+        for (LaunchConfiguration lc : lcs) {
+            xml.start("member")
+               .elem("LaunchConfigurationName", lc.getLaunchConfigurationName())
+               .elem("LaunchConfigurationARN", lc.getLaunchConfigurationArn())
+               .elem("ImageId", lc.getImageId() != null ? lc.getImageId() : "")
+               .elem("InstanceType", lc.getInstanceType() != null ? lc.getInstanceType() : "t3.micro")
+               .elem("CreatedTime", ISO_FMT.format(lc.getCreatedTime()))
+               .elem("AssociatePublicIpAddress", String.valueOf(lc.isAssociatePublicIpAddress()));
+            if (lc.getKeyName() != null) { xml.elem("KeyName", lc.getKeyName()); }
+            if (lc.getUserData() != null) { xml.elem("UserData", lc.getUserData()); }
+            if (lc.getIamInstanceProfile() != null) { xml.elem("IamInstanceProfile", lc.getIamInstanceProfile()); }
+            xml.start("SecurityGroups");
+            for (String sg : lc.getSecurityGroups()) { xml.elem("member", sg); }
+            xml.end("SecurityGroups").end("member");
+        }
+        xml.end("LaunchConfigurations")
+           .end("DescribeLaunchConfigurationsResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeLaunchConfigurationsResponse");
+        return ok(xml.build());
+    }
+
+    private Response handleDeleteLaunchConfiguration(MultivaluedMap<String, String> p, String region) {
+        service.deleteLaunchConfiguration(region, p.getFirst("LaunchConfigurationName"));
+        return ok(new XmlBuilder()
+                .start("DeleteLaunchConfigurationResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteLaunchConfigurationResponse").build());
+    }
+
+    // ── Auto Scaling Group ────────────────────────────────────────────────────
+
+    private Response handleCreateAutoScalingGroup(MultivaluedMap<String, String> p, String region) {
+        service.createAutoScalingGroup(region,
+                p.getFirst("AutoScalingGroupName"),
+                p.getFirst("LaunchConfigurationName"),
+                p.getFirst("LaunchTemplate.LaunchTemplateName"),
+                p.getFirst("LaunchTemplate.Version"),
+                intParam(p, "MinSize", 0),
+                intParam(p, "MaxSize", 0),
+                intParam(p, "DesiredCapacity", intParam(p, "MinSize", 0)),
+                intParam(p, "DefaultCooldown", 300),
+                memberList(p, "AvailabilityZones"),
+                memberList(p, "TargetGroupARNs"),
+                memberList(p, "LoadBalancerNames"),
+                p.getFirst("HealthCheckType"),
+                intParam(p, "HealthCheckGracePeriod", 0),
+                memberList(p, "TerminationPolicies"),
+                parseTags(p));
+        return ok(new XmlBuilder()
+                .start("CreateAutoScalingGroupResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("CreateAutoScalingGroupResponse").build());
+    }
+
+    private Response handleUpdateAutoScalingGroup(MultivaluedMap<String, String> p, String region) {
+        List<String> azs = memberList(p, "AvailabilityZones");
+        List<String> tps = memberList(p, "TerminationPolicies");
+        service.updateAutoScalingGroup(region,
+                p.getFirst("AutoScalingGroupName"),
+                p.getFirst("LaunchConfigurationName"),
+                p.getFirst("LaunchTemplate.LaunchTemplateName"),
+                p.getFirst("LaunchTemplate.Version"),
+                p.getFirst("MinSize") != null ? Integer.parseInt(p.getFirst("MinSize")) : null,
+                p.getFirst("MaxSize") != null ? Integer.parseInt(p.getFirst("MaxSize")) : null,
+                p.getFirst("DesiredCapacity") != null ? Integer.parseInt(p.getFirst("DesiredCapacity")) : null,
+                p.getFirst("DefaultCooldown") != null ? Integer.parseInt(p.getFirst("DefaultCooldown")) : null,
+                azs.isEmpty() ? null : azs,
+                p.getFirst("HealthCheckType"),
+                p.getFirst("HealthCheckGracePeriod") != null ? Integer.parseInt(p.getFirst("HealthCheckGracePeriod")) : null,
+                tps.isEmpty() ? null : tps);
+        return ok(new XmlBuilder()
+                .start("UpdateAutoScalingGroupResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("UpdateAutoScalingGroupResponse").build());
+    }
+
+    private Response handleDeleteAutoScalingGroup(MultivaluedMap<String, String> p, String region) {
+        service.deleteAutoScalingGroup(region,
+                p.getFirst("AutoScalingGroupName"),
+                "true".equalsIgnoreCase(p.getFirst("ForceDelete")));
+        return ok(new XmlBuilder()
+                .start("DeleteAutoScalingGroupResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteAutoScalingGroupResponse").build());
+    }
+
+    private Response handleDescribeAutoScalingGroups(MultivaluedMap<String, String> p, String region) {
+        List<AutoScalingGroup> groups = service.describeAutoScalingGroups(
+                region, memberList(p, "AutoScalingGroupNames"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeAutoScalingGroupsResponse", NS)
+                  .start("DescribeAutoScalingGroupsResult")
+                    .start("AutoScalingGroups");
+        for (AutoScalingGroup asg : groups) {
+            xml.start("member");
+            appendAsgXml(xml, asg);
+            xml.end("member");
+        }
+        xml.end("AutoScalingGroups")
+           .end("DescribeAutoScalingGroupsResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeAutoScalingGroupsResponse");
+        return ok(xml.build());
+    }
+
+    private void appendAsgXml(XmlBuilder xml, AutoScalingGroup asg) {
+        xml.elem("AutoScalingGroupName", asg.getAutoScalingGroupName())
+           .elem("AutoScalingGroupARN", asg.getAutoScalingGroupArn())
+           .elem("MinSize", String.valueOf(asg.getMinSize()))
+           .elem("MaxSize", String.valueOf(asg.getMaxSize()))
+           .elem("DesiredCapacity", String.valueOf(asg.getDesiredCapacity()))
+           .elem("DefaultCooldown", String.valueOf(asg.getDefaultCooldown()))
+           .elem("HealthCheckType", asg.getHealthCheckType())
+           .elem("HealthCheckGracePeriod", String.valueOf(asg.getHealthCheckGracePeriod()))
+           .elem("CreatedTime", ISO_FMT.format(asg.getCreatedTime()));
+
+        if (asg.getLaunchConfigurationName() != null) {
+            xml.elem("LaunchConfigurationName", asg.getLaunchConfigurationName());
+        }
+        if (asg.getLaunchTemplateName() != null) {
+            xml.start("LaunchTemplate")
+               .elem("LaunchTemplateName", asg.getLaunchTemplateName());
+            if (asg.getLaunchTemplateVersion() != null) {
+                xml.elem("Version", asg.getLaunchTemplateVersion());
+            }
+            xml.end("LaunchTemplate");
+        }
+
+        xml.start("AvailabilityZones");
+        for (String az : asg.getAvailabilityZones()) { xml.elem("member", az); }
+        xml.end("AvailabilityZones");
+
+        xml.start("TargetGroupARNs");
+        for (String arn : asg.getTargetGroupARNs()) { xml.elem("member", arn); }
+        xml.end("TargetGroupARNs");
+
+        xml.start("LoadBalancerNames");
+        for (String lb : asg.getLoadBalancerNames()) { xml.elem("member", lb); }
+        xml.end("LoadBalancerNames");
+
+        xml.start("TerminationPolicies");
+        for (String tp : asg.getTerminationPolicies()) { xml.elem("member", tp); }
+        xml.end("TerminationPolicies");
+
+        xml.start("Instances");
+        for (AsgInstance inst : asg.getInstances()) {
+            xml.start("member")
+               .elem("InstanceId", inst.getInstanceId())
+               .elem("AvailabilityZone", inst.getAvailabilityZone())
+               .elem("LifecycleState", inst.getLifecycleState())
+               .elem("HealthStatus", inst.getHealthStatus())
+               .elem("ProtectedFromScaleIn", String.valueOf(inst.isProtectedFromScaleIn()));
+            if (inst.getLaunchConfigurationName() != null) {
+                xml.elem("LaunchConfigurationName", inst.getLaunchConfigurationName());
+            }
+            if (inst.getInstanceType() != null) { xml.elem("InstanceType", inst.getInstanceType()); }
+            xml.end("member");
+        }
+        xml.end("Instances");
+
+        xml.start("Tags");
+        for (Map.Entry<String, String> tag : asg.getTags().entrySet()) {
+            xml.start("member")
+               .elem("Key", tag.getKey())
+               .elem("Value", tag.getValue())
+               .elem("ResourceId", asg.getAutoScalingGroupName())
+               .elem("ResourceType", "auto-scaling-group")
+               .elem("PropagateAtLaunch", "false")
+               .end("member");
+        }
+        xml.end("Tags");
+
+        if (asg.getStatus() != null) { xml.elem("Status", asg.getStatus()); }
+    }
+
+    private Response handleSetDesiredCapacity(MultivaluedMap<String, String> p, String region) {
+        service.setDesiredCapacity(region,
+                p.getFirst("AutoScalingGroupName"),
+                intParam(p, "DesiredCapacity", 0));
+        return ok(new XmlBuilder()
+                .start("SetDesiredCapacityResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("SetDesiredCapacityResponse").build());
+    }
+
+    // ── Instances ─────────────────────────────────────────────────────────────
+
+    private Response handleDescribeAutoScalingInstances(MultivaluedMap<String, String> p, String region) {
+        List<AsgInstance> instances = service.describeAutoScalingInstances(
+                region, memberList(p, "InstanceIds"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeAutoScalingInstancesResponse", NS)
+                  .start("DescribeAutoScalingInstancesResult")
+                    .start("AutoScalingInstances");
+        for (AsgInstance inst : instances) {
+            xml.start("member")
+               .elem("InstanceId", inst.getInstanceId())
+               .elem("AvailabilityZone", inst.getAvailabilityZone())
+               .elem("LifecycleState", inst.getLifecycleState())
+               .elem("HealthStatus", inst.getHealthStatus())
+               .elem("ProtectedFromScaleIn", String.valueOf(inst.isProtectedFromScaleIn()));
+            if (inst.getLaunchConfigurationName() != null) {
+                xml.elem("LaunchConfigurationName", inst.getLaunchConfigurationName());
+            }
+            if (inst.getInstanceType() != null) { xml.elem("InstanceType", inst.getInstanceType()); }
+            xml.end("member");
+        }
+        xml.end("AutoScalingInstances")
+           .end("DescribeAutoScalingInstancesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeAutoScalingInstancesResponse");
+        return ok(xml.build());
+    }
+
+    private Response handleAttachInstances(MultivaluedMap<String, String> p, String region) {
+        service.attachInstances(region, p.getFirst("AutoScalingGroupName"), memberList(p, "InstanceIds"));
+        return ok(new XmlBuilder()
+                .start("AttachInstancesResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("AttachInstancesResponse").build());
+    }
+
+    private Response handleDetachInstances(MultivaluedMap<String, String> p, String region) {
+        service.detachInstances(region, p.getFirst("AutoScalingGroupName"),
+                memberList(p, "InstanceIds"),
+                "true".equalsIgnoreCase(p.getFirst("ShouldDecrementDesiredCapacity")));
+        return ok(new XmlBuilder()
+                .start("DetachInstancesResponse", NS)
+                  .start("DetachInstancesResult")
+                    .start("Activities").end("Activities")
+                  .end("DetachInstancesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DetachInstancesResponse").build());
+    }
+
+    private Response handleTerminateInstance(MultivaluedMap<String, String> p, String region) {
+        service.terminateInstanceInAutoScalingGroup(region,
+                p.getFirst("InstanceId"),
+                "true".equalsIgnoreCase(p.getFirst("ShouldDecrementDesiredCapacity")));
+        return ok(new XmlBuilder()
+                .start("TerminateInstanceInAutoScalingGroupResponse", NS)
+                  .start("TerminateInstanceInAutoScalingGroupResult")
+                  .end("TerminateInstanceInAutoScalingGroupResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("TerminateInstanceInAutoScalingGroupResponse").build());
+    }
+
+    // ── Load balancer attachment ───────────────────────────────────────────────
+
+    private Response handleAttachLoadBalancerTargetGroups(MultivaluedMap<String, String> p, String region) {
+        service.attachLoadBalancerTargetGroups(region,
+                p.getFirst("AutoScalingGroupName"), memberList(p, "TargetGroupARNs"));
+        return ok(new XmlBuilder()
+                .start("AttachLoadBalancerTargetGroupsResponse", NS)
+                  .start("AttachLoadBalancerTargetGroupsResult").end("AttachLoadBalancerTargetGroupsResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("AttachLoadBalancerTargetGroupsResponse").build());
+    }
+
+    private Response handleDetachLoadBalancerTargetGroups(MultivaluedMap<String, String> p, String region) {
+        service.detachLoadBalancerTargetGroups(region,
+                p.getFirst("AutoScalingGroupName"), memberList(p, "TargetGroupARNs"));
+        return ok(new XmlBuilder()
+                .start("DetachLoadBalancerTargetGroupsResponse", NS)
+                  .start("DetachLoadBalancerTargetGroupsResult").end("DetachLoadBalancerTargetGroupsResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DetachLoadBalancerTargetGroupsResponse").build());
+    }
+
+    private Response handleDescribeLoadBalancerTargetGroups(MultivaluedMap<String, String> p, String region) {
+        List<String> tgArns = service.describeLoadBalancerTargetGroups(
+                region, p.getFirst("AutoScalingGroupName"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeLoadBalancerTargetGroupsResponse", NS)
+                  .start("DescribeLoadBalancerTargetGroupsResult")
+                    .start("LoadBalancerTargetGroups");
+        for (String arn : tgArns) {
+            xml.start("member")
+               .elem("LoadBalancerTargetGroupARN", arn)
+               .elem("State", "InService")
+               .end("member");
+        }
+        xml.end("LoadBalancerTargetGroups")
+           .end("DescribeLoadBalancerTargetGroupsResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeLoadBalancerTargetGroupsResponse");
+        return ok(xml.build());
+    }
+
+    private Response handleAttachLoadBalancers(MultivaluedMap<String, String> p, String region) {
+        service.attachLoadBalancers(region,
+                p.getFirst("AutoScalingGroupName"), memberList(p, "LoadBalancerNames"));
+        return ok(new XmlBuilder()
+                .start("AttachLoadBalancersResponse", NS)
+                  .start("AttachLoadBalancersResult").end("AttachLoadBalancersResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("AttachLoadBalancersResponse").build());
+    }
+
+    private Response handleDetachLoadBalancers(MultivaluedMap<String, String> p, String region) {
+        service.detachLoadBalancers(region,
+                p.getFirst("AutoScalingGroupName"), memberList(p, "LoadBalancerNames"));
+        return ok(new XmlBuilder()
+                .start("DetachLoadBalancersResponse", NS)
+                  .start("DetachLoadBalancersResult").end("DetachLoadBalancersResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DetachLoadBalancersResponse").build());
+    }
+
+    private Response handleDescribeLoadBalancers(MultivaluedMap<String, String> p, String region) {
+        String name = p.getFirst("AutoScalingGroupName");
+        List<String> lbNames = service.describeAutoScalingGroups(region, List.of(name))
+                .stream().findFirst().map(AutoScalingGroup::getLoadBalancerNames).orElse(List.of());
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeLoadBalancersResponse", NS)
+                  .start("DescribeLoadBalancersResult")
+                    .start("LoadBalancers");
+        for (String lb : lbNames) {
+            xml.start("member")
+               .elem("LoadBalancerName", lb)
+               .elem("State", "InService")
+               .end("member");
+        }
+        xml.end("LoadBalancers")
+           .end("DescribeLoadBalancersResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeLoadBalancersResponse");
+        return ok(xml.build());
+    }
+
+    // ── Lifecycle hooks ────────────────────────────────────────────────────────
+
+    private Response handlePutLifecycleHook(MultivaluedMap<String, String> p, String region) {
+        Integer timeout = p.getFirst("HeartbeatTimeout") != null
+                ? Integer.parseInt(p.getFirst("HeartbeatTimeout")) : null;
+        service.putLifecycleHook(region,
+                p.getFirst("AutoScalingGroupName"),
+                p.getFirst("LifecycleHookName"),
+                p.getFirst("LifecycleTransition"),
+                p.getFirst("NotificationTargetARN"),
+                p.getFirst("RoleARN"),
+                p.getFirst("NotificationMetadata"),
+                timeout,
+                p.getFirst("DefaultResult"));
+        return ok(new XmlBuilder()
+                .start("PutLifecycleHookResponse", NS)
+                  .start("PutLifecycleHookResult").end("PutLifecycleHookResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("PutLifecycleHookResponse").build());
+    }
+
+    private Response handleDeleteLifecycleHook(MultivaluedMap<String, String> p, String region) {
+        service.deleteLifecycleHook(region,
+                p.getFirst("AutoScalingGroupName"), p.getFirst("LifecycleHookName"));
+        return ok(new XmlBuilder()
+                .start("DeleteLifecycleHookResponse", NS)
+                  .start("DeleteLifecycleHookResult").end("DeleteLifecycleHookResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteLifecycleHookResponse").build());
+    }
+
+    private Response handleDescribeLifecycleHooks(MultivaluedMap<String, String> p, String region) {
+        List<LifecycleHook> hooks = service.describeLifecycleHooks(region,
+                p.getFirst("AutoScalingGroupName"), memberList(p, "LifecycleHookNames"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeLifecycleHooksResponse", NS)
+                  .start("DescribeLifecycleHooksResult")
+                    .start("LifecycleHooks");
+        for (LifecycleHook hook : hooks) {
+            xml.start("member")
+               .elem("LifecycleHookName", hook.getLifecycleHookName())
+               .elem("AutoScalingGroupName", hook.getAutoScalingGroupName())
+               .elem("LifecycleTransition", hook.getLifecycleTransition())
+               .elem("HeartbeatTimeout", String.valueOf(hook.getHeartbeatTimeout()))
+               .elem("GlobalTimeout", String.valueOf(hook.getGlobalTimeout()))
+               .elem("DefaultResult", hook.getDefaultResult());
+            if (hook.getNotificationTargetArn() != null) {
+                xml.elem("NotificationTargetARN", hook.getNotificationTargetArn());
+            }
+            if (hook.getRoleArn() != null) { xml.elem("RoleARN", hook.getRoleArn()); }
+            xml.end("member");
+        }
+        xml.end("LifecycleHooks")
+           .end("DescribeLifecycleHooksResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeLifecycleHooksResponse");
+        return ok(xml.build());
+    }
+
+    private Response handleCompleteLifecycleAction(MultivaluedMap<String, String> p, String region) {
+        service.completeLifecycleAction(region,
+                p.getFirst("AutoScalingGroupName"), p.getFirst("LifecycleHookName"),
+                p.getFirst("InstanceId"), p.getFirst("LifecycleActionResult"),
+                p.getFirst("LifecycleActionToken"));
+        return ok(new XmlBuilder()
+                .start("CompleteLifecycleActionResponse", NS)
+                  .start("CompleteLifecycleActionResult").end("CompleteLifecycleActionResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("CompleteLifecycleActionResponse").build());
+    }
+
+    private Response handleRecordLifecycleActionHeartbeat() {
+        return ok(new XmlBuilder()
+                .start("RecordLifecycleActionHeartbeatResponse", NS)
+                  .start("RecordLifecycleActionHeartbeatResult").end("RecordLifecycleActionHeartbeatResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("RecordLifecycleActionHeartbeatResponse").build());
+    }
+
+    // ── Scaling policies ───────────────────────────────────────────────────────
+
+    private Response handlePutScalingPolicy(MultivaluedMap<String, String> p, String region) {
+        ScalingPolicy policy = service.putScalingPolicy(region,
+                p.getFirst("AutoScalingGroupName"),
+                p.getFirst("PolicyName"),
+                p.getFirst("PolicyType"),
+                p.getFirst("AdjustmentType"),
+                intParam(p, "ScalingAdjustment", 0),
+                intParam(p, "Cooldown", 300));
+        return ok(new XmlBuilder()
+                .start("PutScalingPolicyResponse", NS)
+                  .start("PutScalingPolicyResult")
+                    .elem("PolicyARN", policy.getPolicyArn())
+                  .end("PutScalingPolicyResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("PutScalingPolicyResponse").build());
+    }
+
+    private Response handleDeletePolicy(MultivaluedMap<String, String> p, String region) {
+        service.deletePolicy(region,
+                p.getFirst("AutoScalingGroupName"), p.getFirst("PolicyName"));
+        return ok(new XmlBuilder()
+                .start("DeletePolicyResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeletePolicyResponse").build());
+    }
+
+    private Response handleDescribePolicies(MultivaluedMap<String, String> p, String region) {
+        List<ScalingPolicy> policies = service.describePolicies(
+                region, p.getFirst("AutoScalingGroupName"), memberList(p, "PolicyNames"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribePoliciesResponse", NS)
+                  .start("DescribePoliciesResult")
+                    .start("ScalingPolicies");
+        for (ScalingPolicy policy : policies) {
+            xml.start("member")
+               .elem("PolicyName", policy.getPolicyName())
+               .elem("PolicyARN", policy.getPolicyArn())
+               .elem("AutoScalingGroupName", policy.getAutoScalingGroupName())
+               .elem("PolicyType", policy.getPolicyType() != null ? policy.getPolicyType() : "SimpleScaling")
+               .elem("ScalingAdjustment", String.valueOf(policy.getScalingAdjustment()))
+               .elem("Cooldown", String.valueOf(policy.getCooldown()));
+            if (policy.getAdjustmentType() != null) { xml.elem("AdjustmentType", policy.getAdjustmentType()); }
+            xml.end("member");
+        }
+        xml.end("ScalingPolicies")
+           .end("DescribePoliciesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribePoliciesResponse");
+        return ok(xml.build());
+    }
+
+    // ── Activities ────────────────────────────────────────────────────────────
+
+    private Response handleDescribeScalingActivities(MultivaluedMap<String, String> p, String region) {
+        List<ScalingActivity> activities = service.describeScalingActivities(
+                region, p.getFirst("AutoScalingGroupName"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeScalingActivitiesResponse", NS)
+                  .start("DescribeScalingActivitiesResult")
+                    .start("Activities");
+        for (ScalingActivity a : activities) {
+            xml.start("member")
+               .elem("ActivityId", a.getActivityId())
+               .elem("AutoScalingGroupName", a.getAutoScalingGroupName())
+               .elem("StatusCode", a.getStatusCode())
+               .elem("Progress", String.valueOf(a.getProgress()))
+               .elem("StartTime", ISO_FMT.format(a.getStartTime()));
+            if (a.getDescription() != null) { xml.elem("Description", a.getDescription()); }
+            if (a.getCause() != null) { xml.elem("Cause", a.getCause()); }
+            if (a.getEndTime() != null) { xml.elem("EndTime", ISO_FMT.format(a.getEndTime())); }
+            if (a.getStatusMessage() != null) { xml.elem("StatusMessage", a.getStatusMessage()); }
+            xml.end("member");
+        }
+        xml.end("Activities")
+           .end("DescribeScalingActivitiesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeScalingActivitiesResponse");
+        return ok(xml.build());
+    }
+
+    // ── Metadata responses ────────────────────────────────────────────────────
+
+    private Response handleDescribeNotificationTypes() {
+        return ok(new XmlBuilder()
+                .start("DescribeAutoScalingNotificationTypesResponse", NS)
+                  .start("DescribeAutoScalingNotificationTypesResult")
+                    .start("AutoScalingNotificationTypes")
+                      .elem("member", "autoscaling:EC2_INSTANCE_LAUNCH")
+                      .elem("member", "autoscaling:EC2_INSTANCE_LAUNCH_ERROR")
+                      .elem("member", "autoscaling:EC2_INSTANCE_TERMINATE")
+                      .elem("member", "autoscaling:EC2_INSTANCE_TERMINATE_ERROR")
+                    .end("AutoScalingNotificationTypes")
+                  .end("DescribeAutoScalingNotificationTypesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeAutoScalingNotificationTypesResponse").build());
+    }
+
+    private Response handleDescribeTerminationPolicyTypes() {
+        return ok(new XmlBuilder()
+                .start("DescribeTerminationPolicyTypesResponse", NS)
+                  .start("DescribeTerminationPolicyTypesResult")
+                    .start("TerminationPolicyTypes")
+                      .elem("member", "Default")
+                      .elem("member", "OldestInstance")
+                      .elem("member", "NewestInstance")
+                      .elem("member", "OldestLaunchConfiguration")
+                      .elem("member", "ClosestToNextInstanceHour")
+                    .end("TerminationPolicyTypes")
+                  .end("DescribeTerminationPolicyTypesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeTerminationPolicyTypesResponse").build());
+    }
+
+    private Response handleDescribeAdjustmentTypes() {
+        return ok(new XmlBuilder()
+                .start("DescribeAdjustmentTypesResponse", NS)
+                  .start("DescribeAdjustmentTypesResult")
+                    .start("AdjustmentTypes")
+                      .elem("member", "ChangeInCapacity")
+                      .elem("member", "ExactCapacity")
+                      .elem("member", "PercentChangeInCapacity")
+                    .end("AdjustmentTypes")
+                  .end("DescribeAdjustmentTypesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeAdjustmentTypesResponse").build());
+    }
+
+    private Response handleDescribeAccountLimits() {
+        return ok(new XmlBuilder()
+                .start("DescribeAccountLimitsResponse", NS)
+                  .start("DescribeAccountLimitsResult")
+                    .elem("MaxNumberOfAutoScalingGroups", "200")
+                    .elem("MaxNumberOfLaunchConfigurations", "200")
+                    .elem("NumberOfAutoScalingGroups", "0")
+                    .elem("NumberOfLaunchConfigurations", "0")
+                  .end("DescribeAccountLimitsResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeAccountLimitsResponse").build());
+    }
+
+    private Response handleDescribeLifecycleHookTypes() {
+        return ok(new XmlBuilder()
+                .start("DescribeLifecycleHookTypesResponse", NS)
+                  .start("DescribeLifecycleHookTypesResult")
+                    .start("LifecycleHookTypes")
+                      .elem("member", "autoscaling:EC2_INSTANCE_LAUNCHING")
+                      .elem("member", "autoscaling:EC2_INSTANCE_TERMINATING")
+                    .end("LifecycleHookTypes")
+                  .end("DescribeLifecycleHookTypesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeLifecycleHookTypesResponse").build());
+    }
+
+    private Response handleDescribeMetricCollectionTypes() {
+        return ok(new XmlBuilder()
+                .start("DescribeMetricCollectionTypesResponse", NS)
+                  .start("DescribeMetricCollectionTypesResult")
+                    .start("Metrics")
+                      .elem("member", "GroupMinSize")
+                      .elem("member", "GroupMaxSize")
+                      .elem("member", "GroupDesiredCapacity")
+                      .elem("member", "GroupInServiceInstances")
+                      .elem("member", "GroupTotalInstances")
+                    .end("Metrics")
+                    .start("Granularities")
+                      .elem("member", "1Minute")
+                    .end("Granularities")
+                  .end("DescribeMetricCollectionTypesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeMetricCollectionTypesResponse").build());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private List<String> memberList(MultivaluedMap<String, String> p, String prefix) {
+        List<String> result = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String val = p.getFirst(prefix + ".member." + i);
+            if (val == null) { break; }
+            result.add(val);
+        }
+        return result;
+    }
+
+    private Map<String, String> parseTags(MultivaluedMap<String, String> p) {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (int i = 1; ; i++) {
+            String key = p.getFirst("Tags.member." + i + ".Key");
+            if (key == null) { break; }
+            String value = p.getFirst("Tags.member." + i + ".Value");
+            result.put(key, value != null ? value : "");
+        }
+        return result;
+    }
+
+    private int intParam(MultivaluedMap<String, String> p, String key, int defaultValue) {
+        String val = p.getFirst(key);
+        if (val == null || val.isBlank()) { return defaultValue; }
+        try { return Integer.parseInt(val); } catch (NumberFormatException e) { return defaultValue; }
+    }
+
+    private Response ok(String xml) {
+        return Response.ok(xml).type("application/xml").build();
+    }
+
+    private Response xmlError(String code, String message, int status) {
+        String xml = new XmlBuilder()
+                .start("ErrorResponse", NS)
+                  .start("Error")
+                    .elem("Type", "Sender")
+                    .elem("Code", code)
+                    .elem("Message", message)
+                  .end("Error")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("ErrorResponse")
+                .build();
+        return Response.status(status).entity(xml).type("application/xml").build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -1,0 +1,215 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
+import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
+import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
+import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class AutoScalingReconciler {
+
+    private static final Logger LOG = Logger.getLogger(AutoScalingReconciler.class);
+
+    private final AutoScalingService asgService;
+    private final Ec2Service ec2Service;
+    private final ElbV2Service elbV2Service;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            r -> new Thread(r, "asg-reconciler"));
+
+    @Inject
+    AutoScalingReconciler(AutoScalingService asgService, Ec2Service ec2Service,
+                          ElbV2Service elbV2Service) {
+        this.asgService = asgService;
+        this.ec2Service = ec2Service;
+        this.elbV2Service = elbV2Service;
+    }
+
+    @PostConstruct
+    void start() {
+        scheduler.scheduleAtFixedRate(this::reconcileAll, 5, 10, TimeUnit.SECONDS);
+    }
+
+    void reconcileAll() {
+        for (AutoScalingGroup asg : asgService.describeAutoScalingGroups(null, null)) {
+            try {
+                reconcile(asg);
+            } catch (Exception e) {
+                LOG.warnv("Reconcile failed for ASG {0}: {1}", asg.getAutoScalingGroupName(), e.getMessage());
+            }
+        }
+    }
+
+    public void reconcile(AutoScalingGroup asg) {
+        promoteReadyInstances(asg);
+
+        long inService = asg.getInstances().stream()
+                .filter(i -> "InService".equals(i.getLifecycleState()))
+                .count();
+        int desired = asg.getDesiredCapacity();
+
+        if (inService < desired) {
+            scaleOut(asg, (int) (desired - inService));
+        } else if (inService > desired) {
+            scaleIn(asg, (int) (inService - desired));
+        }
+    }
+
+    private void promoteReadyInstances(AutoScalingGroup asg) {
+        for (AsgInstance asgInst : asg.getInstances()) {
+            if (!"Pending".equals(asgInst.getLifecycleState())) {
+                continue;
+            }
+            try {
+                List<Instance> ec2Instances = ec2Service
+                        .describeInstances(asg.getRegion(), List.of(asgInst.getInstanceId()), null)
+                        .stream().flatMap(r -> r.getInstances().stream()).collect(Collectors.toList());
+                if (ec2Instances.isEmpty()) {
+                    continue;
+                }
+                String ec2State = ec2Instances.get(0).getState().getName();
+                if ("running".equals(ec2State)) {
+                    asgInst.setLifecycleState("InService");
+                    asgInst.setHealthStatus("Healthy");
+                    registerWithTargetGroups(asg, asgInst);
+                    asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
+                            "Launching a new EC2 instance: " + asgInst.getInstanceId(),
+                            "An instance was started in response to a desired capacity change.",
+                            "Successful");
+                    LOG.infov("ASG {0}: instance {1} is now InService",
+                            asg.getAutoScalingGroupName(), asgInst.getInstanceId());
+                }
+            } catch (Exception e) {
+                LOG.debugv("ASG {0}: could not promote instance {1}: {2}",
+                        asg.getAutoScalingGroupName(), asgInst.getInstanceId(), e.getMessage());
+            }
+        }
+    }
+
+    private void scaleOut(AutoScalingGroup asg, int count) {
+        LaunchConfiguration lc = resolveLaunchConfiguration(asg);
+        if (lc == null) {
+            LOG.warnv("ASG {0}: no launch configuration found, cannot scale out", asg.getAutoScalingGroupName());
+            return;
+        }
+        LOG.infov("ASG {0}: scaling out by {1}", asg.getAutoScalingGroupName(), count);
+        String az = asg.getAvailabilityZones().isEmpty()
+                ? asg.getRegion() + "a"
+                : asg.getAvailabilityZones().get(0);
+        try {
+            Reservation reservation = ec2Service.runInstances(
+                    asg.getRegion(),
+                    lc.getImageId(),
+                    lc.getInstanceType(),
+                    count, count,
+                    lc.getKeyName(),
+                    lc.getSecurityGroups(),
+                    null,
+                    null,
+                    null,
+                    lc.getUserData(),
+                    lc.getIamInstanceProfile());
+
+            for (Instance ec2Inst : reservation.getInstances()) {
+                AsgInstance asgInst = new AsgInstance();
+                asgInst.setInstanceId(ec2Inst.getInstanceId());
+                asgInst.setAvailabilityZone(az);
+                asgInst.setLifecycleState("Pending");
+                asgInst.setHealthStatus("Healthy");
+                asgInst.setLaunchConfigurationName(lc.getLaunchConfigurationName());
+                asgInst.setInstanceType(lc.getInstanceType());
+                asg.getInstances().add(asgInst);
+                LOG.infov("ASG {0}: launched instance {1} (Pending)",
+                        asg.getAutoScalingGroupName(), ec2Inst.getInstanceId());
+            }
+        } catch (Exception e) {
+            LOG.warnv("ASG {0}: failed to launch instances: {1}",
+                    asg.getAutoScalingGroupName(), e.getMessage());
+        }
+    }
+
+    private void scaleIn(AutoScalingGroup asg, int count) {
+        List<AsgInstance> candidates = asg.getInstances().stream()
+                .filter(i -> "InService".equals(i.getLifecycleState()))
+                .filter(i -> !i.isProtectedFromScaleIn())
+                .collect(Collectors.toList());
+
+        List<AsgInstance> toTerminate = candidates.subList(0, Math.min(count, candidates.size()));
+        if (toTerminate.isEmpty()) {
+            return;
+        }
+        LOG.infov("ASG {0}: scaling in {1} instance(s)", asg.getAutoScalingGroupName(), toTerminate.size());
+
+        List<String> instanceIds = toTerminate.stream()
+                .map(AsgInstance::getInstanceId)
+                .collect(Collectors.toList());
+
+        // Deregister from all attached target groups first
+        for (String tgArn : asg.getTargetGroupARNs()) {
+            try {
+                List<TargetDescription> targets = instanceIds.stream()
+                        .map(id -> { TargetDescription td = new TargetDescription(); td.setId(id); return td; })
+                        .collect(Collectors.toList());
+                elbV2Service.deregisterTargets(asg.getRegion(), tgArn, targets);
+            } catch (Exception e) {
+                LOG.debugv("ASG {0}: could not deregister from TG {1}: {2}",
+                        asg.getAutoScalingGroupName(), tgArn, e.getMessage());
+            }
+        }
+
+        try {
+            ec2Service.terminateInstances(asg.getRegion(), instanceIds);
+        } catch (Exception e) {
+            LOG.warnv("ASG {0}: failed to terminate instances {1}: {2}",
+                    asg.getAutoScalingGroupName(), instanceIds, e.getMessage());
+        }
+
+        asg.getInstances().removeIf(i -> instanceIds.contains(i.getInstanceId()));
+        asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
+                "Terminating EC2 instance(s): " + instanceIds,
+                "An instance was terminated in response to a desired capacity change.",
+                "Successful");
+    }
+
+    private void registerWithTargetGroups(AutoScalingGroup asg, AsgInstance asgInst) {
+        for (String tgArn : asg.getTargetGroupARNs()) {
+            try {
+                TargetDescription td = new TargetDescription();
+                td.setId(asgInst.getInstanceId());
+                elbV2Service.registerTargets(asg.getRegion(), tgArn, List.of(td));
+                LOG.debugv("ASG {0}: registered {1} with TG {2}",
+                        asg.getAutoScalingGroupName(), asgInst.getInstanceId(), tgArn);
+            } catch (Exception e) {
+                LOG.warnv("ASG {0}: could not register {1} with TG {2}: {3}",
+                        asg.getAutoScalingGroupName(), asgInst.getInstanceId(), tgArn, e.getMessage());
+            }
+        }
+    }
+
+    private LaunchConfiguration resolveLaunchConfiguration(AutoScalingGroup asg) {
+        String lcName = asg.getLaunchConfigurationName();
+        if (lcName == null || lcName.isBlank()) {
+            return null;
+        }
+        List<LaunchConfiguration> lcs = asgService.describeLaunchConfigurations(
+                asg.getRegion(), List.of(lcName));
+        return lcs.isEmpty() ? null : lcs.get(0);
+    }
+
+    // Override for describeAutoScalingGroups with null region (all regions)
+    // The service only filters by region when non-null; null means all.
+    // We add a bridge here to avoid changing the service signature.
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -1,0 +1,412 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.autoscaling.model.*;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class AutoScalingService {
+
+    private static final String DEFAULT_ACCOUNT = "000000000000";
+
+    // region :: name → resource
+    private final Map<String, LaunchConfiguration> launchConfigs = new ConcurrentHashMap<>();
+    private final Map<String, AutoScalingGroup>    groups         = new ConcurrentHashMap<>();
+    private final Map<String, LifecycleHook>       hooks          = new ConcurrentHashMap<>();
+    private final Map<String, ScalingPolicy>       policies       = new ConcurrentHashMap<>();
+    private final Map<String, ScalingActivity>     activities     = new ConcurrentHashMap<>();
+
+    // ── Launch Configurations ──────────────────────────────────────────────────
+
+    public LaunchConfiguration createLaunchConfiguration(String region, String name, String imageId,
+                                                          String instanceType, String keyName,
+                                                          List<String> securityGroups, String userData,
+                                                          String iamInstanceProfile,
+                                                          boolean associatePublicIpAddress) {
+        String key = lcKey(region, name);
+        if (launchConfigs.containsKey(key)) {
+            throw new AwsException("AlreadyExists",
+                    "Launch configuration '" + name + "' already exists.", 400);
+        }
+        LaunchConfiguration lc = new LaunchConfiguration();
+        lc.setLaunchConfigurationName(name);
+        lc.setLaunchConfigurationArn(
+                AwsArnUtils.Arn.of("autoscaling", region, DEFAULT_ACCOUNT,
+                        "launchConfiguration:" + name).toString());
+        lc.setImageId(imageId);
+        lc.setInstanceType(instanceType != null ? instanceType : "t3.micro");
+        lc.setKeyName(keyName);
+        lc.setSecurityGroups(securityGroups != null ? new ArrayList<>(securityGroups) : new ArrayList<>());
+        lc.setUserData(userData);
+        lc.setIamInstanceProfile(iamInstanceProfile);
+        lc.setAssociatePublicIpAddress(associatePublicIpAddress);
+        lc.setCreatedTime(Instant.now());
+        lc.setRegion(region);
+        launchConfigs.put(key, lc);
+        return lc;
+    }
+
+    public List<LaunchConfiguration> describeLaunchConfigurations(String region, List<String> names) {
+        if (names != null && !names.isEmpty()) {
+            return names.stream()
+                    .map(n -> launchConfigs.get(lcKey(region, n)))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+        return launchConfigs.values().stream()
+                .filter(lc -> region.equals(lc.getRegion()))
+                .collect(Collectors.toList());
+    }
+
+    public void deleteLaunchConfiguration(String region, String name) {
+        if (launchConfigs.remove(lcKey(region, name)) == null) {
+            throw new AwsException("ValidationError",
+                    "Launch configuration '" + name + "' not found.", 400);
+        }
+    }
+
+    // ── Auto Scaling Groups ────────────────────────────────────────────────────
+
+    public AutoScalingGroup createAutoScalingGroup(String region, String name,
+                                                    String launchConfigName,
+                                                    String launchTemplateName, String launchTemplateVersion,
+                                                    int minSize, int maxSize, int desiredCapacity,
+                                                    int defaultCooldown, List<String> availabilityZones,
+                                                    List<String> targetGroupArns, List<String> lbNames,
+                                                    String healthCheckType, int healthCheckGracePeriod,
+                                                    List<String> terminationPolicies,
+                                                    Map<String, String> tags) {
+        String key = asgKey(region, name);
+        if (groups.containsKey(key)) {
+            throw new AwsException("AlreadyExists",
+                    "Auto Scaling group '" + name + "' already exists.", 400);
+        }
+        if (launchConfigName == null && launchTemplateName == null) {
+            throw new AwsException("ValidationError",
+                    "Either LaunchConfigurationName or LaunchTemplate must be specified.", 400);
+        }
+
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setAutoScalingGroupName(name);
+        asg.setAutoScalingGroupArn(
+                AwsArnUtils.Arn.of("autoscaling", region, DEFAULT_ACCOUNT,
+                        "autoScalingGroup:" + name).toString());
+        asg.setLaunchConfigurationName(launchConfigName);
+        asg.setLaunchTemplateName(launchTemplateName);
+        asg.setLaunchTemplateVersion(launchTemplateVersion);
+        asg.setMinSize(minSize);
+        asg.setMaxSize(maxSize);
+        asg.setDesiredCapacity(desiredCapacity);
+        asg.setDefaultCooldown(defaultCooldown > 0 ? defaultCooldown : 300);
+        asg.setAvailabilityZones(availabilityZones != null ? new ArrayList<>(availabilityZones) : new ArrayList<>());
+        asg.setTargetGroupARNs(targetGroupArns != null ? new ArrayList<>(targetGroupArns) : new ArrayList<>());
+        asg.setLoadBalancerNames(lbNames != null ? new ArrayList<>(lbNames) : new ArrayList<>());
+        asg.setHealthCheckType(healthCheckType != null ? healthCheckType : "EC2");
+        asg.setHealthCheckGracePeriod(healthCheckGracePeriod);
+        asg.setTerminationPolicies(terminationPolicies != null ? new ArrayList<>(terminationPolicies) : List.of("Default"));
+        asg.setCreatedTime(Instant.now());
+        asg.setRegion(region);
+        if (tags != null) {
+            asg.getTags().putAll(tags);
+        }
+        groups.put(key, asg);
+        return asg;
+    }
+
+    public void updateAutoScalingGroup(String region, String name,
+                                        String launchConfigName,
+                                        String launchTemplateName, String launchTemplateVersion,
+                                        Integer minSize, Integer maxSize, Integer desiredCapacity,
+                                        Integer defaultCooldown, List<String> availabilityZones,
+                                        String healthCheckType, Integer healthCheckGracePeriod,
+                                        List<String> terminationPolicies) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        if (launchConfigName != null) {
+            asg.setLaunchConfigurationName(launchConfigName);
+        }
+        if (launchTemplateName != null) {
+            asg.setLaunchTemplateName(launchTemplateName);
+            asg.setLaunchTemplateVersion(launchTemplateVersion);
+        }
+        if (minSize != null) { asg.setMinSize(minSize); }
+        if (maxSize != null) { asg.setMaxSize(maxSize); }
+        if (desiredCapacity != null) { asg.setDesiredCapacity(desiredCapacity); }
+        if (defaultCooldown != null) { asg.setDefaultCooldown(defaultCooldown); }
+        if (availabilityZones != null) { asg.setAvailabilityZones(new ArrayList<>(availabilityZones)); }
+        if (healthCheckType != null) { asg.setHealthCheckType(healthCheckType); }
+        if (healthCheckGracePeriod != null) { asg.setHealthCheckGracePeriod(healthCheckGracePeriod); }
+        if (terminationPolicies != null) { asg.setTerminationPolicies(new ArrayList<>(terminationPolicies)); }
+    }
+
+    public void deleteAutoScalingGroup(String region, String name, boolean forceDelete) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        List<AsgInstance> active = asg.getInstances().stream()
+                .filter(i -> !"Terminated".equals(i.getLifecycleState()))
+                .collect(Collectors.toList());
+        if (!active.isEmpty() && !forceDelete) {
+            throw new AwsException("ResourceInUse",
+                    "Auto Scaling group '" + name + "' has " + active.size()
+                            + " instance(s). Set ForceDelete=true to delete anyway.", 400);
+        }
+        groups.remove(asgKey(region, name));
+        // clean up associated hooks and policies
+        hooks.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
+        policies.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
+    }
+
+    public List<AutoScalingGroup> describeAutoScalingGroups(String region, List<String> names) {
+        if (names != null && !names.isEmpty()) {
+            return names.stream()
+                    .map(n -> groups.get(asgKey(region, n)))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+        return groups.values().stream()
+                .filter(g -> region == null || region.equals(g.getRegion()))
+                .collect(Collectors.toList());
+    }
+
+    public void setDesiredCapacity(String region, String name, int desiredCapacity) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        if (desiredCapacity < asg.getMinSize() || desiredCapacity > asg.getMaxSize()) {
+            throw new AwsException("ValidationError",
+                    "New DesiredCapacity=" + desiredCapacity + " must be between MinSize="
+                            + asg.getMinSize() + " and MaxSize=" + asg.getMaxSize() + ".", 400);
+        }
+        asg.setDesiredCapacity(desiredCapacity);
+    }
+
+    // ── Instance management ────────────────────────────────────────────────────
+
+    public List<AsgInstance> describeAutoScalingInstances(String region, List<String> instanceIds) {
+        List<AsgInstance> all = groups.values().stream()
+                .filter(g -> region.equals(g.getRegion()))
+                .flatMap(g -> g.getInstances().stream())
+                .collect(Collectors.toList());
+        if (instanceIds != null && !instanceIds.isEmpty()) {
+            Set<String> ids = new HashSet<>(instanceIds);
+            return all.stream().filter(i -> ids.contains(i.getInstanceId())).collect(Collectors.toList());
+        }
+        return all;
+    }
+
+    public void attachInstances(String region, String name, List<String> instanceIds) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        for (String id : instanceIds) {
+            AsgInstance inst = new AsgInstance();
+            inst.setInstanceId(id);
+            inst.setLifecycleState("InService");
+            inst.setHealthStatus("Healthy");
+            inst.setAvailabilityZone(
+                    asg.getAvailabilityZones().isEmpty() ? region + "a" : asg.getAvailabilityZones().get(0));
+            inst.setLaunchConfigurationName(asg.getLaunchConfigurationName());
+            asg.getInstances().add(inst);
+        }
+        if (asg.getInstances().size() > asg.getDesiredCapacity()) {
+            asg.setDesiredCapacity(asg.getInstances().size());
+        }
+    }
+
+    public void detachInstances(String region, String name, List<String> instanceIds,
+                                 boolean decrementDesiredCapacity) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        asg.getInstances().removeIf(i -> instanceIds.contains(i.getInstanceId()));
+        if (decrementDesiredCapacity) {
+            int newDesired = Math.max(asg.getMinSize(), asg.getDesiredCapacity() - instanceIds.size());
+            asg.setDesiredCapacity(newDesired);
+        }
+    }
+
+    public void terminateInstanceInAutoScalingGroup(String region, String instanceId,
+                                                     boolean decrementDesiredCapacity) {
+        AutoScalingGroup asg = groups.values().stream()
+                .filter(g -> region.equals(g.getRegion()))
+                .filter(g -> g.getInstances().stream().anyMatch(i -> instanceId.equals(i.getInstanceId())))
+                .findFirst()
+                .orElseThrow(() -> new AwsException("ValidationError",
+                        "Instance '" + instanceId + "' not found in any Auto Scaling group.", 400));
+        asg.getInstances().stream()
+                .filter(i -> instanceId.equals(i.getInstanceId()))
+                .findFirst()
+                .ifPresent(i -> i.setLifecycleState("Terminating"));
+        if (decrementDesiredCapacity) {
+            int newDesired = Math.max(asg.getMinSize(), asg.getDesiredCapacity() - 1);
+            asg.setDesiredCapacity(newDesired);
+        }
+    }
+
+    // ── Load balancer attachment ───────────────────────────────────────────────
+
+    public void attachLoadBalancerTargetGroups(String region, String name, List<String> tgArns) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        for (String arn : tgArns) {
+            if (!asg.getTargetGroupARNs().contains(arn)) {
+                asg.getTargetGroupARNs().add(arn);
+            }
+        }
+    }
+
+    public void detachLoadBalancerTargetGroups(String region, String name, List<String> tgArns) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        asg.getTargetGroupARNs().removeAll(tgArns);
+    }
+
+    public List<String> describeLoadBalancerTargetGroups(String region, String name) {
+        return requireGroup(region, name).getTargetGroupARNs();
+    }
+
+    public void attachLoadBalancers(String region, String name, List<String> lbNames) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        for (String lb : lbNames) {
+            if (!asg.getLoadBalancerNames().contains(lb)) {
+                asg.getLoadBalancerNames().add(lb);
+            }
+        }
+    }
+
+    public void detachLoadBalancers(String region, String name, List<String> lbNames) {
+        requireGroup(region, name).getLoadBalancerNames().removeAll(lbNames);
+    }
+
+    // ── Lifecycle hooks ────────────────────────────────────────────────────────
+
+    public void putLifecycleHook(String region, String asgName, String hookName,
+                                  String transition, String notificationTargetArn,
+                                  String roleArn, String notificationMetadata,
+                                  Integer heartbeatTimeout, String defaultResult) {
+        requireGroup(region, asgName);
+        String key = hookKey(region, asgName, hookName);
+        LifecycleHook hook = hooks.computeIfAbsent(key, k -> new LifecycleHook());
+        hook.setLifecycleHookName(hookName);
+        hook.setAutoScalingGroupName(asgName);
+        hook.setLifecycleTransition(transition);
+        hook.setNotificationTargetArn(notificationTargetArn);
+        hook.setRoleArn(roleArn);
+        hook.setNotificationMetadata(notificationMetadata);
+        if (heartbeatTimeout != null) { hook.setHeartbeatTimeout(heartbeatTimeout); }
+        if (defaultResult != null) { hook.setDefaultResult(defaultResult); }
+    }
+
+    public void deleteLifecycleHook(String region, String asgName, String hookName) {
+        hooks.remove(hookKey(region, asgName, hookName));
+    }
+
+    public List<LifecycleHook> describeLifecycleHooks(String region, String asgName, List<String> hookNames) {
+        requireGroup(region, asgName);
+        List<LifecycleHook> result = hooks.values().stream()
+                .filter(h -> asgName.equals(h.getAutoScalingGroupName()))
+                .collect(Collectors.toList());
+        if (hookNames != null && !hookNames.isEmpty()) {
+            Set<String> names = new HashSet<>(hookNames);
+            result = result.stream().filter(h -> names.contains(h.getLifecycleHookName())).collect(Collectors.toList());
+        }
+        return result;
+    }
+
+    public void completeLifecycleAction(String region, String asgName, String hookName,
+                                         String instanceId, String actionResult, String token) {
+        // Stored-only — Phase 2 reconciler observes this via the instance lifecycle state
+        requireGroup(region, asgName);
+    }
+
+    // ── Scaling policies ───────────────────────────────────────────────────────
+
+    public ScalingPolicy putScalingPolicy(String region, String asgName, String policyName,
+                                           String policyType, String adjustmentType,
+                                           int scalingAdjustment, int cooldown) {
+        requireGroup(region, asgName);
+        String key = policyKey(region, asgName, policyName);
+        ScalingPolicy policy = policies.computeIfAbsent(key, k -> new ScalingPolicy());
+        policy.setPolicyName(policyName);
+        policy.setPolicyArn(AwsArnUtils.Arn.of("autoscaling", region, DEFAULT_ACCOUNT,
+                "scalingPolicy:" + asgName + ":" + policyName).toString());
+        policy.setAutoScalingGroupName(asgName);
+        policy.setPolicyType(policyType != null ? policyType : "SimpleScaling");
+        policy.setAdjustmentType(adjustmentType);
+        policy.setScalingAdjustment(scalingAdjustment);
+        policy.setCooldown(cooldown);
+        policy.setRegion(region);
+        return policy;
+    }
+
+    public void deletePolicy(String region, String asgName, String policyNameOrArn) {
+        policies.entrySet().removeIf(e -> {
+            ScalingPolicy p = e.getValue();
+            return p.getPolicyName().equals(policyNameOrArn) || p.getPolicyArn().equals(policyNameOrArn);
+        });
+    }
+
+    public List<ScalingPolicy> describePolicies(String region, String asgName, List<String> policyNames) {
+        return policies.values().stream()
+                .filter(p -> region.equals(p.getRegion()))
+                .filter(p -> asgName == null || asgName.equals(p.getAutoScalingGroupName()))
+                .filter(p -> policyNames == null || policyNames.isEmpty() || policyNames.contains(p.getPolicyName()))
+                .collect(Collectors.toList());
+    }
+
+    // ── Scaling activities ─────────────────────────────────────────────────────
+
+    public List<ScalingActivity> describeScalingActivities(String region, String asgName) {
+        return activities.values().stream()
+                .filter(a -> asgName == null || asgName.equals(a.getAutoScalingGroupName()))
+                .sorted(Comparator.comparing(ScalingActivity::getStartTime).reversed())
+                .collect(Collectors.toList());
+    }
+
+    public ScalingActivity recordActivity(String region, String asgName, String description,
+                                           String cause, String statusCode) {
+        ScalingActivity activity = new ScalingActivity();
+        activity.setActivityId(UUID.randomUUID().toString());
+        activity.setAutoScalingGroupName(asgName);
+        activity.setDescription(description);
+        activity.setCause(cause);
+        activity.setStartTime(Instant.now());
+        activity.setStatusCode(statusCode);
+        activity.setProgress("Successful".equals(statusCode) ? 100 : 0);
+        activities.put(activity.getActivityId(), activity);
+        return activity;
+    }
+
+    public void completeActivity(String activityId, String statusCode, String statusMessage) {
+        ScalingActivity activity = activities.get(activityId);
+        if (activity != null) {
+            activity.setEndTime(Instant.now());
+            activity.setStatusCode(statusCode);
+            activity.setStatusMessage(statusMessage);
+            activity.setProgress(100);
+        }
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────────────────
+
+    AutoScalingGroup requireGroup(String region, String name) {
+        AutoScalingGroup asg = groups.get(asgKey(region, name));
+        if (asg == null) {
+            throw new AwsException("ValidationError",
+                    "Auto Scaling group '" + name + "' not found.", 400);
+        }
+        return asg;
+    }
+
+    private static String lcKey(String region, String name) {
+        return region + "::" + name;
+    }
+
+    static String asgKey(String region, String name) {
+        return region + "::" + name;
+    }
+
+    private static String hookKey(String region, String asgName, String hookName) {
+        return region + "::" + asgName + "::" + hookName;
+    }
+
+    private static String policyKey(String region, String asgName, String policyName) {
+        return region + "::" + asgName + "::" + policyName;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AsgInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AsgInstance.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AsgInstance {
+
+    private String instanceId;
+    private String availabilityZone;
+    private String lifecycleState;   // Pending | InService | Terminating | Terminated | Detached
+    private String healthStatus;     // Healthy | Unhealthy
+    private String launchConfigurationName;
+    private String instanceType;
+    private boolean protectedFromScaleIn;
+
+    public AsgInstance() {}
+
+    public String getInstanceId() { return instanceId; }
+    public void setInstanceId(String v) { this.instanceId = v; }
+
+    public String getAvailabilityZone() { return availabilityZone; }
+    public void setAvailabilityZone(String v) { this.availabilityZone = v; }
+
+    public String getLifecycleState() { return lifecycleState; }
+    public void setLifecycleState(String v) { this.lifecycleState = v; }
+
+    public String getHealthStatus() { return healthStatus; }
+    public void setHealthStatus(String v) { this.healthStatus = v; }
+
+    public String getLaunchConfigurationName() { return launchConfigurationName; }
+    public void setLaunchConfigurationName(String v) { this.launchConfigurationName = v; }
+
+    public String getInstanceType() { return instanceType; }
+    public void setInstanceType(String v) { this.instanceType = v; }
+
+    public boolean isProtectedFromScaleIn() { return protectedFromScaleIn; }
+    public void setProtectedFromScaleIn(boolean v) { this.protectedFromScaleIn = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
@@ -1,0 +1,98 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AutoScalingGroup {
+
+    private String autoScalingGroupName;
+    private String autoScalingGroupArn;
+    private String launchConfigurationName;
+    private String launchTemplateName;
+    private String launchTemplateVersion;
+    private int minSize;
+    private int maxSize;
+    private int desiredCapacity;
+    private int defaultCooldown = 300;
+    private List<String> availabilityZones = new ArrayList<>();
+    private List<String> loadBalancerNames = new ArrayList<>();
+    private List<String> targetGroupARNs = new ArrayList<>();
+    private String healthCheckType = "EC2";
+    private int healthCheckGracePeriod = 0;
+    private List<AsgInstance> instances = new ArrayList<>();
+    private List<String> terminationPolicies = new ArrayList<>();
+    private Instant createdTime;
+    private String region;
+    private Map<String, String> tags = new ConcurrentHashMap<>();
+    private String status;  // null = active, "Delete in progress" = deleting
+
+    public AutoScalingGroup() {}
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public String getAutoScalingGroupArn() { return autoScalingGroupArn; }
+    public void setAutoScalingGroupArn(String v) { this.autoScalingGroupArn = v; }
+
+    public String getLaunchConfigurationName() { return launchConfigurationName; }
+    public void setLaunchConfigurationName(String v) { this.launchConfigurationName = v; }
+
+    public String getLaunchTemplateName() { return launchTemplateName; }
+    public void setLaunchTemplateName(String v) { this.launchTemplateName = v; }
+
+    public String getLaunchTemplateVersion() { return launchTemplateVersion; }
+    public void setLaunchTemplateVersion(String v) { this.launchTemplateVersion = v; }
+
+    public int getMinSize() { return minSize; }
+    public void setMinSize(int v) { this.minSize = v; }
+
+    public int getMaxSize() { return maxSize; }
+    public void setMaxSize(int v) { this.maxSize = v; }
+
+    public int getDesiredCapacity() { return desiredCapacity; }
+    public void setDesiredCapacity(int v) { this.desiredCapacity = v; }
+
+    public int getDefaultCooldown() { return defaultCooldown; }
+    public void setDefaultCooldown(int v) { this.defaultCooldown = v; }
+
+    public List<String> getAvailabilityZones() { return availabilityZones; }
+    public void setAvailabilityZones(List<String> v) { this.availabilityZones = v; }
+
+    public List<String> getLoadBalancerNames() { return loadBalancerNames; }
+    public void setLoadBalancerNames(List<String> v) { this.loadBalancerNames = v; }
+
+    public List<String> getTargetGroupARNs() { return targetGroupARNs; }
+    public void setTargetGroupARNs(List<String> v) { this.targetGroupARNs = v; }
+
+    public String getHealthCheckType() { return healthCheckType; }
+    public void setHealthCheckType(String v) { this.healthCheckType = v; }
+
+    public int getHealthCheckGracePeriod() { return healthCheckGracePeriod; }
+    public void setHealthCheckGracePeriod(int v) { this.healthCheckGracePeriod = v; }
+
+    public List<AsgInstance> getInstances() { return instances; }
+    public void setInstances(List<AsgInstance> v) { this.instances = v; }
+
+    public List<String> getTerminationPolicies() { return terminationPolicies; }
+    public void setTerminationPolicies(List<String> v) { this.terminationPolicies = v; }
+
+    public Instant getCreatedTime() { return createdTime; }
+    public void setCreatedTime(Instant v) { this.createdTime = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> v) { this.tags = v; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String v) { this.status = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfiguration.java
@@ -1,0 +1,60 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LaunchConfiguration {
+
+    private String launchConfigurationName;
+    private String launchConfigurationArn;
+    private String imageId;
+    private String instanceType;
+    private String keyName;
+    private List<String> securityGroups = new ArrayList<>();
+    private String userData;
+    private String iamInstanceProfile;
+    private boolean associatePublicIpAddress;
+    private Instant createdTime;
+    private String region;
+
+    public LaunchConfiguration() {}
+
+    public String getLaunchConfigurationName() { return launchConfigurationName; }
+    public void setLaunchConfigurationName(String v) { this.launchConfigurationName = v; }
+
+    public String getLaunchConfigurationArn() { return launchConfigurationArn; }
+    public void setLaunchConfigurationArn(String v) { this.launchConfigurationArn = v; }
+
+    public String getImageId() { return imageId; }
+    public void setImageId(String v) { this.imageId = v; }
+
+    public String getInstanceType() { return instanceType; }
+    public void setInstanceType(String v) { this.instanceType = v; }
+
+    public String getKeyName() { return keyName; }
+    public void setKeyName(String v) { this.keyName = v; }
+
+    public List<String> getSecurityGroups() { return securityGroups; }
+    public void setSecurityGroups(List<String> v) { this.securityGroups = v; }
+
+    public String getUserData() { return userData; }
+    public void setUserData(String v) { this.userData = v; }
+
+    public String getIamInstanceProfile() { return iamInstanceProfile; }
+    public void setIamInstanceProfile(String v) { this.iamInstanceProfile = v; }
+
+    public boolean isAssociatePublicIpAddress() { return associatePublicIpAddress; }
+    public void setAssociatePublicIpAddress(boolean v) { this.associatePublicIpAddress = v; }
+
+    public Instant getCreatedTime() { return createdTime; }
+    public void setCreatedTime(Instant v) { this.createdTime = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LifecycleHook.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LifecycleHook.java
@@ -1,0 +1,48 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LifecycleHook {
+
+    private String lifecycleHookName;
+    private String autoScalingGroupName;
+    private String lifecycleTransition;  // autoscaling:EC2_INSTANCE_LAUNCHING | autoscaling:EC2_INSTANCE_TERMINATING
+    private String notificationTargetArn;
+    private String roleArn;
+    private String notificationMetadata;
+    private int heartbeatTimeout = 3600;
+    private int globalTimeout = 172800;
+    private String defaultResult = "ABANDON";  // CONTINUE | ABANDON
+
+    public LifecycleHook() {}
+
+    public String getLifecycleHookName() { return lifecycleHookName; }
+    public void setLifecycleHookName(String v) { this.lifecycleHookName = v; }
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public String getLifecycleTransition() { return lifecycleTransition; }
+    public void setLifecycleTransition(String v) { this.lifecycleTransition = v; }
+
+    public String getNotificationTargetArn() { return notificationTargetArn; }
+    public void setNotificationTargetArn(String v) { this.notificationTargetArn = v; }
+
+    public String getRoleArn() { return roleArn; }
+    public void setRoleArn(String v) { this.roleArn = v; }
+
+    public String getNotificationMetadata() { return notificationMetadata; }
+    public void setNotificationMetadata(String v) { this.notificationMetadata = v; }
+
+    public int getHeartbeatTimeout() { return heartbeatTimeout; }
+    public void setHeartbeatTimeout(int v) { this.heartbeatTimeout = v; }
+
+    public int getGlobalTimeout() { return globalTimeout; }
+    public void setGlobalTimeout(int v) { this.globalTimeout = v; }
+
+    public String getDefaultResult() { return defaultResult; }
+    public void setDefaultResult(String v) { this.defaultResult = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingActivity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingActivity.java
@@ -1,0 +1,50 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScalingActivity {
+
+    private String activityId;
+    private String autoScalingGroupName;
+    private String description;
+    private String cause;
+    private Instant startTime;
+    private Instant endTime;
+    private String statusCode;  // InProgress | Successful | Failed | Cancelled
+    private String statusMessage;
+    private int progress;       // 0-100
+
+    public ScalingActivity() {}
+
+    public String getActivityId() { return activityId; }
+    public void setActivityId(String v) { this.activityId = v; }
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String v) { this.description = v; }
+
+    public String getCause() { return cause; }
+    public void setCause(String v) { this.cause = v; }
+
+    public Instant getStartTime() { return startTime; }
+    public void setStartTime(Instant v) { this.startTime = v; }
+
+    public Instant getEndTime() { return endTime; }
+    public void setEndTime(Instant v) { this.endTime = v; }
+
+    public String getStatusCode() { return statusCode; }
+    public void setStatusCode(String v) { this.statusCode = v; }
+
+    public String getStatusMessage() { return statusMessage; }
+    public void setStatusMessage(String v) { this.statusMessage = v; }
+
+    public int getProgress() { return progress; }
+    public void setProgress(int v) { this.progress = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingPolicy.java
@@ -1,0 +1,48 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScalingPolicy {
+
+    private String policyName;
+    private String policyArn;
+    private String autoScalingGroupName;
+    private String policyType;          // SimpleScaling | StepScaling | TargetTrackingScaling
+    private String adjustmentType;      // ChangeInCapacity | ExactCapacity | PercentChangeInCapacity
+    private int scalingAdjustment;
+    private int cooldown;
+    private String metricAggregationType;
+    private String region;
+
+    public ScalingPolicy() {}
+
+    public String getPolicyName() { return policyName; }
+    public void setPolicyName(String v) { this.policyName = v; }
+
+    public String getPolicyArn() { return policyArn; }
+    public void setPolicyArn(String v) { this.policyArn = v; }
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public String getPolicyType() { return policyType; }
+    public void setPolicyType(String v) { this.policyType = v; }
+
+    public String getAdjustmentType() { return adjustmentType; }
+    public void setAdjustmentType(String v) { this.adjustmentType = v; }
+
+    public int getScalingAdjustment() { return scalingAdjustment; }
+    public void setScalingAdjustment(int v) { this.scalingAdjustment = v; }
+
+    public int getCooldown() { return cooldown; }
+    public void setCooldown(int v) { this.cooldown = v; }
+
+    public String getMetricAggregationType() { return metricAggregationType; }
+    public void setMetricAggregationType(String v) { this.metricAggregationType = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -229,3 +229,5 @@ floci:
       # docker-network: floci-network
     codedeploy:
       enabled: true
+    autoscaling:
+      enabled: true

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
@@ -54,7 +54,8 @@ class HealthControllerIntegrationTest {
                 "pipes": "running",
                 "elasticloadbalancing": "running",
                 "codebuild": "running",
-                "codedeploy": "running"
+                "codedeploy": "running",
+                "autoscaling": "running"
               },
               "edition": "floci-always-free",
               "version": "dev"

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -1,0 +1,433 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AutoScalingIntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260501/us-east-1/autoscaling/aws4_request";
+
+    private static String policyArn;
+
+    // ── Launch Configurations ─────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void createLaunchConfiguration() {
+        given()
+                .formParam("Action", "CreateLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t3.micro")
+                .formParam("SecurityGroups.member.1", "sg-default")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateLaunchConfigurationResponse"));
+    }
+
+    @Test
+    @Order(2)
+    void describeLaunchConfigurations() {
+        given()
+                .formParam("Action", "DescribeLaunchConfigurations")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("my-lc"))
+                .body(containsString("ami-12345678"))
+                .body(containsString("t3.micro"));
+    }
+
+    // ── Auto Scaling Groups ───────────────────────────────────────────────────
+
+    @Test
+    @Order(3)
+    void createAutoScalingGroup() {
+        given()
+                .formParam("Action", "CreateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("LaunchConfigurationName", "my-lc")
+                .formParam("MinSize", "0")
+                .formParam("MaxSize", "3")
+                .formParam("DesiredCapacity", "0")
+                .formParam("AvailabilityZones.member.1", "us-east-1a")
+                .formParam("Tags.member.1.Key", "env")
+                .formParam("Tags.member.1.Value", "test")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateAutoScalingGroupResponse"));
+    }
+
+    @Test
+    @Order(4)
+    void describeAutoScalingGroups() {
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("my-asg"))
+                .body(containsString("my-lc"))
+                .body(containsString("us-east-1a"))
+                .body(containsString("<DesiredCapacity>0</DesiredCapacity>"))
+                .body(containsString("<MinSize>0</MinSize>"))
+                .body(containsString("<MaxSize>3</MaxSize>"))
+                .body(containsString("env"))
+                .body(containsString("test"));
+    }
+
+    @Test
+    @Order(5)
+    void setDesiredCapacity() {
+        given()
+                .formParam("Action", "SetDesiredCapacity")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("DesiredCapacity", "1")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("SetDesiredCapacityResponse"));
+    }
+
+    @Test
+    @Order(6)
+    void describeAutoScalingGroupsAfterSetDesired() {
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<DesiredCapacity>1</DesiredCapacity>"));
+    }
+
+    @Test
+    @Order(7)
+    void updateAutoScalingGroup() {
+        given()
+                .formParam("Action", "UpdateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("MaxSize", "5")
+                .formParam("DefaultCooldown", "180")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("UpdateAutoScalingGroupResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<MaxSize>5</MaxSize>"))
+                .body(containsString("<DefaultCooldown>180</DefaultCooldown>"));
+    }
+
+    // ── Target group attachment ───────────────────────────────────────────────
+
+    @Test
+    @Order(8)
+    void attachLoadBalancerTargetGroups() {
+        given()
+                .formParam("Action", "AttachLoadBalancerTargetGroups")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("TargetGroupARNs.member.1",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/abc123")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(9)
+    void describeLoadBalancerTargetGroups() {
+        given()
+                .formParam("Action", "DescribeLoadBalancerTargetGroups")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("my-tg"));
+    }
+
+    @Test
+    @Order(10)
+    void detachLoadBalancerTargetGroups() {
+        given()
+                .formParam("Action", "DetachLoadBalancerTargetGroups")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("TargetGroupARNs.member.1",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/my-tg/abc123")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeLoadBalancerTargetGroups")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("my-tg")));
+    }
+
+    // ── Lifecycle hooks ────────────────────────────────────────────────────────
+
+    @Test
+    @Order(11)
+    void putLifecycleHook() {
+        given()
+                .formParam("Action", "PutLifecycleHook")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("LifecycleHookName", "launch-hook")
+                .formParam("LifecycleTransition", "autoscaling:EC2_INSTANCE_LAUNCHING")
+                .formParam("DefaultResult", "CONTINUE")
+                .formParam("HeartbeatTimeout", "300")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(12)
+    void describeLifecycleHooks() {
+        given()
+                .formParam("Action", "DescribeLifecycleHooks")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("launch-hook"))
+                .body(containsString("autoscaling:EC2_INSTANCE_LAUNCHING"))
+                .body(containsString("CONTINUE"));
+    }
+
+    @Test
+    @Order(13)
+    void deleteLifecycleHook() {
+        given()
+                .formParam("Action", "DeleteLifecycleHook")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("LifecycleHookName", "launch-hook")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeLifecycleHooks")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("launch-hook")));
+    }
+
+    // ── Scaling policies ───────────────────────────────────────────────────────
+
+    @Test
+    @Order(14)
+    void putScalingPolicy() {
+        policyArn = given()
+                .formParam("Action", "PutScalingPolicy")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("PolicyName", "scale-out")
+                .formParam("PolicyType", "SimpleScaling")
+                .formParam("AdjustmentType", "ChangeInCapacity")
+                .formParam("ScalingAdjustment", "1")
+                .formParam("Cooldown", "60")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("PolicyARN"))
+                .extract().xmlPath().getString("PutScalingPolicyResponse.PutScalingPolicyResult.PolicyARN");
+    }
+
+    @Test
+    @Order(15)
+    void describePolicies() {
+        given()
+                .formParam("Action", "DescribePolicies")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("scale-out"))
+                .body(containsString("SimpleScaling"))
+                .body(containsString("ChangeInCapacity"));
+    }
+
+    @Test
+    @Order(16)
+    void deletePolicy() {
+        given()
+                .formParam("Action", "DeletePolicy")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("PolicyName", "scale-out")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DescribePolicies")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("scale-out")));
+    }
+
+    // ── Metadata ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(17)
+    void describeTerminationPolicyTypes() {
+        given()
+                .formParam("Action", "DescribeTerminationPolicyTypes")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("Default"))
+                .body(containsString("OldestInstance"));
+    }
+
+    @Test
+    @Order(18)
+    void describeAccountLimits() {
+        given()
+                .formParam("Action", "DescribeAccountLimits")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("MaxNumberOfAutoScalingGroups"));
+    }
+
+    @Test
+    @Order(19)
+    void describeLifecycleHookTypes() {
+        given()
+                .formParam("Action", "DescribeLifecycleHookTypes")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("autoscaling:EC2_INSTANCE_LAUNCHING"))
+                .body(containsString("autoscaling:EC2_INSTANCE_TERMINATING"));
+    }
+
+    @Test
+    @Order(20)
+    void describeScalingActivities() {
+        given()
+                .formParam("Action", "DescribeScalingActivities")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DescribeScalingActivitiesResponse"));
+    }
+
+    // ── Cleanup ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(21)
+    void deleteAutoScalingGroup() {
+        given()
+                .formParam("Action", "DeleteAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ForceDelete", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteAutoScalingGroupResponse"));
+    }
+
+    @Test
+    @Order(22)
+    void deleteLaunchConfiguration() {
+        given()
+                .formParam("Action", "DeleteLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteLaunchConfigurationResponse"));
+    }
+
+    @Test
+    @Order(23)
+    void describeAutoScalingGroupsEmpty() {
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("my-asg")));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -159,3 +159,5 @@ floci:
       # docker-network: floci-network
     codedeploy:
       enabled: true
+    autoscaling:
+      enabled: true


### PR DESCRIPTION
## Summary

  - **Phase 1 — Management API**: 30 operations covering launch configurations, ASG lifecycle (`CreateAutoScalingGroup`, `UpdateAutoScalingGroup`, `DeleteAutoScalingGroup`, `SetDesiredCapacity`), instance management, ELB v2 target group attachment, lifecycle hooks, and scaling policies. Query protocol (form-encoded POST, XML response) oncredential scope `autoscaling`.                                                                                                                                       
  - **Phase 2 — Capacity reconciler**: `AutoScalingReconciler` runs a 10s background loop per ASG. Scale-out calls `Ec2Service.runInstances()` using the ASG's launch configuration and registers new instances with all attached ELB v2 target groups. Scale-in deregisters from target groups first, then terminates instances via `Ec2Service`.
  - **Wiring**: `AwsNamespaces.AUTOSCALING`, `AutoScalingServiceConfig` in `EmulatorConfig`, descriptor in `ResolvedServiceCatalog`, routing key + action fallback set in `AwsQueryController`, `application.yml` (main + test).                                                                                                                 
                                                         
## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
