### PR TITLE
refactor(pipes): remove unused 2-arg invokeSqs overload

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesTargetInvoker.java
@@ -84,12 +84,6 @@ public class PipesTargetInvoker {
         LOG.debugv("Pipe delivered to Lambda: {0}", arn);
     }
 
-    private void invokeSqs(String arn, String payload) {
-        String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
-        sqsService.sendMessage(queueUrl, payload, 0);
-        LOG.debugv("Pipe delivered to SQS: {0}", arn);
-    }
-
     private void invokeSqs(String arn, String payload, String region) {
         String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
         sqsService.sendMessage(queueUrl, payload, 0, region);


### PR DESCRIPTION
## Summary

Remove the unused 2-arg `PipesTargetInvoker.invokeSqs(arn, payload)` overload. After #714, only the region-aware 3-arg version is called from `invoke()`.

Related: #714

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behavior change. The removed overload had no callers.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)