### PR TITLE
docs: update secrets manager docs with new handlers

### DIFF
--- a/docs/services/secrets-manager.md
+++ b/docs/services/secrets-manager.md
@@ -16,6 +16,9 @@
 | `DeleteSecret` | Delete a secret (with recovery window) |
 | `RotateSecret` | Trigger secret rotation via a Lambda |
 | `ListSecretVersionIds` | List all versions of a secret |
+| `UpdateSecretVersionStage` | Move a staging label between versions |
+| `BatchGetSecretValue` | Retrieve multiple secret values in one call |
+| `GetRandomPassword` | Generate a random password |
 | `GetResourcePolicy` | Get the resource policy |
 | `PutResourcePolicy` | Attach a resource policy |
 | `DeleteResourcePolicy` | Remove the resource policy |
@@ -73,5 +76,24 @@ aws secretsmanager delete-secret \
 aws secretsmanager delete-secret \
   --secret-id /app/database-url \
   --force-delete-without-recovery \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Generate a random password
+aws secretsmanager get-random-password \
+  --password-length 24 \
+  --exclude-punctuation \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Batch-fetch multiple secrets in one call
+aws secretsmanager batch-get-secret-value \
+  --secret-id-list /app/database-url /app/api-keys \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Move the AWSCURRENT label to a different version (e.g. during a rotation)
+aws secretsmanager update-secret-version-stage \
+  --secret-id /app/database-url \
+  --version-stage AWSCURRENT \
+  --move-to-version-id <new-version-id> \
+  --remove-from-version-id <old-version-id> \
   --endpoint-url $AWS_ENDPOINT_URL
 ```


### PR DESCRIPTION
## Summary

The Secrets Manager service handler supports three actions that aren't listed on the docs page:
  - GetRandomPassword
  - BatchGetSecretValue
  - UpdateSecretVersionStage

Small but honest PR because I got blocked thinking Floci did not support `UpdateSecretVersionStage` while writing some integration tests here. Hope this helps someone facing similar issues.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Checklist

- [x] `mkdocs` builds and serves correctly
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
