### PR TITLE
feat(eventbridge): add Archive and Replay support

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
@@ -1,0 +1,243 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.*;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("EventBridge Archive and Replay")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeReplayTest {
+
+    private static EventBridgeClient eb;
+    private static SqsClient sqs;
+
+    private static String busName;
+    private static String busArn;
+    private static String archiveName;
+    private static String archiveArn;
+    private static String queueUrl;
+    private static String queueArn;
+    private static Instant beforePut;
+
+    @BeforeAll
+    static void setup() {
+        eb = TestFixtures.eventBridgeClient();
+        sqs = TestFixtures.sqsClient();
+        busName = TestFixtures.uniqueName("replay-bus");
+        archiveName = TestFixtures.uniqueName("replay-archive");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        try { eb.deleteArchive(DeleteArchiveRequest.builder().archiveName(archiveName).build()); } catch (Exception ignored) {}
+        try {
+            eb.removeTargets(RemoveTargetsRequest.builder().rule("replay-compat-rule").eventBusName(busName).ids("sink").build());
+        } catch (Exception ignored) {}
+        try {
+            eb.deleteRule(DeleteRuleRequest.builder().name("replay-compat-rule").eventBusName(busName).build());
+        } catch (Exception ignored) {}
+        try { eb.deleteEventBus(DeleteEventBusRequest.builder().name(busName).build()); } catch (Exception ignored) {}
+        try { sqs.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build()); } catch (Exception ignored) {}
+        eb.close();
+        sqs.close();
+    }
+
+    // ──────────────────────────── Setup ────────────────────────────
+
+    @Test
+    @Order(1)
+    void createEventBus() {
+        busArn = eb.createEventBus(CreateEventBusRequest.builder().name(busName).build())
+                .eventBusArn();
+        assertThat(busArn).contains(busName);
+    }
+
+    @Test
+    @Order(2)
+    void createArchive() {
+        CreateArchiveResponse response = eb.createArchive(CreateArchiveRequest.builder()
+                .archiveName(archiveName)
+                .eventSourceArn(busArn)
+                .description("Replay compatibility test archive")
+                .retentionDays(1)
+                .build());
+        archiveArn = response.archiveArn();
+        assertThat(archiveArn).contains(archiveName);
+        assertThat(response.state()).isEqualTo(ArchiveState.ENABLED);
+    }
+
+    @Test
+    @Order(3)
+    void describeArchive() {
+        DescribeArchiveResponse response = eb.describeArchive(
+                DescribeArchiveRequest.builder().archiveName(archiveName).build());
+        assertThat(response.archiveName()).isEqualTo(archiveName);
+        assertThat(response.eventSourceArn()).isEqualTo(busArn);
+        assertThat(response.state()).isEqualTo(ArchiveState.ENABLED);
+        assertThat(response.retentionDays()).isEqualTo(1);
+        assertThat(response.eventCount()).isZero();
+    }
+
+    @Test
+    @Order(4)
+    void listArchivesReturnsCreatedArchive() {
+        ListArchivesResponse response = eb.listArchives(ListArchivesRequest.builder().build());
+        assertThat(response.archives())
+                .extracting(Archive::archiveName)
+                .contains(archiveName);
+    }
+
+    @Test
+    @Order(5)
+    void updateArchive() {
+        UpdateArchiveResponse response = eb.updateArchive(UpdateArchiveRequest.builder()
+                .archiveName(archiveName)
+                .description("Updated description")
+                .retentionDays(7)
+                .build());
+        assertThat(response.state()).isEqualTo(ArchiveState.ENABLED);
+
+        DescribeArchiveResponse desc = eb.describeArchive(
+                DescribeArchiveRequest.builder().archiveName(archiveName).build());
+        assertThat(desc.description()).isEqualTo("Updated description");
+        assertThat(desc.retentionDays()).isEqualTo(7);
+    }
+
+    // ──────────────────────────── Capture events via PutEvents ────────────────────────────
+
+    @Test
+    @Order(10)
+    void createSinkQueueAndRule() {
+        queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(TestFixtures.uniqueName("replay-sink")).build()).queueUrl();
+        queueArn = sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
+                .queueUrl(queueUrl).attributeNamesWithStrings("QueueArn").build())
+                .attributesAsStrings().get("QueueArn");
+
+        eb.putRule(PutRuleRequest.builder()
+                .name("replay-compat-rule")
+                .eventBusName(busName)
+                .eventPattern("{\"source\":[\"compat.replay.test\"]}")
+                .state(RuleState.ENABLED)
+                .build());
+
+        eb.putTargets(PutTargetsRequest.builder()
+                .rule("replay-compat-rule")
+                .eventBusName(busName)
+                .targets(Target.builder().id("sink").arn(queueArn).build())
+                .build());
+    }
+
+    @Test
+    @Order(11)
+    void putEventsAreArchivedAndDelivered() {
+        beforePut = Instant.now().minusSeconds(1);
+
+        PutEventsResponse response = eb.putEvents(PutEventsRequest.builder()
+                .entries(
+                        PutEventsRequestEntry.builder()
+                                .eventBusName(busName)
+                                .source("compat.replay.test")
+                                .detailType("OrderCreated")
+                                .detail("{\"orderId\":\"A1\"}")
+                                .build(),
+                        PutEventsRequestEntry.builder()
+                                .eventBusName(busName)
+                                .source("compat.replay.test")
+                                .detailType("OrderShipped")
+                                .detail("{\"orderId\":\"A2\"}")
+                                .build()
+                )
+                .build());
+
+        assertThat(response.failedEntryCount()).isZero();
+
+        // Verify archive captured both events
+        DescribeArchiveResponse desc = eb.describeArchive(
+                DescribeArchiveRequest.builder().archiveName(archiveName).build());
+        assertThat(desc.eventCount()).isEqualTo(2);
+    }
+
+    // ──────────────────────────── Replay ────────────────────────────
+
+    @Test
+    @Order(20)
+    void startReplay() throws InterruptedException {
+        // Drain events already delivered by putEvents
+        sqs.receiveMessage(ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl).maxNumberOfMessages(10).build());
+
+        Instant afterPut = Instant.now().plusSeconds(1);
+        String replayName = TestFixtures.uniqueName("replay");
+
+        StartReplayResponse response = eb.startReplay(StartReplayRequest.builder()
+                .replayName(replayName)
+                .eventSourceArn(archiveArn)
+                .eventStartTime(beforePut)
+                .eventEndTime(afterPut)
+                .destination(ReplayDestination.builder().arn(busArn).build())
+                .build());
+
+        assertThat(response.replayArn()).contains(replayName);
+        assertThat(response.state()).isIn(ReplayState.STARTING, ReplayState.RUNNING);
+
+        // Poll until completed (up to 5 s)
+        ReplayState state = response.state();
+        for (int i = 0; i < 50 && state != ReplayState.COMPLETED && state != ReplayState.FAILED; i++) {
+            Thread.sleep(100);
+            state = eb.describeReplay(DescribeReplayRequest.builder().replayName(replayName).build()).state();
+        }
+        assertThat(state).isEqualTo(ReplayState.COMPLETED);
+
+        // Verify 2 replayed events arrived in the queue
+        List<Message> messages = sqs.receiveMessage(ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl).maxNumberOfMessages(10).waitTimeSeconds(2).build())
+                .messages();
+        assertThat(messages).hasSize(2);
+    }
+
+    @Test
+    @Order(21)
+    void listReplaysFilterByState() {
+        ListReplaysResponse response = eb.listReplays(ListReplaysRequest.builder()
+                .state(ReplayState.COMPLETED)
+                .build());
+        assertThat(response.replays()).isNotEmpty();
+        assertThat(response.replays()).allMatch(r -> r.state() == ReplayState.COMPLETED);
+    }
+
+    @Test
+    @Order(22)
+    void describeReplayShowsTimestamps() {
+        String replayName = eb.listReplays(ListReplaysRequest.builder()
+                .state(ReplayState.COMPLETED).build())
+                .replays().get(0).replayName();
+
+        DescribeReplayResponse desc = eb.describeReplay(
+                DescribeReplayRequest.builder().replayName(replayName).build());
+
+        assertThat(desc.state()).isEqualTo(ReplayState.COMPLETED);
+        assertThat(desc.replayStartTime()).isNotNull();
+        assertThat(desc.replayEndTime()).isNotNull();
+        assertThat(desc.eventLastReplayedTime()).isNotNull();
+    }
+
+    // ──────────────────────────── Cleanup ────────────────────────────
+
+    @Test
+    @Order(90)
+    void deleteArchive() {
+        eb.deleteArchive(DeleteArchiveRequest.builder().archiveName(archiveName).build());
+
+        assertThatThrownBy(() ->
+                eb.describeArchive(DescribeArchiveRequest.builder().archiveName(archiveName).build()))
+                .isInstanceOf(software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException.class);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -3,10 +3,14 @@ package io.github.hectorvent.floci.services.eventbridge;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsJson11Controller;
+import io.github.hectorvent.floci.services.eventbridge.model.Archive;
+import io.github.hectorvent.floci.services.eventbridge.model.ArchiveState;
 import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
+import io.github.hectorvent.floci.services.eventbridge.model.InputTransformer;
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
+import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
-import io.github.hectorvent.floci.services.eventbridge.model.InputTransformer;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +21,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,6 +68,15 @@ public class EventBridgeHandler {
                 case "UntagResource" -> handleUntagResource(request, region);
                 case "PutPermission" -> handlePutPermission(request, region);
                 case "RemovePermission" -> handleRemovePermission(request, region);
+                case "CreateArchive" -> handleCreateArchive(request, region);
+                case "DescribeArchive" -> handleDescribeArchive(request, region);
+                case "UpdateArchive" -> handleUpdateArchive(request, region);
+                case "DeleteArchive" -> handleDeleteArchive(request, region);
+                case "ListArchives" -> handleListArchives(request, region);
+                case "StartReplay" -> handleStartReplay(request, region);
+                case "DescribeReplay" -> handleDescribeReplay(request, region);
+                case "CancelReplay" -> handleCancelReplay(request, region);
+                case "ListReplays" -> handleListReplays(request, region);
                 default -> Response.status(400)
                         .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                         .build();
@@ -348,6 +362,112 @@ public class EventBridgeHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    // ──────────────────────────── Archives ────────────────────────────
+
+    private Response handleCreateArchive(JsonNode request, String region) {
+        String archiveName = request.path("ArchiveName").asText(null);
+        String eventSourceArn = request.path("EventSourceArn").asText(null);
+        String description = request.path("Description").asText(null);
+        String eventPattern = request.path("EventPattern").asText(null);
+        int retentionDays = request.path("RetentionDays").asInt(0);
+        Archive archive = eventBridgeService.createArchive(
+                archiveName, eventSourceArn, description, eventPattern, retentionDays, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ArchiveArn", archive.getArchiveArn());
+        response.put("State", archive.getState().name());
+        response.put("CreationTime", archive.getCreationTime().getEpochSecond());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDescribeArchive(JsonNode request, String region) {
+        String archiveName = request.path("ArchiveName").asText(null);
+        Archive archive = eventBridgeService.describeArchive(archiveName, region);
+        return Response.ok(buildArchiveNode(archive, true)).build();
+    }
+
+    private Response handleUpdateArchive(JsonNode request, String region) {
+        String archiveName = request.path("ArchiveName").asText(null);
+        String description = request.path("Description").asText(null);
+        String eventPattern = request.path("EventPattern").asText(null);
+        int retentionDays = request.path("RetentionDays").asInt(0);
+        Archive archive = eventBridgeService.updateArchive(
+                archiveName, description, eventPattern, retentionDays, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ArchiveArn", archive.getArchiveArn());
+        response.put("State", archive.getState().name());
+        response.put("CreationTime", archive.getCreationTime().getEpochSecond());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteArchive(JsonNode request, String region) {
+        String archiveName = request.path("ArchiveName").asText(null);
+        eventBridgeService.deleteArchive(archiveName, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleListArchives(JsonNode request, String region) {
+        String namePrefix = request.path("NamePrefix").asText(null);
+        String eventSourceArn = request.path("EventSourceArn").asText(null);
+        ArchiveState state = parseArchiveState(request.path("State").asText(null));
+        List<Archive> archives = eventBridgeService.listArchives(namePrefix, eventSourceArn, state, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode archivesArray = response.putArray("Archives");
+        for (Archive archive : archives) {
+            archivesArray.add(buildArchiveNode(archive, false));
+        }
+        return Response.ok(response).build();
+    }
+
+    // ──────────────────────────── Replays ────────────────────────────
+
+    private Response handleStartReplay(JsonNode request, String region) {
+        String replayName = request.path("ReplayName").asText(null);
+        String description = request.path("Description").asText(null);
+        String eventSourceArn = request.path("EventSourceArn").asText(null);
+        Instant eventStartTime = parseTimestamp(request.path("EventStartTime"));
+        Instant eventEndTime = parseTimestamp(request.path("EventEndTime"));
+        String destinationArn = request.path("Destination").path("Arn").asText(null);
+        Replay replay = eventBridgeService.startReplay(
+                replayName, description, eventSourceArn,
+                eventStartTime, eventEndTime, destinationArn, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ReplayArn", replay.getReplayArn());
+        response.put("State", replay.getState().name());
+        response.put("ReplayStartTime", replay.getReplayStartTime().getEpochSecond());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDescribeReplay(JsonNode request, String region) {
+        String replayName = request.path("ReplayName").asText(null);
+        Replay replay = eventBridgeService.describeReplay(replayName, region);
+        return Response.ok(buildReplayNode(replay, true)).build();
+    }
+
+    private Response handleCancelReplay(JsonNode request, String region) {
+        String replayName = request.path("ReplayName").asText(null);
+        Replay replay = eventBridgeService.cancelReplay(replayName, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ReplayArn", replay.getReplayArn());
+        response.put("State", replay.getState().name());
+        if (replay.getStateReason() != null) {
+            response.put("StateReason", replay.getStateReason());
+        }
+        return Response.ok(response).build();
+    }
+
+    private Response handleListReplays(JsonNode request, String region) {
+        String namePrefix = request.path("NamePrefix").asText(null);
+        String eventSourceArn = request.path("EventSourceArn").asText(null);
+        ReplayState state = parseReplayState(request.path("State").asText(null));
+        List<Replay> replays = eventBridgeService.listReplays(namePrefix, eventSourceArn, state, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode replaysArray = response.putArray("Replays");
+        for (Replay replay : replays) {
+            replaysArray.add(buildReplayNode(replay, false));
+        }
+        return Response.ok(response).build();
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private ObjectNode buildBusNode(EventBus bus) {
@@ -409,5 +529,97 @@ public class EventBridgeHandler {
             }
         }
         return tags;
+    }
+
+    private ObjectNode buildArchiveNode(Archive archive, boolean full) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ArchiveName", archive.getArchiveName());
+        node.put("EventSourceArn", archive.getEventSourceArn());
+        node.put("State", archive.getState().name());
+        node.put("EventCount", archive.getEventCount());
+        node.put("SizeBytes", archive.getSizeBytes());
+        node.put("RetentionDays", archive.getRetentionDays());
+        if (archive.getCreationTime() != null) {
+            node.put("CreationTime", archive.getCreationTime().getEpochSecond());
+        }
+        if (full) {
+            node.put("ArchiveArn", archive.getArchiveArn());
+            if (archive.getDescription() != null) {
+                node.put("Description", archive.getDescription());
+            }
+            if (archive.getEventPattern() != null) {
+                node.put("EventPattern", archive.getEventPattern());
+            }
+            if (archive.getStateReason() != null) {
+                node.put("StateReason", archive.getStateReason());
+            }
+        }
+        return node;
+    }
+
+    private ObjectNode buildReplayNode(Replay replay, boolean full) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ReplayName", replay.getReplayName());
+        node.put("EventSourceArn", replay.getEventSourceArn());
+        node.put("State", replay.getState().name());
+        if (replay.getEventStartTime() != null) {
+            node.put("EventStartTime", replay.getEventStartTime().getEpochSecond());
+        }
+        if (replay.getEventEndTime() != null) {
+            node.put("EventEndTime", replay.getEventEndTime().getEpochSecond());
+        }
+        if (replay.getEventLastReplayedTime() != null) {
+            node.put("EventLastReplayedTime", replay.getEventLastReplayedTime().getEpochSecond());
+        }
+        if (replay.getReplayStartTime() != null) {
+            node.put("ReplayStartTime", replay.getReplayStartTime().getEpochSecond());
+        }
+        if (replay.getReplayEndTime() != null) {
+            node.put("ReplayEndTime", replay.getReplayEndTime().getEpochSecond());
+        }
+        if (full) {
+            node.put("ReplayArn", replay.getReplayArn());
+            if (replay.getDescription() != null) {
+                node.put("Description", replay.getDescription());
+            }
+            if (replay.getStateReason() != null) {
+                node.put("StateReason", replay.getStateReason());
+            }
+            if (replay.getDestinationArn() != null) {
+                ObjectNode dest = node.putObject("Destination");
+                dest.put("Arn", replay.getDestinationArn());
+            }
+        }
+        return node;
+    }
+
+    private ArchiveState parseArchiveState(String state) {
+        if (state == null || state.isBlank()) return null;
+        try {
+            return ArchiveState.valueOf(state);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private ReplayState parseReplayState(String state) {
+        if (state == null || state.isBlank()) return null;
+        try {
+            return ReplayState.valueOf(state);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private Instant parseTimestamp(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) return null;
+        if (node.isNumber()) {
+            return Instant.ofEpochSecond(node.asLong());
+        }
+        try {
+            return Instant.parse(node.asText());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -6,7 +6,12 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.eventbridge.model.Archive;
+import io.github.hectorvent.floci.services.eventbridge.model.ArchiveState;
+import io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent;
 import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
+import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
@@ -34,10 +39,14 @@ public class EventBridgeService {
     private final StorageBackend<String, EventBus> busStore;
     private final StorageBackend<String, Rule> ruleStore;
     private final StorageBackend<String, List<Target>> targetStore;
+    private final StorageBackend<String, Archive> archiveStore;
+    private final StorageBackend<String, List<ArchivedEvent>> archivedEventStore;
+    private final StorageBackend<String, Replay> replayStore;
     private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
     private final RuleScheduler ruleScheduler;
     private final EventBridgeInvoker invoker;
+    private final ReplayDispatcher replayDispatcher;
 
     @Inject
     public EventBridgeService(StorageFactory storageFactory,
@@ -45,7 +54,8 @@ public class EventBridgeService {
                               RegionResolver regionResolver,
                               ObjectMapper objectMapper,
                               RuleScheduler ruleScheduler,
-                              EventBridgeInvoker invoker) {
+                              EventBridgeInvoker invoker,
+                              ReplayDispatcher replayDispatcher) {
         this(
                 storageFactory.create("eventbridge", "eventbridge-buses.json",
                         new TypeReference<Map<String, EventBus>>() {}),
@@ -53,24 +63,38 @@ public class EventBridgeService {
                         new TypeReference<Map<String, Rule>>() {}),
                 storageFactory.create("eventbridge", "eventbridge-targets.json",
                         new TypeReference<Map<String, List<Target>>>() {}),
-                regionResolver, objectMapper, ruleScheduler, invoker
+                storageFactory.create("eventbridge", "eventbridge-archives.json",
+                        new TypeReference<Map<String, Archive>>() {}),
+                storageFactory.create("eventbridge", "eventbridge-archived-events.json",
+                        new TypeReference<Map<String, List<ArchivedEvent>>>() {}),
+                storageFactory.create("eventbridge", "eventbridge-replays.json",
+                        new TypeReference<Map<String, Replay>>() {}),
+                regionResolver, objectMapper, ruleScheduler, invoker, replayDispatcher
         );
     }
 
     EventBridgeService(StorageBackend<String, EventBus> busStore,
                        StorageBackend<String, Rule> ruleStore,
                        StorageBackend<String, List<Target>> targetStore,
+                       StorageBackend<String, Archive> archiveStore,
+                       StorageBackend<String, List<ArchivedEvent>> archivedEventStore,
+                       StorageBackend<String, Replay> replayStore,
                        RegionResolver regionResolver,
                        ObjectMapper objectMapper,
                        RuleScheduler ruleScheduler,
-                       EventBridgeInvoker invoker) {
+                       EventBridgeInvoker invoker,
+                       ReplayDispatcher replayDispatcher) {
         this.busStore = busStore;
         this.ruleStore = ruleStore;
         this.targetStore = targetStore;
+        this.archiveStore = archiveStore;
+        this.archivedEventStore = archivedEventStore;
+        this.replayStore = replayStore;
         this.regionResolver = regionResolver;
         this.objectMapper = objectMapper;
         this.ruleScheduler = ruleScheduler;
         this.invoker = invoker;
+        this.replayDispatcher = replayDispatcher;
     }
 
     @PostConstruct
@@ -336,10 +360,27 @@ public class EventBridgeService {
                     .map(Rule::getTags)
                     .orElse(Map.of());
         }
+        if (resourceArn.contains("archive/")) {
+            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+            String key = archiveKey(region, archiveName);
+            return archiveStore.get(key)
+                    .map(Archive::getTags)
+                    .orElse(Map.of());
+        }
         return Map.of();
     }
 
     public void tagResource(String resourceArn, Map<String, String> tags, String region) {
+        if (resourceArn.contains("archive/")) {
+            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+            String key = archiveKey(region, archiveName);
+            Archive archive = archiveStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Archive not found: " + archiveName, 404));
+            archive.getTags().putAll(tags);
+            archiveStore.put(key, archive);
+            return;
+        }
         if (resourceArn.contains("event-bus/")) {
             String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
             String key = busKey(region, busName);
@@ -374,6 +415,16 @@ public class EventBridgeService {
     }
 
     public void untagResource(String resourceArn, List<String> tagKeys, String region) {
+        if (resourceArn.contains("archive/")) {
+            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+            String key = archiveKey(region, archiveName);
+            Archive archive = archiveStore.get(key)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "Archive not found: " + archiveName, 404));
+            tagKeys.forEach(archive.getTags()::remove);
+            archiveStore.put(key, archive);
+            return;
+        }
         if (resourceArn.contains("event-bus/")) {
             String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
             String key = busKey(region, busName);
@@ -556,6 +607,8 @@ public class EventBridgeService {
                 }
             }
 
+            captureToArchives(entry, busStoreKey, eventId, region);
+
             Map<String, String> successEntry = new HashMap<>();
             successEntry.put("EventId", eventId);
             resultEntries.add(successEntry);
@@ -737,6 +790,261 @@ public class EventBridgeService {
             return regionResolver.buildArn("events", region, "rule/" + ruleName);
         }
         return regionResolver.buildArn("events", region, "rule/" + busName + "/" + ruleName);
+    }
+
+    // ──────────────────────────── Archives ────────────────────────────
+
+    public Archive createArchive(String archiveName, String eventSourceArn, String description,
+                                 String eventPattern, int retentionDays, String region) {
+        if (archiveName == null || archiveName.isBlank()) {
+            throw new AwsException("ValidationException", "ArchiveName is required.", 400);
+        }
+        if (eventSourceArn == null || eventSourceArn.isBlank()) {
+            throw new AwsException("ValidationException", "EventSourceArn is required.", 400);
+        }
+        String key = archiveKey(region, archiveName);
+        if (archiveStore.get(key).isPresent()) {
+            throw new AwsException("ResourceAlreadyExistsException",
+                    "Archive already exists: " + archiveName, 400);
+        }
+        Archive archive = new Archive();
+        archive.setArchiveName(archiveName);
+        archive.setArchiveArn(regionResolver.buildArn("events", region, "archive/" + archiveName));
+        archive.setEventSourceArn(eventSourceArn);
+        archive.setDescription(description);
+        archive.setEventPattern(eventPattern);
+        archive.setRetentionDays(retentionDays);
+        archive.setState(ArchiveState.ENABLED);
+        archive.setCreationTime(Instant.now());
+        archiveStore.put(key, archive);
+        LOG.infov("Created archive: {0} for source {1}", archiveName, eventSourceArn);
+        return archive;
+    }
+
+    public Archive describeArchive(String archiveName, String region) {
+        return archiveStore.get(archiveKey(region, archiveName))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Archive not found: " + archiveName, 404));
+    }
+
+    public Archive updateArchive(String archiveName, String description,
+                                 String eventPattern, int retentionDays, String region) {
+        String key = archiveKey(region, archiveName);
+        Archive archive = archiveStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Archive not found: " + archiveName, 404));
+        if (description != null) {
+            archive.setDescription(description);
+        }
+        archive.setEventPattern(eventPattern);
+        archive.setRetentionDays(retentionDays);
+        archiveStore.put(key, archive);
+        return archive;
+    }
+
+    public void deleteArchive(String archiveName, String region) {
+        String key = archiveKey(region, archiveName);
+        archiveStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Archive not found: " + archiveName, 404));
+        archiveStore.delete(key);
+        archivedEventStore.delete(archivedEventKey(region, archiveName));
+        LOG.infov("Deleted archive: {0}", archiveName);
+    }
+
+    public List<Archive> listArchives(String namePrefix, String eventSourceArn,
+                                      ArchiveState state, String region) {
+        String prefix = "archive:" + region + ":";
+        return archiveStore.scan(k -> {
+            if (!k.startsWith(prefix)) return false;
+            Archive a = archiveStore.get(k).orElse(null);
+            if (a == null) return false;
+            if (namePrefix != null && !namePrefix.isBlank()
+                    && !a.getArchiveName().startsWith(namePrefix)) {
+                return false;
+            }
+            if (eventSourceArn != null && !eventSourceArn.isBlank()
+                    && !eventSourceArn.equals(a.getEventSourceArn())) {
+                return false;
+            }
+            if (state != null && state != a.getState()) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    private void captureToArchives(Map<String, Object> entry, String busStoreKey,
+                                   String eventId, String region) {
+        EventBus bus = busStore.get(busStoreKey).orElse(null);
+        if (bus == null) {
+            return;
+        }
+        String busArn = bus.getArn();
+        String archivePrefix = "archive:" + region + ":";
+        List<Archive> candidates = archiveStore.scan(k ->
+                k.startsWith(archivePrefix)
+                        && archiveStore.get(k).map(a ->
+                        a.getState() == ArchiveState.ENABLED
+                                && busArn.equals(a.getEventSourceArn())).orElse(false));
+
+        for (Archive archive : candidates) {
+            if (matchesPattern(entry, archive.getEventPattern())) {
+                String evKey = archivedEventKey(region, archive.getArchiveName());
+                List<ArchivedEvent> stored = new ArrayList<>(
+                        archivedEventStore.get(evKey).orElse(new ArrayList<>()));
+                ArchivedEvent ae = new ArchivedEvent(
+                        eventId,
+                        Instant.now(),
+                        (String) entry.get("Source"),
+                        (String) entry.get("DetailType"),
+                        (String) entry.get("Detail"),
+                        busArn
+                );
+                stored.add(ae);
+                archivedEventStore.put(evKey, stored);
+                archive.setEventCount(archive.getEventCount() + 1);
+                archiveStore.put(archiveKey(region, archive.getArchiveName()), archive);
+            }
+        }
+    }
+
+    // ──────────────────────────── Replays ────────────────────────────
+
+    public Replay startReplay(String replayName, String description, String eventSourceArn,
+                              Instant eventStartTime, Instant eventEndTime,
+                              String destinationArn, String region) {
+        if (replayName == null || replayName.isBlank()) {
+            throw new AwsException("ValidationException", "ReplayName is required.", 400);
+        }
+        String key = replayKey(region, replayName);
+        if (replayStore.get(key).isPresent()) {
+            throw new AwsException("ResourceAlreadyExistsException",
+                    "Replay already exists: " + replayName, 400);
+        }
+
+        // resolve archive
+        String archiveName = archiveNameFromArn(eventSourceArn);
+        Archive archive = archiveStore.get(archiveKey(region, archiveName))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Archive not found: " + archiveName, 404));
+
+        List<ArchivedEvent> events = archivedEventStore
+                .get(archivedEventKey(region, archiveName))
+                .orElse(List.of());
+
+        Replay replay = new Replay();
+        replay.setReplayName(replayName);
+        replay.setReplayArn(regionResolver.buildArn("events", region, "replay/" + replayName));
+        replay.setDescription(description);
+        replay.setEventSourceArn(eventSourceArn);
+        replay.setDestinationArn(destinationArn);
+        replay.setEventStartTime(eventStartTime);
+        replay.setEventEndTime(eventEndTime);
+        replay.setState(ReplayState.STARTING);
+        replay.setReplayStartTime(Instant.now());
+        replayStore.put(key, replay);
+
+        replayDispatcher.dispatch(
+                replay,
+                events,
+                entries -> putEvents(entries, region),
+                (name, state) -> updateReplayState(name, state, region),
+                time -> updateReplayLastReplayed(replayName, time, region)
+        );
+
+        LOG.infov("Started replay: {0} from archive {1}", replayName, archiveName);
+        return replay;
+    }
+
+    public Replay describeReplay(String replayName, String region) {
+        return replayStore.get(replayKey(region, replayName))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Replay not found: " + replayName, 404));
+    }
+
+    public Replay cancelReplay(String replayName, String region) {
+        String key = replayKey(region, replayName);
+        Replay replay = replayStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Replay not found: " + replayName, 404));
+        if (replay.getState() != ReplayState.RUNNING && replay.getState() != ReplayState.STARTING) {
+            throw new AwsException("IllegalStatusException",
+                    "Replay is not in a cancellable state: " + replay.getState(), 400);
+        }
+        boolean signalled = replayDispatcher.requestCancel(replayName);
+        if (!signalled) {
+            // already completed between check and cancel
+            replay = replayStore.get(key).orElse(replay);
+        } else {
+            replay.setState(ReplayState.CANCELLING);
+            replay.setStateReason("Cancellation requested.");
+            replayStore.put(key, replay);
+        }
+        return replay;
+    }
+
+    public List<Replay> listReplays(String namePrefix, String eventSourceArn,
+                                    ReplayState state, String region) {
+        String prefix = "replay:" + region + ":";
+        return replayStore.scan(k -> {
+            if (!k.startsWith(prefix)) return false;
+            Replay r = replayStore.get(k).orElse(null);
+            if (r == null) return false;
+            if (namePrefix != null && !namePrefix.isBlank()
+                    && !r.getReplayName().startsWith(namePrefix)) {
+                return false;
+            }
+            if (eventSourceArn != null && !eventSourceArn.isBlank()
+                    && !eventSourceArn.equals(r.getEventSourceArn())) {
+                return false;
+            }
+            if (state != null && state != r.getState()) {
+                return false;
+            }
+            return true;
+        });
+    }
+
+    void updateReplayState(String replayName, ReplayState state, String region) {
+        String key = replayKey(region, replayName);
+        replayStore.get(key).ifPresent(r -> {
+            r.setState(state);
+            if (state == ReplayState.COMPLETED || state == ReplayState.CANCELLED
+                    || state == ReplayState.FAILED) {
+                r.setReplayEndTime(Instant.now());
+            }
+            replayStore.put(key, r);
+            LOG.debugv("Replay {0} transitioned to {1}", replayName, state);
+        });
+    }
+
+    void updateReplayLastReplayed(String replayName, Instant eventTime, String region) {
+        String key = replayKey(region, replayName);
+        replayStore.get(key).ifPresent(r -> {
+            r.setEventLastReplayedTime(eventTime);
+            replayStore.put(key, r);
+        });
+    }
+
+    // ──────────────────────────── Storage key helpers ────────────────────────────
+
+    private static String archiveKey(String region, String archiveName) {
+        return "archive:" + region + ":" + archiveName;
+    }
+
+    private static String archivedEventKey(String region, String archiveName) {
+        return "archivedEvents:" + region + ":" + archiveName;
+    }
+
+    private static String replayKey(String region, String replayName) {
+        return "replay:" + region + ":" + replayName;
+    }
+
+    private static String archiveNameFromArn(String arn) {
+        if (arn == null) return null;
+        int idx = arn.lastIndexOf("archive/");
+        return idx >= 0 ? arn.substring(idx + "archive/".length()) : arn;
     }
 
     private void startSchedulerIfNeeded(Rule rule) {

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcher.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent;
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
+import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
+import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+@ApplicationScoped
+public class ReplayDispatcher {
+
+    private static final Logger LOG = Logger.getLogger(ReplayDispatcher.class);
+
+    private final Vertx vertx;
+    private final ConcurrentHashMap<String, AtomicBoolean> cancelFlags = new ConcurrentHashMap<>();
+
+    @Inject
+    public ReplayDispatcher(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    /**
+     * Starts an async replay. Events are dispatched via {@code eventSender} in event-time order.
+     *
+     * @param replay          the replay metadata (must be in STARTING state)
+     * @param events          all archived events for the source archive
+     * @param eventSender     sends a batch of events to the destination bus (calls putEvents)
+     * @param stateUpdater    called to transition replay state (replayName, newState)
+     * @param progressUpdater called after each dispatched event with the event timestamp
+     */
+    void dispatch(Replay replay,
+                  List<ArchivedEvent> events,
+                  Consumer<List<Map<String, Object>>> eventSender,
+                  BiConsumer<String, ReplayState> stateUpdater,
+                  Consumer<Instant> progressUpdater) {
+
+        String replayName = replay.getReplayName();
+        AtomicBoolean cancelled = new AtomicBoolean(false);
+        cancelFlags.put(replayName, cancelled);
+
+        vertx.executeBlocking(promise -> {
+            try {
+                stateUpdater.accept(replayName, ReplayState.RUNNING);
+
+                Instant start = replay.getEventStartTime();
+                Instant end = replay.getEventEndTime();
+                String destArn = replay.getDestinationArn();
+                String destBusName = busNameFromArn(destArn);
+
+                List<ArchivedEvent> window = events.stream()
+                        .filter(e -> !e.getEventTime().isBefore(start) && !e.getEventTime().isAfter(end))
+                        .sorted(Comparator.comparing(ArchivedEvent::getEventTime))
+                        .toList();
+
+                LOG.debugv("Replay {0}: dispatching {1} events to bus {2}", replayName, window.size(), destBusName);
+
+                for (ArchivedEvent event : window) {
+                    if (cancelled.get()) {
+                        stateUpdater.accept(replayName, ReplayState.CANCELLED);
+                        promise.complete();
+                        return;
+                    }
+                    Map<String, Object> entry = new HashMap<>();
+                    entry.put("Source", event.getSource());
+                    entry.put("DetailType", event.getDetailType());
+                    entry.put("Detail", event.getDetail() != null ? event.getDetail() : "{}");
+                    entry.put("EventBusName", destBusName);
+                    eventSender.accept(List.of(entry));
+                    progressUpdater.accept(event.getEventTime());
+                }
+
+                stateUpdater.accept(replayName, ReplayState.COMPLETED);
+                promise.complete();
+            } catch (Exception e) {
+                LOG.warnv("Replay {0} failed: {1}", replayName, e.getMessage());
+                stateUpdater.accept(replayName, ReplayState.FAILED);
+                promise.fail(e);
+            } finally {
+                cancelFlags.remove(replayName);
+            }
+        });
+    }
+
+    /**
+     * Signals a running replay to stop after the current event. Returns false if the replay is
+     * not running (already completed, cancelled, or unknown).
+     */
+    boolean requestCancel(String replayName) {
+        AtomicBoolean flag = cancelFlags.get(replayName);
+        if (flag != null) {
+            flag.set(true);
+            return true;
+        }
+        return false;
+    }
+
+    private static String busNameFromArn(String arn) {
+        if (arn == null) {
+            return "default";
+        }
+        int idx = arn.lastIndexOf("event-bus/");
+        return idx >= 0 ? arn.substring(idx + "event-bus/".length()) : arn;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Archive.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Archive.java
@@ -1,0 +1,62 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@RegisterForReflection
+public class Archive {
+
+    private String archiveName;
+    private String archiveArn;
+    private String eventSourceArn;
+    private String description;
+    private String eventPattern;
+    private int retentionDays;
+    private ArchiveState state;
+    private String stateReason;
+    private long eventCount;
+    private long sizeBytes;
+    private Instant creationTime;
+    private Map<String, String> tags = new HashMap<>();
+
+    public Archive() {}
+
+    public String getArchiveName() { return archiveName; }
+    public void setArchiveName(String archiveName) { this.archiveName = archiveName; }
+
+    public String getArchiveArn() { return archiveArn; }
+    public void setArchiveArn(String archiveArn) { this.archiveArn = archiveArn; }
+
+    public String getEventSourceArn() { return eventSourceArn; }
+    public void setEventSourceArn(String eventSourceArn) { this.eventSourceArn = eventSourceArn; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getEventPattern() { return eventPattern; }
+    public void setEventPattern(String eventPattern) { this.eventPattern = eventPattern; }
+
+    public int getRetentionDays() { return retentionDays; }
+    public void setRetentionDays(int retentionDays) { this.retentionDays = retentionDays; }
+
+    public ArchiveState getState() { return state; }
+    public void setState(ArchiveState state) { this.state = state; }
+
+    public String getStateReason() { return stateReason; }
+    public void setStateReason(String stateReason) { this.stateReason = stateReason; }
+
+    public long getEventCount() { return eventCount; }
+    public void setEventCount(long eventCount) { this.eventCount = eventCount; }
+
+    public long getSizeBytes() { return sizeBytes; }
+    public void setSizeBytes(long sizeBytes) { this.sizeBytes = sizeBytes; }
+
+    public Instant getCreationTime() { return creationTime; }
+    public void setCreationTime(Instant creationTime) { this.creationTime = creationTime; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchiveState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchiveState.java
@@ -1,0 +1,5 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+public enum ArchiveState {
+    ENABLED, DISABLED, CREATING, UPDATING, DELETING
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchivedEvent.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchivedEvent.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+public class ArchivedEvent {
+
+    private String eventId;
+    private Instant eventTime;
+    private String source;
+    private String detailType;
+    private String detail;
+    private String eventBusArn;
+
+    public ArchivedEvent() {}
+
+    public ArchivedEvent(String eventId, Instant eventTime, String source,
+                         String detailType, String detail, String eventBusArn) {
+        this.eventId = eventId;
+        this.eventTime = eventTime;
+        this.source = source;
+        this.detailType = detailType;
+        this.detail = detail;
+        this.eventBusArn = eventBusArn;
+    }
+
+    public String getEventId() { return eventId; }
+    public void setEventId(String eventId) { this.eventId = eventId; }
+
+    public Instant getEventTime() { return eventTime; }
+    public void setEventTime(Instant eventTime) { this.eventTime = eventTime; }
+
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+
+    public String getDetailType() { return detailType; }
+    public void setDetailType(String detailType) { this.detailType = detailType; }
+
+    public String getDetail() { return detail; }
+    public void setDetail(String detail) { this.detail = detail; }
+
+    public String getEventBusArn() { return eventBusArn; }
+    public void setEventBusArn(String eventBusArn) { this.eventBusArn = eventBusArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Replay.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Replay.java
@@ -1,0 +1,60 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+public class Replay {
+
+    private String replayName;
+    private String replayArn;
+    private String description;
+    private String eventSourceArn;
+    private String destinationArn;
+    private Instant eventStartTime;
+    private Instant eventEndTime;
+    private Instant eventLastReplayedTime;
+    private ReplayState state;
+    private String stateReason;
+    private Instant replayStartTime;
+    private Instant replayEndTime;
+
+    public Replay() {}
+
+    public String getReplayName() { return replayName; }
+    public void setReplayName(String replayName) { this.replayName = replayName; }
+
+    public String getReplayArn() { return replayArn; }
+    public void setReplayArn(String replayArn) { this.replayArn = replayArn; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getEventSourceArn() { return eventSourceArn; }
+    public void setEventSourceArn(String eventSourceArn) { this.eventSourceArn = eventSourceArn; }
+
+    public String getDestinationArn() { return destinationArn; }
+    public void setDestinationArn(String destinationArn) { this.destinationArn = destinationArn; }
+
+    public Instant getEventStartTime() { return eventStartTime; }
+    public void setEventStartTime(Instant eventStartTime) { this.eventStartTime = eventStartTime; }
+
+    public Instant getEventEndTime() { return eventEndTime; }
+    public void setEventEndTime(Instant eventEndTime) { this.eventEndTime = eventEndTime; }
+
+    public Instant getEventLastReplayedTime() { return eventLastReplayedTime; }
+    public void setEventLastReplayedTime(Instant eventLastReplayedTime) { this.eventLastReplayedTime = eventLastReplayedTime; }
+
+    public ReplayState getState() { return state; }
+    public void setState(ReplayState state) { this.state = state; }
+
+    public String getStateReason() { return stateReason; }
+    public void setStateReason(String stateReason) { this.stateReason = stateReason; }
+
+    public Instant getReplayStartTime() { return replayStartTime; }
+    public void setReplayStartTime(Instant replayStartTime) { this.replayStartTime = replayStartTime; }
+
+    public Instant getReplayEndTime() { return replayEndTime; }
+    public void setReplayEndTime(Instant replayEndTime) { this.replayEndTime = replayEndTime; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ReplayState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ReplayState.java
@@ -1,0 +1,5 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+public enum ReplayState {
+    STARTING, RUNNING, CANCELLING, COMPLETED, CANCELLED, FAILED
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
@@ -1,0 +1,309 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.*;
+
+import java.time.Instant;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeReplayIntegrationTest {
+
+    private static final String EB_CT = "application/x-amz-json-1.1";
+    private static final String SQS_CT = "application/x-amz-json-1.0";
+
+    private static String busArn;
+    private static String archiveArn;
+    private static String queueUrl;
+    private static String queueArn;
+    private static long beforePut;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createCustomBus() {
+        busArn = given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"replay-test-bus\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("EventBusArn", notNullValue())
+                .extract().jsonPath().getString("EventBusArn");
+    }
+
+    @Test
+    @Order(2)
+    void createArchive() {
+        archiveArn = given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.CreateArchive")
+                .body("""
+                        {
+                          "ArchiveName": "replay-test-archive",
+                          "EventSourceArn": "%s",
+                          "Description": "Archive for replay integration test",
+                          "RetentionDays": 7
+                        }
+                        """.formatted(busArn))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("ArchiveArn", notNullValue())
+                .body("State", equalTo("ENABLED"))
+                .extract().jsonPath().getString("ArchiveArn");
+    }
+
+    @Test
+    @Order(3)
+    void describeArchive() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeArchive")
+                .body("{\"ArchiveName\":\"replay-test-archive\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("ArchiveName", equalTo("replay-test-archive"))
+                .body("EventSourceArn", equalTo(busArn))
+                .body("State", equalTo("ENABLED"))
+                .body("EventCount", equalTo(0))
+                .body("RetentionDays", equalTo(7));
+    }
+
+    @Test
+    @Order(4)
+    void createSinkQueueAndRule() {
+        queueUrl = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"replay-sink-queue\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+
+        queueArn = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"AttributeNames\":[\"All\"]}")
+                .when().post("/0000000000/replay-sink-queue")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                        {
+                          "Name": "replay-test-rule",
+                          "EventBusName": "replay-test-bus",
+                          "EventPattern": "{\\"source\\":[\\"replay.test\\"]}"
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutTargets")
+                .body("""
+                        {
+                          "Rule": "replay-test-rule",
+                          "EventBusName": "replay-test-bus",
+                          "Targets": [{"Id": "1", "Arn": "%s"}]
+                        }
+                        """.formatted(queueArn))
+                .when().post("/")
+                .then().statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void putEventsAndVerifyArchived() {
+        beforePut = Instant.now().getEpochSecond() - 1;
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutEvents")
+                .body("""
+                        {
+                          "Entries": [
+                            {
+                              "EventBusName": "replay-test-bus",
+                              "Source": "replay.test",
+                              "DetailType": "OrderCreated",
+                              "Detail": "{\\"orderId\\":\\"001\\"}"
+                            },
+                            {
+                              "EventBusName": "replay-test-bus",
+                              "Source": "replay.test",
+                              "DetailType": "OrderShipped",
+                              "Detail": "{\\"orderId\\":\\"002\\"}"
+                            }
+                          ]
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeArchive")
+                .body("{\"ArchiveName\":\"replay-test-archive\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("EventCount", equalTo(2));
+    }
+
+    @Test
+    @Order(6)
+    void listArchives() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.ListArchives")
+                .body("{\"NamePrefix\":\"replay-test\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Archives", hasSize(1))
+                .body("Archives[0].ArchiveName", equalTo("replay-test-archive"))
+                .body("Archives[0].EventCount", equalTo(2));
+    }
+
+    @Test
+    @Order(7)
+    void startReplayAndPollUntilCompleted() throws InterruptedException {
+        // drain any prior messages delivered by putEvents
+        given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"MaxNumberOfMessages\":10}")
+                .when().post("/0000000000/replay-sink-queue");
+
+        long afterPut = Instant.now().getEpochSecond() + 1;
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.StartReplay")
+                .body("""
+                        {
+                          "ReplayName": "test-replay-1",
+                          "EventSourceArn": "%s",
+                          "EventStartTime": %d,
+                          "EventEndTime": %d,
+                          "Destination": {"Arn": "%s"}
+                        }
+                        """.formatted(archiveArn, beforePut, afterPut, busArn))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("ReplayArn", notNullValue())
+                .body("State", anyOf(equalTo("STARTING"), equalTo("RUNNING")));
+
+        // poll until COMPLETED (up to 5 s)
+        String state = "STARTING";
+        for (int i = 0; i < 50 && !"COMPLETED".equals(state) && !"FAILED".equals(state); i++) {
+            Thread.sleep(100);
+            state = given()
+                    .contentType(EB_CT)
+                    .header("X-Amz-Target", "AWSEvents.DescribeReplay")
+                    .body("{\"ReplayName\":\"test-replay-1\"}")
+                    .when().post("/")
+                    .then().statusCode(200)
+                    .extract().jsonPath().getString("State");
+        }
+
+        Assertions.assertEquals("COMPLETED", state, "Replay did not reach COMPLETED state");
+    }
+
+    @Test
+    @Order(8)
+    void verifyReplayedEventsArrivedInQueue() {
+        given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"MaxNumberOfMessages\":10}")
+                .when().post("/0000000000/replay-sink-queue")
+                .then().statusCode(200)
+                .body("Messages", hasSize(2));
+    }
+
+    @Test
+    @Order(9)
+    void listReplays() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.ListReplays")
+                .body("{\"NamePrefix\":\"test-replay\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Replays", hasSize(1))
+                .body("Replays[0].ReplayName", equalTo("test-replay-1"))
+                .body("Replays[0].State", equalTo("COMPLETED"));
+    }
+
+    @Test
+    @Order(10)
+    void describeReplayShowsEndTime() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeReplay")
+                .body("{\"ReplayName\":\"test-replay-1\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("ReplayName", equalTo("test-replay-1"))
+                .body("State", equalTo("COMPLETED"))
+                .body("ReplayEndTime", notNullValue())
+                .body("EventLastReplayedTime", notNullValue());
+    }
+
+    @Test
+    @Order(11)
+    void updateArchive() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.UpdateArchive")
+                .body("""
+                        {
+                          "ArchiveName": "replay-test-archive",
+                          "Description": "Updated description",
+                          "RetentionDays": 30
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200)
+                .body("State", equalTo("ENABLED"));
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeArchive")
+                .body("{\"ArchiveName\":\"replay-test-archive\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("Updated description"))
+                .body("RetentionDays", equalTo(30));
+    }
+
+    @Test
+    @Order(12)
+    void deleteArchive() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DeleteArchive")
+                .body("{\"ArchiveName\":\"replay-test-archive\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeArchive")
+                .body("{\"ArchiveName\":\"replay-test-archive\"}")
+                .when().post("/")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
@@ -5,7 +5,10 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.eventbridge.model.Archive;
+import io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent;
 import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
@@ -40,10 +43,12 @@ class EventBridgeSchedulerIntegrationTest {
         EventBridgeInvoker invoker = new EventBridgeInvoker(null, null, null, new ObjectMapper(), createConfig());
         scheduler = new RuleScheduler(vertx, createConfig(), new ObjectMapper(), invoker);
 
+        ReplayDispatcher replayDispatcher = new ReplayDispatcher(vertx);
         eventBridgeService = new EventBridgeService(
                 busStore, ruleStore, targetStore,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new RegionResolver(REGION, ACCOUNT),
-                new ObjectMapper(), scheduler, invoker);
+                new ObjectMapper(), scheduler, invoker, replayDispatcher);
     }
 
     @AfterEach

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -9,7 +9,6 @@ import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,10 +35,14 @@ class EventBridgeServiceTest {
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
                 new RegionResolver("us-east-1", "000000000000"),
                 new ObjectMapper(),
                 null,
-                invokerMock
+                invokerMock,
+                null
         );
     }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

- Implements the full EventBridge Archive and Replay surface area (9 AWS actions: CreateArchive, DescribeArchive, UpdateArchive, DeleteArchive, ListArchives, StartReplay, DescribeReplay, CancelReplay, ListReplays)
- Events published via `PutEvents` are automatically captured to matching archives; replayed events are re-injected into the destination bus and delivered through existing rule/target dispatch
- Replay runs asynchronously in a Vertx `executeBlocking` worker (consistent with `RuleScheduler`); cancellation is supported via a per-replay `AtomicBoolean` flag
- Archive and replay tag operations are wired into the existing `TagResource` / `UntagResource` / `ListTagsForResource` handlers
- Three new `StorageBackend` instances (archives, archivedEvents, replays) follow the `StorageFactory` pattern

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
