### PR TITLE
docs(lambda): clarify Compose hostname for Lambda containers

### DIFF
--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -33,9 +33,12 @@ services:
       - ./data:/app/data
     environment:
       FLOCI_SERVICES_DOCKER_NETWORK: my-project_default  # (1)
+      FLOCI_HOSTNAME: floci                             # (2)
 ```
 
 1. Set this to the Docker network name that your compose project creates (usually `<project-name>_default`). Floci uses it to attach spawned Lambda / ElastiCache / RDS containers to the same network.
+2. Set this to the Compose service name when other containers, including
+   Lambda containers spawned by Floci, need to call Floci by Docker DNS.
 
 !!! warning "Docker socket"
     Lambda, ElastiCache, and RDS require access to the Docker socket (`/var/run/docker.sock`) to spawn and manage containers. If you don't use these services, you can omit that volume.
@@ -75,6 +78,12 @@ services:
 With this setting Floci returns URLs like
 `http://floci:4566/000000000000/my-queue` that other containers in the same
 network can reach.
+
+This is also the recommended setting when Floci launches Lambda containers into
+your Compose network via `FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK` or
+`FLOCI_SERVICES_DOCKER_NETWORK`. It makes the endpoint Floci injects into
+Lambda containers, and response fields such as SQS `QueueUrl`, use a Docker
+service name (`floci`) instead of a host-only `localhost` address.
 
 This affects any response field that embeds the endpoint hostname:
 

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -247,6 +247,17 @@ No extra configuration or `cap_add` is needed — Docker containers have
 `CAP_NET_BIND_SERVICE` in their default capability set, so Floci (running as a
 non-root user) can bind UDP/53 without any changes to your Compose file.
 
+!!! tip "Docker Compose service names"
+    If Floci runs as a Docker Compose service and you attach Lambda containers
+    to that Compose network, set `FLOCI_HOSTNAME` to the service name, for
+    example `FLOCI_HOSTNAME=floci`. Floci then injects
+    `AWS_ENDPOINT_URL=http://floci:4566` into Lambda containers and returns
+    SQS `QueueUrl` values with the same reachable host.
+
+    This avoids function-side rewrites from `localhost` or `localhost.floci.io`
+    to `floci`, and keeps normal AWS SDK clients pointed at the Docker DNS name
+    that the Lambda container can resolve.
+
 !!! note "Path-style as a workaround"
     If you cannot use virtual-hosted-style (e.g. Floci is running natively on
     the host, not in Docker), configure the SDK client with


### PR DESCRIPTION
## Summary
- document using FLOCI_HOSTNAME with FLOCI_SERVICES_DOCKER_NETWORK / FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK
- call out the Docker Compose service-name pattern for Lambda containers
- explain that this avoids function-side rewrites from localhost-style URLs to the Compose service name

## Tests
- git diff --check