### PR TITLE
fix(cfn): adopt existing DynamoDB tables on update

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import io.github.hectorvent.floci.services.ecr.EcrService;
 import io.github.hectorvent.floci.services.ecr.model.Repository;
 import io.github.hectorvent.floci.services.iam.IamService;
@@ -320,7 +321,15 @@ public class CloudFormationResourceProvisioner {
             attrDefs.add(new AttributeDefinition("id", "S"));
         }
 
-        var table = dynamoDbService.createTable(tableName, keySchema, attrDefs, null, null, gsis, lsis, region);
+        TableDefinition table;
+        try {
+            table = dynamoDbService.createTable(tableName, keySchema, attrDefs, null, null, gsis, lsis, region);
+        } catch (AwsException e) {
+            if (!"ResourceInUseException".equals(e.getErrorCode())) {
+                throw e;
+            }
+            table = dynamoDbService.describeTable(tableName, region);
+        }
         r.setPhysicalId(tableName);
         r.getAttributes().put("Arn", table.getTableArn());
         r.getAttributes().put("StreamArn", table.getTableArn() + "/stream/2024-01-01T00:00:00.000");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -820,6 +820,93 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void updateStack_dynamoDbRefStillResolvesWhenTableAlreadyExists() {
+        String suffix = Long.toHexString(System.nanoTime());
+        String stackName = "redeploy-ref-stack-" + suffix;
+        String tableName = "redeploy-ref-table-" + suffix;
+        String parameterName = "/app/redeploy-ref-table-" + suffix;
+        String template = """
+            {
+              "Resources": {
+                "MyTable": {
+                  "Type": "AWS::DynamoDB::Table",
+                  "Properties": {
+                    "TableName": "%s",
+                    "AttributeDefinitions": [
+                      {"AttributeName": "pk", "AttributeType": "S"}
+                    ],
+                    "KeySchema": [
+                      {"AttributeName": "pk", "KeyType": "HASH"}
+                    ],
+                    "BillingMode": "PAY_PER_REQUEST"
+                  }
+                },
+                "TableNameParam": {
+                  "Type": "AWS::SSM::Parameter",
+                  "Properties": {
+                    "Name": "%s",
+                    "Type": "String",
+                    "Value": {"Ref": "MyTable"}
+                  }
+                }
+              },
+              "Outputs": {
+                "TableName": {
+                  "Value": {"Ref": "MyTable"}
+                }
+              }
+            }
+            """.formatted(tableName, parameterName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(containsString("<OutputKey>TableName</OutputKey>"))
+            .body(containsString("<OutputValue>" + tableName + "</OutputValue>"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {"Name": "%s", "WithDecryption": true}
+                """.formatted(parameterName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Name", equalTo(parameterName))
+            .body("Parameter.Value", equalTo(tableName));
+    }
+
+    @Test
     void createStack_explicitNamesPreserved() {
         // When explicit names are provided, CloudFormation uses them as-is.
         // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-name.html


### PR DESCRIPTION
## Summary
- Adopt an existing DynamoDB table during CloudFormation stack updates when CreateTable reports ResourceInUseException.
- Keep the table name as the CloudFormation physical id so Ref-backed values continue resolving after redeploys.
- Add a regression for CreateStack followed by UpdateStack with a Ref-backed SSM parameter and stack output.

## Tests
- `./mvnw -Dmaven.repo.local=/tmp/codex-m2 -Dtest=CloudFormationIntegrationTest#updateStack_dynamoDbRefStillResolvesWhenTableAlreadyExists test`
- `git diff --check`
