### PR TITLE
fix(cfn): resolve floci virtual-hosted TemplateURL hosts

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.cloudformation;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.github.hectorvent.floci.services.cloudformation.model.ChangeSet;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackEvent;
@@ -500,7 +501,7 @@ public class CloudFormationService {
     private String fetchTemplateFromS3(String url) {
         // Parse S3 URL — three forms:
         //   Virtual-hosted AWS:   https://bucket.s3[.region].amazonaws.com/key
-        //   Virtual-hosted local: http://bucket.localhost:4566/key  (or configured hostname)
+        //   Virtual-hosted local: http://bucket.localhost:4566/key  (or configured/default hostname)
         //   Path-style (both):    https://s3[.region].amazonaws.com/bucket/key
         //                         http://host:port/bucket/key
         //
@@ -516,7 +517,7 @@ public class CloudFormationService {
 
         boolean isVirtualHosted = host != null && (
                 host.contains(".s3.")
-                || (config.hostname().isPresent() && host.endsWith("." + config.hostname().get()))
+                || isConfiguredVirtualHostedS3Host(host)
                 || host.endsWith(".localhost"));
 
         if (isVirtualHosted) {
@@ -537,6 +538,21 @@ public class CloudFormationService {
             LOG.errorv("Failed to fetch CloudFormation template from {0}: {1}", url, e.getMessage());
             throw new RuntimeException("Failed to fetch CloudFormation template from " + url + ": " + e.getMessage(), e);
         }
+    }
+
+    private boolean isConfiguredVirtualHostedS3Host(String host) {
+        String suffix = config.hostname().orElse(EmbeddedDnsServer.DEFAULT_SUFFIX);
+        return hasBucketPrefixForSuffix(host, suffix);
+    }
+
+    private static boolean hasBucketPrefixForSuffix(String host, String suffix) {
+        if (host == null || suffix == null || suffix.isBlank()) {
+            return false;
+        }
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
+        String normalizedSuffix = suffix.toLowerCase(Locale.ROOT);
+        return normalizedHost.length() > normalizedSuffix.length() + 1
+                && normalizedHost.endsWith("." + normalizedSuffix);
     }
 
     private Stack newStack(String stackName, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -2392,6 +2392,67 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_templateUrlFlociVirtualHost_resolvesLocalS3() {
+        String suffix = Long.toHexString(System.nanoTime());
+        String bucket = "cfn-floci-template-" + suffix;
+        String key = "templates/template.json";
+        String queueName = "cfn-floci-template-queue-" + suffix;
+        String stackName = "cfn-floci-template-stack-" + suffix;
+        String template = """
+            {
+              "Resources": {
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "%s"
+                  }
+                }
+              }
+            }
+            """.formatted(queueName);
+
+        given().when().put("/" + bucket).then().statusCode(200);
+        given()
+            .contentType("application/json")
+            .body(template)
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        String templateUrl = "http://" + bucket + ".localhost.floci.io:4566/" + key;
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateURL", templateUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CREATE_COMPLETE"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", queueName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void createStack_lambdaEventSourceMapping() throws Exception {
         String stackName = "cfn-esm-stack";
         String funcName = "cfn-esm-func";


### PR DESCRIPTION
## Summary
- Recognize Floci's default `localhost.floci.io` suffix when CloudFormation fetches S3 TemplateURL objects.
- Preserve configured hostname handling while allowing CDK-style `bucket.localhost.floci.io` template URLs.
- Add a regression that uploads a template to S3 and creates a stack from a Floci virtual-hosted TemplateURL.

## Tests
- `./mvnw -Dmaven.repo.local=/tmp/codex-m2 -Dtest=CloudFormationIntegrationTest#createStack_templateUrlFlociVirtualHost_resolvesLocalS3 test`
- `git diff --check`
