### PR TITLE
fix(sqs): add SenderId and ApproximateFirstReceiveTimestamp to Lambda event records

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
@@ -212,7 +212,7 @@ public class SqsEventSourcePoller {
         }
     }
 
-    private String buildSqsEvent(List<Message> messages, EventSourceMapping esm) {
+    String buildSqsEvent(List<Message> messages, EventSourceMapping esm) {
         try {
             var records = objectMapper.createArrayNode();
             for (Message msg : messages) {
@@ -222,7 +222,9 @@ public class SqsEventSourcePoller {
                 record.put("body", msg.getBody());
                 ObjectNode attrs = record.putObject("attributes");
                 attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
-                attrs.put("SentTimestamp", String.valueOf(System.currentTimeMillis()));
+                attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
+                attrs.put("SenderId", AwsArnUtils.accountOrDefault(esm.getEventSourceArn(), "000000000000"));
+                attrs.put("ApproximateFirstReceiveTimestamp", String.valueOf(System.currentTimeMillis()));
                 record.putObject("messageAttributes");
                 record.put("md5OfBody", msg.getMd5OfBody() != null ? msg.getMd5OfBody() : "");
                 record.put("eventSource", "aws:sqs");

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
@@ -404,7 +404,9 @@ public class PipesPoller {
             record.put("body", msg.getBody());
             ObjectNode attrs = record.putObject("attributes");
             attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
-            attrs.put("SentTimestamp", String.valueOf(System.currentTimeMillis()));
+            attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
+            attrs.put("SenderId", AwsArnUtils.accountOrDefault(pipe.getSource(), "000000000000"));
+            attrs.put("ApproximateFirstReceiveTimestamp", String.valueOf(System.currentTimeMillis()));
             ObjectNode msgAttrs = record.putObject("messageAttributes");
             for (Map.Entry<String, MessageAttributeValue> entry : msg.getMessageAttributes().entrySet()) {
                 ObjectNode attrNode = msgAttrs.putObject(entry.getKey());

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.lambda.model.EventSourceMapping;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.model.Message;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SqsEventSourcePollerTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private SqsEventSourcePoller poller;
+
+    @BeforeEach
+    void setUp() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.LambdaServiceConfig lambdaConfig = mock(EmulatorConfig.LambdaServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.lambda()).thenReturn(lambdaConfig);
+        when(lambdaConfig.pollIntervalMs()).thenReturn(1000L);
+        when(config.effectiveBaseUrl()).thenReturn("http://localhost:4566");
+
+        poller = new SqsEventSourcePoller(
+                mock(Vertx.class),
+                mock(SqsService.class),
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(EsmStore.class),
+                config,
+                OBJECT_MAPPER
+        );
+    }
+
+    @Test
+    void buildSqsEventIncludesAllRequiredAttributes() throws Exception {
+        Message msg = new Message();
+        msg.setBody("{\"key\":\"value\"}");
+        msg.setSentTimestamp(Instant.parse("2026-01-15T10:30:00Z"));
+
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setEventSourceArn("arn:aws:sqs:us-east-1:123456789012:my-queue");
+        esm.setRegion("us-east-1");
+
+        String event = poller.buildSqsEvent(List.of(msg), esm);
+        JsonNode root = OBJECT_MAPPER.readTree(event);
+        JsonNode record = root.get("Records").get(0);
+        JsonNode attrs = record.get("attributes");
+
+        assertNotNull(attrs.get("ApproximateReceiveCount"));
+        assertNotNull(attrs.get("SentTimestamp"));
+        assertNotNull(attrs.get("SenderId"));
+        assertNotNull(attrs.get("ApproximateFirstReceiveTimestamp"));
+
+        assertEquals("123456789012", attrs.get("SenderId").asText());
+        assertEquals(String.valueOf(Instant.parse("2026-01-15T10:30:00Z").toEpochMilli()),
+                attrs.get("SentTimestamp").asText());
+        assertEquals("aws:sqs", record.get("eventSource").asText());
+        assertEquals("arn:aws:sqs:us-east-1:123456789012:my-queue", record.get("eventSourceARN").asText());
+        assertEquals("us-east-1", record.get("awsRegion").asText());
+    }
+
+    @Test
+    void buildSqsEventUsesDefaultAccountWhenArnParsingFails() throws Exception {
+        Message msg = new Message();
+        msg.setBody("test");
+        msg.setSentTimestamp(Instant.now());
+
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setEventSourceArn("invalid-arn");
+        esm.setRegion("us-east-1");
+
+        String event = poller.buildSqsEvent(List.of(msg), esm);
+        JsonNode root = OBJECT_MAPPER.readTree(event);
+        JsonNode attrs = root.get("Records").get(0).get("attributes");
+
+        assertEquals("000000000000", attrs.get("SenderId").asText());
+    }
+}


### PR DESCRIPTION
## Summary

Adds missing `SenderId` and `ApproximateFirstReceiveTimestamp` attributes to SQS event records delivered to Lambda functions via event source mappings. Also fixes `SentTimestamp` to use the actual message send time instead of the current time.

Closes #724

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was:
- `SenderId` was completely missing from the `attributes` object in SQS Lambda event records
- `ApproximateFirstReceiveTimestamp` was completely missing
- `SentTimestamp` was incorrectly set to the poll time rather than the original message send time

This caused AWS Lambda Powertools' `SqsEnvelope` parser to fail validation. After this fix, the attributes match the [AWS Lambda SQS event documentation](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html).

The same fix is applied to PipesPoller which builds identical SQS record envelopes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)