### PR TITLE
fix(lambda): use function region for container AWS SDK env

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -143,6 +143,7 @@ public class ContainerLauncher {
         // CloudWatch log coordinates — computed here so they can be injected as env vars
         String cwLogGroup  = "/aws/lambda/" + fn.getFunctionName();
         String cwLogStream = LOG_STREAM_DATE_FMT.format(LocalDate.now()) + "/[$LATEST]" + shortId;
+        String lambdaRegion = extractRegionFromArn(fn.getFunctionArn(), config.defaultRegion());
 
         // Floci endpoint reachable from inside the container.
         // When the embedded DNS server is active, Lambda containers already have it wired as their
@@ -166,8 +167,8 @@ public class ContainerLauncher {
         if (fn.getHandler() != null && !fn.getHandler().isBlank()) {
             env.add("_HANDLER=" + fn.getHandler());
         }
-        env.add("AWS_DEFAULT_REGION=us-east-1");
-        env.add("AWS_REGION=us-east-1");
+        env.add("AWS_DEFAULT_REGION=" + lambdaRegion);
+        env.add("AWS_REGION=" + lambdaRegion);
         env.add("AWS_ACCESS_KEY_ID=test");
         env.add("AWS_SECRET_ACCESS_KEY=test");
         env.add("AWS_SESSION_TOKEN=test");
@@ -241,9 +242,8 @@ public class ContainerLauncher {
         ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), runtimeApiServer, ContainerState.WARM, fn.isHotReload());
 
         // Attach log streaming
-        String region = extractRegionFromArn(fn.getFunctionArn());
         Closeable logHandle = logStreamer.attach(
-                containerId, cwLogGroup, cwLogStream, region, "lambda:" + fn.getFunctionName());
+                containerId, cwLogGroup, cwLogStream, lambdaRegion, "lambda:" + fn.getFunctionName());
         handle.setLogStream(logHandle);
 
         return handle;
@@ -324,12 +324,12 @@ public class ContainerLauncher {
         return runtime != null && runtime.startsWith("provided");
     }
 
-    private static String extractRegionFromArn(String arn) {
+    private static String extractRegionFromArn(String arn, String defaultRegion) {
         if (arn == null) {
-            return "us-east-1";
+            return defaultRegion;
         }
         String[] parts = arn.split(":");
-        return parts.length >= 4 && !parts[3].isEmpty() ? parts[3] : "us-east-1";
+        return parts.length >= 4 && !parts[3].isEmpty() ? parts[3] : defaultRegion;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
@@ -17,6 +17,9 @@ class DynamoDbTableArnIntegrationTest {
 
     private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
     private static final String KINESIS_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String AUTH_DDB_EU_WEST_2 =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260215/eu-west-2/dynamodb/aws4_request, "
+                    + "SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=abc";
 
     @BeforeAll
     static void configureRestAssured() {
@@ -304,6 +307,50 @@ class DynamoDbTableArnIntegrationTest {
     }
 
     @Test
+    void signedBatchWriteItemAcceptsTemporaryCredentialsInAuthRegion() {
+        String tableName = tableName("signed-batch");
+        createTable(tableName, AUTH_DDB_EU_WEST_2);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .header("Authorization", AUTH_DDB_EU_WEST_2)
+            .header("X-Amz-Date", "20260215T120000Z")
+            .header("X-Amz-Security-Token", "session-token")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [
+                            {"PutRequest": {"Item": {"pk": {"S": "user-1"}, "name": {"S": "Alice"}}}}
+                        ]
+                    }
+                }
+                """.formatted(tableName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .header("Authorization", AUTH_DDB_EU_WEST_2)
+            .header("X-Amz-Date", "20260215T120000Z")
+            .header("X-Amz-Security-Token", "session-token")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "user-1"}}
+                }
+                """.formatted(tableName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.name.S", equalTo("Alice"));
+    }
+
+    @Test
     void consumedCapacityReturnsCanonicalTableName() {
         String tableName = tableName("consumed-cap");
         String tableArn = createTable(tableName);
@@ -407,10 +454,20 @@ class DynamoDbTableArnIntegrationTest {
     }
 
     private static String createTable(String tableName) {
-        return given()
+        return createTable(tableName, null);
+    }
+
+    private static String createTable(String tableName, String authorization) {
+        var request = given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
-            .contentType(DYNAMODB_CONTENT_TYPE)
-            .body("""
+            .contentType(DYNAMODB_CONTENT_TYPE);
+        if (authorization != null) {
+            request.header("Authorization", authorization)
+                    .header("X-Amz-Date", "20260215T120000Z")
+                    .header("X-Amz-Security-Token", "session-token");
+        }
+
+        return request.body("""
                 {
                     "TableName": "%s",
                     "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -68,6 +68,7 @@ class ContainerLauncherTest {
         when(docker.logMaxSize()).thenReturn("10m");
         when(docker.logMaxFile()).thenReturn("3");
         when(config.baseUrl()).thenReturn("http://localhost:4566");
+        lenient().when(config.defaultRegion()).thenReturn("us-east-1");
         lenient().when(config.hostname()).thenReturn(Optional.empty());
 
         when(embeddedDnsServer.getServerIp()).thenReturn(Optional.empty());
@@ -178,6 +179,50 @@ class ContainerLauncherTest {
                 "default AWS_SECRET_ACCESS_KEY should be injected");
         assertTrue(env.contains("AWS_SESSION_TOKEN=test"),
                 "default AWS_SESSION_TOKEN should be injected");
+    }
+
+    @Test
+    void launchFunction_injectsConfiguredDefaultRegionWhenArnMissing() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("region-default"));
+        when(config.defaultRegion()).thenReturn("eu-central-1");
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("region-default-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+
+        List<String> env = specCaptor.getValue().env();
+        assertTrue(env.contains("AWS_DEFAULT_REGION=eu-central-1"));
+        assertTrue(env.contains("AWS_REGION=eu-central-1"));
+    }
+
+    @Test
+    void launchFunction_injectsFunctionArnRegionForAwsSdkSigning() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("region-arn"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("region-arn-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setFunctionArn("arn:aws:lambda:eu-west-2:000000000000:function:region-arn-fn");
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+
+        List<String> env = specCaptor.getValue().env();
+        assertTrue(env.contains("AWS_DEFAULT_REGION=eu-west-2"));
+        assertTrue(env.contains("AWS_REGION=eu-west-2"));
+        verify(logStreamer).attach(
+                eq("container-123"), any(), any(), eq("eu-west-2"), eq("lambda:region-arn-fn"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -26,6 +26,9 @@ class SqsJsonProtocolTest {
     private static final String CONTENT_TYPE = "application/x-amz-json-1.0";
     private static final String ACCOUNT_ID = "000000000000";
     private static final String QUEUE_NAME = "json-protocol-test-queue";
+    private static final String AUTH_SQS_EU_WEST_2 =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260215/eu-west-2/sqs/aws4_request, "
+                    + "SignedHeaders=host;x-amz-date;x-amz-security-token, Signature=abc";
 
     private static String queueUrl;
     private static String receiptHandle;
@@ -182,5 +185,59 @@ class SqsJsonProtocolTest {
             .post("/" + ACCOUNT_ID + "/" + QUEUE_NAME)
         .then()
             .statusCode(200);
+    }
+
+    @Test
+    @Order(8)
+    void signedJsonRequestsAcceptTemporaryCredentialsAndRewrittenQueueHost() {
+        String signedQueueName = QUEUE_NAME + "-signed";
+        String createBody = "{\"QueueName\":\"" + signedQueueName + "\"}";
+
+        String signedQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .header("Authorization", AUTH_SQS_EU_WEST_2)
+            .header("X-Amz-Date", "20260215T120000Z")
+            .header("X-Amz-Security-Token", "session-token")
+            .body(createBody)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("QueueUrl", containsString(signedQueueName))
+            .extract().jsonPath().getString("QueueUrl");
+
+        String lambdaReachableQueueUrl = signedQueueUrl.replaceFirst("://[^/]+", "://floci:4566");
+        String sendBody = "{\"QueueUrl\":\"" + lambdaReachableQueueUrl + "\","
+                + "\"MessageBody\":\"hello from signed json\"}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessage")
+            .header("Authorization", AUTH_SQS_EU_WEST_2)
+            .header("X-Amz-Date", "20260215T120000Z")
+            .header("X-Amz-Security-Token", "session-token")
+            .body(sendBody)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("MessageId", notNullValue());
+
+        String receiveBody = "{\"QueueUrl\":\"" + lambdaReachableQueueUrl + "\",\"MaxNumberOfMessages\":1}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .header("Authorization", AUTH_SQS_EU_WEST_2)
+            .header("X-Amz-Date", "20260215T120000Z")
+            .header("X-Amz-Security-Token", "session-token")
+            .body(receiveBody)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Messages", hasSize(1))
+            .body("Messages[0].Body", equalTo("hello from signed json"));
     }
 }


### PR DESCRIPTION
## Summary
- Set Lambda container AWS_DEFAULT_REGION/AWS_REGION from the function ARN region, falling back to floci.default-region.
- Use the same derived region for CloudWatch log streaming.
- Add regression coverage for boto3-style signed SQS/DynamoDB JSON requests, including session-token headers and rewritten SQS QueueUrl hosts.

## Why
Floci stores SQS queues and DynamoDB tables in regional namespaces. Lambda containers previously always received us-east-1, so SDK calls from functions deployed in another region signed requests for the wrong region and could see NonExistentQueue or missing DynamoDB resources even when those resources existed.

## Tests
- ./mvnw -Dmaven.repo.local=/tmp/codex-m2 -Dtest=ContainerLauncherTest,SqsJsonProtocolTest,DynamoDbTableArnIntegrationTest test
- git diff --check