### PR TITLE
feat(apigatewayv2): WebSocket support and 27 new management-plane ops

### DIFF
--- a/compatibility-tests/sdk-test-java/README.md
+++ b/compatibility-tests/sdk-test-java/README.md
@@ -22,6 +22,7 @@ Runs 313 tests across 16 test classes against a live Floci instance — no mocks
 | `CloudWatchTest`                 | PutMetricData, ListMetrics, GetMetricStatistics, alarms  |
 | `CloudFormationVirtualHostTests` | Virtual host style S3 access via CloudFormation          |
 | `ApigwSfnJsonataCrudlTests`      | API Gateway + Step Functions JSONata CRUDL integration   |
+| `ApiGatewayV2WebSocketAndExtendedOpsTest` | API GW v2 WebSocket APIs, Update ops, Route/Integration Responses, Models, Tagging |
 | `Ec2Tests`                       | EC2 instances, VPCs, security groups, subnets            |
 | `EcsTests`                       | ECS clusters, task definitions, services                 |
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2WebSocketAndExtendedOpsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2WebSocketAndExtendedOpsTest.java
@@ -1,0 +1,530 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.services.apigatewayv2.ApiGatewayV2Client;
+import software.amazon.awssdk.services.apigatewayv2.model.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Compatibility tests for the new API Gateway v2 operations added in issue #526:
+ * WebSocket API support, Update operations, Route Responses, Integration Responses,
+ * Models, and Tagging — all exercised via the real AWS SDK v2 Java client.
+ */
+@DisplayName("API Gateway v2 — WebSocket & extended operations")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2WebSocketAndExtendedOpsTest {
+
+    private static ApiGatewayV2Client gw;
+
+    // ── shared resource IDs ──
+    private static String wsApiId;
+    private static String httpApiId;
+    private static String wsRouteId;
+    private static String integrationId;
+    private static String authorizerId;
+    private static String deploymentId;
+    private static String routeResponseId;
+    private static String integrationResponseId;
+    private static String modelId;
+
+    @BeforeAll
+    static void setup() {
+        gw = TestFixtures.apiGatewayV2Client();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (gw == null) return;
+        safeDelete(() -> gw.deleteApi(DeleteApiRequest.builder().apiId(wsApiId).build()));
+        safeDelete(() -> gw.deleteApi(DeleteApiRequest.builder().apiId(httpApiId).build()));
+        gw.close();
+    }
+
+    // ──────────────────────────── HTTP API defaults ────────────────────────────
+
+    @Test @Order(1)
+    @DisplayName("CreateApi (HTTP) populates AWS defaults")
+    void createHttpApiWithDefaults() {
+        var res = gw.createApi(CreateApiRequest.builder()
+                .name(TestFixtures.uniqueName("http-ext"))
+                .protocolType(ProtocolType.HTTP)
+                .build());
+        httpApiId = res.apiId();
+
+        assertThat(httpApiId).isNotBlank();
+        assertThat(res.protocolType()).isEqualTo(ProtocolType.HTTP);
+        assertThat(res.apiEndpoint()).contains("https://");
+        assertThat(res.routeSelectionExpression()).isEqualTo("${request.method} ${request.path}");
+        assertThat(res.apiKeySelectionExpression()).isEqualTo("$request.header.x-api-key");
+        assertThat(res.createdDate()).isNotNull();
+    }
+
+    @Test @Order(2)
+    @DisplayName("GetApi (HTTP) returns persisted defaults")
+    void getHttpApiVerifyDefaults() {
+        requireHttpApi();
+        var res = gw.getApi(GetApiRequest.builder().apiId(httpApiId).build());
+
+        assertThat(res.routeSelectionExpression()).isEqualTo("${request.method} ${request.path}");
+        assertThat(res.apiKeySelectionExpression()).isEqualTo("$request.header.x-api-key");
+    }
+
+    // ──────────────────────────── WebSocket API lifecycle ────────────────────────────
+
+    @Test @Order(10)
+    @DisplayName("CreateApi (WEBSOCKET) with routeSelectionExpression")
+    void createWebSocketApi() {
+        var res = gw.createApi(CreateApiRequest.builder()
+                .name(TestFixtures.uniqueName("ws-ext"))
+                .protocolType(ProtocolType.WEBSOCKET)
+                .routeSelectionExpression("$request.body.action")
+                .description("Java compat WS API")
+                .apiKeySelectionExpression("$request.header.x-api-key")
+                .build());
+        wsApiId = res.apiId();
+
+        assertThat(wsApiId).isNotBlank();
+        assertThat(res.protocolType()).isEqualTo(ProtocolType.WEBSOCKET);
+        assertThat(res.apiEndpoint()).contains("wss://");
+        assertThat(res.routeSelectionExpression()).isEqualTo("$request.body.action");
+        assertThat(res.description()).isEqualTo("Java compat WS API");
+    }
+
+    @Test @Order(11)
+    @DisplayName("CreateApi (WEBSOCKET) without routeSelectionExpression is rejected")
+    void createWebSocketApiMissingRse() {
+        assertThatThrownBy(() -> gw.createApi(CreateApiRequest.builder()
+                .name(TestFixtures.uniqueName("ws-no-rse"))
+                .protocolType(ProtocolType.WEBSOCKET)
+                .build()))
+                .isInstanceOf(ApiGatewayV2Exception.class);
+    }
+
+    @Test @Order(12)
+    @DisplayName("UpdateApi preserves unmodified fields")
+    void updateWebSocketApi() {
+        requireWsApi();
+        var res = gw.updateApi(UpdateApiRequest.builder()
+                .apiId(wsApiId)
+                .name("ws-updated-java")
+                .build());
+
+        assertThat(res.name()).isEqualTo("ws-updated-java");
+        assertThat(res.protocolType()).isEqualTo(ProtocolType.WEBSOCKET);
+        assertThat(res.routeSelectionExpression()).isEqualTo("$request.body.action");
+        assertThat(res.apiEndpoint()).contains("wss://");
+    }
+
+    @Test @Order(13)
+    @DisplayName("UpdateApi on non-existent API returns 404")
+    void updateApiNotFound() {
+        assertThatThrownBy(() -> gw.updateApi(UpdateApiRequest.builder()
+                .apiId("nonexistent999")
+                .name("ghost")
+                .build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ──────────────────────────── Routes with routeResponseSelectionExpression ────────────────────────────
+
+    @Test @Order(20)
+    @DisplayName("CreateRoute with routeResponseSelectionExpression")
+    void createRouteWithRrse() {
+        requireWsApi();
+        var res = gw.createRoute(CreateRouteRequest.builder()
+                .apiId(wsApiId)
+                .routeKey("$default")
+                .authorizationType("NONE")
+                .routeResponseSelectionExpression("$default")
+                .build());
+        wsRouteId = res.routeId();
+
+        assertThat(wsRouteId).isNotBlank();
+        assertThat(res.routeKey()).isEqualTo("$default");
+        assertThat(res.routeResponseSelectionExpression()).isEqualTo("$default");
+    }
+
+    @Test @Order(21)
+    @DisplayName("UpdateRoute preserves unmodified fields")
+    void updateRoute() {
+        requireWsApi(); requireWsRoute();
+        var res = gw.updateRoute(UpdateRouteRequest.builder()
+                .apiId(wsApiId)
+                .routeId(wsRouteId)
+                .target("integrations/fake-id")
+                .build());
+
+        assertThat(res.target()).isEqualTo("integrations/fake-id");
+        assertThat(res.routeKey()).isEqualTo("$default");
+        assertThat(res.routeResponseSelectionExpression()).isEqualTo("$default");
+    }
+
+    // ──────────────────────────── Integrations + Update ────────────────────────────
+
+    @Test @Order(30)
+    @DisplayName("CreateIntegration")
+    void createIntegration() {
+        requireWsApi();
+        var res = gw.createIntegration(CreateIntegrationRequest.builder()
+                .apiId(wsApiId)
+                .integrationType(IntegrationType.HTTP_PROXY)
+                .integrationUri("https://example.com")
+                .payloadFormatVersion("2.0")
+                .build());
+        integrationId = res.integrationId();
+
+        assertThat(integrationId).isNotBlank();
+    }
+
+    @Test @Order(31)
+    @DisplayName("UpdateIntegration preserves unmodified fields")
+    void updateIntegration() {
+        requireWsApi(); requireIntegration();
+        var res = gw.updateIntegration(UpdateIntegrationRequest.builder()
+                .apiId(wsApiId)
+                .integrationId(integrationId)
+                .integrationUri("https://updated.example.com")
+                .build());
+
+        assertThat(res.integrationUri()).isEqualTo("https://updated.example.com");
+        assertThat(res.integrationType()).isEqualTo(IntegrationType.HTTP_PROXY);
+        assertThat(res.payloadFormatVersion()).isEqualTo("2.0");
+    }
+
+    // ──────────────────────────── Authorizers + Update ────────────────────────────
+
+    @Test @Order(40)
+    @DisplayName("CreateAuthorizer (JWT) with string identitySource")
+    void createAuthorizer() {
+        requireWsApi();
+        var res = gw.createAuthorizer(CreateAuthorizerRequest.builder()
+                .apiId(wsApiId)
+                .name("jwt-ext-auth")
+                .authorizerType(AuthorizerType.JWT)
+                .identitySource("$request.header.Authorization")
+                .jwtConfiguration(j -> j.issuer("https://issuer.example.com").audience("aud-1"))
+                .build());
+        authorizerId = res.authorizerId();
+
+        assertThat(authorizerId).isNotBlank();
+        assertThat(res.authorizerType()).isEqualTo(AuthorizerType.JWT);
+        assertThat(res.identitySource()).containsExactly("$request.header.Authorization");
+    }
+
+    @Test @Order(41)
+    @DisplayName("UpdateAuthorizer preserves unmodified fields")
+    void updateAuthorizer() {
+        requireWsApi(); requireAuthorizer();
+        var res = gw.updateAuthorizer(UpdateAuthorizerRequest.builder()
+                .apiId(wsApiId)
+                .authorizerId(authorizerId)
+                .name("jwt-updated")
+                .build());
+
+        assertThat(res.name()).isEqualTo("jwt-updated");
+        assertThat(res.authorizerType()).isEqualTo(AuthorizerType.JWT);
+        assertThat(res.identitySource()).containsExactly("$request.header.Authorization");
+    }
+
+    // ──────────────────────────── Stages & Deployments + Update ────────────────────────────
+
+    @Test @Order(50)
+    @DisplayName("CreateDeployment")
+    void createDeployment() {
+        requireWsApi();
+        var res = gw.createDeployment(CreateDeploymentRequest.builder()
+                .apiId(wsApiId)
+                .description("ext-deploy")
+                .build());
+        deploymentId = res.deploymentId();
+
+        assertThat(deploymentId).isNotBlank();
+    }
+
+    @Test @Order(51)
+    @DisplayName("UpdateDeployment preserves unmodified fields")
+    void updateDeployment() {
+        requireWsApi(); requireDeployment();
+        var res = gw.updateDeployment(UpdateDeploymentRequest.builder()
+                .apiId(wsApiId)
+                .deploymentId(deploymentId)
+                .description("updated-deploy")
+                .build());
+
+        assertThat(res.description()).isEqualTo("updated-deploy");
+        assertThat(res.deploymentStatusAsString()).isEqualTo("DEPLOYED");
+    }
+
+    @Test @Order(52)
+    @DisplayName("CreateStage + UpdateStage preserves unmodified fields")
+    void createAndUpdateStage() {
+        requireWsApi(); requireDeployment();
+        gw.createStage(CreateStageRequest.builder()
+                .apiId(wsApiId)
+                .stageName("dev")
+                .deploymentId(deploymentId)
+                .autoDeploy(false)
+                .build());
+
+        var res = gw.updateStage(UpdateStageRequest.builder()
+                .apiId(wsApiId)
+                .stageName("dev")
+                .autoDeploy(true)
+                .build());
+
+        assertThat(res.autoDeploy()).isTrue();
+        assertThat(res.deploymentId()).isEqualTo(deploymentId);
+        assertThat(res.lastUpdatedDate()).isNotNull();
+    }
+
+    // ──────────────────────────── Route Responses ────────────────────────────
+
+    @Test @Order(60)
+    @DisplayName("Route Response full CRUD")
+    void routeResponseCrud() {
+        requireWsApi(); requireWsRoute();
+
+        // Create
+        var createRes = gw.createRouteResponse(CreateRouteResponseRequest.builder()
+                .apiId(wsApiId)
+                .routeId(wsRouteId)
+                .routeResponseKey("$default")
+                .modelSelectionExpression("$default")
+                .build());
+        routeResponseId = createRes.routeResponseId();
+        assertThat(routeResponseId).isNotBlank();
+        assertThat(createRes.routeResponseKey()).isEqualTo("$default");
+
+        // Get
+        var getRes = gw.getRouteResponse(GetRouteResponseRequest.builder()
+                .apiId(wsApiId).routeId(wsRouteId).routeResponseId(routeResponseId).build());
+        assertThat(getRes.routeResponseId()).isEqualTo(routeResponseId);
+
+        // List
+        var listRes = gw.getRouteResponses(GetRouteResponsesRequest.builder()
+                .apiId(wsApiId).routeId(wsRouteId).build());
+        assertThat(listRes.items()).extracting(RouteResponse::routeResponseId).contains(routeResponseId);
+
+        // Update
+        var updateRes = gw.updateRouteResponse(UpdateRouteResponseRequest.builder()
+                .apiId(wsApiId).routeId(wsRouteId).routeResponseId(routeResponseId)
+                .routeResponseKey("$updated")
+                .build());
+        assertThat(updateRes.routeResponseKey()).isEqualTo("$updated");
+
+        // Delete
+        gw.deleteRouteResponse(DeleteRouteResponseRequest.builder()
+                .apiId(wsApiId).routeId(wsRouteId).routeResponseId(routeResponseId).build());
+        assertThatThrownBy(() -> gw.getRouteResponse(GetRouteResponseRequest.builder()
+                .apiId(wsApiId).routeId(wsRouteId).routeResponseId(routeResponseId).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ──────────────────────────── Integration Responses ────────────────────────────
+
+    @Test @Order(70)
+    @DisplayName("Integration Response full CRUD")
+    void integrationResponseCrud() {
+        requireWsApi(); requireIntegration();
+
+        // Create
+        var createRes = gw.createIntegrationResponse(CreateIntegrationResponseRequest.builder()
+                .apiId(wsApiId)
+                .integrationId(integrationId)
+                .integrationResponseKey("$default")
+                .contentHandlingStrategy("CONVERT_TO_TEXT")
+                .build());
+        integrationResponseId = createRes.integrationResponseId();
+        assertThat(integrationResponseId).isNotBlank();
+        assertThat(createRes.contentHandlingStrategy()).hasToString("CONVERT_TO_TEXT");
+
+        // Get
+        var getRes = gw.getIntegrationResponse(GetIntegrationResponseRequest.builder()
+                .apiId(wsApiId).integrationId(integrationId)
+                .integrationResponseId(integrationResponseId).build());
+        assertThat(getRes.integrationResponseId()).isEqualTo(integrationResponseId);
+
+        // List
+        var listRes = gw.getIntegrationResponses(GetIntegrationResponsesRequest.builder()
+                .apiId(wsApiId).integrationId(integrationId).build());
+        assertThat(listRes.items()).extracting(IntegrationResponse::integrationResponseId)
+                .contains(integrationResponseId);
+
+        // Update
+        var updateRes = gw.updateIntegrationResponse(UpdateIntegrationResponseRequest.builder()
+                .apiId(wsApiId).integrationId(integrationId)
+                .integrationResponseId(integrationResponseId)
+                .contentHandlingStrategy("CONVERT_TO_BINARY")
+                .build());
+        assertThat(updateRes.contentHandlingStrategy()).hasToString("CONVERT_TO_BINARY");
+
+        // Delete
+        gw.deleteIntegrationResponse(DeleteIntegrationResponseRequest.builder()
+                .apiId(wsApiId).integrationId(integrationId)
+                .integrationResponseId(integrationResponseId).build());
+        assertThatThrownBy(() -> gw.getIntegrationResponse(GetIntegrationResponseRequest.builder()
+                .apiId(wsApiId).integrationId(integrationId)
+                .integrationResponseId(integrationResponseId).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ──────────────────────────── Models ────────────────────────────
+
+    @Test @Order(80)
+    @DisplayName("Model full CRUD with merge-patch")
+    void modelCrud() {
+        requireWsApi();
+
+        // Create
+        var createRes = gw.createModel(CreateModelRequest.builder()
+                .apiId(wsApiId)
+                .name("PetModel")
+                .schema("{\"type\":\"object\"}")
+                .contentType("application/json")
+                .description("A pet schema")
+                .build());
+        modelId = createRes.modelId();
+        assertThat(modelId).isNotBlank();
+        assertThat(createRes.name()).isEqualTo("PetModel");
+
+        // Get
+        var getRes = gw.getModel(GetModelRequest.builder()
+                .apiId(wsApiId).modelId(modelId).build());
+        assertThat(getRes.name()).isEqualTo("PetModel");
+        assertThat(getRes.contentType()).isEqualTo("application/json");
+
+        // List
+        var listRes = gw.getModels(GetModelsRequest.builder().apiId(wsApiId).build());
+        assertThat(listRes.items()).extracting(Model::modelId).contains(modelId);
+
+        // Update (merge-patch)
+        var updateRes = gw.updateModel(UpdateModelRequest.builder()
+                .apiId(wsApiId).modelId(modelId)
+                .description("updated description")
+                .build());
+        assertThat(updateRes.description()).isEqualTo("updated description");
+        assertThat(updateRes.name()).isEqualTo("PetModel");
+        assertThat(updateRes.contentType()).isEqualTo("application/json");
+
+        // Delete
+        gw.deleteModel(DeleteModelRequest.builder().apiId(wsApiId).modelId(modelId).build());
+        assertThatThrownBy(() -> gw.getModel(GetModelRequest.builder()
+                .apiId(wsApiId).modelId(modelId).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ──────────────────────────── Tagging ────────────────────────────
+
+    @Test @Order(90)
+    @DisplayName("Create API with tags, TagResource, UntagResource, GetTags")
+    void tagging() {
+        // Create API with initial tags
+        var createRes = gw.createApi(CreateApiRequest.builder()
+                .name(TestFixtures.uniqueName("tag-java"))
+                .protocolType(ProtocolType.HTTP)
+                .tags(Map.of("initial", "tag"))
+                .build());
+        String tagApiId = createRes.apiId();
+        String arn = "arn:aws:apigateway:us-east-1::/apis/" + tagApiId;
+
+        try {
+            // Verify tags on create
+            assertThat(createRes.tags()).containsEntry("initial", "tag");
+
+            // TagResource — add more tags
+            gw.tagResource(TagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tags(Map.of("env", "production", "team", "platform"))
+                    .build());
+
+            var tags = gw.getTags(GetTagsRequest.builder().resourceArn(arn).build()).tags();
+            assertThat(tags).containsEntry("initial", "tag");
+            assertThat(tags).containsEntry("env", "production");
+            assertThat(tags).containsEntry("team", "platform");
+
+            // UntagResource — remove specific keys
+            gw.untagResource(UntagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tagKeys("initial", "team")
+                    .build());
+
+            var tagsAfter = gw.getTags(GetTagsRequest.builder().resourceArn(arn).build()).tags();
+            assertThat(tagsAfter).containsEntry("env", "production");
+            assertThat(tagsAfter).doesNotContainKey("initial");
+            assertThat(tagsAfter).doesNotContainKey("team");
+
+        } finally {
+            safeDelete(() -> gw.deleteApi(DeleteApiRequest.builder().apiId(tagApiId).build()));
+        }
+    }
+
+    @Test @Order(91)
+    @DisplayName("GetTags on API with no tags returns empty map")
+    void getTagsEmpty() {
+        var createRes = gw.createApi(CreateApiRequest.builder()
+                .name(TestFixtures.uniqueName("notag-java"))
+                .protocolType(ProtocolType.HTTP)
+                .build());
+        String noTagApiId = createRes.apiId();
+        String arn = "arn:aws:apigateway:us-east-1::/apis/" + noTagApiId;
+
+        try {
+            var tags = gw.getTags(GetTagsRequest.builder().resourceArn(arn).build()).tags();
+            assertThat(tags).isEmpty();
+        } finally {
+            safeDelete(() -> gw.deleteApi(DeleteApiRequest.builder().apiId(noTagApiId).build()));
+        }
+    }
+
+    @Test @Order(92)
+    @DisplayName("TagResource on non-existent API returns 404")
+    void tagResourceNotFound() {
+        assertThatThrownBy(() -> gw.tagResource(TagResourceRequest.builder()
+                .resourceArn("arn:aws:apigateway:us-east-1::/apis/nonexistent999")
+                .tags(Map.of("k", "v"))
+                .build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private static void safeDelete(Runnable r) {
+        try { r.run(); } catch (Exception ignored) {}
+    }
+
+    private static void requireWsApi() {
+        Assumptions.assumeTrue(wsApiId != null, "WebSocket API must exist");
+    }
+
+    private static void requireHttpApi() {
+        Assumptions.assumeTrue(httpApiId != null, "HTTP API must exist");
+    }
+
+    private static void requireWsRoute() {
+        Assumptions.assumeTrue(wsRouteId != null, "WebSocket route must exist");
+    }
+
+    private static void requireIntegration() {
+        Assumptions.assumeTrue(integrationId != null, "Integration must exist");
+    }
+
+    private static void requireAuthorizer() {
+        Assumptions.assumeTrue(authorizerId != null, "Authorizer must exist");
+    }
+
+    private static void requireDeployment() {
+        Assumptions.assumeTrue(deploymentId != null, "Deployment must exist");
+    }
+}

--- a/compatibility-tests/sdk-test-node/README.md
+++ b/compatibility-tests/sdk-test-node/README.md
@@ -23,6 +23,7 @@ Compatibility tests for [Floci](https://github.com/hectorvent/floci) using the *
 | `cloudformation-naming` | Auto physical name generation, explicit name precedence, cross-reference                           |
 | `cognito`               | User pools, clients, AdminCreateUser, InitiateAuth, GetUser                                        |
 | `cognito-oauth`         | Resource server CRUD, confidential clients, `/oauth2/token`, OIDC discovery, JWKS/JWT verification |
+| `apigatewayv2`          | HTTP & WebSocket API lifecycle, routes, integrations, authorizers, stages, deployments, route responses, models, tagging |
 
 ## Requirements
 

--- a/compatibility-tests/sdk-test-node/package.json
+++ b/compatibility-tests/sdk-test-node/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-acm": "^3.500.0",
+    "@aws-sdk/client-apigatewayv2": "^3.500.0",
     "@aws-sdk/client-eventbridge": "^3.500.0",
     "@aws-sdk/client-cloudformation": "^3.500.0",
     "@aws-sdk/client-cloudwatch": "^3.500.0",

--- a/compatibility-tests/sdk-test-node/tests/apigatewayv2.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/apigatewayv2.test.ts
@@ -1,0 +1,627 @@
+/**
+ * API Gateway v2 (HTTP & WebSocket APIs) compatibility tests.
+ *
+ * Validates management-plane CRUD for APIs, Routes, Integrations, Authorizers,
+ * Stages, Deployments, Route Responses, Integration Responses, Models, and Tags
+ * using the AWS SDK v3 ApiGatewayV2Client — the same client real applications use.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  ApiGatewayV2Client,
+  CreateApiCommand,
+  GetApiCommand,
+  GetApisCommand,
+  UpdateApiCommand,
+  DeleteApiCommand,
+  CreateRouteCommand,
+  GetRouteCommand,
+  GetRoutesCommand,
+  UpdateRouteCommand,
+  DeleteRouteCommand,
+  CreateIntegrationCommand,
+  GetIntegrationCommand,
+  GetIntegrationsCommand,
+  UpdateIntegrationCommand,
+  DeleteIntegrationCommand,
+  CreateAuthorizerCommand,
+  GetAuthorizerCommand,
+  GetAuthorizersCommand,
+  UpdateAuthorizerCommand,
+  DeleteAuthorizerCommand,
+  CreateStageCommand,
+  GetStageCommand,
+  GetStagesCommand,
+  UpdateStageCommand,
+  DeleteStageCommand,
+  CreateDeploymentCommand,
+  GetDeploymentCommand,
+  GetDeploymentsCommand,
+  UpdateDeploymentCommand,
+  DeleteDeploymentCommand,
+  CreateRouteResponseCommand,
+  GetRouteResponseCommand,
+  GetRouteResponsesCommand,
+  UpdateRouteResponseCommand,
+  DeleteRouteResponseCommand,
+  CreateModelCommand,
+  GetModelCommand,
+  GetModelsCommand,
+  UpdateModelCommand,
+  DeleteModelCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+  GetTagsCommand,
+} from '@aws-sdk/client-apigatewayv2';
+import { makeClient, uniqueName, REGION, ACCOUNT } from './setup';
+
+describe('API Gateway v2', () => {
+  let gw: ApiGatewayV2Client;
+
+  beforeAll(() => {
+    gw = makeClient(ApiGatewayV2Client);
+  });
+
+  // ──────────────────────────── HTTP API lifecycle ────────────────────────────
+
+  describe('HTTP API lifecycle', () => {
+    let apiId: string;
+
+    afterAll(async () => {
+      try { if (apiId) await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create an HTTP API with correct defaults', async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('http-api'),
+        ProtocolType: 'HTTP',
+      }));
+      apiId = res.ApiId!;
+      expect(apiId).toBeTruthy();
+      expect(res.ProtocolType).toBe('HTTP');
+      expect(res.ApiEndpoint).toContain('https://');
+      expect(res.RouteSelectionExpression).toBe('${request.method} ${request.path}');
+      expect(res.ApiKeySelectionExpression).toBe('$request.header.x-api-key');
+    });
+
+    it('should get the API', async () => {
+      const res = await gw.send(new GetApiCommand({ ApiId: apiId }));
+      expect(res.ApiId).toBe(apiId);
+      expect(res.ProtocolType).toBe('HTTP');
+      expect(res.RouteSelectionExpression).toBe('${request.method} ${request.path}');
+      expect(res.ApiKeySelectionExpression).toBe('$request.header.x-api-key');
+    });
+
+    it('should list APIs including the created one', async () => {
+      const res = await gw.send(new GetApisCommand({}));
+      expect(res.Items!.some(a => a.ApiId === apiId)).toBe(true);
+    });
+
+    it('should update the API', async () => {
+      const res = await gw.send(new UpdateApiCommand({
+        ApiId: apiId,
+        Description: 'updated-description',
+      }));
+      expect(res.Description).toBe('updated-description');
+      expect(res.ProtocolType).toBe('HTTP');
+    });
+
+    it('should delete the API', async () => {
+      await gw.send(new DeleteApiCommand({ ApiId: apiId }));
+      await expect(gw.send(new GetApiCommand({ ApiId: apiId }))).rejects.toThrow();
+      apiId = '';
+    });
+  });
+
+  // ──────────────────────────── WebSocket API lifecycle ────────────────────────────
+
+  describe('WebSocket API lifecycle', () => {
+    let wsApiId: string;
+
+    afterAll(async () => {
+      try { if (wsApiId) await gw.send(new DeleteApiCommand({ ApiId: wsApiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a WebSocket API', async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('ws-api'),
+        ProtocolType: 'WEBSOCKET',
+        RouteSelectionExpression: '$request.body.action',
+        Description: 'WS compat test',
+        ApiKeySelectionExpression: '$request.header.x-api-key',
+      }));
+      wsApiId = res.ApiId!;
+      expect(wsApiId).toBeTruthy();
+      expect(res.ProtocolType).toBe('WEBSOCKET');
+      expect(res.ApiEndpoint).toContain('wss://');
+      expect(res.RouteSelectionExpression).toBe('$request.body.action');
+      expect(res.Description).toBe('WS compat test');
+    });
+
+    it('should reject WebSocket API without RouteSelectionExpression', async () => {
+      await expect(gw.send(new CreateApiCommand({
+        Name: uniqueName('ws-no-rse'),
+        ProtocolType: 'WEBSOCKET',
+      }))).rejects.toThrow();
+    });
+
+    it('should update a WebSocket API preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateApiCommand({
+        ApiId: wsApiId,
+        Name: 'ws-updated',
+      }));
+      expect(res.Name).toBe('ws-updated');
+      expect(res.ProtocolType).toBe('WEBSOCKET');
+      expect(res.RouteSelectionExpression).toBe('$request.body.action');
+      expect(res.ApiEndpoint).toContain('wss://');
+    });
+  });
+
+  // ──────────────────────────── Routes ────────────────────────────
+
+  describe('Routes', () => {
+    let apiId: string;
+    let routeId: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('route-test'),
+        ProtocolType: 'WEBSOCKET',
+        RouteSelectionExpression: '$request.body.action',
+      }));
+      apiId = res.ApiId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a route with routeResponseSelectionExpression', async () => {
+      const res = await gw.send(new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: '$default',
+        AuthorizationType: 'NONE',
+        RouteResponseSelectionExpression: '$default',
+      }));
+      routeId = res.RouteId!;
+      expect(routeId).toBeTruthy();
+      expect(res.RouteKey).toBe('$default');
+      expect(res.RouteResponseSelectionExpression).toBe('$default');
+    });
+
+    it('should get the route', async () => {
+      const res = await gw.send(new GetRouteCommand({ ApiId: apiId, RouteId: routeId }));
+      expect(res.RouteId).toBe(routeId);
+      expect(res.RouteResponseSelectionExpression).toBe('$default');
+    });
+
+    it('should list routes', async () => {
+      const res = await gw.send(new GetRoutesCommand({ ApiId: apiId }));
+      expect(res.Items!.some(r => r.RouteId === routeId)).toBe(true);
+    });
+
+    it('should update a route preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateRouteCommand({
+        ApiId: apiId,
+        RouteId: routeId,
+        Target: 'integrations/fake-id',
+      }));
+      expect(res.Target).toBe('integrations/fake-id');
+      expect(res.RouteKey).toBe('$default');
+      expect(res.RouteResponseSelectionExpression).toBe('$default');
+    });
+
+    it('should delete the route', async () => {
+      await gw.send(new DeleteRouteCommand({ ApiId: apiId, RouteId: routeId }));
+      await expect(gw.send(new GetRouteCommand({ ApiId: apiId, RouteId: routeId }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Integrations ────────────────────────────
+
+  describe('Integrations', () => {
+    let apiId: string;
+    let integrationId: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('integ-test'),
+        ProtocolType: 'HTTP',
+      }));
+      apiId = res.ApiId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create an integration', async () => {
+      const res = await gw.send(new CreateIntegrationCommand({
+        ApiId: apiId,
+        IntegrationType: 'HTTP_PROXY',
+        IntegrationUri: 'https://example.com',
+        PayloadFormatVersion: '2.0',
+      }));
+      integrationId = res.IntegrationId!;
+      expect(integrationId).toBeTruthy();
+      expect(res.IntegrationType).toBe('HTTP_PROXY');
+    });
+
+    it('should get the integration', async () => {
+      const res = await gw.send(new GetIntegrationCommand({ ApiId: apiId, IntegrationId: integrationId }));
+      expect(res.IntegrationId).toBe(integrationId);
+      expect(res.IntegrationUri).toBe('https://example.com');
+    });
+
+    it('should list integrations', async () => {
+      const res = await gw.send(new GetIntegrationsCommand({ ApiId: apiId }));
+      expect(res.Items!.some(i => i.IntegrationId === integrationId)).toBe(true);
+    });
+
+    it('should update an integration preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateIntegrationCommand({
+        ApiId: apiId,
+        IntegrationId: integrationId,
+        IntegrationUri: 'https://updated.example.com',
+      }));
+      expect(res.IntegrationUri).toBe('https://updated.example.com');
+      expect(res.IntegrationType).toBe('HTTP_PROXY');
+      expect(res.PayloadFormatVersion).toBe('2.0');
+    });
+
+    it('should delete the integration', async () => {
+      await gw.send(new DeleteIntegrationCommand({ ApiId: apiId, IntegrationId: integrationId }));
+      await expect(gw.send(new GetIntegrationCommand({ ApiId: apiId, IntegrationId: integrationId }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Authorizers ────────────────────────────
+
+  describe('Authorizers', () => {
+    let apiId: string;
+    let authorizerId: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('auth-test'),
+        ProtocolType: 'HTTP',
+      }));
+      apiId = res.ApiId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a JWT authorizer', async () => {
+      const res = await gw.send(new CreateAuthorizerCommand({
+        ApiId: apiId,
+        AuthorizerType: 'JWT',
+        Name: 'test-jwt-auth',
+        IdentitySource: '$request.header.Authorization',
+        JwtConfiguration: {
+          Issuer: 'https://issuer.example.com',
+          Audience: ['my-audience'],
+        },
+      }));
+      authorizerId = res.AuthorizerId!;
+      expect(authorizerId).toBeTruthy();
+      expect(res.Name).toBe('test-jwt-auth');
+    });
+
+    it('should get the authorizer', async () => {
+      const res = await gw.send(new GetAuthorizerCommand({ ApiId: apiId, AuthorizerId: authorizerId }));
+      expect(res.AuthorizerId).toBe(authorizerId);
+      expect(res.AuthorizerType).toBe('JWT');
+    });
+
+    it('should list authorizers', async () => {
+      const res = await gw.send(new GetAuthorizersCommand({ ApiId: apiId }));
+      expect(res.Items!.some(a => a.AuthorizerId === authorizerId)).toBe(true);
+    });
+
+    it('should update an authorizer preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateAuthorizerCommand({
+        ApiId: apiId,
+        AuthorizerId: authorizerId,
+        Name: 'updated-auth',
+      }));
+      expect(res.Name).toBe('updated-auth');
+      expect(res.AuthorizerType).toBe('JWT');
+    });
+
+    it('should delete the authorizer', async () => {
+      await gw.send(new DeleteAuthorizerCommand({ ApiId: apiId, AuthorizerId: authorizerId }));
+      await expect(gw.send(new GetAuthorizerCommand({ ApiId: apiId, AuthorizerId: authorizerId }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Stages & Deployments ────────────────────────────
+
+  describe('Stages & Deployments', () => {
+    let apiId: string;
+    let deploymentId: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('stage-test'),
+        ProtocolType: 'HTTP',
+      }));
+      apiId = res.ApiId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteStageCommand({ ApiId: apiId, StageName: 'dev' })); } catch { /* ignore */ }
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a deployment', async () => {
+      const res = await gw.send(new CreateDeploymentCommand({
+        ApiId: apiId,
+        Description: 'initial',
+      }));
+      deploymentId = res.DeploymentId!;
+      expect(deploymentId).toBeTruthy();
+    });
+
+    it('should get the deployment', async () => {
+      const res = await gw.send(new GetDeploymentCommand({ ApiId: apiId, DeploymentId: deploymentId }));
+      expect(res.DeploymentId).toBe(deploymentId);
+    });
+
+    it('should list deployments', async () => {
+      const res = await gw.send(new GetDeploymentsCommand({ ApiId: apiId }));
+      expect(res.Items!.some(d => d.DeploymentId === deploymentId)).toBe(true);
+    });
+
+    it('should update a deployment', async () => {
+      const res = await gw.send(new UpdateDeploymentCommand({
+        ApiId: apiId,
+        DeploymentId: deploymentId,
+        Description: 'updated',
+      }));
+      expect(res.Description).toBe('updated');
+    });
+
+    it('should create a stage', async () => {
+      const res = await gw.send(new CreateStageCommand({
+        ApiId: apiId,
+        StageName: 'dev',
+        DeploymentId: deploymentId,
+        AutoDeploy: false,
+      }));
+      expect(res.StageName).toBe('dev');
+      expect(res.DeploymentId).toBe(deploymentId);
+    });
+
+    it('should get the stage', async () => {
+      const res = await gw.send(new GetStageCommand({ ApiId: apiId, StageName: 'dev' }));
+      expect(res.StageName).toBe('dev');
+    });
+
+    it('should list stages', async () => {
+      const res = await gw.send(new GetStagesCommand({ ApiId: apiId }));
+      expect(res.Items!.some(s => s.StageName === 'dev')).toBe(true);
+    });
+
+    it('should update a stage preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateStageCommand({
+        ApiId: apiId,
+        StageName: 'dev',
+        AutoDeploy: true,
+      }));
+      expect(res.AutoDeploy).toBe(true);
+      expect(res.DeploymentId).toBe(deploymentId);
+    });
+
+    it('should delete the deployment', async () => {
+      await gw.send(new DeleteDeploymentCommand({ ApiId: apiId, DeploymentId: deploymentId }));
+      await expect(gw.send(new GetDeploymentCommand({ ApiId: apiId, DeploymentId: deploymentId }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Route Responses ────────────────────────────
+
+  describe('Route Responses', () => {
+    let apiId: string;
+    let routeId: string;
+    let routeResponseId: string;
+
+    beforeAll(async () => {
+      const api = await gw.send(new CreateApiCommand({
+        Name: uniqueName('rr-test'),
+        ProtocolType: 'WEBSOCKET',
+        RouteSelectionExpression: '$request.body.action',
+      }));
+      apiId = api.ApiId!;
+      const route = await gw.send(new CreateRouteCommand({
+        ApiId: apiId,
+        RouteKey: '$default',
+        RouteResponseSelectionExpression: '$default',
+      }));
+      routeId = route.RouteId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a route response', async () => {
+      const res = await gw.send(new CreateRouteResponseCommand({
+        ApiId: apiId,
+        RouteId: routeId,
+        RouteResponseKey: '$default',
+        ModelSelectionExpression: '$default',
+      }));
+      routeResponseId = res.RouteResponseId!;
+      expect(routeResponseId).toBeTruthy();
+      expect(res.RouteResponseKey).toBe('$default');
+    });
+
+    it('should get the route response', async () => {
+      const res = await gw.send(new GetRouteResponseCommand({
+        ApiId: apiId, RouteId: routeId, RouteResponseId: routeResponseId,
+      }));
+      expect(res.RouteResponseId).toBe(routeResponseId);
+      expect(res.RouteResponseKey).toBe('$default');
+    });
+
+    it('should list route responses', async () => {
+      const res = await gw.send(new GetRouteResponsesCommand({ ApiId: apiId, RouteId: routeId }));
+      expect(res.Items!.some(rr => rr.RouteResponseId === routeResponseId)).toBe(true);
+    });
+
+    it('should update a route response', async () => {
+      const res = await gw.send(new UpdateRouteResponseCommand({
+        ApiId: apiId,
+        RouteId: routeId,
+        RouteResponseId: routeResponseId,
+        RouteResponseKey: '$updated',
+      }));
+      expect(res.RouteResponseKey).toBe('$updated');
+    });
+
+    it('should delete the route response', async () => {
+      await gw.send(new DeleteRouteResponseCommand({
+        ApiId: apiId, RouteId: routeId, RouteResponseId: routeResponseId,
+      }));
+      await expect(gw.send(new GetRouteResponseCommand({
+        ApiId: apiId, RouteId: routeId, RouteResponseId: routeResponseId,
+      }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Models ────────────────────────────
+
+  describe('Models', () => {
+    let apiId: string;
+    let modelId: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('model-test'),
+        ProtocolType: 'HTTP',
+      }));
+      apiId = res.ApiId!;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create a model', async () => {
+      const res = await gw.send(new CreateModelCommand({
+        ApiId: apiId,
+        Name: 'PetModel',
+        Schema: '{"$schema":"http://json-schema.org/draft-04/schema#","title":"Pet","type":"object"}',
+        ContentType: 'application/json',
+        Description: 'A pet schema',
+      }));
+      modelId = res.ModelId!;
+      expect(modelId).toBeTruthy();
+      expect(res.Name).toBe('PetModel');
+    });
+
+    it('should get the model', async () => {
+      const res = await gw.send(new GetModelCommand({ ApiId: apiId, ModelId: modelId }));
+      expect(res.ModelId).toBe(modelId);
+      expect(res.Name).toBe('PetModel');
+      expect(res.ContentType).toBe('application/json');
+    });
+
+    it('should list models', async () => {
+      const res = await gw.send(new GetModelsCommand({ ApiId: apiId }));
+      expect(res.Items!.some(m => m.ModelId === modelId)).toBe(true);
+    });
+
+    it('should update a model preserving unmodified fields', async () => {
+      const res = await gw.send(new UpdateModelCommand({
+        ApiId: apiId,
+        ModelId: modelId,
+        Description: 'updated description',
+      }));
+      expect(res.Description).toBe('updated description');
+      expect(res.Name).toBe('PetModel');
+      expect(res.ContentType).toBe('application/json');
+    });
+
+    it('should delete the model', async () => {
+      await gw.send(new DeleteModelCommand({ ApiId: apiId, ModelId: modelId }));
+      await expect(gw.send(new GetModelCommand({ ApiId: apiId, ModelId: modelId }))).rejects.toThrow();
+    });
+  });
+
+  // ──────────────────────────── Tagging ────────────────────────────
+
+  describe('Tagging', () => {
+    let apiId: string;
+    let apiArn: string;
+
+    beforeAll(async () => {
+      const res = await gw.send(new CreateApiCommand({
+        Name: uniqueName('tag-test'),
+        ProtocolType: 'HTTP',
+        Tags: { initial: 'tag' },
+      }));
+      apiId = res.ApiId!;
+      apiArn = `arn:aws:apigateway:${REGION}::/apis/${apiId}`;
+    });
+
+    afterAll(async () => {
+      try { await gw.send(new DeleteApiCommand({ ApiId: apiId })); } catch { /* ignore */ }
+    });
+
+    it('should create API with tags', async () => {
+      const res = await gw.send(new GetApiCommand({ ApiId: apiId }));
+      expect(res.Tags?.initial).toBe('tag');
+    });
+
+    it('should add tags via TagResource', async () => {
+      await gw.send(new TagResourceCommand({
+        ResourceArn: apiArn,
+        Tags: { env: 'production', team: 'platform' },
+      }));
+      const res = await gw.send(new GetTagsCommand({ ResourceArn: apiArn }));
+      expect(res.Tags?.env).toBe('production');
+      expect(res.Tags?.team).toBe('platform');
+      expect(res.Tags?.initial).toBe('tag');
+    });
+
+    it('should remove tags via UntagResource', async () => {
+      await gw.send(new UntagResourceCommand({
+        ResourceArn: apiArn,
+        TagKeys: ['initial', 'team'],
+      }));
+      const res = await gw.send(new GetTagsCommand({ ResourceArn: apiArn }));
+      expect(res.Tags?.env).toBe('production');
+      expect(res.Tags?.initial).toBeUndefined();
+      expect(res.Tags?.team).toBeUndefined();
+    });
+
+    it('should return empty tags for untagged API', async () => {
+      const fresh = await gw.send(new CreateApiCommand({
+        Name: uniqueName('no-tags'),
+        ProtocolType: 'HTTP',
+      }));
+      const freshArn = `arn:aws:apigateway:${REGION}::/apis/${fresh.ApiId}`;
+      const res = await gw.send(new GetTagsCommand({ ResourceArn: freshArn }));
+      expect(Object.keys(res.Tags ?? {}).length).toBe(0);
+      await gw.send(new DeleteApiCommand({ ApiId: fresh.ApiId! }));
+    });
+  });
+
+  // ──────────────────────────── Not-found errors ────────────────────────────
+
+  describe('Not-found errors', () => {
+    it('should 404 on GetApi with non-existent ID', async () => {
+      await expect(gw.send(new GetApiCommand({ ApiId: 'nonexistent999' }))).rejects.toThrow();
+    });
+
+    it('should 404 on UpdateApi with non-existent ID', async () => {
+      await expect(gw.send(new UpdateApiCommand({
+        ApiId: 'nonexistent999',
+        Name: 'ghost',
+      }))).rejects.toThrow();
+    });
+  });
+});

--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -102,21 +102,34 @@ curl http://localhost:4566/restapis/$API_ID/dev/_user_request_/users
 
 ---
 
-## API Gateway v2 (HTTP APIs) {#v2}
+## API Gateway v2 (HTTP and WebSocket APIs) {#v2}
 
 **Protocol:** REST JSON
 **Endpoint:** `http://localhost:4566/v2/apis/...`
+
+Both HTTP and WebSocket protocol types are supported for the management plane. WebSocket data-plane (actual connection handling) is not yet implemented.
 
 ### Supported Operations
 
 | Category | Operations |
 |---|---|
-| **APIs** | CreateApi, GetApi, GetApis, DeleteApi |
-| **Routes** | CreateRoute, GetRoute, GetRoutes, DeleteRoute |
-| **Integrations** | CreateIntegration, GetIntegration, GetIntegrations |
-| **Authorizers** | CreateAuthorizer, GetAuthorizer, GetAuthorizers, DeleteAuthorizer |
-| **Stages** | CreateStage, GetStage, GetStages, DeleteStage |
-| **Deployments** | CreateDeployment, GetDeployments |
+| **APIs** | CreateApi, GetApi, GetApis, UpdateApi, DeleteApi |
+| **Routes** | CreateRoute, GetRoute, GetRoutes, UpdateRoute, DeleteRoute |
+| **Route Responses** | CreateRouteResponse, GetRouteResponse, GetRouteResponses, UpdateRouteResponse, DeleteRouteResponse |
+| **Integrations** | CreateIntegration, GetIntegration, GetIntegrations, UpdateIntegration, DeleteIntegration |
+| **Integration Responses** | CreateIntegrationResponse, GetIntegrationResponse, GetIntegrationResponses, UpdateIntegrationResponse, DeleteIntegrationResponse |
+| **Authorizers** | CreateAuthorizer, GetAuthorizer, GetAuthorizers, UpdateAuthorizer, DeleteAuthorizer |
+| **Stages** | CreateStage, GetStage, GetStages, UpdateStage, DeleteStage |
+| **Deployments** | CreateDeployment, GetDeployment, GetDeployments, UpdateDeployment, DeleteDeployment |
+| **Models** | CreateModel, GetModel, GetModels, UpdateModel, DeleteModel |
+| **Tags** | TagResource, UntagResource, GetTags |
+
+### Not Implemented
+
+- WebSocket data-plane: actual WebSocket connection handling, `@connections` management API
+- `ReimportApi`, `ExportApi`, `GetApiMapping`, `CreateApiMapping`, `DeleteApiMapping`
+- `GetDomainName`, `CreateDomainName`, `DeleteDomainName`
+- `CreateVpcLink`, `GetVpcLink`, `GetVpcLinks`, `UpdateVpcLink`, `DeleteVpcLink`
 
 ### Examples
 
@@ -151,5 +164,53 @@ aws apigatewayv2 create-stage \
   --api-id $API_ID \
   --stage-name dev \
   --auto-deploy \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
+#### WebSocket API
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+# Create a WebSocket API
+WS_API_ID=$(aws apigatewayv2 create-api \
+  --name "My WebSocket API" \
+  --protocol-type WEBSOCKET \
+  --route-selection-expression '$request.body.action' \
+  --query ApiId --output text \
+  --endpoint-url $AWS_ENDPOINT_URL)
+
+# Create a Lambda integration
+WS_INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+  --api-id $WS_API_ID \
+  --integration-type AWS_PROXY \
+  --integration-uri "arn:aws:lambda:us-east-1:000000000000:function:my-ws-handler" \
+  --query IntegrationId --output text \
+  --endpoint-url $AWS_ENDPOINT_URL)
+
+# Create $connect, $disconnect, and $default routes
+aws apigatewayv2 create-route \
+  --api-id $WS_API_ID \
+  --route-key '$connect' \
+  --target "integrations/$WS_INTEGRATION_ID" \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+aws apigatewayv2 create-route \
+  --api-id $WS_API_ID \
+  --route-key '$disconnect' \
+  --target "integrations/$WS_INTEGRATION_ID" \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+aws apigatewayv2 create-route \
+  --api-id $WS_API_ID \
+  --route-key '$default' \
+  --route-response-selection-expression '$default' \
+  --target "integrations/$WS_INTEGRATION_ID" \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Deploy
+aws apigatewayv2 create-stage \
+  --api-id $WS_API_ID \
+  --stage-name prod \
   --endpoint-url $AWS_ENDPOINT_URL
 ```

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -18,7 +18,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [DynamoDB Streams](dynamodb.md#streams) | `POST /` + `X-Amz-Target: DynamoDBStreams_20120810.*` | JSON 1.1 | 4 |
 | [Lambda](lambda.md) | `/2015-03-31/functions/...` | REST JSON | 30 |
 | [API Gateway v1](api-gateway.md) | `/restapis/...` | REST JSON | 62 |
-| [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 21 |
+| [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 48 |
 | [IAM](iam.md) | `POST /` with `Action=` param | Query | 68 |
 | [STS](sts.md) | `POST /` with `Action=` param | Query | 7 |
 | [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 43 |

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -11,7 +11,10 @@ import io.github.hectorvent.floci.services.apigatewayv2.model.Api;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Authorizer;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Deployment;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Integration;
+import io.github.hectorvent.floci.services.apigatewayv2.model.IntegrationResponse;
+import io.github.hectorvent.floci.services.apigatewayv2.model.Model;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Route;
+import io.github.hectorvent.floci.services.apigatewayv2.model.RouteResponse;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Stage;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -104,7 +107,7 @@ public class ApiGatewayController {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            IntegrationResponse ir = service.putIntegrationResponse(region, apiId, resourceId, httpMethod, statusCode, request);
+            io.github.hectorvent.floci.services.apigateway.model.IntegrationResponse ir = service.putIntegrationResponse(region, apiId, resourceId, httpMethod, statusCode, request);
             return Response.status(201).entity(toIntegrationResponseNode(ir).toString()).type(MediaType.APPLICATION_JSON).build();
         } catch (IOException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
@@ -830,6 +833,20 @@ public class ApiGatewayController {
         return Response.noContent().build();
     }
 
+    @PATCH
+    @Path("/v2/apis/{apiId}")
+    public Response updateApi(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Api updatedApi = v2Service.updateApi(region, apiId, request);
+            return Response.ok(toV2ApiNode(updatedApi).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
     @POST
     @Path("/v2/apis/{apiId}/routes")
     public Response createRoute(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
@@ -870,6 +887,23 @@ public class ApiGatewayController {
         return Response.noContent().build();
     }
 
+    @PATCH
+    @Path("/v2/apis/{apiId}/routes/{routeId}")
+    public Response updateRoute(@Context HttpHeaders headers,
+                                @PathParam("apiId") String apiId,
+                                @PathParam("routeId") String routeId,
+                                String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Route updatedRoute = v2Service.updateRoute(region, apiId, routeId, request);
+            return Response.ok(toV2RouteNode(updatedRoute).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
     @POST
     @Path("/v2/apis/{apiId}/integrations")
     public Response createIntegration(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
@@ -907,6 +941,168 @@ public class ApiGatewayController {
     public Response deleteIntegration(@Context HttpHeaders headers, @PathParam("apiId") String apiId, @PathParam("integrationId") String integrationId) {
         String region = regionResolver.resolveRegion(headers);
         v2Service.deleteIntegration(region, apiId, integrationId);
+        return Response.noContent().build();
+    }
+
+    @PATCH
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}")
+    public Response updateV2Integration(@Context HttpHeaders headers,
+                                        @PathParam("apiId") String apiId,
+                                        @PathParam("integrationId") String integrationId,
+                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Integration integration = v2Service.updateIntegration(region, apiId, integrationId, request);
+            return Response.ok(toV2IntegrationNode(integration).toString())
+                    .type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── Route Responses (v2) ────────────────────────────
+
+    @POST
+    @Path("/v2/apis/{apiId}/routes/{routeId}/routeresponses")
+    public Response createRouteResponse(@Context HttpHeaders headers,
+                                        @PathParam("apiId") String apiId,
+                                        @PathParam("routeId") String routeId,
+                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            RouteResponse rr = v2Service.createRouteResponse(region, apiId, routeId, request);
+            return Response.status(201).entity(toV2RouteResponseNode(rr).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}")
+    public Response getRouteResponse(@Context HttpHeaders headers,
+                                     @PathParam("apiId") String apiId,
+                                     @PathParam("routeId") String routeId,
+                                     @PathParam("routeResponseId") String routeResponseId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2RouteResponseNode(v2Service.getRouteResponse(region, apiId, routeId, routeResponseId)).toString())
+                .type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/routes/{routeId}/routeresponses")
+    public Response getRouteResponses(@Context HttpHeaders headers,
+                                      @PathParam("apiId") String apiId,
+                                      @PathParam("routeId") String routeId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<RouteResponse> routeResponses = v2Service.getRouteResponses(region, apiId, routeId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        routeResponses.forEach(rr -> items.add(toV2RouteResponseNode(rr)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @PATCH
+    @Path("/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}")
+    public Response updateRouteResponse(@Context HttpHeaders headers,
+                                        @PathParam("apiId") String apiId,
+                                        @PathParam("routeId") String routeId,
+                                        @PathParam("routeResponseId") String routeResponseId,
+                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            RouteResponse rr = v2Service.updateRouteResponse(region, apiId, routeId, routeResponseId, request);
+            return Response.ok(toV2RouteResponseNode(rr).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}")
+    public Response deleteRouteResponse(@Context HttpHeaders headers,
+                                        @PathParam("apiId") String apiId,
+                                        @PathParam("routeId") String routeId,
+                                        @PathParam("routeResponseId") String routeResponseId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteRouteResponse(region, apiId, routeId, routeResponseId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Integration Responses (v2) ────────────────────────────
+
+    @POST
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses")
+    public Response createIntegrationResponse(@Context HttpHeaders headers,
+                                              @PathParam("apiId") String apiId,
+                                              @PathParam("integrationId") String integrationId,
+                                              String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            IntegrationResponse ir = v2Service.createIntegrationResponse(region, apiId, integrationId, request);
+            return Response.status(201).entity(toV2IntegrationResponseNode(ir).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}")
+    public Response getIntegrationResponse(@Context HttpHeaders headers,
+                                           @PathParam("apiId") String apiId,
+                                           @PathParam("integrationId") String integrationId,
+                                           @PathParam("integrationResponseId") String integrationResponseId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2IntegrationResponseNode(v2Service.getIntegrationResponse(region, apiId, integrationId, integrationResponseId)).toString())
+                .type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses")
+    public Response getIntegrationResponses(@Context HttpHeaders headers,
+                                            @PathParam("apiId") String apiId,
+                                            @PathParam("integrationId") String integrationId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<IntegrationResponse> integrationResponses = v2Service.getIntegrationResponses(region, apiId, integrationId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        integrationResponses.forEach(ir -> items.add(toV2IntegrationResponseNode(ir)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @PATCH
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}")
+    public Response updateIntegrationResponse(@Context HttpHeaders headers,
+                                              @PathParam("apiId") String apiId,
+                                              @PathParam("integrationId") String integrationId,
+                                              @PathParam("integrationResponseId") String integrationResponseId,
+                                              String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            IntegrationResponse ir = v2Service.updateIntegrationResponse(region, apiId, integrationId, integrationResponseId, request);
+            return Response.ok(toV2IntegrationResponseNode(ir).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}")
+    public Response deleteIntegrationResponse(@Context HttpHeaders headers,
+                                              @PathParam("apiId") String apiId,
+                                              @PathParam("integrationId") String integrationId,
+                                              @PathParam("integrationResponseId") String integrationResponseId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteIntegrationResponse(region, apiId, integrationId, integrationResponseId);
         return Response.noContent().build();
     }
 
@@ -950,6 +1146,24 @@ public class ApiGatewayController {
         return Response.noContent().build();
     }
 
+    @PATCH
+    @Path("/v2/apis/{apiId}/authorizers/{authorizerId}")
+    public Response updateV2Authorizer(@Context HttpHeaders headers,
+                                       @PathParam("apiId") String apiId,
+                                       @PathParam("authorizerId") String authorizerId,
+                                       String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Authorizer authorizer = v2Service.updateAuthorizer(region, apiId, authorizerId, request);
+            return Response.ok(toV2AuthorizerNode(authorizer).toString())
+                    .type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
     @POST
     @Path("/v2/apis/{apiId}/stages")
     public Response createV2Stage(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
@@ -990,6 +1204,24 @@ public class ApiGatewayController {
         return Response.noContent().build();
     }
 
+    @PATCH
+    @Path("/v2/apis/{apiId}/stages/{stageName}")
+    public Response updateV2Stage(@Context HttpHeaders headers,
+                                  @PathParam("apiId") String apiId,
+                                  @PathParam("stageName") String stageName,
+                                  String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Stage stage = v2Service.updateStage(region, apiId, stageName, request);
+            return Response.ok(toV2StageNode(stage).toString())
+                    .type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
     @POST
     @Path("/v2/apis/{apiId}/deployments")
     public Response createV2Deployment(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
@@ -1028,6 +1260,127 @@ public class ApiGatewayController {
         String region = regionResolver.resolveRegion(headers);
         v2Service.deleteDeployment(region, apiId, deploymentId);
         return Response.noContent().build();
+    }
+
+    @PATCH
+    @Path("/v2/apis/{apiId}/deployments/{deploymentId}")
+    public Response updateV2Deployment(@Context HttpHeaders headers,
+                                       @PathParam("apiId") String apiId,
+                                       @PathParam("deploymentId") String deploymentId,
+                                       String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Deployment deployment = v2Service.updateDeployment(region, apiId, deploymentId, request);
+            return Response.ok(toV2DeploymentNode(deployment).toString())
+                    .type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── Models (v2) ────────────────────────────
+
+    @POST
+    @Path("/v2/apis/{apiId}/models")
+    public Response createV2Model(@Context HttpHeaders headers, @PathParam("apiId") String apiId, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Model model = v2Service.createModel(region, apiId, request);
+            return Response.status(201).entity(toV2ModelNode(model).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/models")
+    public Response getV2Models(@Context HttpHeaders headers, @PathParam("apiId") String apiId) {
+        String region = regionResolver.resolveRegion(headers);
+        List<Model> models = v2Service.getModels(region, apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("items");
+        models.forEach(m -> items.add(toV2ModelNode(m)));
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @GET
+    @Path("/v2/apis/{apiId}/models/{modelId}")
+    public Response getV2Model(@Context HttpHeaders headers,
+                               @PathParam("apiId") String apiId,
+                               @PathParam("modelId") String modelId) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(toV2ModelNode(v2Service.getModel(region, apiId, modelId)).toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    @PATCH
+    @Path("/v2/apis/{apiId}/models/{modelId}")
+    public Response updateV2Model(@Context HttpHeaders headers,
+                                  @PathParam("apiId") String apiId,
+                                  @PathParam("modelId") String modelId,
+                                  String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Model model = v2Service.updateModel(region, apiId, modelId, request);
+            return Response.ok(toV2ModelNode(model).toString()).type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/v2/apis/{apiId}/models/{modelId}")
+    public Response deleteV2Model(@Context HttpHeaders headers,
+                                  @PathParam("apiId") String apiId,
+                                  @PathParam("modelId") String modelId) {
+        String region = regionResolver.resolveRegion(headers);
+        v2Service.deleteModel(region, apiId, modelId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Tagging (v2) ────────────────────────────
+
+    @POST
+    @Path("/v2/tags/{resourceArn: .+}")
+    public Response tagResource(@Context HttpHeaders headers,
+                                @PathParam("resourceArn") String resourceArn,
+                                String body) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            @SuppressWarnings("unchecked")
+            Map<String, String> tags = (Map<String, String>) request.get("tags");
+            v2Service.tagResource(resourceArn, tags);
+            return Response.status(201).entity("{}").type(MediaType.APPLICATION_JSON).build();
+        } catch (IOException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/v2/tags/{resourceArn: .+}")
+    public Response untagResource(@Context HttpHeaders headers,
+                                  @PathParam("resourceArn") String resourceArn,
+                                  @QueryParam("tagKeys") List<String> tagKeys) {
+        v2Service.untagResource(resourceArn,
+                tagKeys != null ? tagKeys : java.util.Collections.emptyList());
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v2/tags/{resourceArn: .+}")
+    public Response getTagsForResource(@Context HttpHeaders headers,
+                                       @PathParam("resourceArn") String resourceArn) {
+        Map<String, String> tags = v2Service.getTags(resourceArn);
+        ObjectNode root = objectMapper.createObjectNode();
+        ObjectNode tagsNode = root.putObject("tags");
+        tags.forEach(tagsNode::put);
+        return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
     }
 
     // ──────────────────────────── Helpers ────────────────────────────
@@ -1087,7 +1440,7 @@ public class ApiGatewayController {
         return node;
     }
 
-    private ObjectNode toIntegrationResponseNode(IntegrationResponse r) {
+    private ObjectNode toIntegrationResponseNode(io.github.hectorvent.floci.services.apigateway.model.IntegrationResponse r) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("statusCode", r.statusCode());
         node.put("selectionPattern", r.selectionPattern());
@@ -1198,6 +1551,14 @@ public class ApiGatewayController {
         node.put("protocolType", api.getProtocolType());
         node.put("apiEndpoint", api.getApiEndpoint());
         node.put("createdDate", java.time.Instant.ofEpochMilli(api.getCreatedDate()).toString());
+        if (api.getRouteSelectionExpression() != null) node.put("routeSelectionExpression", api.getRouteSelectionExpression());
+        if (api.getDescription() != null) node.put("description", api.getDescription());
+        if (api.getApiKeySelectionExpression() != null) node.put("apiKeySelectionExpression", api.getApiKeySelectionExpression());
+        if (api.getTags() != null && !api.getTags().isEmpty()) {
+            ObjectNode tagsNode = objectMapper.createObjectNode();
+            api.getTags().forEach(tagsNode::put);
+            node.set("tags", tagsNode);
+        }
         return node;
     }
 
@@ -1207,6 +1568,7 @@ public class ApiGatewayController {
         node.put("routeKey", r.getRouteKey());
         node.put("authorizationType", r.getAuthorizationType());
         if (r.getTarget() != null) node.put("target", r.getTarget());
+        if (r.getRouteResponseSelectionExpression() != null) node.put("routeResponseSelectionExpression", r.getRouteResponseSelectionExpression());
         return node;
     }
 
@@ -1257,6 +1619,55 @@ public class ApiGatewayController {
                 jwt.put("issuer", a.getJwtConfiguration().issuer());
             }
         }
+        return node;
+    }
+
+    private ObjectNode toV2RouteResponseNode(RouteResponse rr) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("routeResponseId", rr.getRouteResponseId());
+        node.put("routeResponseKey", rr.getRouteResponseKey());
+        if (rr.getRouteId() != null) node.put("routeId", rr.getRouteId());
+        if (rr.getModelSelectionExpression() != null) node.put("modelSelectionExpression", rr.getModelSelectionExpression());
+        if (rr.getResponseModels() != null) {
+            ObjectNode models = objectMapper.createObjectNode();
+            rr.getResponseModels().forEach(models::put);
+            node.set("responseModels", models);
+        }
+        if (rr.getResponseParameters() != null) {
+            ObjectNode params = objectMapper.createObjectNode();
+            rr.getResponseParameters().forEach(params::put);
+            node.set("responseParameters", params);
+        }
+        return node;
+    }
+
+    private ObjectNode toV2IntegrationResponseNode(IntegrationResponse ir) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("integrationResponseId", ir.getIntegrationResponseId());
+        node.put("integrationResponseKey", ir.getIntegrationResponseKey());
+        if (ir.getIntegrationId() != null) node.put("integrationId", ir.getIntegrationId());
+        if (ir.getContentHandlingStrategy() != null) node.put("contentHandlingStrategy", ir.getContentHandlingStrategy());
+        if (ir.getTemplateSelectionExpression() != null) node.put("templateSelectionExpression", ir.getTemplateSelectionExpression());
+        if (ir.getResponseTemplates() != null) {
+            ObjectNode templates = objectMapper.createObjectNode();
+            ir.getResponseTemplates().forEach(templates::put);
+            node.set("responseTemplates", templates);
+        }
+        if (ir.getResponseParameters() != null) {
+            ObjectNode params = objectMapper.createObjectNode();
+            ir.getResponseParameters().forEach(params::put);
+            node.set("responseParameters", params);
+        }
+        return node;
+    }
+
+    private ObjectNode toV2ModelNode(Model m) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("modelId", m.getModelId());
+        node.put("name", m.getName());
+        if (m.getSchema() != null)      node.put("schema", m.getSchema());
+        if (m.getDescription() != null) node.put("description", m.getDescription());
+        if (m.getContentType() != null) node.put("contentType", m.getContentType());
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -33,27 +33,51 @@ public class ApiGatewayV2JsonHandler {
                 case "CreateApi" -> handleCreateApi(request, region);
                 case "GetApis" -> handleGetApis(region);
                 case "GetApi" -> handleGetApi(request, region);
+                case "UpdateApi" -> handleUpdateApi(request, region);
                 case "DeleteApi" -> handleDeleteApi(request, region);
                 case "CreateRoute" -> handleCreateRoute(request, region);
                 case "GetRoute" -> handleGetRoute(request, region);
                 case "GetRoutes" -> handleGetRoutes(request, region);
+                case "UpdateRoute" -> handleUpdateRoute(request, region);
                 case "DeleteRoute" -> handleDeleteRoute(request, region);
                 case "CreateIntegration" -> handleCreateIntegration(request, region);
                 case "GetIntegration" -> handleGetIntegration(request, region);
                 case "GetIntegrations" -> handleGetIntegrations(request, region);
+                case "UpdateIntegration" -> handleUpdateIntegration(request, region);
                 case "CreateAuthorizer" -> handleCreateAuthorizer(request, region);
                 case "GetAuthorizer" -> handleGetAuthorizer(request, region);
                 case "GetAuthorizers" -> handleGetAuthorizers(request, region);
                 case "DeleteAuthorizer" -> handleDeleteAuthorizer(request, region);
+                case "UpdateAuthorizer" -> handleUpdateAuthorizer(request, region);
                 case "CreateStage" -> handleCreateStage(request, region);
                 case "GetStage" -> handleGetStage(request, region);
                 case "GetStages" -> handleGetStages(request, region);
                 case "DeleteStage" -> handleDeleteStage(request, region);
+                case "UpdateStage" -> handleUpdateStage(request, region);
                 case "CreateDeployment" -> handleCreateDeployment(request, region);
                 case "GetDeployment" -> handleGetDeployment(request, region);
                 case "GetDeployments" -> handleGetDeployments(request, region);
                 case "DeleteDeployment" -> handleDeleteDeployment(request, region);
+                case "UpdateDeployment" -> handleUpdateDeployment(request, region);
                 case "DeleteIntegration" -> handleDeleteIntegration(request, region);
+                case "CreateRouteResponse" -> handleCreateRouteResponse(request, region);
+                case "GetRouteResponse" -> handleGetRouteResponse(request, region);
+                case "GetRouteResponses" -> handleGetRouteResponses(request, region);
+                case "UpdateRouteResponse" -> handleUpdateRouteResponse(request, region);
+                case "DeleteRouteResponse" -> handleDeleteRouteResponse(request, region);
+                case "CreateIntegrationResponse" -> handleCreateIntegrationResponse(request, region);
+                case "GetIntegrationResponse" -> handleGetIntegrationResponse(request, region);
+                case "GetIntegrationResponses" -> handleGetIntegrationResponses(request, region);
+                case "UpdateIntegrationResponse" -> handleUpdateIntegrationResponse(request, region);
+                case "DeleteIntegrationResponse" -> handleDeleteIntegrationResponse(request, region);
+                case "CreateModel" -> handleCreateModel(request, region);
+                case "GetModel" -> handleGetModel(request, region);
+                case "GetModels" -> handleGetModels(request, region);
+                case "UpdateModel" -> handleUpdateModel(request, region);
+                case "DeleteModel" -> handleDeleteModel(request, region);
+                case "TagResource" -> handleTagResource(request, region);
+                case "UntagResource" -> handleUntagResource(request, region);
+                case "GetTags" -> handleGetTags(request, region);
                 default -> JsonErrorResponseUtils.createUnknownOperationErrorResponse(action);
             };
         } catch (AwsException e) {
@@ -89,6 +113,14 @@ public class ApiGatewayV2JsonHandler {
         return Response.noContent().build();
     }
 
+    private Response handleUpdateApi(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Api api = service.updateApi(region, apiId, map);
+        return Response.ok(toApiNode(api).toString()).build();
+    }
+
     // ──────────────────────────── Authorizer ────────────────────────────
 
     private Response handleCreateAuthorizer(JsonNode request, String region) {
@@ -119,6 +151,15 @@ public class ApiGatewayV2JsonHandler {
         String authorizerId = request.path("AuthorizerId").asText();
         service.deleteAuthorizer(region, apiId, authorizerId);
         return Response.noContent().build();
+    }
+
+    private Response handleUpdateAuthorizer(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String authorizerId = request.path("AuthorizerId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Authorizer auth = service.updateAuthorizer(region, apiId, authorizerId, map);
+        return Response.ok(toAuthorizerNode(auth).toString()).build();
     }
 
     // ──────────────────────────── Route ────────────────────────────
@@ -153,6 +194,15 @@ public class ApiGatewayV2JsonHandler {
         return Response.noContent().build();
     }
 
+    private Response handleUpdateRoute(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Route route = service.updateRoute(region, apiId, routeId, map);
+        return Response.ok(toRouteNode(route).toString()).build();
+    }
+
     // ──────────────────────────── Integration ────────────────────────────
 
     private Response handleCreateIntegration(JsonNode request, String region) {
@@ -176,6 +226,15 @@ public class ApiGatewayV2JsonHandler {
         ArrayNode items = root.putArray("Items");
         integrations.forEach(i -> items.add(toIntegrationNode(i)));
         return Response.ok(root.toString()).build();
+    }
+
+    private Response handleUpdateIntegration(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Integration integration = service.updateIntegration(region, apiId, integrationId, map);
+        return Response.ok(toIntegrationNode(integration).toString()).build();
     }
 
     // ──────────────────────────── Stage ────────────────────────────
@@ -210,6 +269,15 @@ public class ApiGatewayV2JsonHandler {
         return Response.noContent().build();
     }
 
+    private Response handleUpdateStage(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String stageName = request.path("StageName").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Stage stage = service.updateStage(region, apiId, stageName, map);
+        return Response.ok(toStageNode(stage).toString()).build();
+    }
+
     // ──────────────────────────── Deployment ────────────────────────────
 
     private Response handleCreateDeployment(JsonNode request, String region) {
@@ -242,11 +310,180 @@ public class ApiGatewayV2JsonHandler {
         return Response.noContent().build();
     }
 
+    private Response handleUpdateDeployment(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String deploymentId = request.path("DeploymentId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Deployment deployment = service.updateDeployment(region, apiId, deploymentId, map);
+        return Response.ok(toDeploymentNode(deployment).toString()).build();
+    }
+
     private Response handleDeleteIntegration(JsonNode request, String region) {
         String apiId = request.path("ApiId").asText();
         String integrationId = request.path("IntegrationId").asText();
         service.deleteIntegration(region, apiId, integrationId);
         return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Route Response ────────────────────────────
+
+    private Response handleCreateRouteResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        RouteResponse rr = service.createRouteResponse(region, apiId, routeId, map);
+        return Response.status(201).entity(toRouteResponseNode(rr).toString()).build();
+    }
+
+    private Response handleGetRouteResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        String routeResponseId = request.path("RouteResponseId").asText();
+        return Response.ok(toRouteResponseNode(service.getRouteResponse(region, apiId, routeId, routeResponseId)).toString()).build();
+    }
+
+    private Response handleGetRouteResponses(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        List<RouteResponse> routeResponses = service.getRouteResponses(region, apiId, routeId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("Items");
+        routeResponses.forEach(rr -> items.add(toRouteResponseNode(rr)));
+        return Response.ok(root.toString()).build();
+    }
+
+    private Response handleUpdateRouteResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        String routeResponseId = request.path("RouteResponseId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        RouteResponse rr = service.updateRouteResponse(region, apiId, routeId, routeResponseId, map);
+        return Response.ok(toRouteResponseNode(rr).toString()).build();
+    }
+
+    private Response handleDeleteRouteResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String routeId = request.path("RouteId").asText();
+        String routeResponseId = request.path("RouteResponseId").asText();
+        service.deleteRouteResponse(region, apiId, routeId, routeResponseId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Integration Response ────────────────────────────
+
+    private Response handleCreateIntegrationResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        IntegrationResponse ir = service.createIntegrationResponse(region, apiId, integrationId, map);
+        return Response.status(201).entity(toIntegrationResponseNode(ir).toString()).build();
+    }
+
+    private Response handleGetIntegrationResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        String integrationResponseId = request.path("IntegrationResponseId").asText();
+        return Response.ok(toIntegrationResponseNode(service.getIntegrationResponse(region, apiId, integrationId, integrationResponseId)).toString()).build();
+    }
+
+    private Response handleGetIntegrationResponses(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        List<IntegrationResponse> integrationResponses = service.getIntegrationResponses(region, apiId, integrationId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("Items");
+        integrationResponses.forEach(ir -> items.add(toIntegrationResponseNode(ir)));
+        return Response.ok(root.toString()).build();
+    }
+
+    private Response handleUpdateIntegrationResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        String integrationResponseId = request.path("IntegrationResponseId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        IntegrationResponse ir = service.updateIntegrationResponse(region, apiId, integrationId, integrationResponseId, map);
+        return Response.ok(toIntegrationResponseNode(ir).toString()).build();
+    }
+
+    private Response handleDeleteIntegrationResponse(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String integrationId = request.path("IntegrationId").asText();
+        String integrationResponseId = request.path("IntegrationResponseId").asText();
+        service.deleteIntegrationResponse(region, apiId, integrationId, integrationResponseId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Model ────────────────────────────
+
+    private Response handleCreateModel(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Model model = service.createModel(region, apiId, map);
+        return Response.status(201).entity(toModelNode(model).toString()).build();
+    }
+
+    private Response handleGetModel(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String modelId = request.path("ModelId").asText();
+        return Response.ok(toModelNode(service.getModel(region, apiId, modelId)).toString()).build();
+    }
+
+    private Response handleGetModels(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        List<Model> models = service.getModels(region, apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("Items");
+        models.forEach(m -> items.add(toModelNode(m)));
+        return Response.ok(root.toString()).build();
+    }
+
+    private Response handleUpdateModel(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String modelId = request.path("ModelId").asText();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = toLowerCamelCase(objectMapper.convertValue(request, Map.class));
+        Model model = service.updateModel(region, apiId, modelId, map);
+        return Response.ok(toModelNode(model).toString()).build();
+    }
+
+    private Response handleDeleteModel(JsonNode request, String region) {
+        String apiId = request.path("ApiId").asText();
+        String modelId = request.path("ModelId").asText();
+        service.deleteModel(region, apiId, modelId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Tagging ────────────────────────────
+
+    private Response handleTagResource(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        Map<String, String> tags = objectMapper.convertValue(
+                request.path("Tags"), new com.fasterxml.jackson.core.type.TypeReference<Map<String, String>>() {});
+        service.tagResource(resourceArn, tags);
+        return Response.ok("{}").build();
+    }
+
+    private Response handleUntagResource(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        List<String> tagKeys = new java.util.ArrayList<>();
+        request.path("TagKeys").forEach(n -> tagKeys.add(n.asText()));
+        service.untagResource(resourceArn, tagKeys);
+        return Response.noContent().build();
+    }
+
+    private Response handleGetTags(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        Map<String, String> tags = service.getTags(resourceArn);
+        ObjectNode root = objectMapper.createObjectNode();
+        ObjectNode tagsNode = root.putObject("Tags");
+        tags.forEach(tagsNode::put);
+        return Response.ok(root.toString()).build();
     }
 
     // ──────────────────────────── Serializers ────────────────────────────
@@ -258,6 +495,19 @@ public class ApiGatewayV2JsonHandler {
         node.put("ProtocolType", api.getProtocolType());
         node.put("ApiEndpoint", api.getApiEndpoint());
         node.put("CreatedDate", api.getCreatedDate() / 1000.0);
+        if (api.getRouteSelectionExpression() != null) {
+            node.put("RouteSelectionExpression", api.getRouteSelectionExpression());
+        }
+        if (api.getDescription() != null) {
+            node.put("Description", api.getDescription());
+        }
+        if (api.getApiKeySelectionExpression() != null) {
+            node.put("ApiKeySelectionExpression", api.getApiKeySelectionExpression());
+        }
+        if (api.getTags() != null && !api.getTags().isEmpty()) {
+            ObjectNode tagsNode = node.putObject("Tags");
+            api.getTags().forEach(tagsNode::put);
+        }
         return node;
     }
 
@@ -290,6 +540,9 @@ public class ApiGatewayV2JsonHandler {
         node.put("AuthorizationType", r.getAuthorizationType());
         if (r.getAuthorizerId() != null) node.put("AuthorizerId", r.getAuthorizerId());
         if (r.getTarget() != null) node.put("Target", r.getTarget());
+        if (r.getRouteResponseSelectionExpression() != null) {
+            node.put("RouteResponseSelectionExpression", r.getRouteResponseSelectionExpression());
+        }
         return node;
     }
 
@@ -318,6 +571,61 @@ public class ApiGatewayV2JsonHandler {
         node.put("DeploymentStatus", d.getDeploymentStatus());
         node.put("CreatedDate", d.getCreatedDate() / 1000.0);
         if (d.getDescription() != null) node.put("Description", d.getDescription());
+        return node;
+    }
+
+    private ObjectNode toRouteResponseNode(RouteResponse rr) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("RouteResponseId", rr.getRouteResponseId());
+        node.put("RouteResponseKey", rr.getRouteResponseKey());
+        if (rr.getRouteId() != null) {
+            node.put("RouteId", rr.getRouteId());
+        }
+        if (rr.getModelSelectionExpression() != null) {
+            node.put("ModelSelectionExpression", rr.getModelSelectionExpression());
+        }
+        if (rr.getResponseModels() != null) {
+            ObjectNode responseModels = node.putObject("ResponseModels");
+            rr.getResponseModels().forEach(responseModels::put);
+        }
+        if (rr.getResponseParameters() != null) {
+            ObjectNode responseParameters = node.putObject("ResponseParameters");
+            rr.getResponseParameters().forEach(responseParameters::put);
+        }
+        return node;
+    }
+
+    private ObjectNode toIntegrationResponseNode(IntegrationResponse ir) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("IntegrationResponseId", ir.getIntegrationResponseId());
+        node.put("IntegrationResponseKey", ir.getIntegrationResponseKey());
+        if (ir.getIntegrationId() != null) {
+            node.put("IntegrationId", ir.getIntegrationId());
+        }
+        if (ir.getContentHandlingStrategy() != null) {
+            node.put("ContentHandlingStrategy", ir.getContentHandlingStrategy());
+        }
+        if (ir.getTemplateSelectionExpression() != null) {
+            node.put("TemplateSelectionExpression", ir.getTemplateSelectionExpression());
+        }
+        if (ir.getResponseTemplates() != null) {
+            ObjectNode responseTemplates = node.putObject("ResponseTemplates");
+            ir.getResponseTemplates().forEach(responseTemplates::put);
+        }
+        if (ir.getResponseParameters() != null) {
+            ObjectNode responseParameters = node.putObject("ResponseParameters");
+            ir.getResponseParameters().forEach(responseParameters::put);
+        }
+        return node;
+    }
+
+    private ObjectNode toModelNode(Model m) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ModelId", m.getModelId());
+        node.put("Name", m.getName());
+        if (m.getSchema() != null)      node.put("Schema", m.getSchema());
+        if (m.getDescription() != null) node.put("Description", m.getDescription());
+        if (m.getContentType() != null) node.put("ContentType", m.getContentType());
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -27,6 +27,9 @@ public class ApiGatewayV2Service {
     private final StorageBackend<String, Authorizer> authorizerStore;
     private final StorageBackend<String, Deployment> deploymentStore;
     private final StorageBackend<String, Stage> stageStore;
+    private final StorageBackend<String, RouteResponse> routeResponseStore;
+    private final StorageBackend<String, IntegrationResponse> integrationResponseStore;
+    private final StorageBackend<String, Model> modelStore;
     private final RegionResolver regionResolver;
 
     @Inject
@@ -43,6 +46,12 @@ public class ApiGatewayV2Service {
                 new TypeReference<>() {});
         this.stageStore = storageFactory.create("apigatewayv2", "apigatewayv2-stages.json",
                 new TypeReference<>() {});
+        this.routeResponseStore = storageFactory.create("apigatewayv2", "apigatewayv2-routeresponses.json",
+                new TypeReference<>() {});
+        this.integrationResponseStore = storageFactory.create("apigatewayv2", "apigatewayv2-integrationresponses.json",
+                new TypeReference<>() {});
+        this.modelStore = storageFactory.create("apigatewayv2", "apigatewayv2-models.json",
+                new TypeReference<>() {});
         this.regionResolver = regionResolver;
     }
 
@@ -51,16 +60,46 @@ public class ApiGatewayV2Service {
     public Api createApi(String region, Map<String, Object> request) {
         String name = (String) request.get("name");
         String protocolType = (String) request.getOrDefault("protocolType", "HTTP");
+        String routeSelectionExpression = (String) request.get("routeSelectionExpression");
+        String description = (String) request.get("description");
+        String apiKeySelectionExpression = (String) request.get("apiKeySelectionExpression");
+
+        if ("WEBSOCKET".equals(protocolType) && (routeSelectionExpression == null || routeSelectionExpression.isBlank())) {
+            throw new AwsException("BadRequestException",
+                    "RouteSelectionExpression is required for WEBSOCKET protocol", 400);
+        }
+
+        // Apply AWS defaults
+        if (apiKeySelectionExpression == null) {
+            apiKeySelectionExpression = "$request.header.x-api-key";
+        }
+        if ("HTTP".equals(protocolType) && routeSelectionExpression == null) {
+            routeSelectionExpression = "${request.method} ${request.path}";
+        }
 
         Api api = new Api();
         api.setApiId(shortId(10));
         api.setName(name);
         api.setProtocolType(protocolType);
         api.setCreatedDate(System.currentTimeMillis());
-        api.setApiEndpoint(String.format("https://%s.execute-api.%s.amazonaws.com", api.getApiId(), region));
+        api.setRouteSelectionExpression(routeSelectionExpression);
+        api.setDescription(description);
+        api.setApiKeySelectionExpression(apiKeySelectionExpression);
+
+        if ("WEBSOCKET".equals(protocolType)) {
+            api.setApiEndpoint(String.format("wss://%s.execute-api.%s.amazonaws.com", api.getApiId(), region));
+        } else {
+            api.setApiEndpoint(String.format("https://%s.execute-api.%s.amazonaws.com", api.getApiId(), region));
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) request.get("tags");
+        if (tags != null) {
+            api.setTags(tags);
+        }
 
         apiStore.put(apiKey(region, api.getApiId()), api);
-        LOG.infov("Created HTTP API: {0} ({1}) in {2}", api.getName(), api.getApiId(), region);
+        LOG.infov("Created {0} API: {1} ({2}) in {3}", protocolType, api.getName(), api.getApiId(), region);
         return api;
     }
 
@@ -79,6 +118,31 @@ public class ApiGatewayV2Service {
         apiStore.delete(apiKey(region, apiId));
     }
 
+    public Api updateApi(String region, String apiId, Map<String, Object> request) {
+        Api api = getApi(region, apiId);
+
+        if (request.containsKey("name") && request.get("name") != null) {
+            api.setName((String) request.get("name"));
+        }
+        if (request.containsKey("description") && request.get("description") != null) {
+            api.setDescription((String) request.get("description"));
+        }
+        if (request.containsKey("routeSelectionExpression") && request.get("routeSelectionExpression") != null) {
+            api.setRouteSelectionExpression((String) request.get("routeSelectionExpression"));
+        }
+        if (request.containsKey("apiKeySelectionExpression") && request.get("apiKeySelectionExpression") != null) {
+            api.setApiKeySelectionExpression((String) request.get("apiKeySelectionExpression"));
+        }
+        if (request.containsKey("tags")) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> tags = (Map<String, String>) request.get("tags");
+            api.setTags(tags);
+        }
+
+        apiStore.put(apiKey(region, apiId), api);
+        return api;
+    }
+
     // ──────────────────────────── Authorizer CRUD ────────────────────────────
 
     public Authorizer createAuthorizer(String region, String apiId, Map<String, Object> request) {
@@ -88,9 +152,14 @@ public class ApiGatewayV2Service {
         auth.setName((String) request.get("name"));
         auth.setAuthorizerType((String) request.get("authorizerType"));
 
-        @SuppressWarnings("unchecked")
-        List<String> identitySource = (List<String>) request.get("identitySource");
-        auth.setIdentitySource(identitySource);
+        Object identitySourceRaw = request.get("identitySource");
+        if (identitySourceRaw instanceof String s) {
+            auth.setIdentitySource(List.of(s));
+        } else if (identitySourceRaw instanceof List<?>) {
+            @SuppressWarnings("unchecked")
+            List<String> identitySource = (List<String>) identitySourceRaw;
+            auth.setIdentitySource(identitySource);
+        }
 
         @SuppressWarnings("unchecked")
         Map<String, Object> jwtConfig = (Map<String, Object>) request.get("jwtConfiguration");
@@ -121,6 +190,39 @@ public class ApiGatewayV2Service {
         authorizerStore.delete(authorizerKey(region, apiId, authorizerId));
     }
 
+    public Authorizer updateAuthorizer(String region, String apiId, String authorizerId,
+                                       Map<String, Object> request) {
+        Authorizer auth = getAuthorizer(region, apiId, authorizerId);
+
+        if (request.containsKey("name") && request.get("name") != null) {
+            auth.setName((String) request.get("name"));
+        }
+        if (request.containsKey("authorizerType") && request.get("authorizerType") != null) {
+            auth.setAuthorizerType((String) request.get("authorizerType"));
+        }
+        if (request.containsKey("identitySource") && request.get("identitySource") != null) {
+            Object identitySourceRaw = request.get("identitySource");
+            if (identitySourceRaw instanceof String s) {
+                auth.setIdentitySource(List.of(s));
+            } else if (identitySourceRaw instanceof List<?>) {
+                @SuppressWarnings("unchecked")
+                List<String> identitySource = (List<String>) identitySourceRaw;
+                auth.setIdentitySource(identitySource);
+            }
+        }
+        if (request.containsKey("jwtConfiguration") && request.get("jwtConfiguration") != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> jwtConfig = (Map<String, Object>) request.get("jwtConfiguration");
+            @SuppressWarnings("unchecked")
+            List<String> audience = (List<String>) jwtConfig.get("audience");
+            String issuer = (String) jwtConfig.get("issuer");
+            auth.setJwtConfiguration(new Authorizer.JwtConfiguration(audience, issuer));
+        }
+
+        authorizerStore.put(authorizerKey(region, apiId, authorizerId), auth);
+        return auth;
+    }
+
     // ──────────────────────────── Route CRUD ────────────────────────────
 
     public Route createRoute(String region, String apiId, Map<String, Object> request) {
@@ -131,6 +233,7 @@ public class ApiGatewayV2Service {
         route.setAuthorizationType((String) request.getOrDefault("authorizationType", "NONE"));
         route.setAuthorizerId((String) request.get("authorizerId"));
         route.setTarget((String) request.get("target"));
+        route.setRouteResponseSelectionExpression((String) request.get("routeResponseSelectionExpression"));
 
         routeStore.put(routeKey(region, apiId, route.getRouteId()), route);
         return route;
@@ -149,6 +252,29 @@ public class ApiGatewayV2Service {
     public void deleteRoute(String region, String apiId, String routeId) {
         getRoute(region, apiId, routeId);
         routeStore.delete(routeKey(region, apiId, routeId));
+    }
+
+    public Route updateRoute(String region, String apiId, String routeId, Map<String, Object> request) {
+        Route route = getRoute(region, apiId, routeId);
+
+        if (request.containsKey("routeKey") && request.get("routeKey") != null) {
+            route.setRouteKey((String) request.get("routeKey"));
+        }
+        if (request.containsKey("authorizationType") && request.get("authorizationType") != null) {
+            route.setAuthorizationType((String) request.get("authorizationType"));
+        }
+        if (request.containsKey("authorizerId") && request.get("authorizerId") != null) {
+            route.setAuthorizerId((String) request.get("authorizerId"));
+        }
+        if (request.containsKey("target") && request.get("target") != null) {
+            route.setTarget((String) request.get("target"));
+        }
+        if (request.containsKey("routeResponseSelectionExpression") && request.get("routeResponseSelectionExpression") != null) {
+            route.setRouteResponseSelectionExpression((String) request.get("routeResponseSelectionExpression"));
+        }
+
+        routeStore.put(routeKey(region, apiId, routeId), route);
+        return route;
     }
 
     /**
@@ -229,6 +355,24 @@ public class ApiGatewayV2Service {
         integrationStore.delete(integrationKey(region, apiId, integrationId));
     }
 
+    public Integration updateIntegration(String region, String apiId, String integrationId,
+                                         Map<String, Object> request) {
+        Integration integration = getIntegration(region, apiId, integrationId);
+
+        if (request.containsKey("integrationType") && request.get("integrationType") != null) {
+            integration.setIntegrationType((String) request.get("integrationType"));
+        }
+        if (request.containsKey("integrationUri") && request.get("integrationUri") != null) {
+            integration.setIntegrationUri((String) request.get("integrationUri"));
+        }
+        if (request.containsKey("payloadFormatVersion") && request.get("payloadFormatVersion") != null) {
+            integration.setPayloadFormatVersion((String) request.get("payloadFormatVersion"));
+        }
+
+        integrationStore.put(integrationKey(region, apiId, integrationId), integration);
+        return integration;
+    }
+
     // ──────────────────────────── Stage CRUD ────────────────────────────
 
     public Stage createStage(String region, String apiId, Map<String, Object> request) {
@@ -258,6 +402,22 @@ public class ApiGatewayV2Service {
     public void deleteStage(String region, String apiId, String stageName) {
         getStage(region, apiId, stageName);
         stageStore.delete(stageKey(region, apiId, stageName));
+    }
+
+    public Stage updateStage(String region, String apiId, String stageName,
+                             Map<String, Object> request) {
+        Stage stage = getStage(region, apiId, stageName);
+
+        if (request.containsKey("deploymentId") && request.get("deploymentId") != null) {
+            stage.setDeploymentId((String) request.get("deploymentId"));
+        }
+        if (request.containsKey("autoDeploy") && request.get("autoDeploy") != null) {
+            stage.setAutoDeploy(Boolean.parseBoolean(String.valueOf(request.get("autoDeploy"))));
+        }
+
+        stage.setLastUpdatedDate(System.currentTimeMillis());
+        stageStore.put(stageKey(region, apiId, stageName), stage);
+        return stage;
     }
 
     // ──────────────────────────── Deployment CRUD ────────────────────────────
@@ -306,6 +466,259 @@ public class ApiGatewayV2Service {
         deploymentStore.delete(deploymentKey(region, apiId, deploymentId));
     }
 
+    public Deployment updateDeployment(String region, String apiId, String deploymentId,
+                                       Map<String, Object> request) {
+        Deployment deployment = getDeployment(region, apiId, deploymentId);
+
+        if (request.containsKey("description") && request.get("description") != null) {
+            deployment.setDescription((String) request.get("description"));
+        }
+
+        deploymentStore.put(deploymentKey(region, apiId, deploymentId), deployment);
+        return deployment;
+    }
+
+    // ──────────────────────────── Route Response CRUD ────────────────────────────
+
+    public RouteResponse createRouteResponse(String region, String apiId, String routeId, Map<String, Object> request) {
+        getApi(region, apiId);
+        getRoute(region, apiId, routeId);
+
+        RouteResponse rr = new RouteResponse();
+        rr.setRouteResponseId(shortId(8));
+        rr.setRouteId(routeId);
+        rr.setRouteResponseKey((String) request.get("routeResponseKey"));
+        rr.setModelSelectionExpression((String) request.get("modelSelectionExpression"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> responseModels = (Map<String, String>) request.get("responseModels");
+        rr.setResponseModels(responseModels);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> responseParameters = (Map<String, String>) request.get("responseParameters");
+        rr.setResponseParameters(responseParameters);
+
+        routeResponseStore.put(routeResponseKey(region, apiId, routeId, rr.getRouteResponseId()), rr);
+        return rr;
+    }
+
+    public RouteResponse getRouteResponse(String region, String apiId, String routeId, String routeResponseId) {
+        return routeResponseStore.get(routeResponseKey(region, apiId, routeId, routeResponseId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Route response not found", 404));
+    }
+
+    public List<RouteResponse> getRouteResponses(String region, String apiId, String routeId) {
+        String prefix = region + "::" + apiId + "::" + routeId + "::";
+        return routeResponseStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public RouteResponse updateRouteResponse(String region, String apiId, String routeId, String routeResponseId, Map<String, Object> request) {
+        RouteResponse rr = getRouteResponse(region, apiId, routeId, routeResponseId);
+
+        if (request.containsKey("routeResponseKey") && request.get("routeResponseKey") != null) {
+            rr.setRouteResponseKey((String) request.get("routeResponseKey"));
+        }
+        if (request.containsKey("modelSelectionExpression") && request.get("modelSelectionExpression") != null) {
+            rr.setModelSelectionExpression((String) request.get("modelSelectionExpression"));
+        }
+        if (request.containsKey("responseModels") && request.get("responseModels") != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> responseModels = (Map<String, String>) request.get("responseModels");
+            rr.setResponseModels(responseModels);
+        }
+        if (request.containsKey("responseParameters") && request.get("responseParameters") != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> responseParameters = (Map<String, String>) request.get("responseParameters");
+            rr.setResponseParameters(responseParameters);
+        }
+
+        routeResponseStore.put(routeResponseKey(region, apiId, routeId, routeResponseId), rr);
+        return rr;
+    }
+
+    public void deleteRouteResponse(String region, String apiId, String routeId, String routeResponseId) {
+        getRouteResponse(region, apiId, routeId, routeResponseId);
+        routeResponseStore.delete(routeResponseKey(region, apiId, routeId, routeResponseId));
+    }
+
+    // ──────────────────────────── Integration Response CRUD ────────────────────────────
+
+    public IntegrationResponse createIntegrationResponse(String region, String apiId, String integrationId, Map<String, Object> request) {
+        getApi(region, apiId);
+        getIntegration(region, apiId, integrationId);
+
+        IntegrationResponse ir = new IntegrationResponse();
+        ir.setIntegrationResponseId(shortId(8));
+        ir.setIntegrationId(integrationId);
+        ir.setIntegrationResponseKey((String) request.get("integrationResponseKey"));
+        ir.setContentHandlingStrategy((String) request.get("contentHandlingStrategy"));
+        ir.setTemplateSelectionExpression((String) request.get("templateSelectionExpression"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> responseTemplates = (Map<String, String>) request.get("responseTemplates");
+        ir.setResponseTemplates(responseTemplates);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> responseParameters = (Map<String, String>) request.get("responseParameters");
+        ir.setResponseParameters(responseParameters);
+
+        integrationResponseStore.put(integrationResponseKey(region, apiId, integrationId, ir.getIntegrationResponseId()), ir);
+        return ir;
+    }
+
+    public IntegrationResponse getIntegrationResponse(String region, String apiId, String integrationId, String integrationResponseId) {
+        return integrationResponseStore.get(integrationResponseKey(region, apiId, integrationId, integrationResponseId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Integration response not found", 404));
+    }
+
+    public List<IntegrationResponse> getIntegrationResponses(String region, String apiId, String integrationId) {
+        String prefix = region + "::" + apiId + "::" + integrationId + "::";
+        return integrationResponseStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public IntegrationResponse updateIntegrationResponse(String region, String apiId, String integrationId, String integrationResponseId, Map<String, Object> request) {
+        IntegrationResponse ir = getIntegrationResponse(region, apiId, integrationId, integrationResponseId);
+
+        if (request.containsKey("integrationResponseKey") && request.get("integrationResponseKey") != null) {
+            ir.setIntegrationResponseKey((String) request.get("integrationResponseKey"));
+        }
+        if (request.containsKey("contentHandlingStrategy") && request.get("contentHandlingStrategy") != null) {
+            ir.setContentHandlingStrategy((String) request.get("contentHandlingStrategy"));
+        }
+        if (request.containsKey("templateSelectionExpression") && request.get("templateSelectionExpression") != null) {
+            ir.setTemplateSelectionExpression((String) request.get("templateSelectionExpression"));
+        }
+        if (request.containsKey("responseTemplates") && request.get("responseTemplates") != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> responseTemplates = (Map<String, String>) request.get("responseTemplates");
+            ir.setResponseTemplates(responseTemplates);
+        }
+        if (request.containsKey("responseParameters") && request.get("responseParameters") != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> responseParameters = (Map<String, String>) request.get("responseParameters");
+            ir.setResponseParameters(responseParameters);
+        }
+
+        integrationResponseStore.put(integrationResponseKey(region, apiId, integrationId, integrationResponseId), ir);
+        return ir;
+    }
+
+    public void deleteIntegrationResponse(String region, String apiId, String integrationId, String integrationResponseId) {
+        getIntegrationResponse(region, apiId, integrationId, integrationResponseId);
+        integrationResponseStore.delete(integrationResponseKey(region, apiId, integrationId, integrationResponseId));
+    }
+
+    // ──────────────────────────── Model CRUD ────────────────────────────
+
+    public Model createModel(String region, String apiId, Map<String, Object> request) {
+        getApi(region, apiId);
+        Model model = new Model();
+        model.setModelId(shortId(10));
+        model.setName((String) request.get("name"));
+        model.setSchema((String) request.get("schema"));
+        model.setDescription((String) request.get("description"));
+        model.setContentType((String) request.get("contentType"));
+        modelStore.put(modelKey(region, apiId, model.getModelId()), model);
+        return model;
+    }
+
+    public Model getModel(String region, String apiId, String modelId) {
+        return modelStore.get(modelKey(region, apiId, modelId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Model not found", 404));
+    }
+
+    public List<Model> getModels(String region, String apiId) {
+        String prefix = region + "::" + apiId + "::";
+        return modelStore.scan(k -> k.startsWith(prefix));
+    }
+
+    public Model updateModel(String region, String apiId, String modelId, Map<String, Object> request) {
+        Model model = getModel(region, apiId, modelId);
+
+        if (request.containsKey("name") && request.get("name") != null) {
+            model.setName((String) request.get("name"));
+        }
+        if (request.containsKey("schema") && request.get("schema") != null) {
+            model.setSchema((String) request.get("schema"));
+        }
+        if (request.containsKey("description") && request.get("description") != null) {
+            model.setDescription((String) request.get("description"));
+        }
+        if (request.containsKey("contentType") && request.get("contentType") != null) {
+            model.setContentType((String) request.get("contentType"));
+        }
+
+        modelStore.put(modelKey(region, apiId, modelId), model);
+        return model;
+    }
+
+    public void deleteModel(String region, String apiId, String modelId) {
+        getModel(region, apiId, modelId);
+        modelStore.delete(modelKey(region, apiId, modelId));
+    }
+
+    // ──────────────────────────── Standalone Tagging ────────────────────────────
+
+    /**
+     * Parses an API Gateway v2 resource ARN and returns a two-element array
+     * [region, apiId]. Throws BadRequestException if the ARN is malformed.
+     *
+     * Expected format: arn:aws:apigateway:{region}::/apis/{apiId}
+     */
+    private String[] parseArn(String resourceArn) {
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw new AwsException("BadRequestException", "ResourceArn must not be blank", 400);
+        }
+        String[] parts = resourceArn.split(":");
+        if (parts.length < 6) {
+            throw new AwsException("BadRequestException",
+                    "Invalid ResourceArn format: " + resourceArn, 400);
+        }
+        String region = parts[3];
+        String resource = parts[5]; // e.g. "/apis/abc1234567"
+        int lastSlash = resource.lastIndexOf('/');
+        if (lastSlash < 0 || lastSlash == resource.length() - 1) {
+            throw new AwsException("BadRequestException",
+                    "Cannot extract apiId from ResourceArn: " + resourceArn, 400);
+        }
+        String apiId = resource.substring(lastSlash + 1);
+        return new String[]{region, apiId};
+    }
+
+    public void tagResource(String resourceArn, Map<String, String> tags) {
+        String[] parsed = parseArn(resourceArn);
+        String region = parsed[0];
+        String apiId  = parsed[1];
+        Api api = getApi(region, apiId);
+        if (tags != null && !tags.isEmpty()) {
+            if (api.getTags() == null) {
+                api.setTags(new java.util.HashMap<>());
+            }
+            api.getTags().putAll(tags);
+        }
+        apiStore.put(apiKey(region, apiId), api);
+    }
+
+    public void untagResource(String resourceArn, List<String> tagKeys) {
+        String[] parsed = parseArn(resourceArn);
+        String region = parsed[0];
+        String apiId  = parsed[1];
+        Api api = getApi(region, apiId);
+        if (tagKeys != null && api.getTags() != null) {
+            tagKeys.forEach(k -> api.getTags().remove(k));
+        }
+        apiStore.put(apiKey(region, apiId), api);
+    }
+
+    public Map<String, String> getTags(String resourceArn) {
+        String[] parsed = parseArn(resourceArn);
+        String region = parsed[0];
+        String apiId  = parsed[1];
+        Api api = getApi(region, apiId);
+        Map<String, String> tags = api.getTags();
+        return (tags != null) ? new java.util.HashMap<>(tags) : java.util.Collections.emptyMap();
+    }
+
     // ──────────────────────────── Key helpers ────────────────────────────
 
     private String apiKey(String region, String apiId) {
@@ -330,6 +743,18 @@ public class ApiGatewayV2Service {
 
     private String deploymentKey(String region, String apiId, String deploymentId) {
         return region + "::" + apiId + "::" + deploymentId;
+    }
+
+    private String routeResponseKey(String region, String apiId, String routeId, String routeResponseId) {
+        return region + "::" + apiId + "::" + routeId + "::" + routeResponseId;
+    }
+
+    private String integrationResponseKey(String region, String apiId, String integrationId, String integrationResponseId) {
+        return region + "::" + apiId + "::" + integrationId + "::" + integrationResponseId;
+    }
+
+    private String modelKey(String region, String apiId, String modelId) {
+        return region + "::" + apiId + "::" + modelId;
     }
 
     private static String shortId(int length) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Api.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Api.java
@@ -15,6 +15,9 @@ public class Api {
     private String apiEndpoint;
     private long createdDate;
     private Map<String, String> tags = new HashMap<>();
+    private String routeSelectionExpression;
+    private String description;
+    private String apiKeySelectionExpression;
 
     public Api() {}
 
@@ -35,4 +38,13 @@ public class Api {
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+    public String getRouteSelectionExpression() { return routeSelectionExpression; }
+    public void setRouteSelectionExpression(String routeSelectionExpression) { this.routeSelectionExpression = routeSelectionExpression; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getApiKeySelectionExpression() { return apiKeySelectionExpression; }
+    public void setApiKeySelectionExpression(String apiKeySelectionExpression) { this.apiKeySelectionExpression = apiKeySelectionExpression; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/IntegrationResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/IntegrationResponse.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.apigatewayv2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IntegrationResponse {
+    private String integrationResponseId;
+    private String integrationResponseKey;
+    private String integrationId;
+    private String contentHandlingStrategy;
+    private String templateSelectionExpression;
+    private Map<String, String> responseTemplates;
+    private Map<String, String> responseParameters;
+
+    public IntegrationResponse() {}
+
+    public String getIntegrationResponseId() { return integrationResponseId; }
+    public void setIntegrationResponseId(String integrationResponseId) { this.integrationResponseId = integrationResponseId; }
+
+    public String getIntegrationResponseKey() { return integrationResponseKey; }
+    public void setIntegrationResponseKey(String integrationResponseKey) { this.integrationResponseKey = integrationResponseKey; }
+
+    public String getIntegrationId() { return integrationId; }
+    public void setIntegrationId(String integrationId) { this.integrationId = integrationId; }
+
+    public String getContentHandlingStrategy() { return contentHandlingStrategy; }
+    public void setContentHandlingStrategy(String contentHandlingStrategy) { this.contentHandlingStrategy = contentHandlingStrategy; }
+
+    public String getTemplateSelectionExpression() { return templateSelectionExpression; }
+    public void setTemplateSelectionExpression(String templateSelectionExpression) { this.templateSelectionExpression = templateSelectionExpression; }
+
+    public Map<String, String> getResponseTemplates() { return responseTemplates; }
+    public void setResponseTemplates(Map<String, String> responseTemplates) { this.responseTemplates = responseTemplates; }
+
+    public Map<String, String> getResponseParameters() { return responseParameters; }
+    public void setResponseParameters(Map<String, String> responseParameters) { this.responseParameters = responseParameters; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Model.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Model.java
@@ -1,0 +1,31 @@
+package io.github.hectorvent.floci.services.apigatewayv2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Model {
+    private String modelId;
+    private String name;
+    private String schema;
+    private String description;
+    private String contentType;
+
+    public Model() {}
+
+    public String getModelId() { return modelId; }
+    public void setModelId(String modelId) { this.modelId = modelId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getSchema() { return schema; }
+    public void setSchema(String schema) { this.schema = schema; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getContentType() { return contentType; }
+    public void setContentType(String contentType) { this.contentType = contentType; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Route.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Route.java
@@ -11,6 +11,7 @@ public class Route {
     private String authorizationType; // NONE, AWS_IAM, CUSTOM, JWT
     private String authorizerId;
     private String target; // integrations/{integrationId}
+    private String routeResponseSelectionExpression;
 
     public Route() {}
 
@@ -28,4 +29,7 @@ public class Route {
 
     public String getTarget() { return target; }
     public void setTarget(String target) { this.target = target; }
+
+    public String getRouteResponseSelectionExpression() { return routeResponseSelectionExpression; }
+    public void setRouteResponseSelectionExpression(String routeResponseSelectionExpression) { this.routeResponseSelectionExpression = routeResponseSelectionExpression; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/RouteResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/RouteResponse.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.apigatewayv2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RouteResponse {
+    private String routeResponseId;
+    private String routeResponseKey;
+    private String routeId;
+    private String modelSelectionExpression;
+    private Map<String, String> responseModels;
+    private Map<String, String> responseParameters;
+
+    public RouteResponse() {}
+
+    public String getRouteResponseId() { return routeResponseId; }
+    public void setRouteResponseId(String routeResponseId) { this.routeResponseId = routeResponseId; }
+
+    public String getRouteResponseKey() { return routeResponseKey; }
+    public void setRouteResponseKey(String routeResponseKey) { this.routeResponseKey = routeResponseKey; }
+
+    public String getRouteId() { return routeId; }
+    public void setRouteId(String routeId) { this.routeId = routeId; }
+
+    public String getModelSelectionExpression() { return modelSelectionExpression; }
+    public void setModelSelectionExpression(String modelSelectionExpression) { this.modelSelectionExpression = modelSelectionExpression; }
+
+    public Map<String, String> getResponseModels() { return responseModels; }
+    public void setResponseModels(Map<String, String> responseModels) { this.responseModels = responseModels; }
+
+    public Map<String, String> getResponseParameters() { return responseParameters; }
+    public void setResponseParameters(Map<String, String> responseParameters) { this.responseParameters = responseParameters; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationResponseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationResponseIntegrationTest.java
@@ -1,0 +1,229 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2IntegrationResponseIntegrationTest {
+
+    private static String apiId;
+    private static String integrationId;
+    private static String integrationResponseId;
+
+    // ──────────────────────────── Prerequisites ────────────────────────────
+
+    @Test @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"test-http-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("name", equalTo("test-http-api"))
+                .body("protocolType", equalTo("HTTP"))
+                .extract().path("apiId");
+    }
+
+    @Test @Order(2)
+    void createIntegration() {
+        integrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationType":"HTTP_PROXY","integrationUri":"http://example.com","payloadFormatVersion":"2.0"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(201)
+                .body("integrationId", notNullValue())
+                .extract().path("integrationId");
+    }
+
+    // ──────────────────────────── Integration Response CRUD ────────────────────────────
+
+    @Test @Order(3)
+    void createIntegrationResponse() {
+        integrationResponseId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "integrationResponseKey": "$default",
+                          "contentHandlingStrategy": "CONVERT_TO_TEXT",
+                          "templateSelectionExpression": "$default",
+                          "responseTemplates": {"application/json": "{}"},
+                          "responseParameters": {"append:header.X-Custom": "integration.response.header.X-Custom"}
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses")
+                .then()
+                .statusCode(201)
+                .body("integrationResponseId", notNullValue())
+                .body("integrationResponseKey", equalTo("$default"))
+                .body("integrationId", equalTo(integrationId))
+                .body("contentHandlingStrategy", equalTo("CONVERT_TO_TEXT"))
+                .body("templateSelectionExpression", equalTo("$default"))
+                .body("responseTemplates", notNullValue())
+                .body("responseParameters", notNullValue())
+                .extract().path("integrationResponseId");
+    }
+
+    @Test @Order(4)
+    void getIntegrationResponse() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/" + integrationResponseId)
+                .then()
+                .statusCode(200)
+                .body("integrationResponseId", equalTo(integrationResponseId))
+                .body("integrationResponseKey", equalTo("$default"))
+                .body("integrationId", equalTo(integrationId))
+                .body("contentHandlingStrategy", equalTo("CONVERT_TO_TEXT"))
+                .body("templateSelectionExpression", equalTo("$default"))
+                .body("responseTemplates", notNullValue())
+                .body("responseParameters", notNullValue());
+    }
+
+    @Test @Order(5)
+    void getIntegrationResponses() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses")
+                .then()
+                .statusCode(200)
+                .body("items", notNullValue())
+                .body("items.size()", greaterThanOrEqualTo(1))
+                .body("items.integrationResponseId", hasItem(integrationResponseId));
+    }
+
+    @Test @Order(6)
+    void updateIntegrationResponse() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"contentHandlingStrategy": "CONVERT_TO_BINARY"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/" + integrationResponseId)
+                .then()
+                .statusCode(200)
+                .body("integrationResponseId", equalTo(integrationResponseId))
+                .body("contentHandlingStrategy", equalTo("CONVERT_TO_BINARY"))
+                .body("integrationResponseKey", equalTo("$default"));
+    }
+
+    @Test @Order(7)
+    void deleteIntegrationResponse() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/" + integrationResponseId)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(8)
+    void getIntegrationResponseAfterDelete() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/" + integrationResponseId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Parent Validation ────────────────────────────
+
+    @Test @Order(9)
+    void createIntegrationResponseWithNonExistentApi() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/nonexistent/integrations/nonexistent/integrationresponses")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(10)
+    void createIntegrationResponseWithNonExistentIntegration() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations/nonexistent/integrationresponses")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Not Found Errors ────────────────────────────
+
+    @Test @Order(11)
+    void getIntegrationResponseNotFound() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(12)
+    void updateIntegrationResponseNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"contentHandlingStrategy": "CONVERT_TO_BINARY"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(13)
+    void deleteIntegrationResponseNotFound() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Listing Isolation ────────────────────────────
+
+    @Test @Order(14)
+    void listingIsolation() {
+        // Create a second integration
+        String secondIntegrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationType":"HTTP_PROXY","integrationUri":"http://other.example.com","payloadFormatVersion":"2.0"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(201)
+                .body("integrationId", notNullValue())
+                .extract().path("integrationId");
+
+        // Create an integration response on the second integration
+        String secondIntegrationResponseId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations/" + secondIntegrationId + "/integrationresponses")
+                .then()
+                .statusCode(201)
+                .body("integrationResponseId", notNullValue())
+                .extract().path("integrationResponseId");
+
+        // List integration responses for the first integration — the second integration's response must NOT appear
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId + "/integrationresponses")
+                .then()
+                .statusCode(200)
+                .body("items.integrationResponseId", not(hasItem(secondIntegrationResponseId)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationResponseJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationResponseJson11Test.java
@@ -1,0 +1,209 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for API Gateway v2 Integration Response CRUD via the JSON 1.1 path.
+ * Verifies PascalCase key normalization and all Integration Response CRUD operations
+ * through the AmazonApiGatewayV2.* X-Amz-Target header.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2IntegrationResponseJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String apiId;
+    private static String integrationId;
+    private static String integrationResponseId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── CreateApi ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"ir-json11-test","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("ir-json11-test"))
+                .extract().path("ApiId");
+    }
+
+    // ──────────────────────────── CreateIntegration ────────────────────────────
+
+    @Test
+    @Order(2)
+    void createIntegration() {
+        integrationId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationType":"HTTP_PROXY","IntegrationUri":"http://example.com","PayloadFormatVersion":"2.0"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("IntegrationId", notNullValue())
+                .extract().path("IntegrationId");
+    }
+
+    // ──────────────────────────── CreateIntegrationResponse ────────────────────────────
+
+    @Test
+    @Order(3)
+    void createIntegrationResponse() {
+        integrationResponseId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateIntegrationResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationResponseKey":"$default","ContentHandlingStrategy":"CONVERT_TO_TEXT","TemplateSelectionExpression":"$default"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("IntegrationResponseId", notNullValue())
+                .body("IntegrationResponseKey", equalTo("$default"))
+                .body("ContentHandlingStrategy", equalTo("CONVERT_TO_TEXT"))
+                .body("TemplateSelectionExpression", equalTo("$default"))
+                .extract().path("IntegrationResponseId");
+    }
+
+    // ──────────────────────────── GetIntegrationResponse ────────────────────────────
+
+    @Test
+    @Order(4)
+    void getIntegrationResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetIntegrationResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationResponseId":"%s"}
+                        """.formatted(apiId, integrationId, integrationResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("IntegrationResponseId", equalTo(integrationResponseId))
+                .body("IntegrationResponseKey", equalTo("$default"))
+                .body("ContentHandlingStrategy", equalTo("CONVERT_TO_TEXT"))
+                .body("TemplateSelectionExpression", equalTo("$default"));
+    }
+
+    // ──────────────────────────── GetIntegrationResponses ────────────────────────────
+
+    @Test
+    @Order(5)
+    void getIntegrationResponses() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetIntegrationResponses")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items", notNullValue())
+                .body("Items.IntegrationResponseId", hasItem(integrationResponseId));
+    }
+
+    // ──────────────────────────── UpdateIntegrationResponse ────────────────────────────
+
+    @Test
+    @Order(6)
+    void updateIntegrationResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateIntegrationResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationResponseId":"%s","ContentHandlingStrategy":"CONVERT_TO_BINARY"}
+                        """.formatted(apiId, integrationId, integrationResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("ContentHandlingStrategy", equalTo("CONVERT_TO_BINARY"))
+                .body("IntegrationResponseKey", equalTo("$default"));
+    }
+
+    // ──────────────────────────── DeleteIntegrationResponse ────────────────────────────
+
+    @Test
+    @Order(7)
+    void deleteIntegrationResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteIntegrationResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationResponseId":"%s"}
+                        """.formatted(apiId, integrationId, integrationResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── GetIntegrationResponse after delete ────────────────────────────
+
+    @Test
+    @Order(8)
+    void getIntegrationResponseAfterDelete() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetIntegrationResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationResponseId":"%s"}
+                        """.formatted(apiId, integrationId, integrationResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(not(equalTo(200)));
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s"}
+                            """.formatted(apiId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -36,6 +36,9 @@ class ApiGatewayV2IntegrationTest {
                 .body("name", equalTo("test-http-api"))
                 .body("protocolType", equalTo("HTTP"))
                 .body("apiEndpoint", notNullValue())
+                // AWS defaults must be populated
+                .body("routeSelectionExpression", equalTo("${request.method} ${request.path}"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
                 .extract().path("apiId");
     }
 
@@ -46,7 +49,9 @@ class ApiGatewayV2IntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("apiId", equalTo(apiId))
-                .body("name", equalTo("test-http-api"));
+                .body("name", equalTo("test-http-api"))
+                .body("routeSelectionExpression", equalTo("${request.method} ${request.path}"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"));
     }
 
     @Test @Order(3)

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
@@ -56,6 +56,9 @@ class ApiGatewayV2JsonHandlerTest {
                 .body("ApiId", notNullValue())
                 .body("Name", equalTo("json11-test"))
                 .body("ProtocolType", equalTo("HTTP"))
+                // AWS defaults must be populated
+                .body("RouteSelectionExpression", equalTo("${request.method} ${request.path}"))
+                .body("ApiKeySelectionExpression", equalTo("$request.header.x-api-key"))
                 .extract().path("ApiId");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2ModelsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2ModelsIntegrationTest.java
@@ -1,0 +1,198 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2ModelsIntegrationTest {
+
+    private static String apiId;
+    private static String modelId;
+
+    // ──────────────────────────── Prerequisites ────────────────────────────
+
+    @Test @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"models-rest-test","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("name", equalTo("models-rest-test"))
+                .body("protocolType", equalTo("HTTP"))
+                .extract().path("apiId");
+    }
+
+    // ──────────────────────────── Model CRUD ────────────────────────────
+
+    @Test @Order(2)
+    void createModel() {
+        modelId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "name": "PetModel",
+                          "schema": "{\\"$schema\\":\\"http://json-schema.org/draft-04/schema#\\",\\"title\\":\\"Pet\\",\\"type\\":\\"object\\"}",
+                          "description": "Schema for a pet object",
+                          "contentType": "application/json"
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/models")
+                .then()
+                .statusCode(201)
+                .body("modelId", notNullValue())
+                .body("name", equalTo("PetModel"))
+                .body("schema", notNullValue())
+                .body("description", equalTo("Schema for a pet object"))
+                .body("contentType", equalTo("application/json"))
+                .extract().path("modelId");
+    }
+
+    @Test @Order(3)
+    void getModel() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/models/" + modelId)
+                .then()
+                .statusCode(200)
+                .body("modelId", equalTo(modelId))
+                .body("name", equalTo("PetModel"))
+                .body("schema", notNullValue())
+                .body("description", equalTo("Schema for a pet object"))
+                .body("contentType", equalTo("application/json"));
+    }
+
+    @Test @Order(4)
+    void getModels() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/models")
+                .then()
+                .statusCode(200)
+                .body("items", notNullValue())
+                .body("items.size()", greaterThanOrEqualTo(1))
+                .body("items.modelId", hasItem(modelId));
+    }
+
+    @Test @Order(5)
+    void updateModel() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"updated description"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/models/" + modelId)
+                .then()
+                .statusCode(200)
+                .body("modelId", equalTo(modelId))
+                .body("description", equalTo("updated description"))
+                .body("name", equalTo("PetModel"))
+                .body("contentType", equalTo("application/json"));
+    }
+
+    @Test @Order(6)
+    void deleteModel() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/models/" + modelId)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(7)
+    void getModelAfterDelete() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/models/" + modelId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Parent Validation ────────────────────────────
+
+    @Test @Order(8)
+    void createModelWithNonExistentApi() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"test"}
+                        """)
+                .when().post("/v2/apis/nonexistent/models")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Not Found Errors ────────────────────────────
+
+    @Test @Order(9)
+    void getModelNotFound() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/models/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(10)
+    void updateModelNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"x"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/models/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(11)
+    void deleteModelNotFound() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/models/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Listing Isolation ────────────────────────────
+
+    @Test @Order(12)
+    void listingIsolation() {
+        // Create a second API
+        String secondApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"models-rest-test-2","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+
+        // Create a Model on the second API
+        String secondModelId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"OtherModel","contentType":"application/json"}
+                        """)
+                .when().post("/v2/apis/" + secondApiId + "/models")
+                .then()
+                .statusCode(201)
+                .body("modelId", notNullValue())
+                .extract().path("modelId");
+
+        // List Models for the first API — the second API's Model must NOT appear
+        given()
+                .when().get("/v2/apis/" + apiId + "/models")
+                .then()
+                .statusCode(200)
+                .body("items.modelId", not(hasItem(secondModelId)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2ModelsJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2ModelsJson11Test.java
@@ -1,0 +1,195 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for API Gateway v2 Models CRUD via the JSON 1.1 path.
+ * Verifies PascalCase key normalization and all Model CRUD operations
+ * through the AmazonApiGatewayV2.* X-Amz-Target header.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2ModelsJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String apiId;
+    private static String modelId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── CreateApi ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"models-json11-test","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("models-json11-test"))
+                .extract().path("ApiId");
+    }
+
+    // ──────────────────────────── CreateModel ────────────────────────────
+
+    @Test
+    @Order(2)
+    void createModel() {
+        modelId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateModel")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {
+                          "ApiId": "%s",
+                          "Name": "PetModel",
+                          "Schema": "{\\"$schema\\":\\"http://json-schema.org/draft-04/schema#\\",\\"title\\":\\"Pet\\",\\"type\\":\\"object\\"}",
+                          "ContentType": "application/json"
+                        }
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ModelId", notNullValue())
+                .body("Name", equalTo("PetModel"))
+                .body("Schema", notNullValue())
+                .body("ContentType", equalTo("application/json"))
+                .extract().path("ModelId");
+    }
+
+    // ──────────────────────────── GetModel ────────────────────────────
+
+    @Test
+    @Order(3)
+    void getModel() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetModel")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","ModelId":"%s"}
+                        """.formatted(apiId, modelId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("ModelId", equalTo(modelId))
+                .body("Name", equalTo("PetModel"))
+                .body("Schema", notNullValue())
+                .body("ContentType", equalTo("application/json"));
+    }
+
+    // ──────────────────────────── GetModels ────────────────────────────
+
+    @Test
+    @Order(4)
+    void getModels() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetModels")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items", notNullValue())
+                .body("Items.ModelId", hasItem(modelId));
+    }
+
+    // ──────────────────────────── UpdateModel ────────────────────────────
+
+    @Test
+    @Order(5)
+    void updateModel() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateModel")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","ModelId":"%s","Description":"updated description"}
+                        """.formatted(apiId, modelId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("ModelId", equalTo(modelId))
+                .body("Description", equalTo("updated description"))
+                .body("Name", equalTo("PetModel"));
+    }
+
+    // ──────────────────────────── DeleteModel ────────────────────────────
+
+    @Test
+    @Order(6)
+    void deleteModel() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteModel")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","ModelId":"%s"}
+                        """.formatted(apiId, modelId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── GetModel after delete ────────────────────────────
+
+    @Test
+    @Order(7)
+    void getModelAfterDelete() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetModel")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","ModelId":"%s"}
+                        """.formatted(apiId, modelId))
+                .when().post("/")
+                .then()
+                .statusCode(not(equalTo(200)));
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s"}
+                            """.formatted(apiId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2RouteResponseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2RouteResponseIntegrationTest.java
@@ -1,0 +1,227 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2RouteResponseIntegrationTest {
+
+    private static String apiId;
+    private static String routeId;
+    private static String routeResponseId;
+
+    // ──────────────────────────── Prerequisites ────────────────────────────
+
+    @Test @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"test-ws-api","protocolType":"WEBSOCKET","routeSelectionExpression":"$request.body.action"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("name", equalTo("test-ws-api"))
+                .body("protocolType", equalTo("WEBSOCKET"))
+                .extract().path("apiId");
+    }
+
+    @Test @Order(2)
+    void createRoute() {
+        routeId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$default"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeId", notNullValue())
+                .body("routeKey", equalTo("$default"))
+                .extract().path("routeId");
+    }
+
+    // ──────────────────────────── Route Response CRUD ────────────────────────────
+
+    @Test @Order(3)
+    void createRouteResponse() {
+        routeResponseId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "routeResponseKey": "$default",
+                          "modelSelectionExpression": "$default",
+                          "responseModels": {"application/json": "Empty"},
+                          "responseParameters": {"method.response.header.Content-Type": "integration.response.header.Content-Type"}
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses")
+                .then()
+                .statusCode(201)
+                .body("routeResponseId", notNullValue())
+                .body("routeResponseKey", equalTo("$default"))
+                .body("routeId", equalTo(routeId))
+                .body("modelSelectionExpression", equalTo("$default"))
+                .body("responseModels", notNullValue())
+                .body("responseParameters", notNullValue())
+                .extract().path("routeResponseId");
+    }
+
+    @Test @Order(4)
+    void getRouteResponse() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/" + routeResponseId)
+                .then()
+                .statusCode(200)
+                .body("routeResponseId", equalTo(routeResponseId))
+                .body("routeResponseKey", equalTo("$default"))
+                .body("routeId", equalTo(routeId))
+                .body("modelSelectionExpression", equalTo("$default"))
+                .body("responseModels", notNullValue())
+                .body("responseParameters", notNullValue());
+    }
+
+    @Test @Order(5)
+    void getRouteResponses() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses")
+                .then()
+                .statusCode(200)
+                .body("items", notNullValue())
+                .body("items.size()", greaterThanOrEqualTo(1))
+                .body("items.routeResponseId", hasItem(routeResponseId));
+    }
+
+    @Test @Order(6)
+    void updateRouteResponse() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeResponseKey": "$updated"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/" + routeResponseId)
+                .then()
+                .statusCode(200)
+                .body("routeResponseId", equalTo(routeResponseId))
+                .body("routeResponseKey", equalTo("$updated"))
+                .body("modelSelectionExpression", equalTo("$default"));
+    }
+
+    @Test @Order(7)
+    void deleteRouteResponse() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/" + routeResponseId)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(8)
+    void getRouteResponseAfterDelete() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/" + routeResponseId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Parent Validation ────────────────────────────
+
+    @Test @Order(9)
+    void createRouteResponseWithNonExistentApi() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/nonexistent/routes/nonexistent/routeresponses")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(10)
+    void createRouteResponseWithNonExistentRoute() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes/nonexistent/routeresponses")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Not Found Errors ────────────────────────────
+
+    @Test @Order(11)
+    void getRouteResponseNotFound() {
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(12)
+    void updateRouteResponseNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeResponseKey": "$default"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(13)
+    void deleteRouteResponseNotFound() {
+        given()
+                .when().delete("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses/nonexistent")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Listing Isolation ────────────────────────────
+
+    @Test @Order(14)
+    void listingIsolation() {
+        // Create a second route
+        String secondRouteId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$connect"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeId", notNullValue())
+                .extract().path("routeId");
+
+        // Create a route response on the second route
+        String secondRouteResponseId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeResponseKey": "$default"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes/" + secondRouteId + "/routeresponses")
+                .then()
+                .statusCode(201)
+                .body("routeResponseId", notNullValue())
+                .extract().path("routeResponseId");
+
+        // List route responses for the first route — the second route's response must NOT appear
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId + "/routeresponses")
+                .then()
+                .statusCode(200)
+                .body("items.routeResponseId", not(hasItem(secondRouteResponseId)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2RouteResponseJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2RouteResponseJson11Test.java
@@ -1,0 +1,210 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for API Gateway v2 Route Response CRUD via the JSON 1.1 path.
+ * Verifies PascalCase key normalization and all Route Response CRUD operations
+ * through the AmazonApiGatewayV2.* X-Amz-Target header.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2RouteResponseJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String apiId;
+    private static String routeId;
+    private static String routeResponseId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── CreateApi ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"rr-json11-test","ProtocolType":"WEBSOCKET","RouteSelectionExpression":"$request.body.action"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("rr-json11-test"))
+                .body("ProtocolType", equalTo("WEBSOCKET"))
+                .extract().path("ApiId");
+    }
+
+    // ──────────────────────────── CreateRoute ────────────────────────────
+
+    @Test
+    @Order(2)
+    void createRoute() {
+        routeId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteKey":"$default","AuthorizationType":"NONE","RouteResponseSelectionExpression":"$default"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("RouteId", notNullValue())
+                .body("RouteKey", equalTo("$default"))
+                .extract().path("RouteId");
+    }
+
+    // ──────────────────────────── CreateRouteResponse ────────────────────────────
+
+    @Test
+    @Order(3)
+    void createRouteResponse() {
+        routeResponseId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateRouteResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseKey":"$default","ModelSelectionExpression":"$default"}
+                        """.formatted(apiId, routeId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("RouteResponseId", notNullValue())
+                .body("RouteResponseKey", equalTo("$default"))
+                .body("ModelSelectionExpression", equalTo("$default"))
+                .extract().path("RouteResponseId");
+    }
+
+    // ──────────────────────────── GetRouteResponse ────────────────────────────
+
+    @Test
+    @Order(4)
+    void getRouteResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRouteResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseId":"%s"}
+                        """.formatted(apiId, routeId, routeResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteResponseId", equalTo(routeResponseId))
+                .body("RouteResponseKey", equalTo("$default"))
+                .body("ModelSelectionExpression", equalTo("$default"));
+    }
+
+    // ──────────────────────────── GetRouteResponses ────────────────────────────
+
+    @Test
+    @Order(5)
+    void getRouteResponses() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRouteResponses")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s"}
+                        """.formatted(apiId, routeId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items", notNullValue())
+                .body("Items.RouteResponseId", hasItem(routeResponseId));
+    }
+
+    // ──────────────────────────── UpdateRouteResponse ────────────────────────────
+
+    @Test
+    @Order(6)
+    void updateRouteResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateRouteResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseId":"%s","RouteResponseKey":"$updated"}
+                        """.formatted(apiId, routeId, routeResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteResponseId", equalTo(routeResponseId))
+                .body("RouteResponseKey", equalTo("$updated"))
+                .body("ModelSelectionExpression", equalTo("$default"));
+    }
+
+    // ──────────────────────────── DeleteRouteResponse ────────────────────────────
+
+    @Test
+    @Order(7)
+    void deleteRouteResponse() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteRouteResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseId":"%s"}
+                        """.formatted(apiId, routeId, routeResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── GetRouteResponse after delete ────────────────────────────
+
+    @Test
+    @Order(8)
+    void getRouteResponseAfterDelete() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRouteResponse")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseId":"%s"}
+                        """.formatted(apiId, routeId, routeResponseId))
+                .when().post("/")
+                .then()
+                .statusCode(not(equalTo(200)));
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s"}
+                            """.formatted(apiId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2TaggingJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2TaggingJson11Test.java
@@ -1,0 +1,348 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * JSON 1.1 path integration tests for the three standalone tagging operations:
+ * AmazonApiGatewayV2.TagResource, AmazonApiGatewayV2.UntagResource, and
+ * AmazonApiGatewayV2.GetTags.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2TaggingJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String apiId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    /** Builds the ARN for the given API ID. */
+    private static String arn(String id) {
+        return "arn:aws:apigateway:us-east-1::/apis/" + id;
+    }
+
+    // ──────────────────────────── Setup: create shared API ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"tagging-json11-test-api","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("tagging-json11-test-api"))
+                .extract().path("ApiId");
+    }
+
+    // ──────────────────────────── TagResource — HTTP 201 + empty body ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.TagResource with PascalCase ResourceArn and Tags,
+     * verify HTTP 201 and {} response.
+     */
+    @Test
+    @Order(10)
+    void tagResource_returns200AndEmptyBody() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "TagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","Tags":{"env":"production","team":"platform"}}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body(equalTo("{}"));
+    }
+
+    // ──────────────────────────── GetTags after TagResource ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.GetTags after tagging — verify Tags map in response
+     * contains the added tags.
+     */
+    @Test
+    @Order(11)
+    void getTags_afterTagResource_containsAddedTags() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetTags")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s"}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags.env", equalTo("production"))
+                .body("Tags.team", equalTo("platform"));
+    }
+
+    // ──────────────────────────── TagResource merge semantics ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.TagResource twice with different keys — verify merge
+     * semantics via GetTags (both sets present).
+     */
+    @Test
+    @Order(20)
+    void tagResource_mergeSemantics_bothSetsPresent() {
+        // First call: add "env" and "team"
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "TagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","Tags":{"env":"staging","team":"backend"}}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Second call: add a different key "owner"
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "TagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","Tags":{"owner":"alice"}}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Both sets must be present
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetTags")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s"}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags.env", equalTo("staging"))
+                .body("Tags.team", equalTo("backend"))
+                .body("Tags.owner", equalTo("alice"));
+    }
+
+    // ──────────────────────────── TagResource not-found ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.TagResource with a non-existent ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(30)
+    void tagResource_notFound_returns404() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "TagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"arn:aws:apigateway:us-east-1::/apis/nonexistent","Tags":{"key":"value"}}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── UntagResource — removes keys ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.UntagResource with a TagKeys array — verify HTTP 204
+     * and keys are removed via GetTags.
+     */
+    @Test
+    @Order(40)
+    void untagResource_removesKeys_returns204() {
+        // Ensure tags are present first
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "TagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","Tags":{"env":"to-be-removed","keep":"this"}}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Remove "env"
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UntagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","TagKeys":["env"]}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+
+        // "env" must be absent; "keep" must still be present
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetTags")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s"}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags", not(hasKey("env")))
+                .body("Tags.keep", equalTo("this"));
+    }
+
+    // ──────────────────────────── UntagResource silent-ignore ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.UntagResource with a key that does not exist —
+     * verify HTTP 204 (silent ignore).
+     */
+    @Test
+    @Order(41)
+    void untagResource_nonexistentKey_silentIgnore_returns204() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UntagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s","TagKeys":["this-key-does-not-exist"]}
+                        """.formatted(arn(apiId)))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── UntagResource not-found ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.UntagResource with a non-existent ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(50)
+    void untagResource_notFound_returns404() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UntagResource")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"arn:aws:apigateway:us-east-1::/apis/nonexistent","TagKeys":["somekey"]}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── GetTags on API with no tags ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.GetTags on an API with no tags — verify HTTP 200
+     * and {"Tags": {}}.
+     */
+    @Test
+    @Order(60)
+    void getTags_noTags_returnsEmptyMap() {
+        // Create a fresh API with no tags
+        String freshApiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"tagging-json11-notags-api","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .extract().path("ApiId");
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetTags")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"%s"}
+                        """.formatted(arn(freshApiId)))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags", anEmptyMap());
+
+        // Cleanup the fresh API
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(freshApiId))
+                .when().post("/")
+                .then()
+                .statusCode(anyOf(equalTo(204), equalTo(404)));
+    }
+
+    // ──────────────────────────── GetTags not-found ────────────────────────────
+
+    /**
+     * Send AmazonApiGatewayV2.GetTags on a non-existent ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(70)
+    void getTags_notFound_returns404() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetTags")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ResourceArn":"arn:aws:apigateway:us-east-1::/apis/nonexistent"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s"}
+                            """.formatted(apiId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2TaggingRestTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2TaggingRestTest.java
@@ -1,0 +1,326 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * REST path integration tests for the three standalone tagging operations:
+ * TagResource (POST /v2/tags/{arn}), UntagResource (DELETE /v2/tags/{arn}),
+ * and GetTags (GET /v2/tags/{arn}).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2TaggingRestTest {
+
+    private static String apiId;
+
+    /** Builds the ARN for the given API ID. */
+    private static String arn(String id) {
+        return "arn:aws:apigateway:us-east-1::/apis/" + id;
+    }
+
+    /** Builds the /v2/tags/{arn} path. Colons are valid in URL paths; slashes in the ARN
+     *  are captured by the {@code {resourceArn: .+}} regex in the controller. */
+    private static String tagsPath(String id) {
+        return "/v2/tags/" + arn(id);
+    }
+
+    // ──────────────────────────── Setup: create shared API ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"tagging-rest-test-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+    }
+
+    // ──────────────────────────── TagResource — HTTP 201 + empty body ────────────────────────────
+
+    /**
+     * Create API, POST /v2/tags/{arn} with a tags map, verify HTTP 201 and {} response body.
+     */
+    @Test
+    @Order(10)
+    void tagResource_returns201AndEmptyBody() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"env":"production","team":"platform"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201)
+                .body(equalTo("{}"));
+    }
+
+    // ──────────────────────────── GetTags after TagResource ────────────────────────────
+
+    /**
+     * GET /v2/tags/{arn} after tagging — verify the response tags map contains the added keys.
+     */
+    @Test
+    @Order(11)
+    void getTags_afterTagResource_containsAddedTags() {
+        given()
+                .when().get(tagsPath(apiId))
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("production"))
+                .body("tags.team", equalTo("platform"));
+    }
+
+    // ──────────────────────────── TagResource merge semantics ────────────────────────────
+
+    /**
+     * Call PUT twice with different keys — verify both sets are present via GetTags.
+     */
+    @Test
+    @Order(20)
+    void tagResource_mergeSemantics_bothSetsPresent() {
+        // First PUT: add "env" and "team" (already done in order 10, but re-add to be explicit)
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"env":"staging","team":"backend"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201);
+
+        // Second PUT: add a different key "owner"
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"owner":"alice"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201);
+
+        // Both sets must be present
+        given()
+                .when().get(tagsPath(apiId))
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("staging"))
+                .body("tags.team", equalTo("backend"))
+                .body("tags.owner", equalTo("alice"));
+    }
+
+    // ──────────────────────────── TagResource overwrite ────────────────────────────
+
+    /**
+     * Call PUT with an existing key and new value — verify the value is updated via GetTags.
+     */
+    @Test
+    @Order(21)
+    void tagResource_overwrite_updatesExistingValue() {
+        // "env" was "staging" from order 20; overwrite it
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"env":"production-overwritten"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get(tagsPath(apiId))
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("production-overwritten"))
+                // Other keys must still be present
+                .body("tags.team", equalTo("backend"))
+                .body("tags.owner", equalTo("alice"));
+    }
+
+    // ──────────────────────────── 4.5 TagResource not-found ────────────────────────────
+
+    /**
+     * 4.5 PUT /v2/tags/{arn} with a non-existent API ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(30)
+    void tagResource_notFound_returns404() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"key":"value"}}
+                        """)
+                .when().post(tagsPath("nonexistent"))
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── UntagResource — removes key ────────────────────────────
+
+    /**
+     * Create API with tags, DELETE /v2/tags/{arn}?tagKeys=key1, verify HTTP 204 and key absent.
+     */
+    @Test
+    @Order(40)
+    void untagResource_removesKey_returns204() {
+        // Ensure "env" is present first
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"env":"to-be-removed","keep":"this"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201);
+
+        // Remove "env"
+        given()
+                .when().delete(tagsPath(apiId) + "?tagKeys=env")
+                .then()
+                .statusCode(204);
+
+        // "env" must be absent; "keep" must still be present
+        given()
+                .when().get(tagsPath(apiId))
+                .then()
+                .statusCode(200)
+                .body("tags", not(hasKey("env")))
+                .body("tags.keep", equalTo("this"));
+    }
+
+    // ──────────────────────────── UntagResource silent-ignore ────────────────────────────
+
+    /**
+     * DELETE /v2/tags/{arn}?tagKeys=nonexistent — verify HTTP 204 (silent ignore).
+     */
+    @Test
+    @Order(41)
+    void untagResource_nonexistentKey_silentIgnore_returns204() {
+        given()
+                .when().delete(tagsPath(apiId) + "?tagKeys=this-key-does-not-exist")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── UntagResource multiple keys ────────────────────────────
+
+    /**
+     * DELETE /v2/tags/{arn}?tagKeys=key1&tagKeys=key2 — verify both keys are removed.
+     */
+    @Test
+    @Order(42)
+    void untagResource_multipleKeys_bothRemoved() {
+        // Add two keys to remove
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"alpha":"1","beta":"2","gamma":"3"}}
+                        """)
+                .when().post(tagsPath(apiId))
+                .then()
+                .statusCode(201);
+
+        // Remove alpha and beta in one call using repeated query params (AWS SDK format)
+        given()
+                .queryParam("tagKeys", "alpha")
+                .queryParam("tagKeys", "beta")
+                .when().delete(tagsPath(apiId))
+                .then()
+                .statusCode(204);
+
+        // alpha and beta must be gone; gamma must remain
+        given()
+                .when().get(tagsPath(apiId))
+                .then()
+                .statusCode(200)
+                .body("tags", not(hasKey("alpha")))
+                .body("tags", not(hasKey("beta")))
+                .body("tags.gamma", equalTo("3"));
+    }
+
+    // ──────────────────────────── UntagResource not-found ────────────────────────────
+
+    /**
+     * DELETE /v2/tags/{arn} with a non-existent API ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(50)
+    void untagResource_notFound_returns404() {
+        given()
+                .when().delete(tagsPath("nonexistent") + "?tagKeys=somekey")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── GetTags on API with no tags ────────────────────────────
+
+    /**
+     * Create an API with no tags, GET /v2/tags/{arn} — verify HTTP 200 and {"tags": {}}.
+     */
+    @Test
+    @Order(60)
+    void getTags_noTags_returnsEmptyMap() {
+        // Create a fresh API with no tags
+        String freshApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"tagging-rest-notags-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .extract().path("apiId");
+
+        given()
+                .when().get(tagsPath(freshApiId))
+                .then()
+                .statusCode(200)
+                .body("tags", anEmptyMap());
+
+        // Cleanup the fresh API
+        given()
+                .when().delete("/v2/apis/" + freshApiId)
+                .then()
+                .statusCode(anyOf(equalTo(204), equalTo(404)));
+    }
+
+    // ──────────────────────────── GetTags not-found ────────────────────────────
+
+    /**
+     * GET /v2/tags/{arn} with a non-existent API ARN — verify HTTP 404.
+     */
+    @Test
+    @Order(70)
+    void getTags_notFound_returns404() {
+        given()
+                .when().get(tagsPath("nonexistent"))
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId != null) {
+            given()
+                    .when().delete("/v2/apis/" + apiId)
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2UpdateOperationsJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2UpdateOperationsJson11Test.java
@@ -1,0 +1,404 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * JSON 1.1 path integration tests for the four missing Update operations:
+ * UpdateIntegration, UpdateAuthorizer, UpdateStage, UpdateDeployment.
+ *
+ * Verifies PascalCase key normalization and merge-patch semantics through
+ * the AmazonApiGatewayV2.* X-Amz-Target header.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2UpdateOperationsJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String apiId;
+    private static String integrationId;
+    private static String authorizerId;
+    private static String stageName;
+    private static String deploymentId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── Setup: create shared resources ────────────────────────────
+
+    @Test
+    @Order(1)
+    void setupCreateApi() {
+        apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"update-ops-json11-api","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .extract().path("ApiId");
+    }
+
+    @Test
+    @Order(2)
+    void setupCreateIntegration() {
+        integrationId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationType":"HTTP_PROXY","IntegrationUri":"https://original.example.com","PayloadFormatVersion":"2.0"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("IntegrationId", notNullValue())
+                .body("IntegrationUri", equalTo("https://original.example.com"))
+                .extract().path("IntegrationId");
+    }
+
+    @Test
+    @Order(3)
+    void setupCreateAuthorizer() {
+        authorizerId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateAuthorizer")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","AuthorizerType":"JWT","Name":"original-authorizer","IdentitySource":["$request.header.Authorization"],"JwtConfiguration":{"Issuer":"https://original-issuer.example.com","Audience":["original-audience"]}}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("AuthorizerId", notNullValue())
+                .body("Name", equalTo("original-authorizer"))
+                .extract().path("AuthorizerId");
+    }
+
+    @Test
+    @Order(4)
+    void setupCreateDeployment() {
+        deploymentId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","Description":"initial-deployment"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("DeploymentId", notNullValue())
+                .extract().path("DeploymentId");
+    }
+
+    @Test
+    @Order(5)
+    void setupCreateStage() {
+        stageName = "test-stage-json11";
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateStage")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","StageName":"%s","DeploymentId":"%s","AutoDeploy":false}
+                        """.formatted(apiId, stageName, deploymentId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("StageName", equalTo(stageName))
+                .body("DeploymentId", equalTo(deploymentId));
+    }
+
+    // ──────────────────────────── UpdateIntegration: PascalCase request/response ────────────────────────────
+
+    /**
+     * Test AmazonApiGatewayV2.UpdateIntegration: send PascalCase request,
+     * verify HTTP 200 and PascalCase response fields.
+     */
+    @Test
+    @Order(10)
+    void updateIntegrationViaPascalCaseKeys() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationUri":"https://updated.example.com"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("IntegrationId", equalTo(integrationId))
+                .body("IntegrationUri", equalTo("https://updated.example.com"));
+    }
+
+    // ──────────────────────────── UpdateIntegration: merge-patch semantics ────────────────────────────
+
+    /**
+     * Test UpdateIntegration merge-patch via JSON 1.1:
+     * verify only provided fields are updated, others preserved.
+     */
+    @Test
+    @Order(11)
+    void updateIntegrationMergePatchPreservesUnprovidedFields() {
+        // PATCH only IntegrationUri; IntegrationType and PayloadFormatVersion must be preserved
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s","IntegrationUri":"https://patched.example.com"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("IntegrationUri", equalTo("https://patched.example.com"))
+                // Fields not in request must be preserved
+                .body("IntegrationType", equalTo("HTTP_PROXY"))
+                .body("PayloadFormatVersion", equalTo("2.0"));
+    }
+
+    // ──────────────────────────── UpdateAuthorizer: PascalCase request/response ────────────────────────────
+
+    /**
+     * Test AmazonApiGatewayV2.UpdateAuthorizer: send PascalCase request,
+     * verify HTTP 200 and PascalCase response fields.
+     */
+    @Test
+    @Order(20)
+    void updateAuthorizerViaPascalCaseKeys() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateAuthorizer")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","AuthorizerId":"%s","Name":"updated-authorizer"}
+                        """.formatted(apiId, authorizerId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("AuthorizerId", equalTo(authorizerId))
+                .body("Name", equalTo("updated-authorizer"));
+    }
+
+    // ──────────────────────────── UpdateAuthorizer: merge-patch semantics ────────────────────────────
+
+    /**
+     * Test UpdateAuthorizer merge-patch via JSON 1.1:
+     * verify only provided fields are updated, others preserved.
+     */
+    @Test
+    @Order(21)
+    void updateAuthorizerMergePatchPreservesUnprovidedFields() {
+        // PATCH only Name; AuthorizerType and IdentitySource must be preserved
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateAuthorizer")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","AuthorizerId":"%s","Name":"merge-patch-authorizer"}
+                        """.formatted(apiId, authorizerId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Name", equalTo("merge-patch-authorizer"))
+                // Fields not in request must be preserved
+                .body("AuthorizerType", equalTo("JWT"))
+                .body("IdentitySource", hasItem("$request.header.Authorization"));
+    }
+
+    // ──────────────────────────── UpdateStage: PascalCase request/response ────────────────────────────
+
+    /**
+     * Test AmazonApiGatewayV2.UpdateStage: send PascalCase request,
+     * verify HTTP 200 and PascalCase response fields.
+     */
+    @Test
+    @Order(30)
+    void updateStageViaPascalCaseKeys() {
+        // Create a second deployment to use as the new DeploymentId
+        String newDeploymentId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","Description":"second-deployment"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .extract().path("DeploymentId");
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateStage")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","StageName":"%s","DeploymentId":"%s"}
+                        """.formatted(apiId, stageName, newDeploymentId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("StageName", equalTo(stageName))
+                .body("DeploymentId", equalTo(newDeploymentId));
+    }
+
+    // ──────────────────────────── UpdateStage: merge-patch semantics ────────────────────────────
+
+    /**
+     * Test UpdateStage merge-patch via JSON 1.1:
+     * verify only provided fields are updated, others preserved.
+     */
+    @Test
+    @Order(31)
+    void updateStageMergePatchPreservesUnprovidedFields() {
+        // PATCH only AutoDeploy; StageName and DeploymentId must be preserved
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateStage")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","StageName":"%s","AutoDeploy":true}
+                        """.formatted(apiId, stageName))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("StageName", equalTo(stageName))
+                .body("AutoDeploy", equalTo(true))
+                // DeploymentId set in order 30 must still be present
+                .body("DeploymentId", notNullValue())
+                // LastUpdatedDate must be present (updated on every PATCH)
+                .body("LastUpdatedDate", notNullValue());
+    }
+
+    // ──────────────────────────── UpdateDeployment: PascalCase request/response ────────────────────────────
+
+    /**
+     * Test AmazonApiGatewayV2.UpdateDeployment: send PascalCase request,
+     * verify HTTP 200 and PascalCase response fields.
+     */
+    @Test
+    @Order(40)
+    void updateDeploymentViaPascalCaseKeys() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","DeploymentId":"%s","Description":"updated-description"}
+                        """.formatted(apiId, deploymentId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("DeploymentId", equalTo(deploymentId))
+                .body("Description", equalTo("updated-description"));
+    }
+
+    // ──────────────────────────── UpdateDeployment: merge-patch semantics ────────────────────────────
+
+    /**
+     * Test UpdateDeployment merge-patch via JSON 1.1:
+     * verify only provided fields are updated, others preserved.
+     */
+    @Test
+    @Order(41)
+    void updateDeploymentMergePatchPreservesUnprovidedFields() {
+        // PATCH only Description; DeploymentStatus must be preserved
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateDeployment")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","DeploymentId":"%s","Description":"merge-patch-description"}
+                        """.formatted(apiId, deploymentId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Description", equalTo("merge-patch-description"))
+                // DeploymentStatus should be preserved
+                .body("DeploymentStatus", equalTo("DEPLOYED"));
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (apiId == null) {
+            return;
+        }
+
+        // Delete stage
+        if (stageName != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteStage")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s","StageName":"%s"}
+                            """.formatted(apiId, stageName))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+
+        // Delete authorizer
+        if (authorizerId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteAuthorizer")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s","AuthorizerId":"%s"}
+                            """.formatted(apiId, authorizerId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+
+        // Delete integration
+        if (integrationId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteIntegration")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s","IntegrationId":"%s"}
+                            """.formatted(apiId, integrationId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+
+        // Delete API (cascades deployments)
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(anyOf(equalTo(204), equalTo(404)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2UpdateOperationsRestTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2UpdateOperationsRestTest.java
@@ -1,0 +1,411 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * REST path integration tests for the four missing Update operations:
+ * UpdateIntegration, UpdateAuthorizer, UpdateStage, UpdateDeployment.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2UpdateOperationsRestTest {
+
+    private static String apiId;
+    private static String integrationId;
+    private static String authorizerId;
+    private static String deploymentId;
+
+    // ──────────────────────────── Setup: create shared API ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"update-ops-test-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+    }
+
+    // ──────────────────────────── UpdateIntegration ────────────────────────────
+
+    /**
+     * Create API + integration, PATCH with new integrationUri, verify HTTP 200 and updated field.
+     */
+    @Test
+    @Order(10)
+    void createIntegrationForUpdate() {
+        integrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationType":"HTTP_PROXY","integrationUri":"https://original.example.com","payloadFormatVersion":"2.0"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(201)
+                .body("integrationId", notNullValue())
+                .body("integrationUri", equalTo("https://original.example.com"))
+                .extract().path("integrationId");
+    }
+
+    @Test
+    @Order(11)
+    void updateIntegrationUri() {
+        // PATCH with new integrationUri, verify HTTP 200 and updated field
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationUri":"https://updated.example.com"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then()
+                .statusCode(200)
+                .body("integrationId", equalTo(integrationId))
+                .body("integrationUri", equalTo("https://updated.example.com"));
+    }
+
+    @Test
+    @Order(12)
+    void updateIntegrationMergePatch() {
+        // Verify fields not in PATCH body are preserved
+        // PATCH only integrationUri; integrationType and payloadFormatVersion must be preserved
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationUri":"https://patched.example.com"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then()
+                .statusCode(200)
+                .body("integrationUri", equalTo("https://patched.example.com"))
+                // Fields not in PATCH body must be preserved
+                .body("integrationType", equalTo("HTTP_PROXY"))
+                .body("payloadFormatVersion", equalTo("2.0"));
+    }
+
+    @Test
+    @Order(13)
+    void updateIntegrationNotFound() {
+        // PATCH non-existent integrationId, verify HTTP 404
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationUri":"https://ghost.example.com"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/nonexistent-integration-id")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── UpdateAuthorizer ────────────────────────────
+
+    /**
+     * Create API + authorizer, PATCH with new name, verify HTTP 200 and updated field.
+     */
+    @Test
+    @Order(20)
+    void createAuthorizerForUpdate() {
+        authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"authorizerType":"JWT","name":"original-authorizer","identitySource":["$request.header.Authorization"],"jwtConfiguration":{"issuer":"https://original-issuer.example.com","audience":["original-audience"]}}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then()
+                .statusCode(201)
+                .body("authorizerId", notNullValue())
+                .body("name", equalTo("original-authorizer"))
+                .extract().path("authorizerId");
+    }
+
+    @Test
+    @Order(21)
+    void updateAuthorizerName() {
+        // PATCH with new name, verify HTTP 200 and updated field
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"updated-authorizer"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then()
+                .statusCode(200)
+                .body("authorizerId", equalTo(authorizerId))
+                .body("name", equalTo("updated-authorizer"));
+    }
+
+    @Test
+    @Order(22)
+    void updateAuthorizerJwtConfiguration() {
+        // PATCH with new audience and issuer, verify nested fields updated
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"jwtConfiguration":{"audience":["new-client-id"],"issuer":"https://new-issuer.example.com"}}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then()
+                .statusCode(200)
+                .body("authorizerId", equalTo(authorizerId))
+                .body("jwtConfiguration.audience", hasItem("new-client-id"))
+                .body("jwtConfiguration.issuer", equalTo("https://new-issuer.example.com"));
+    }
+
+    @Test
+    @Order(23)
+    void updateAuthorizerMergePatch() {
+        // Verify fields not in PATCH body are preserved
+        // PATCH only name; authorizerType and identitySource must be preserved
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"merge-patch-authorizer"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("merge-patch-authorizer"))
+                // Fields not in PATCH body must be preserved
+                .body("authorizerType", equalTo("JWT"))
+                .body("identitySource", hasItem("$request.header.Authorization"));
+    }
+
+    @Test
+    @Order(24)
+    void updateAuthorizerNotFound() {
+        // PATCH non-existent authorizerId, verify HTTP 404
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ghost-authorizer"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/authorizers/nonexistent-authorizer-id")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── UpdateStage ────────────────────────────
+
+    /**
+     * Create API + stage, PATCH with new deploymentId, verify HTTP 200 and updated field.
+     */
+    @Test
+    @Order(30)
+    void createDeploymentAndStageForUpdate() {
+        // Create a deployment first (needed for stage)
+        deploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"initial-deployment"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .body("deploymentId", notNullValue())
+                .extract().path("deploymentId");
+
+        // Create stage with autoDeploy=false and initial deploymentId
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"stageName":"test-stage","deploymentId":"%s","autoDeploy":false}
+                        """.formatted(deploymentId))
+                .when().post("/v2/apis/" + apiId + "/stages")
+                .then()
+                .statusCode(201)
+                .body("stageName", equalTo("test-stage"))
+                .body("deploymentId", equalTo(deploymentId));
+    }
+
+    @Test
+    @Order(31)
+    void updateStageDeploymentId() {
+        // PATCH with new deploymentId, verify HTTP 200 and updated field
+        // Create a second deployment to use as the new deploymentId
+        String newDeploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"second-deployment"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("deploymentId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"deploymentId":"%s"}
+                        """.formatted(newDeploymentId))
+                .when().patch("/v2/apis/" + apiId + "/stages/test-stage")
+                .then()
+                .statusCode(200)
+                .body("stageName", equalTo("test-stage"))
+                .body("deploymentId", equalTo(newDeploymentId));
+    }
+
+    @Test
+    @Order(32)
+    void updateStageLastUpdatedDate() {
+        // Verify lastUpdatedDate is present and non-null after PATCH
+        // First GET to capture current state
+        String lastUpdatedBefore = given()
+                .when().get("/v2/apis/" + apiId + "/stages/test-stage")
+                .then()
+                .statusCode(200)
+                .body("lastUpdatedDate", notNullValue())
+                .extract().path("lastUpdatedDate").toString();
+
+        // PATCH and verify lastUpdatedDate is present (and changes)
+        String lastUpdatedAfter = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"autoDeploy":true}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/stages/test-stage")
+                .then()
+                .statusCode(200)
+                .body("lastUpdatedDate", notNullValue())
+                .extract().path("lastUpdatedDate").toString();
+
+        // lastUpdatedDate should have changed after the PATCH
+        Assertions.assertNotEquals(lastUpdatedBefore, lastUpdatedAfter,
+                "lastUpdatedDate should change after PATCH");
+    }
+
+    @Test
+    @Order(33)
+    void updateStageMergePatch() {
+        // Verify fields not in PATCH body are preserved
+        // PATCH only autoDeploy; stageName must be preserved (it's the key, always present)
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"autoDeploy":false}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/stages/test-stage")
+                .then()
+                .statusCode(200)
+                .body("stageName", equalTo("test-stage"))
+                .body("autoDeploy", equalTo(false))
+                // deploymentId set in order 31 must still be present
+                .body("deploymentId", notNullValue());
+    }
+
+    @Test
+    @Order(34)
+    void updateStageNotFound() {
+        // PATCH non-existent stageName, verify HTTP 404
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"autoDeploy":true}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/stages/nonexistent-stage-name")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── UpdateDeployment ────────────────────────────
+
+    /**
+     * Create API + deployment, PATCH with new description, verify HTTP 200 and updated field.
+     */
+    @Test
+    @Order(40)
+    void updateDeploymentDescription() {
+        // PATCH with new description, verify HTTP 200 and updated field
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"updated-description"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .then()
+                .statusCode(200)
+                .body("deploymentId", equalTo(deploymentId))
+                .body("description", equalTo("updated-description"));
+    }
+
+    @Test
+    @Order(41)
+    void updateDeploymentMergePatch() {
+        // Verify fields not in PATCH body are preserved
+        // PATCH only description; deploymentStatus must be preserved
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"merge-patch-description"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/deployments/" + deploymentId)
+                .then()
+                .statusCode(200)
+                .body("description", equalTo("merge-patch-description"))
+                // deploymentStatus should be preserved
+                .body("deploymentStatus", equalTo("DEPLOYED"));
+    }
+
+    @Test
+    @Order(42)
+    void updateDeploymentNotFound() {
+        // PATCH non-existent deploymentId, verify HTTP 404
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"ghost-description"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/deployments/nonexistent-deployment-id")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        // Delete stage
+        given()
+                .when().delete("/v2/apis/" + apiId + "/stages/test-stage")
+                .then()
+                .statusCode(anyOf(equalTo(204), equalTo(404)));
+
+        // Delete authorizer
+        if (authorizerId != null) {
+            given()
+                    .when().delete("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+
+        // Delete integration
+        if (integrationId != null) {
+            given()
+                    .when().delete("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+
+        // Delete API (cascades deployments)
+        if (apiId != null) {
+            given()
+                    .when().delete("/v2/apis/" + apiId)
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2WebSocketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2WebSocketIntegrationTest.java
@@ -1,0 +1,440 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2WebSocketIntegrationTest {
+
+    private static String wsApiId;
+    private static String wsRouteId;
+    private static String httpApiId;
+    private static String taggedApiId;
+
+    // ──────────────────────────── WebSocket API Creation ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createWebSocketApi() {
+        wsApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ws-test-api","protocolType":"WEBSOCKET","routeSelectionExpression":"$request.body.action","description":"A test WS API","apiKeySelectionExpression":"$request.header.x-api-key"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("name", equalTo("ws-test-api"))
+                .body("protocolType", equalTo("WEBSOCKET"))
+                .body("routeSelectionExpression", equalTo("$request.body.action"))
+                .body("description", equalTo("A test WS API"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("apiEndpoint", startsWith("wss://"))
+                .extract().path("apiId");
+    }
+
+    @Test
+    @Order(2)
+    void createWebSocketApiMissingRouteSelectionExpression() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ws-no-rse","protocolType":"WEBSOCKET"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(400);
+    }
+
+    // ──────────────────────────── GetApi ────────────────────────────
+
+    @Test
+    @Order(3)
+    void getWebSocketApi() {
+        given()
+                .when().get("/v2/apis/" + wsApiId)
+                .then()
+                .statusCode(200)
+                .body("apiId", equalTo(wsApiId))
+                .body("name", equalTo("ws-test-api"))
+                .body("protocolType", equalTo("WEBSOCKET"))
+                .body("routeSelectionExpression", equalTo("$request.body.action"))
+                .body("description", equalTo("A test WS API"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("apiEndpoint", startsWith("wss://"))
+                .body("createdDate", notNullValue());
+    }
+
+    // ──────────────────────────── GetApis ────────────────────────────
+
+    @Test
+    @Order(4)
+    void getApisIncludesWebSocket() {
+        given()
+                .when().get("/v2/apis")
+                .then()
+                .statusCode(200)
+                .body("items.apiId", hasItem(wsApiId))
+                .body("items.find { it.apiId == '" + wsApiId + "' }.routeSelectionExpression",
+                        equalTo("$request.body.action"));
+    }
+
+    // ──────────────────────────── UpdateApi ────────────────────────────
+
+    @Test
+    @Order(5)
+    void updateWebSocketApi() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ws-updated-api","description":"Updated description"}
+                        """)
+                .when().patch("/v2/apis/" + wsApiId)
+                .then()
+                .statusCode(200)
+                .body("apiId", equalTo(wsApiId))
+                .body("name", equalTo("ws-updated-api"))
+                .body("description", equalTo("Updated description"))
+                // Non-provided fields should be preserved
+                .body("protocolType", equalTo("WEBSOCKET"))
+                .body("routeSelectionExpression", equalTo("$request.body.action"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("apiEndpoint", startsWith("wss://"));
+    }
+
+    @Test
+    @Order(6)
+    void updateApiNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ghost"}
+                        """)
+                .when().patch("/v2/apis/nonexistent999")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── DeleteApi ────────────────────────────
+
+    @Test
+    @Order(7)
+    void deleteWebSocketApiAndVerify() {
+        // Create a temporary API to delete
+        String tempApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ws-to-delete","protocolType":"WEBSOCKET","routeSelectionExpression":"$request.body.action"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .extract().path("apiId");
+
+        // Delete it
+        given()
+                .when().delete("/v2/apis/" + tempApiId)
+                .then()
+                .statusCode(204);
+
+        // Verify it's gone
+        given()
+                .when().get("/v2/apis/" + tempApiId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Tags ────────────────────────────
+
+    @Test
+    @Order(8)
+    void createApiWithTagsAndVerifyInGetApi() {
+        taggedApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"ws-tagged","protocolType":"WEBSOCKET","routeSelectionExpression":"$request.body.action","tags":{"env":"dev","team":"platform"}}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("tags.env", equalTo("dev"))
+                .body("tags.team", equalTo("platform"))
+                .extract().path("apiId");
+
+        // GetApi returns tags
+        given()
+                .when().get("/v2/apis/" + taggedApiId)
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("dev"))
+                .body("tags.team", equalTo("platform"));
+
+        // GetApis returns tags
+        given()
+                .when().get("/v2/apis")
+                .then()
+                .statusCode(200)
+                .body("items.find { it.apiId == '" + taggedApiId + "' }.tags.env", equalTo("dev"));
+    }
+
+    @Test
+    @Order(9)
+    void updateApiTagsReplacement() {
+        // Replace tags entirely
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"env":"prod","version":"2"}}
+                        """)
+                .when().patch("/v2/apis/" + taggedApiId)
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("prod"))
+                .body("tags.version", equalTo("2"))
+                .body("tags.team", nullValue())
+                // Non-tag fields preserved
+                .body("name", equalTo("ws-tagged"))
+                .body("routeSelectionExpression", equalTo("$request.body.action"));
+
+        // Cleanup
+        given().when().delete("/v2/apis/" + taggedApiId).then().statusCode(204);
+    }
+
+    // ──────────────────────────── CreateRoute with routeResponseSelectionExpression ────────────────────────────
+
+    @Test
+    @Order(10)
+    void createRouteWithRouteResponseSelectionExpression() {
+        wsRouteId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$default","authorizationType":"NONE","routeResponseSelectionExpression":"$default"}
+                        """)
+                .when().post("/v2/apis/" + wsApiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeId", notNullValue())
+                .body("routeKey", equalTo("$default"))
+                .body("authorizationType", equalTo("NONE"))
+                .body("routeResponseSelectionExpression", equalTo("$default"))
+                .extract().path("routeId");
+    }
+
+    // ──────────────────────────── WebSocket lifecycle route keys ────────────────────────────
+
+    @Test
+    @Order(11)
+    void createConnectRoute() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$connect","authorizationType":"NONE","routeResponseSelectionExpression":"$default"}
+                        """)
+                .when().post("/v2/apis/" + wsApiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeKey", equalTo("$connect"))
+                .body("routeResponseSelectionExpression", equalTo("$default"));
+    }
+
+    @Test
+    @Order(12)
+    void createDisconnectRoute() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$disconnect","authorizationType":"NONE"}
+                        """)
+                .when().post("/v2/apis/" + wsApiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeKey", equalTo("$disconnect"));
+    }
+
+    // ──────────────────────────── GetRoute ────────────────────────────
+
+    @Test
+    @Order(13)
+    void getRouteReturnsRouteResponseSelectionExpression() {
+        given()
+                .when().get("/v2/apis/" + wsApiId + "/routes/" + wsRouteId)
+                .then()
+                .statusCode(200)
+                .body("routeId", equalTo(wsRouteId))
+                .body("routeKey", equalTo("$default"))
+                .body("routeResponseSelectionExpression", equalTo("$default"));
+    }
+
+    // ──────────────────────────── GetRoutes ────────────────────────────
+
+    @Test
+    @Order(14)
+    void getRoutesReturnsAllRoutesWithRouteResponseSelectionExpression() {
+        given()
+                .when().get("/v2/apis/" + wsApiId + "/routes")
+                .then()
+                .statusCode(200)
+                .body("items.routeId", hasItem(wsRouteId))
+                .body("items.find { it.routeId == '" + wsRouteId + "' }.routeResponseSelectionExpression",
+                        equalTo("$default"));
+    }
+
+    // ──────────────────────────── UpdateRoute ────────────────────────────
+
+    @Test
+    @Order(15)
+    void updateRouteMergePatch() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"target":"integrations/int123","routeResponseSelectionExpression":"$default"}
+                        """)
+                .when().patch("/v2/apis/" + wsApiId + "/routes/" + wsRouteId)
+                .then()
+                .statusCode(200)
+                .body("routeId", equalTo(wsRouteId))
+                .body("target", equalTo("integrations/int123"))
+                .body("routeResponseSelectionExpression", equalTo("$default"))
+                // Non-provided fields preserved
+                .body("routeKey", equalTo("$default"))
+                .body("authorizationType", equalTo("NONE"));
+    }
+
+    @Test
+    @Order(16)
+    void updateRouteNotFound() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"$connect"}
+                        """)
+                .when().patch("/v2/apis/" + wsApiId + "/routes/nonexistent999")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── DeleteRoute ────────────────────────────
+
+    @Test
+    @Order(17)
+    void deleteRouteAndVerify() {
+        // Create a temporary route to delete
+        String tempRouteId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"temp-route","authorizationType":"NONE"}
+                        """)
+                .when().post("/v2/apis/" + wsApiId + "/routes")
+                .then()
+                .statusCode(201)
+                .extract().path("routeId");
+
+        // Delete it
+        given()
+                .when().delete("/v2/apis/" + wsApiId + "/routes/" + tempRouteId)
+                .then()
+                .statusCode(204);
+
+        // Verify it's gone
+        given()
+                .when().get("/v2/apis/" + wsApiId + "/routes/" + tempRouteId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── HTTP API backward compatibility ────────────────────────────
+
+    @Test
+    @Order(20)
+    void httpApiCrudStillWorks() {
+        // Create HTTP API
+        httpApiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"http-compat-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("name", equalTo("http-compat-api"))
+                .body("protocolType", equalTo("HTTP"))
+                .body("apiEndpoint", startsWith("https://"))
+                // AWS defaults must be populated even when not provided
+                .body("routeSelectionExpression", equalTo("${request.method} ${request.path}"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .extract().path("apiId");
+
+        // Get HTTP API — verify defaults are persisted
+        given()
+                .when().get("/v2/apis/" + httpApiId)
+                .then()
+                .statusCode(200)
+                .body("apiId", equalTo(httpApiId))
+                .body("protocolType", equalTo("HTTP"))
+                .body("routeSelectionExpression", equalTo("${request.method} ${request.path}"))
+                .body("apiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("createdDate", notNullValue());
+
+        // Create route on HTTP API
+        String httpRouteId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"GET /health","authorizationType":"NONE"}
+                        """)
+                .when().post("/v2/apis/" + httpApiId + "/routes")
+                .then()
+                .statusCode(201)
+                .body("routeId", notNullValue())
+                .body("routeKey", equalTo("GET /health"))
+                .extract().path("routeId");
+
+        // Get route on HTTP API
+        given()
+                .when().get("/v2/apis/" + httpApiId + "/routes/" + httpRouteId)
+                .then()
+                .statusCode(200)
+                .body("routeId", equalTo(httpRouteId))
+                .body("routeKey", equalTo("GET /health"));
+
+        // Delete route
+        given()
+                .when().delete("/v2/apis/" + httpApiId + "/routes/" + httpRouteId)
+                .then()
+                .statusCode(204);
+
+        // Delete HTTP API
+        given()
+                .when().delete("/v2/apis/" + httpApiId)
+                .then()
+                .statusCode(204);
+
+        // Verify deleted
+        given()
+                .when().get("/v2/apis/" + httpApiId)
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanupWebSocketApi() {
+        if (wsApiId != null) {
+            given()
+                    .when().delete("/v2/apis/" + wsApiId)
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2WebSocketJson11Test.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2WebSocketJson11Test.java
@@ -1,0 +1,470 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for API Gateway v2 WebSocket support via the JSON 1.1 path.
+ * Verifies PascalCase key normalization and all WebSocket CRUD operations
+ * through the AmazonApiGatewayV2.* X-Amz-Target header.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2WebSocketJson11Test {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260413/us-east-1/apigatewayv2/aws4_request";
+
+    private static String wsApiId;
+    private static String wsRouteId;
+    private static String taggedApiId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── CreateApi (WebSocket) ────────────────────────────
+
+    @Test
+    @Order(1)
+    void json11CreateWebSocketApiWithPascalCaseKeys() {
+        wsApiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"ws-json11-test","ProtocolType":"WEBSOCKET","RouteSelectionExpression":"$request.body.action","Description":"JSON 1.1 WS API","ApiKeySelectionExpression":"$request.header.x-api-key"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("ApiId", notNullValue())
+                .body("Name", equalTo("ws-json11-test"))
+                .body("ProtocolType", equalTo("WEBSOCKET"))
+                .body("RouteSelectionExpression", equalTo("$request.body.action"))
+                .body("Description", equalTo("JSON 1.1 WS API"))
+                .body("ApiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("ApiEndpoint", startsWith("wss://"))
+                .extract().path("ApiId");
+    }
+
+    // ──────────────────────────── GetApi ────────────────────────────
+
+    @Test
+    @Order(2)
+    void json11GetWebSocketApiReturnsPascalCaseFields() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(wsApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("ApiId", equalTo(wsApiId))
+                .body("Name", equalTo("ws-json11-test"))
+                .body("ProtocolType", equalTo("WEBSOCKET"))
+                .body("RouteSelectionExpression", equalTo("$request.body.action"))
+                .body("Description", equalTo("JSON 1.1 WS API"))
+                .body("ApiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("ApiEndpoint", startsWith("wss://"))
+                .body("CreatedDate", notNullValue());
+    }
+
+    // ──────────────────────────── GetApis ────────────────────────────
+
+    @Test
+    @Order(3)
+    void json11GetApisReturnsPascalCaseWebSocketFields() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetApis")
+                .header("Authorization", AUTH_HEADER)
+                .body("{}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items.ApiId", hasItem(wsApiId))
+                .body("Items.find { it.ApiId == '" + wsApiId + "' }.RouteSelectionExpression",
+                        equalTo("$request.body.action"))
+                .body("Items.find { it.ApiId == '" + wsApiId + "' }.ProtocolType",
+                        equalTo("WEBSOCKET"));
+    }
+
+    // ──────────────────────────── UpdateApi ────────────────────────────
+
+    @Test
+    @Order(4)
+    void json11UpdateApiViaPascalCaseKeys() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","Name":"ws-json11-updated","Description":"Updated via JSON 1.1"}
+                        """.formatted(wsApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("ApiId", equalTo(wsApiId))
+                .body("Name", equalTo("ws-json11-updated"))
+                .body("Description", equalTo("Updated via JSON 1.1"))
+                // Non-provided fields should be preserved
+                .body("ProtocolType", equalTo("WEBSOCKET"))
+                .body("RouteSelectionExpression", equalTo("$request.body.action"))
+                .body("ApiKeySelectionExpression", equalTo("$request.header.x-api-key"))
+                .body("ApiEndpoint", startsWith("wss://"));
+    }
+
+    // ──────────────────────────── CreateRoute ────────────────────────────
+
+    @Test
+    @Order(5)
+    void json11CreateRouteWithRouteResponseSelectionExpression() {
+        wsRouteId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteKey":"$default","AuthorizationType":"NONE","RouteResponseSelectionExpression":"$default"}
+                        """.formatted(wsApiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("RouteId", notNullValue())
+                .body("RouteKey", equalTo("$default"))
+                .body("AuthorizationType", equalTo("NONE"))
+                .body("RouteResponseSelectionExpression", equalTo("$default"))
+                .extract().path("RouteId");
+    }
+
+    // ──────────────────────────── GetRoute ────────────────────────────
+
+    @Test
+    @Order(6)
+    void json11GetRouteReturnsPascalCaseRouteResponseSelectionExpression() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s"}
+                        """.formatted(wsApiId, wsRouteId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteId", equalTo(wsRouteId))
+                .body("RouteKey", equalTo("$default"))
+                .body("AuthorizationType", equalTo("NONE"))
+                .body("RouteResponseSelectionExpression", equalTo("$default"));
+    }
+
+    // ──────────────────────────── GetRoutes ────────────────────────────
+
+    @Test
+    @Order(7)
+    void json11GetRoutesReturnsPascalCaseRouteResponseSelectionExpression() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRoutes")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(wsApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items.RouteId", hasItem(wsRouteId))
+                .body("Items.find { it.RouteId == '" + wsRouteId + "' }.RouteResponseSelectionExpression",
+                        equalTo("$default"));
+    }
+
+    // ──────────────────────────── UpdateRoute ────────────────────────────
+
+    @Test
+    @Order(8)
+    void json11UpdateRouteViaPascalCaseKeys() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","Target":"integrations/int456","RouteResponseSelectionExpression":"$default"}
+                        """.formatted(wsApiId, wsRouteId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteId", equalTo(wsRouteId))
+                .body("Target", equalTo("integrations/int456"))
+                .body("RouteResponseSelectionExpression", equalTo("$default"))
+                // Non-provided fields preserved
+                .body("RouteKey", equalTo("$default"))
+                .body("AuthorizationType", equalTo("NONE"));
+    }
+
+    // ──────────────────────────── DeleteRoute ────────────────────────────
+
+    @Test
+    @Order(9)
+    void json11DeleteRouteViaJson11Path() {
+        // Create a temporary route to delete
+        String tempRouteId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteKey":"$connect","AuthorizationType":"NONE"}
+                        """.formatted(wsApiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .extract().path("RouteId");
+
+        // Delete it via JSON 1.1
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s"}
+                        """.formatted(wsApiId, tempRouteId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+
+        // Verify it's gone
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s"}
+                        """.formatted(wsApiId, tempRouteId))
+                .when().post("/")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── DeleteApi ────────────────────────────
+
+    @Test
+    @Order(10)
+    void json11DeleteApiViaJson11Path() {
+        // Create a temporary API to delete
+        String tempApiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"ws-to-delete-json11","ProtocolType":"WEBSOCKET","RouteSelectionExpression":"$request.body.action"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .extract().path("ApiId");
+
+        // Delete it via JSON 1.1
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(tempApiId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+
+        // Verify it's gone
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(tempApiId))
+                .when().post("/")
+                .then()
+                .statusCode(404);
+    }
+
+    // ──────────────────────────── Tags via JSON 1.1 ────────────────────────────
+
+    @Test
+    @Order(12)
+    void json11CreateApiWithTagsAndVerifyInGetApi() {
+        taggedApiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"ws-tagged-json11","ProtocolType":"WEBSOCKET","RouteSelectionExpression":"$request.body.action","Tags":{"env":"staging","team":"backend"}}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("Tags.env", equalTo("staging"))
+                .body("Tags.team", equalTo("backend"))
+                .extract().path("ApiId");
+
+        // GetApi returns tags
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(taggedApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags.env", equalTo("staging"))
+                .body("Tags.team", equalTo("backend"));
+    }
+
+    @Test
+    @Order(13)
+    void json11UpdateApiTagsReplacement() {
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","Tags":{"env":"prod","release":"v3"}}
+                        """.formatted(taggedApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags.env", equalTo("prod"))
+                .body("Tags.release", equalTo("v3"))
+                .body("Tags.team", nullValue())
+                .body("Name", equalTo("ws-tagged-json11"))
+                .body("RouteSelectionExpression", equalTo("$request.body.action"));
+
+        // Cleanup
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(taggedApiId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── PascalCase normalization verification ────────────────────────────
+
+    @Test
+    @Order(11)
+    void json11PascalCaseNormalizationWorksForAllNewFields() {
+        // Create an API with all WebSocket-specific fields using PascalCase
+        String verifyApiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"ws-pascal-verify","ProtocolType":"WEBSOCKET","RouteSelectionExpression":"$request.body.type","Description":"Pascal test","ApiKeySelectionExpression":"$request.header.key"}
+                        """)
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("RouteSelectionExpression", equalTo("$request.body.type"))
+                .body("Description", equalTo("Pascal test"))
+                .body("ApiKeySelectionExpression", equalTo("$request.header.key"))
+                .extract().path("ApiId");
+
+        // Create a route with RouteResponseSelectionExpression using PascalCase
+        String verifyRouteId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteKey":"$disconnect","AuthorizationType":"NONE","RouteResponseSelectionExpression":"$default"}
+                        """.formatted(verifyApiId))
+                .when().post("/")
+                .then()
+                .statusCode(201)
+                .body("RouteResponseSelectionExpression", equalTo("$default"))
+                .extract().path("RouteId");
+
+        // Update the API with PascalCase keys and verify normalization
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteSelectionExpression":"$request.body.updated","Description":"Updated pascal"}
+                        """.formatted(verifyApiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteSelectionExpression", equalTo("$request.body.updated"))
+                .body("Description", equalTo("Updated pascal"))
+                // Preserved fields
+                .body("ApiKeySelectionExpression", equalTo("$request.header.key"))
+                .body("Name", equalTo("ws-pascal-verify"));
+
+        // Update the route with PascalCase keys and verify normalization
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateRoute")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","RouteId":"%s","RouteResponseSelectionExpression":"$custom","Target":"integrations/int789"}
+                        """.formatted(verifyApiId, verifyRouteId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RouteResponseSelectionExpression", equalTo("$custom"))
+                .body("Target", equalTo("integrations/int789"))
+                // Preserved fields
+                .body("RouteKey", equalTo("$disconnect"))
+                .body("AuthorizationType", equalTo("NONE"));
+
+        // Cleanup
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(verifyApiId))
+                .when().post("/")
+                .then()
+                .statusCode(204);
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        if (wsApiId != null) {
+            given()
+                    .contentType(AMZ_JSON)
+                    .header("X-Amz-Target", TARGET_PREFIX + "DeleteApi")
+                    .header("Authorization", AUTH_HEADER)
+                    .body("""
+                            {"ApiId":"%s"}
+                            """.formatted(wsApiId))
+                    .when().post("/")
+                    .then()
+                    .statusCode(anyOf(equalTo(204), equalTo(404)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add WebSocket protocol support and 27 new management-plane operations to API Gateway v2, bringing the total from 21 to 48 operations. Closes #526

### New operations

| Category | Operations added |
|---|---|
| APIs | UpdateApi + WEBSOCKET protocol type |
| Routes | UpdateRoute + routeResponseSelectionExpression |
| Route Responses | CreateRouteResponse, GetRouteResponse, GetRouteResponses, UpdateRouteResponse, DeleteRouteResponse |
| Integrations | UpdateIntegration, DeleteIntegration |
| Integration Responses | CreateIntegrationResponse, GetIntegrationResponse, GetIntegrationResponses, UpdateIntegrationResponse, DeleteIntegrationResponse |
| Authorizers | UpdateAuthorizer |
| Stages | UpdateStage |
| Deployments | GetDeployment, UpdateDeployment |
| Models | CreateModel, GetModel, GetModels, UpdateModel, DeleteModel |
| Tags | TagResource, UntagResource, GetTags |

WebSocket data-plane (actual connection handling, `@connections` API) is not yet implemented — documented in `docs/services/api-gateway.md` under "Not Implemented".

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Verified with AWS SDK for JavaScript v3 (3.500.0+) via 48 compatibility tests
- Verified with AWS SDK for Java v2 (2.31.8) via 21 compatibility tests
- Wire protocol validated against AWS API Gateway v2 REST API reference
- HTTP APIs default `routeSelectionExpression` to `${request.method} ${request.path}` and `apiKeySelectionExpression` to `$request.header.x-api-key`, matching real AWS behavior

## Checklist

- [x] `./mvnw test` passes locally (3321 tests, 0 failures)
- [x] New or updated integration tests added (14 new test classes, 156 new unit/integration tests, 69 SDK compatibility tests)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)