### PR TITLE
fix(sfn): apply ItemSelector/Parameters transformation in Map state

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -870,9 +870,31 @@ public class AslExecutor {
         String startAt = iterator.path("StartAt").asText();
         JsonNode iteratorStates = iterator.path("States");
 
+        // Determine which transformation field is present (ItemSelector is current; Parameters is legacy)
+        JsonNode itemTransform = stateDef.has("ItemSelector") ? stateDef.get("ItemSelector")
+                : stateDef.has("Parameters") ? stateDef.get("Parameters") : null;
+
+        // Resolve InputPath before iterating so $. in ItemSelector sees the Map state's effective input
+        JsonNode mapInput = applyInputPath(stateDef, input);
+
         ArrayNode results = objectMapper.createArrayNode();
+        int index = 0;
         for (JsonNode item : items) {
-            results.add(executeBranch(startAt, iteratorStates, item, sm, topLevelQueryLanguage, context));
+            JsonNode iterInput = item;
+            if (itemTransform != null) {
+                // Enrich context with Map.Item.Index and Map.Item.Value for $$.Map.* references.
+                // $ in ItemSelector resolves against the Map state's effective input, not the item.
+                ObjectNode iterContext = ((ObjectNode) context).deepCopy();
+                ObjectNode mapCtx = objectMapper.createObjectNode();
+                ObjectNode mapItem = objectMapper.createObjectNode();
+                mapItem.put("Index", index);
+                mapItem.set("Value", item);
+                mapCtx.set("Item", mapItem);
+                iterContext.set("Map", mapCtx);
+                iterInput = resolveParameters(itemTransform, mapInput, iterContext);
+            }
+            results.add(executeBranch(startAt, iteratorStates, iterInput, sm, topLevelQueryLanguage, context));
+            index++;
         }
 
         if (jsonata) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -108,6 +108,88 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void mapStateWithItemSelector_appliesTransformationAndContextVars() throws Exception {
+        // ItemSelector (JSONPath Map state) should transform each item using parent-state
+        // data and $$.Map.Item.Value / $$.Map.Item.Index context variables.
+        // Regression test for: Map state ignores Parameters/ItemSelector (issue #675)
+        String definition = """
+                {
+                    "StartAt": "ProcessItems",
+                    "States": {
+                        "ProcessItems": {
+                            "Type": "Map",
+                            "ItemsPath": "$.items",
+                            "ItemSelector": {
+                                "bucket.$": "$.bucket",
+                                "item.$": "$$.Map.Item.Value",
+                                "index.$": "$$.Map.Item.Index"
+                            },
+                            "ItemProcessor": {
+                                "StartAt": "Pass",
+                                "States": {
+                                    "Pass": {
+                                        "Type": "Pass",
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("map-itemselector-test", definition);
+        String execArn = startExecution(smArn, "{\"bucket\": \"my-bucket\", \"items\": [\"a\", \"b\"]}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(output.contains("my-bucket"), "bucket from parent input should be injected");
+        assertTrue(output.contains("\"item\":\"a\"") || output.contains("\"item\": \"a\""),
+                "item value should be the raw item");
+        assertTrue(output.contains("\"index\":0") || output.contains("\"index\": 0"),
+                "index should start at 0");
+    }
+
+    @Test
+    void mapStateWithParameters_legacySyntax_appliesTransformation() throws Exception {
+        // Parameters is the legacy equivalent of ItemSelector; both must be applied.
+        String definition = """
+                {
+                    "StartAt": "ProcessItems",
+                    "States": {
+                        "ProcessItems": {
+                            "Type": "Map",
+                            "ItemsPath": "$.items",
+                            "Parameters": {
+                                "key.$": "$.key",
+                                "value.$": "$$.Map.Item.Value"
+                            },
+                            "ItemProcessor": {
+                                "StartAt": "Pass",
+                                "States": {
+                                    "Pass": {
+                                        "Type": "Pass",
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("map-parameters-test", definition);
+        String execArn = startExecution(smArn, "{\"key\": \"env\", \"items\": [1, 2]}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(output.contains("\"key\":\"env\"") || output.contains("\"key\": \"env\""),
+                "key from parent input should be injected via Parameters");
+        assertTrue(output.contains("\"value\":1") || output.contains("\"value\": 1"),
+                "value should be the raw item");
+    }
+
+    @Test
     void mapStateWithJsonataItems() throws Exception {
         // Map state using JSONata Items field instead of ItemsPath
         String definition = """


### PR DESCRIPTION
## Summary

**Problem**

The Map state executor ignored ItemSelector and Parameters entirely — each array item was forwarded unchanged into the child branch, making it impossible to inject parent-state data or use $$.Map.Item.Value / $$.Map.Item.Index.
                                                                                                                                                                                
**Fix**             

In AslExecutor.executeMapState:                                                                                                                                               
   
- Detect which transformation field is present (ItemSelector takes priority over Parameters)                                                                                  
- Apply InputPath once before iterating to get the Map state's effective input ($ in ItemSelector must resolve against the parent state input, not the item)
- Per iteration: deep-copy the context, set $$.Map.Item.Index and $$.Map.Item.Value, then call resolveParameters to produce the transformed input before passing it to        
executeBranch                                                                                                                                                                 
- The original unmodified context is still passed to executeBranch so nested states don't leak Map-scoped context variables                                                   

Closes #675 
                                                                                                    
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
