### PR TITLE
fix(eventbridge): support account, region, and nested detail pattern matching

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -639,6 +639,20 @@ public class EventBridgeService {
                     return false;
                 }
             }
+            JsonNode accountField = pattern.get("account");
+            if (accountField != null && accountField.isArray()) {
+                String eventAccount = regionResolver.getAccountId();
+                if (!matchesArrayField(accountField, eventAccount)) {
+                    return false;
+                }
+            }
+            JsonNode regionField = pattern.get("region");
+            if (regionField != null && regionField.isArray()) {
+                String eventRegion = regionResolver.getDefaultRegion();
+                if (!matchesArrayField(regionField, eventRegion)) {
+                    return false;
+                }
+            }
             JsonNode detailPattern = pattern.get("detail");
             if (detailPattern != null && detailPattern.isObject()) {
                 Object eventDetail = event.get("Detail");
@@ -647,15 +661,8 @@ public class EventBridgeService {
                     return false;
                 }
                 JsonNode detailNode = objectMapper.readTree(detailStr);
-                var fields = detailPattern.fields();
-                while (fields.hasNext()) {
-                    var field = fields.next();
-                    JsonNode expected = field.getValue();
-                    JsonNode actual = detailNode.get(field.getKey());
-                    String actualStr = actual != null ? actual.asText(null) : null;
-                    if (expected.isArray() && !matchesArrayField(expected, actualStr)) {
-                        return false;
-                    }
+                if (!matchesDetailNode(detailNode, detailPattern)) {
+                    return false;
                 }
             }
             JsonNode resourcesPattern = pattern.get("resources");
@@ -674,6 +681,37 @@ public class EventBridgeService {
             LOG.warnv("Failed to parse event pattern: {0}", e.getMessage());
             return false;
         }
+    }
+
+    private boolean matchesDetailNode(JsonNode actual, JsonNode pattern) {
+        var fields = pattern.fields();
+        while (fields.hasNext()) {
+            var field = fields.next();
+            JsonNode expected = field.getValue();
+            JsonNode actualField = actual.get(field.getKey());
+            if (expected.isArray()) {
+                String actualStr = actualField != null ? actualField.asText(null) : null;
+                if (!matchesArrayField(expected, actualStr)) {
+                    return false;
+                }
+            } else if (expected.isObject()) {
+                if (actualField == null || actualField.isNull()) {
+                    return false;
+                }
+                JsonNode nestedActual = actualField;
+                if (actualField.isTextual()) {
+                    try {
+                        nestedActual = objectMapper.readTree(actualField.asText());
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }
+                if (!matchesDetailNode(nestedActual, expected)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private boolean matchesArrayField(JsonNode arrayNode, String value) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -483,4 +483,73 @@ class EventBridgeServiceTest {
         assertTrue(service.matchesPattern(event, "{\"detail\":{\"status\":[{\"exists\":true}]}}"));
         assertTrue(service.matchesPattern(event, "{\"detail\":{\"other\":[{\"exists\":false}]}}"));
     }
+
+    @Test
+    void matchesPatternByAccount_matches() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Order");
+        assertTrue(service.matchesPattern(event, "{\"account\":[\"000000000000\"]}"));
     }
+
+    @Test
+    void matchesPatternByAccount_noMatch() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Order");
+        assertFalse(service.matchesPattern(event, "{\"account\":[\"999999999999\"]}"));
+    }
+
+    @Test
+    void matchesPatternByRegion_matches() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Order");
+        assertTrue(service.matchesPattern(event, "{\"region\":[\"us-east-1\"]}"));
+    }
+
+    @Test
+    void matchesPatternByRegion_noMatch() {
+        Map<String, Object> event = Map.of("Source", "my.app", "DetailType", "Order");
+        assertFalse(service.matchesPattern(event, "{\"region\":[\"eu-west-1\"]}"));
+    }
+
+    @Test
+    void matchesPatternByNestedDetail_matches() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"object\":{\"path\":\"uploads/image.png\",\"size\":1024}}"
+        );
+        assertTrue(service.matchesPattern(event,
+                "{\"detail\":{\"object\":{\"path\":[{\"prefix\":\"uploads/\"}]}}}"));
+    }
+
+    @Test
+    void matchesPatternByNestedDetail_noMatch() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"object\":{\"path\":\"downloads/file.txt\",\"size\":1024}}"
+        );
+        assertFalse(service.matchesPattern(event,
+                "{\"detail\":{\"object\":{\"path\":[{\"prefix\":\"uploads/\"}]}}}"));
+    }
+
+    @Test
+    void matchesPatternByDeeplyNestedDetail() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"a\":{\"b\":{\"c\":\"deep-value\"}}}"
+        );
+        assertTrue(service.matchesPattern(event,
+                "{\"detail\":{\"a\":{\"b\":{\"c\":[\"deep-value\"]}}}}"));
+        assertFalse(service.matchesPattern(event,
+                "{\"detail\":{\"a\":{\"b\":{\"c\":[\"wrong\"]}}}}"));
+    }
+
+    @Test
+    void matchesPatternCombinesAccountRegionAndDetail() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "DetailType", "Order",
+                "Detail", "{\"status\":\"CONFIRMED\"}"
+        );
+        assertTrue(service.matchesPattern(event,
+                "{\"source\":[\"my.app\"],\"account\":[\"000000000000\"],\"region\":[\"us-east-1\"],\"detail\":{\"status\":[\"CONFIRMED\"]}}"));
+        assertFalse(service.matchesPattern(event,
+                "{\"source\":[\"my.app\"],\"account\":[\"999999999999\"],\"detail\":{\"status\":[\"CONFIRMED\"]}}"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes EventBridge pattern matching to correctly evaluate `account`, `region`, and nested `detail` object patterns. Previously, rules specifying these fields would match all events regardless of the pattern values.

Closes #709

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was:
- `account` field in event patterns was completely ignored (no code path existed)
- `region` field in event patterns was completely ignored (no code path existed)
- Nested object patterns in `detail` (e.g. `{"detail":{"object":{"path":[{"prefix":"uploads/"}]}}}`) were not recursively evaluated — only flat top-level detail fields worked

After this fix, all three fields are evaluated correctly per AWS EventBridge pattern matching semantics. Nested detail patterns support arbitrary depth with the same operator set (prefix, suffix, equals-ignore-case, anything-but, exists).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)