### PR TITLE
feat(sqs,dynamodb): TRACE-level payload logging

### DIFF
--- a/docs/configuration/application-yml.md
+++ b/docs/configuration/application-yml.md
@@ -278,3 +278,46 @@ floci:
     stepfunctions:
       enabled: false
 ```
+
+## Logging
+
+Floci uses standard [Quarkus logging](https://quarkus.io/guides/logging). The default effective level is `INFO`. Each service logs operation-level events at `DEBUG` (IDs and target resources) and full request/response payloads at `TRACE` — useful when diagnosing TestContainers-based test failures.
+
+Floci ships with `quarkus.log.min-level: TRACE`, so raising a single category to `TRACE` is enough; you don't need to change the min-level yourself.
+
+**Enable TRACE for a service via environment variables:**
+
+```bash
+# SQS: log SendMessage/ReceiveMessage/DeleteMessage bodies and attributes
+QUARKUS_LOG_CATEGORY__IO_GITHUB_HECTORVENT_FLOCI_SERVICES_SQS__LEVEL=TRACE
+
+# DynamoDB: log PutItem/GetItem/UpdateItem/DeleteItem items, Query/Scan counts
+QUARKUS_LOG_CATEGORY__IO_GITHUB_HECTORVENT_FLOCI_SERVICES_DYNAMODB__LEVEL=TRACE
+```
+
+**Or in `application.yml`:**
+
+```yaml
+quarkus:
+  log:
+    category:
+      "io.github.hectorvent.floci.services.sqs":
+        level: TRACE
+      "io.github.hectorvent.floci.services.dynamodb":
+        level: TRACE
+```
+
+**TestContainers example:**
+
+```java
+new GenericContainer<>("floci/floci:latest")
+    .withExposedPorts(4566)
+    .withEnv("QUARKUS_LOG_CATEGORY__IO_GITHUB_HECTORVENT_FLOCI_SERVICES_SQS__LEVEL", "TRACE");
+```
+
+TRACE output includes the payload alongside the existing DEBUG line:
+
+```
+DEBUG [SqsService] Sent message aa7b93e7-... to queue .../events
+TRACE [SqsService] Sent message aa7b93e7-... to queue .../events body={"eventType":"..."} attributes={source=okta}
+```

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -305,6 +305,7 @@ public class DynamoDbService {
             tableItems.put(itemKey, item);
             persistItems(storageKey);
             LOG.debugv("Put item in {0}: key={1}", canonicalTableName, itemKey);
+            LOG.tracev("Put item in {0}: key={1} item={2}", canonicalTableName, itemKey, item);
 
             String eventName = existing == null ? "INSERT" : "MODIFY";
             if (streamService != null) {
@@ -328,9 +329,16 @@ public class DynamoDbService {
 
         String itemKey = buildItemKey(table, key);
         var items = itemsByTable.get(storageKey);
-        if (items == null) return null;
+        if (items == null) {
+            LOG.tracev("Got item from {0}: key={1} item=<not found>", canonicalTableName, itemKey);
+            return null;
+        }
         JsonNode item = items.get(itemKey);
-        if (item != null && isExpired(item, table)) return null;
+        if (item != null && isExpired(item, table)) {
+            LOG.tracev("Got item from {0}: key={1} item=<expired>", canonicalTableName, itemKey);
+            return null;
+        }
+        LOG.tracev("Got item from {0}: key={1} item={2}", canonicalTableName, itemKey, item);
         return item;
     }
 
@@ -365,6 +373,7 @@ public class DynamoDbService {
             JsonNode removed = items.remove(itemKey);
             persistItems(storageKey);
             LOG.debugv("Deleted item from {0}: key={1}", canonicalTableName, itemKey);
+            LOG.tracev("Deleted item from {0}: key={1} removed={2}", canonicalTableName, itemKey, removed);
 
             if (removed != null) {
                 if (streamService != null) {
@@ -451,6 +460,8 @@ public class DynamoDbService {
 
             items.put(itemKey, item);
             persistItems(storageKey);
+            LOG.tracev("Updated item in {0}: key={1} updateExpression={2} item={3}",
+                    canonicalTableName, itemKey, updateExpression, item);
 
             if (streamService != null) {
                 streamService.captureEvent(canonicalTableName, "MODIFY", existing, item, table, region);
@@ -609,6 +620,8 @@ public class DynamoDbService {
                     .toList();
         }
 
+        LOG.tracev("Query on {0}: returned={1} scanned={2}",
+                canonicalTableName, evaluatedItems.size(), scannedCount);
         return new QueryResult(evaluatedItems, scannedCount, lastEvaluatedKey);
     }
 
@@ -663,6 +676,8 @@ public class DynamoDbService {
             results = results.subList(0, limit);
         }
 
+        LOG.tracev("Scan on {0}: returned={1} scanned={2}",
+                canonicalTableName, results.size(), totalScanned);
         return new ScanResult(results, totalScanned, lastEvaluatedKey);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -134,13 +134,21 @@ class GuardedMessageQueue {
         }
     }
 
-    boolean removeByReceiptHandle(String receiptHandle) {
+    Optional<Message> removeByReceiptHandle(String receiptHandle) {
         try (var _ = hold()) {
-            boolean removed = messages.removeIf(m -> receiptHandle.equals(m.getReceiptHandle()));
-            if (removed) {
+            Message removed = null;
+            for (Iterator<Message> it = messages.iterator(); it.hasNext(); ) {
+                Message m = it.next();
+                if (receiptHandle.equals(m.getReceiptHandle())) {
+                    removed = m;
+                    it.remove();
+                    break;
+                }
+            }
+            if (removed != null) {
                 persist();
             }
-            return removed;
+            return Optional.ofNullable(removed);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -398,6 +398,8 @@ public class SqsService {
             notifyReceivers(storageKey);
             LOG.debugv("Sent FIFO message {0} to queue {1}, group={2}, seq={3}",
                     message.getMessageId(), queueUrl, messageGroupId, message.getSequenceNumber());
+            LOG.tracev("Sent message {0} to queue {1} body={2} attributes={3}",
+                    message.getMessageId(), queueUrl, body, message.getMessageAttributes());
             return message;
         }
 
@@ -414,6 +416,8 @@ public class SqsService {
         getOrCreateQueue(storageKey).addMessage(message);
         notifyReceivers(storageKey);
         LOG.debugv("Sent message {0} to queue {1}", message.getMessageId(), queueUrl);
+        LOG.tracev("Sent message {0} to queue {1} body={2} attributes={3}",
+                message.getMessageId(), queueUrl, body, message.getMessageAttributes());
         return message;
     }
 
@@ -488,6 +492,12 @@ public class SqsService {
         while (true) {
             List<Message> result = doReceiveMessage(storageKey, maxMessages, visibilityTimeout, region);
             if (!result.isEmpty() || maxWait <= 0) {
+                if (!result.isEmpty() && LOG.isTraceEnabled()) {
+                    for (Message m : result) {
+                        LOG.tracev("Received message {0} from queue {1} body={2} attributes={3}",
+                                m.getMessageId(), queueUrl, m.getBody(), m.getMessageAttributes());
+                    }
+                }
                 return result;
             }
             long elapsed = System.currentTimeMillis() - start;
@@ -586,13 +596,18 @@ public class SqsService {
         String storageKey = regionKey(region, queueUrl);
         ensureQueueExists(storageKey);
 
-        boolean removed = getOrCreateQueue(storageKey).removeByReceiptHandle(receiptHandle);
+        Optional<Message> removed = getOrCreateQueue(storageKey).removeByReceiptHandle(receiptHandle);
 
-        if (!removed) {
+        if (removed.isEmpty()) {
             throw new AwsException("ReceiptHandleIsInvalid",
                     "The input receipt handle is not a valid receipt handle.", 400);
         }
         LOG.debugv("Deleted message with receipt handle {0}", receiptHandle);
+        if (LOG.isTraceEnabled()) {
+            Message m = removed.get();
+            LOG.tracev("Deleted message {0} from queue {1} body={2}",
+                    m.getMessageId(), queueUrl, m.getBody());
+        }
     }
 
     public void changeMessageVisibility(String queueUrl, String receiptHandle, int visibilityTimeout) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/MessageAttributeValue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/MessageAttributeValue.java
@@ -31,4 +31,15 @@ public class MessageAttributeValue {
 
     public String getDataType() { return dataType; }
     public void setDataType(String dataType) { this.dataType = dataType; }
+
+    @Override
+    public String toString() {
+        if (stringValue != null) {
+            return stringValue;
+        }
+        if (binaryValue != null) {
+            return "<binary:" + binaryValue.length + "B>";
+        }
+        return "";
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 quarkus:
   log:
+    # min-level sets the floor for what can be emitted at runtime. Default is INFO,
+    # which silently filters any TRACE/DEBUG logs even when a category override
+    # asks for them. Lowering the floor to TRACE lets users opt in per-category
+    # (e.g. QUARKUS_LOG_CATEGORY__IO_GITHUB_HECTORVENT_FLOCI_SERVICES_SQS__LEVEL=TRACE)
+    # without also having to raise min-level. Effective level is still INFO by default.
+    min-level: TRACE
     console:
         color: true
   http:

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -89,7 +89,7 @@ class GuardedMessageQueueTest {
         var claimed = queue.claimVisibleMessages(1, 30, false, -1, null);
         String handle = claimed.claimed().get(0).getReceiptHandle();
 
-        assertTrue(queue.removeByReceiptHandle(handle));
+        assertTrue(queue.removeByReceiptHandle(handle).isPresent());
 
         // Message should be gone even with visibility timeout 0
         var result = queue.claimVisibleMessages(1, 0, false, -1, null);
@@ -98,7 +98,7 @@ class GuardedMessageQueueTest {
 
     @Test
     void removeByReceiptHandleInvalidReturnsFalse() {
-        assertFalse(queue.removeByReceiptHandle("nonexistent"));
+        assertFalse(queue.removeByReceiptHandle("nonexistent").isPresent());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -97,7 +97,7 @@ class GuardedMessageQueueTest {
     }
 
     @Test
-    void removeByReceiptHandleInvalidReturnsFalse() {
+    void removeByReceiptHandleInvalidReturnsEmpty() {
         assertFalse(queue.removeByReceiptHandle("nonexistent").isPresent());
     }
 


### PR DESCRIPTION
## Context

Closes #613. When debugging TestContainers-based test failures against Floci, the existing DEBUG logs show which operations were called but not *what data was sent or received*. For SQS `SendMessage` you see the message ID but not the body; for DynamoDB `PutItem` you see the table name but not the item. The WAL storage mode captures payloads, but only in binary CBOR — not useful at the console.

This PR adds TRACE-level logging that includes request/response payloads for the common SQS and DynamoDB operations. TRACE is off by default; users opt in per-category only when they need payload visibility.

## What changed

**SQS** — `SendMessage` / `SendMessageBatch` / `ReceiveMessage` / `DeleteMessage` / `DeleteMessageBatch` log the body and message attributes alongside the existing DEBUG line. The batch operations inherit coverage through the single-item service methods.

**DynamoDB** — `PutItem` / `GetItem` / `UpdateItem` / `DeleteItem` log the item JSON. `Query` and `Scan` log returned and scanned counts only — the issue explicitly flagged item bodies at TRACE as too noisy here.

**Quarkus `min-level`** — shipped `application.yml` now sets `quarkus.log.min-level: TRACE`. Without this, a category override to TRACE gets silently filtered by the INFO-level floor, and users file bug reports. Effective level stays INFO by default; only emission is gated by category.

**Docs** — added a "Logging" section to `docs/configuration/application-yml.md` with the env-var form, the YAML form, and a TestContainers snippet.

**Supporting changes (for future extension)** — the pattern is `LOG.tracev("...", payload)` with no wrapper; other services can adopt it directly. Two small enablers:
- `MessageAttributeValue.toString()` so `Map<String, MessageAttributeValue>` prints cleanly as a log argument.
- `GuardedMessageQueue.removeByReceiptHandle` now returns `Optional<Message>` so `deleteMessage` can log the removed body without a second lookup.

## Test coverage gaps

No new tests. The changes are additive log lines; asserting on log output would couple tests to format. Existing 196 SQS + DynamoDB tests pass, including the `removeByReceiptHandle` signature change.

## Known follow-up items

Issue scope was SQS + DynamoDB. Same visibility gap exists for SNS, Kinesis, EventBridge, CloudWatch Logs — intentionally out of scope here; the pattern can be extended service-by-service in follow-ups.