### PR TITLE
fix(ec2): AssociateRouteTable associationState, RouteTable associatio…

### DIFF
--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -130,7 +130,7 @@ output "secret_arn" {
   value = aws_secretsmanager_secret.db_creds.arn
 }
 
-# ── VPC (issue #468: ModifyVpcAttribute / DescribeVpcAttribute) ────────────
+# ── VPC networking (issues #468, #401: VpcAttribute, RouteTableAssociation, DescribeTags) ──
 resource "aws_vpc" "compat" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = false
@@ -142,6 +142,79 @@ resource "aws_vpc" "compat" {
   }
 }
 
+resource "aws_internet_gateway" "compat" {
+  vpc_id = aws_vpc.compat.id
+
+  tags = {
+    Name = "floci-compat-igw"
+  }
+}
+
+resource "aws_subnet" "compat" {
+  vpc_id            = aws_vpc.compat.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "floci-compat-subnet"
+  }
+}
+
+resource "aws_route_table" "compat" {
+  vpc_id = aws_vpc.compat.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.compat.id
+  }
+
+  tags = {
+    Name = "floci-compat-rt"
+  }
+}
+
+# Exercises AssociateRouteTable + DescribeRouteTables(association.route-table-association-id)
+resource "aws_route_table_association" "compat" {
+  subnet_id      = aws_subnet.compat.id
+  route_table_id = aws_route_table.compat.id
+}
+
+resource "aws_security_group" "compat" {
+  name        = "floci-compat-sg"
+  description = "Compat test security group"
+  vpc_id      = aws_vpc.compat.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "floci-compat-sg"
+  }
+}
+
 output "vpc_id" {
   value = aws_vpc.compat.id
+}
+
+output "subnet_id" {
+  value = aws_subnet.compat.id
+}
+
+output "route_table_id" {
+  value = aws_route_table.compat.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.compat.id
 }

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -208,7 +208,7 @@ output "alarm_arn" {
   value = aws_cloudwatch_metric_alarm.cpu.arn
 }
 
-# -- VPC (issue #468: ModifyVpcAttribute / DescribeVpcAttribute) ---------------
+# -- VPC networking (issues #468, #401: VpcAttribute, RouteTableAssociation, DescribeTags) ------
 resource "aws_vpc" "compat" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_support   = false
@@ -220,6 +220,79 @@ resource "aws_vpc" "compat" {
   }
 }
 
+resource "aws_internet_gateway" "compat" {
+  vpc_id = aws_vpc.compat.id
+
+  tags = {
+    Name = "floci-compat-igw"
+  }
+}
+
+resource "aws_subnet" "compat" {
+  vpc_id            = aws_vpc.compat.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "floci-compat-subnet"
+  }
+}
+
+resource "aws_route_table" "compat" {
+  vpc_id = aws_vpc.compat.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.compat.id
+  }
+
+  tags = {
+    Name = "floci-compat-rt"
+  }
+}
+
+# Exercises AssociateRouteTable + DescribeRouteTables(association.route-table-association-id)
+resource "aws_route_table_association" "compat" {
+  subnet_id      = aws_subnet.compat.id
+  route_table_id = aws_route_table.compat.id
+}
+
+resource "aws_security_group" "compat" {
+  name        = "floci-compat-sg"
+  description = "Compat test security group"
+  vpc_id      = aws_vpc.compat.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "floci-compat-sg"
+  }
+}
+
 output "vpc_id" {
   value = aws_vpc.compat.id
+}
+
+output "subnet_id" {
+  value = aws_subnet.compat.id
+}
+
+output "route_table_id" {
+  value = aws_route_table.compat.id
+}
+
+output "security_group_id" {
+  value = aws_security_group.compat.id
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -948,6 +948,9 @@ public class Ec2QueryHandler {
                 .start("AssociateRouteTableResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
                 .elem("associationId", assoc.getRouteTableAssociationId())
+                .start("associationState")
+                    .elem("state", assoc.getAssociationState())
+                .end("associationState")
                 .end("AssociateRouteTableResponse");
         return xmlResponse(xml.build());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -924,13 +924,32 @@ public class Ec2Service {
 
     public List<Map<String, String>> describeTags(String region, Map<String, List<String>> filters) {
         ensureDefaultResources(region);
+        List<String> filterResourceIds   = filters != null ? filters.get("resource-id")   : null;
+        List<String> filterResourceTypes = filters != null ? filters.get("resource-type") : null;
+        List<String> filterKeys          = filters != null ? filters.get("key")            : null;
+        List<String> filterValues        = filters != null ? filters.get("value")          : null;
+
         List<Map<String, String>> result = new ArrayList<>();
         for (Map.Entry<String, List<Tag>> entry : tags.entrySet()) {
-            String resourceId = entry.getKey();
+            String resourceId   = entry.getKey();
+            String resourceType = inferResourceType(resourceId);
+
+            if (filterResourceIds != null && !filterResourceIds.contains(resourceId)) {
+                continue;
+            }
+            if (filterResourceTypes != null && !filterResourceTypes.contains(resourceType)) {
+                continue;
+            }
             for (Tag tag : entry.getValue()) {
+                if (filterKeys != null && !filterKeys.contains(tag.getKey())) {
+                    continue;
+                }
+                if (filterValues != null && !filterValues.contains(tag.getValue())) {
+                    continue;
+                }
                 Map<String, String> item = new LinkedHashMap<>();
                 item.put("resourceId", resourceId);
-                item.put("resourceType", inferResourceType(resourceId));
+                item.put("resourceType", resourceType);
                 item.put("key", tag.getKey());
                 item.put("value", tag.getValue());
                 result.add(item);
@@ -1270,6 +1289,14 @@ public class Ec2Service {
             return switch (filterName) {
                 case "route-table-id" -> values.contains(rt.getRouteTableId());
                 case "vpc-id" -> values.contains(rt.getVpcId());
+                case "association.route-table-association-id" -> rt.getAssociations().stream()
+                        .anyMatch(a -> values.contains(a.getRouteTableAssociationId()));
+                case "association.subnet-id" -> rt.getAssociations().stream()
+                        .anyMatch(a -> a.getSubnetId() != null && values.contains(a.getSubnetId()));
+                case "association.gateway-id" -> rt.getAssociations().stream()
+                        .anyMatch(a -> a.getGatewayId() != null && values.contains(a.getGatewayId()));
+                case "association.main" -> rt.getAssociations().stream()
+                        .anyMatch(a -> values.contains(String.valueOf(a.isMain())));
                 default -> true;
             };
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/RouteTableAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/RouteTableAssociation.java
@@ -10,6 +10,7 @@ public class RouteTableAssociation {
     private String routeTableAssociationId;
     private String routeTableId;
     private String subnetId;
+    private String gatewayId;
     private boolean main;
     private String associationState = "associated";
 
@@ -23,6 +24,9 @@ public class RouteTableAssociation {
 
     public String getSubnetId() { return subnetId; }
     public void setSubnetId(String subnetId) { this.subnetId = subnetId; }
+
+    public String getGatewayId() { return gatewayId; }
+    public void setGatewayId(String gatewayId) { this.gatewayId = gatewayId; }
 
     public boolean isMain() { return main; }
     public void setMain(boolean main) { this.main = main; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -508,6 +508,7 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .body("AssociateRouteTableResponse.associationId", startsWith("rtbassoc-"))
+            .body("AssociateRouteTableResponse.associationState.state", equalTo("associated"))
             .extract().path("AssociateRouteTableResponse.associationId");
     }
 
@@ -517,6 +518,38 @@ class Ec2IntegrationTest {
         given()
             .formParam("Action", "DescribeRouteTables")
             .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeRouteTablesResponse.routeTableSet.item.routeTableId", equalTo(routeTableId));
+    }
+
+    @Test
+    @Order(64)
+    void describeRouteTablesByAssociationId() {
+        given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("Filter.1.Name", "association.route-table-association-id")
+            .formParam("Filter.1.Value.1", rtbAssocId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeRouteTablesResponse.routeTableSet.item.routeTableId", equalTo(routeTableId))
+            .body("DescribeRouteTablesResponse.routeTableSet.item.associationSet.item[0].routeTableAssociationId",
+                    equalTo(rtbAssocId));
+    }
+
+    @Test
+    @Order(65)
+    void describeRouteTablesBySubnetId() {
+        given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("Filter.1.Name", "association.subnet-id")
+            .formParam("Filter.1.Value.1", subnetId)
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -727,6 +760,52 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"))
             .body("DescribeTagsResponse.tagSet.item.value", equalTo("test-instance"));
+    }
+
+    @Test
+    @Order(92)
+    void describeTagsFilterByResourceId() {
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "resource-id")
+            .formParam("Filter.1.Value.1", instanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.resourceId", equalTo(instanceId))
+            .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"));
+    }
+
+    @Test
+    @Order(92)
+    void describeTagsFilterByKey() {
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "key")
+            .formParam("Filter.1.Value.1", "Name")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"));
+    }
+
+    @Test
+    @Order(92)
+    void describeTagsFilterByKeyNoMatch() {
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "key")
+            .formParam("Filter.1.Value.1", "NonExistentKey")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.size()", equalTo(0));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

**Problem**                                                   
                                                                                                                                                                                
Three EC2 bugs were reported in Discussion #401 when running Terraform/OpenTofu with the AWS provider v6 against Floci:    
                                                                                                                                                                                
1. aws_route_table_association apply hangs — Terraform v6 reads the <associationState> element directly from the AssociateRouteTable response body, then polls DescribeRouteTables with the association.route-table-association-id filter to wait for the state to be associated. Floci's response was missing <associationState> entirely, and the filter was not supported, so Terraform looped until timeout.                                                                                                          
2. DescribeTags returns too many results — All four filter keys (resource-id, resource-type, key, value) were accepted in the request but silently ignored; the handler always returned every tag in the region.                                                                                                                                            
3. EC2 instance terminated immediately — Not a code bug; EC2 mock mode (FLOCI_SERVICES_EC2_MOCK=true) or a Docker socket is required for instance lifecycle. Documented in the PR.                                                                                                                                                                          
                                                            
**Changes**                                                                                                                                                                       
                                                            
- Ec2QueryHandler: handleAssociateRouteTable now includes <associationState><state>associated</state></associationState> in the response.                                     
- Ec2Service: matchesFilter for RouteTable now handles association.route-table-association-id, association.subnet-id, association.gateway-id, and association.main; describeTags now correctly applies all four standard filter keys.                                                                                                             
- RouteTableAssociation: added gatewayId field for association.gateway-id filter support.
- Ec2IntegrationTest: new tests for associationState assertion, route table association filters, and DescribeTags filter combinations (match, key filter, no-match).          
- compat-terraform/main.tf + compat-opentofu/main.tf: added IGW, subnet, route table, route table association, and security group resources. All 11 Terraform and 11 OpenTofu compat tests pass against the updated build.   

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
