### PR TITLE
Fix[Eventbridge pipe - SQS] Eventbridge pipe always delivers sqs message to default region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
@@ -65,7 +65,7 @@ public class PipesTargetInvoker {
         if (targetArn.contains(":lambda:") || targetArn.contains(":function:")) {
             invokeLambda(targetArn, payload, region);
         } else if (targetArn.contains(":sqs:")) {
-            invokeSqs(targetArn, payload);
+            invokeSqs(targetArn, payload, region);
         } else if (targetArn.contains(":sns:")) {
             invokeSns(targetArn, payload, region);
         } else if (targetArn.contains(":events:")) {
@@ -87,6 +87,12 @@ public class PipesTargetInvoker {
     private void invokeSqs(String arn, String payload) {
         String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
         sqsService.sendMessage(queueUrl, payload, 0);
+        LOG.debugv("Pipe delivered to SQS: {0}", arn);
+    }
+
+    private void invokeSqs(String arn, String payload, String region) {
+        String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
+        sqsService.sendMessage(queueUrl, payload, 0, region);
         LOG.debugv("Pipe delivered to SQS: {0}", arn);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -309,6 +309,10 @@ public class SqsService {
         return sendMessage(queueUrl, body, delaySeconds, null, null);
     }
 
+    public Message sendMessage(String queueUrl, String body, int delaySeconds, String region) {
+        return sendMessage(queueUrl, body, delaySeconds, null, null, region);
+    }
+
     public Message sendMessage(String queueUrl, String body, int delaySeconds,
                                String messageGroupId, String messageDeduplicationId) {
         return sendMessage(queueUrl, body, delaySeconds, messageGroupId, messageDeduplicationId, null,

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvokerTest.java
@@ -59,43 +59,47 @@ class PipesTargetInvokerTest {
 
     @Test
     void inputTemplate_replacesPlaceholders() {
+        String region = "us-east-1";
         ObjectNode tp = MAPPER.createObjectNode();
         tp.put("InputTemplate", "{\"id\": <$.messageId>, \"content\": <$.body>}");
 
-        Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", tp);
+        Pipe pipe = createPipe("arn:aws:sqs:" + region + ":000000000000:target", tp);
         String payload = "{\"messageId\": \"msg-123\", \"body\": \"hello world\"}";
 
-        invoker.invoke(pipe, payload, "us-east-1");
+        invoker.invoke(pipe, payload, region);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0));
+        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0), eq(region));
         String sent = captor.getValue();
         assertEquals("{\"id\": \"msg-123\", \"content\": \"hello world\"}", sent);
     }
 
     @Test
     void inputTemplate_missingFieldReplacesWithEmpty() {
+        String region = "us-east-1";
         ObjectNode tp = MAPPER.createObjectNode();
         tp.put("InputTemplate", "{\"id\": \"<$.nonexistent>\"}");
 
-        Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", tp);
+        Pipe pipe = createPipe("arn:aws:sqs:" + region + ":000000000000:target", tp);
         String payload = "{\"messageId\": \"msg-123\"}";
 
-        invoker.invoke(pipe, payload, "us-east-1");
+        invoker.invoke(pipe, payload, region);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0));
+        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0), eq(region));
         assertEquals("{\"id\": \"\"}", captor.getValue());
     }
 
     @Test
     void noInputTemplate_passesPayloadUnchanged() {
-        Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", null);
+        String region = "us-east-1";
+
+        Pipe pipe = createPipe("arn:aws:sqs:" + region + ":000000000000:target", null);
         String payload = "{\"Records\": []}";
 
-        invoker.invoke(pipe, payload, "us-east-1");
+        invoker.invoke(pipe, payload, region);
 
-        verify(sqsService).sendMessage(anyString(), eq(payload), eq(0));
+        verify(sqsService).sendMessage(anyString(), eq(payload), eq(0), eq(region));
     }
 
     @Test
@@ -110,16 +114,17 @@ class PipesTargetInvokerTest {
 
     @Test
     void inputTemplate_objectValuePreservedAsJson() {
+        String region = "us-east-1";
         ObjectNode tp = MAPPER.createObjectNode();
         tp.put("InputTemplate", "{\"data\": <$.nested>}");
 
-        Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", tp);
+        Pipe pipe = createPipe("arn:aws:sqs:" + region + ":000000000000:target", tp);
         String payload = "{\"nested\": {\"key\": \"value\"}}";
 
-        invoker.invoke(pipe, payload, "us-east-1");
+        invoker.invoke(pipe, payload, region);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0));
+        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0), eq(region));
         assertEquals("{\"data\": {\"key\":\"value\"}}", captor.getValue());
     }
 
@@ -227,6 +232,7 @@ class PipesTargetInvokerTest {
 
     @Test
     void inputTemplate_nestedJsonString_endToEnd() {
+        String region = "us-east-1";
         ObjectNode tp = MAPPER.createObjectNode();
         tp.put("InputTemplate",
                 "{\"message\": <$.body.message>, \"messageType\": <$.body.messageType>}");
@@ -234,10 +240,10 @@ class PipesTargetInvokerTest {
         Pipe pipe = createPipe("arn:aws:sqs:us-east-1:000000000000:target", tp);
         String payload = "{\"body\": \"{\\\"message\\\": \\\"user registered\\\", \\\"messageType\\\": \\\"REGISTRATION\\\"}\"}";
 
-        invoker.invoke(pipe, payload, "us-east-1");
+        invoker.invoke(pipe, payload, region);
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0));
+        verify(sqsService).sendMessage(anyString(), captor.capture(), eq(0), eq(region));
         assertEquals(
                 "{\"message\": \"user registered\", \"messageType\": \"REGISTRATION\"}",
                 captor.getValue());


### PR DESCRIPTION
## Summary
Closes #647 
Added support for passing the region in Pipes when SQS is used as the destination. This aligns SQS with the required behavior already implemented for other services such as Lambda and SNS, ensuring consistent region propagation across all supported targets. The implementation follows the established pattern and has been validated with successful test coverage.

Updated Integration tests for pipes to parse region dynamically.

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
N/A
<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Working fix proof:
https://github.com/floci-io/floci/pull/714#issuecomment-4384250469
