### PR TITLE
fix(docker): respect DOCKER_HOST env var and handle missing URI scheme

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
@@ -50,14 +50,54 @@ public class DockerClientProducer {
         return normalized;
     }
 
+    /**
+     * Resolves the effective Docker host to use when creating the client.
+     *
+     * Priority:
+     * 1. If {@code floci.docker.docker-host} is explicitly configured (non-default), use it.
+     * 2. Otherwise fall back to the standard {@code DOCKER_HOST} env var (normalized).
+     * 3. Otherwise use the default unix socket.
+     *
+     * Both the configured value and the env var are normalized to ensure a valid URI scheme.
+     */
+    static String resolveEffectiveDockerHost(String configuredHost, String dockerHostEnv) {
+        String normalizedEnvHost = normalizeDockerHost(dockerHostEnv);
+        if ("unix:///var/run/docker.sock".equals(configuredHost)
+                && normalizedEnvHost != null && !normalizedEnvHost.isBlank()) {
+            return normalizedEnvHost;
+        }
+        return normalizeDockerHost(configuredHost);
+    }
+
+    private static DefaultDockerClientConfig.Builder createDockerConfigBuilder() {
+        try {
+            return DefaultDockerClientConfig.createDefaultConfigBuilder();
+        } catch (IllegalArgumentException e) {
+            // DOCKER_HOST env var is set without a URI scheme (e.g. "10.37.124.101:2375").
+            // docker-java calls URI.create() on it immediately inside createDefaultConfigBuilder(),
+            // which throws before Floci's withDockerHost() override can take effect.
+            // Fall back to a fresh builder; the caller will supply the normalized host.
+            LOG.warnv("Could not initialize Docker config from environment "
+                    + "(DOCKER_HOST env var may be missing a URI scheme): {0}. "
+                    + "Using Floci''s configured host.", e.getMessage());
+            return new DefaultDockerClientConfig.Builder();
+        }
+    }
+
     @Produces
     @ApplicationScoped
     public DockerClient dockerClient() {
-        String dockerHost = normalizeDockerHost(config.docker().dockerHost());
+        String dockerHost = resolveEffectiveDockerHost(
+                config.docker().dockerHost(), System.getenv("DOCKER_HOST"));
         LOG.infov("Creating DockerClient for host: {0}", dockerHost);
 
-        DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost(dockerHost);
+        // createDefaultConfigBuilder() reads DOCKER_HOST directly from System.getenv() and passes
+        // it to withDockerHost(), which calls URI.create() immediately. If DOCKER_HOST is set
+        // without a URI scheme (e.g. "10.37.124.101:2375" in Bitbucket Pipelines), the
+        // URI.create() call throws before Floci's override takes effect. Fall back to a fresh
+        // builder in that case so we can supply the normalized host ourselves.
+        DefaultDockerClientConfig.Builder builder = createDockerConfigBuilder();
+        builder.withDockerHost(dockerHost);
         config.docker().dockerConfigPath().ifPresent(path -> {
             LOG.infov("Using Docker config path: {0}", path);
             builder.withDockerConfig(path);

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
@@ -120,4 +120,65 @@ class DockerClientProducerTest {
         String result = DockerClientProducer.normalizeDockerHost("");
         assertEquals("", result, "Empty string input should return empty string");
     }
+
+    // --- resolveEffectiveDockerHost tests ---
+
+    /**
+     * When floci.docker.docker-host is at its default (unix socket) and DOCKER_HOST env var
+     * is set to a bare host:port, the env var should be used (normalized with tcp://).
+     * This is the Bitbucket Pipelines scenario from issue #663.
+     */
+    @Test
+    void resolveEffectiveDockerHost_dockerHostEnvBareHostPort_usesNormalizedEnv() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", "10.37.124.101:2375");
+        assertEquals("tcp://10.37.124.101:2375", result,
+                "Bare DOCKER_HOST env var should be normalized and used when config is at its default");
+    }
+
+    /**
+     * When floci.docker.docker-host is at its default and DOCKER_HOST env var is already
+     * a valid tcp:// URI, it should be used unchanged.
+     */
+    @Test
+    void resolveEffectiveDockerHost_dockerHostEnvTcpUri_usedDirectly() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", "tcp://10.37.124.101:2375");
+        assertEquals("tcp://10.37.124.101:2375", result,
+                "Valid tcp:// DOCKER_HOST env var should be used when config is at its default");
+    }
+
+    /**
+     * When floci.docker.docker-host is explicitly configured to a non-default value,
+     * that value takes priority over DOCKER_HOST env var.
+     */
+    @Test
+    void resolveEffectiveDockerHost_explicitFlociConfig_takesPriorityOverEnv() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "tcp://custom-daemon:2376", "10.37.124.101:2375");
+        assertEquals("tcp://custom-daemon:2376", result,
+                "Explicit floci.docker.docker-host should take priority over DOCKER_HOST env var");
+    }
+
+    /**
+     * When DOCKER_HOST env var is null and floci.docker.docker-host is default, use the default.
+     */
+    @Test
+    void resolveEffectiveDockerHost_noEnvVar_usesDefault() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", null);
+        assertEquals("unix:///var/run/docker.sock", result,
+                "Default unix socket should be used when DOCKER_HOST env var is not set");
+    }
+
+    /**
+     * When DOCKER_HOST env var is blank and floci.docker.docker-host is default, use the default.
+     */
+    @Test
+    void resolveEffectiveDockerHost_blankEnvVar_usesDefault() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", "");
+        assertEquals("unix:///var/run/docker.sock", result,
+                "Default unix socket should be used when DOCKER_HOST env var is blank");
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes a crash where `DOCKER_HOST=10.37.124.101:2375` (no `tcp://` scheme) caused `IllegalArgumentException` inside docker-java's `createDefaultConfigBuilder()` before Floci's host override could take effect. The root cause PR #665 missed                                                                                                     
- `DockerClientProducer` now catches that exception and falls back to a fresh builder                                                                                         
- When `floci.docker.docker-host` is at its default (unix socket) and `DOCKER_HOST` env var is set, Floci now honors it (normalized) — no separate `FLOCI_DOCKER_DOCKER_HOST` required in CI environments like Bitbucket Pipelines

Complete fix for #663                                                                                                                    
                                                                                                                                                                              
## Root cause                                                                                                                                                                 
                  
`DefaultDockerClientConfig.createDefaultConfigBuilder()` reads `DOCKER_HOST` from `System.getenv()` and immediately calls `URI.create(value)` inside `withDockerHost()`. A bare `host:port` value (no scheme) is not a valid URI — Java rejects it with `Illegal character in scheme name`. This crash happens at Docker client initialization time, not at connection time, which is why it surfaced as a Lambda invocation failure.
 
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
