### PR TITLE
fix(s3): persist x-amz-meta-* metadata from presigned POST uploads

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1894,7 +1894,19 @@ public class S3Controller {
             objectContentType = "application/octet-stream";
         }
 
-        S3Object obj = s3Service.putObject(bucket, key, fileData, objectContentType, null);
+        Map<String, String> metadata = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            String fieldName = entry.getKey().toLowerCase(Locale.ROOT);
+            if (fieldName.startsWith("x-amz-meta-")) {
+                String metaKey = fieldName.substring("x-amz-meta-".length());
+                if (!metaKey.isBlank()) {
+                    metadata.put(metaKey, entry.getValue());
+                }
+            }
+        }
+
+        S3Object obj = s3Service.putObject(bucket, key, fileData, objectContentType,
+                metadata.isEmpty() ? null : metadata);
         LOG.infov("Presigned POST upload: {0}/{1} ({2} bytes)", bucket, key, fileData.length);
 
         String xml = new XmlBuilder()

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -477,6 +477,40 @@ class S3PresignedPostIntegrationTest {
     }
 
     @Test
+    @Order(97)
+    void presignedPostPersistsUserMetadata() {
+        String key = "uploads/with-metadata.txt";
+        String fileContent = "metadata test";
+
+        String policy = buildPolicy(BUCKET, key, "text/plain", 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .multiPart("key", key)
+            .multiPart("Content-Type", "text/plain")
+            .multiPart("policy", policyBase64)
+            .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+            .multiPart("x-amz-credential", "AKIAIOSFODNN7EXAMPLE/20260330/us-east-1/s3/aws4_request")
+            .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+            .multiPart("x-amz-signature", "dummysignature")
+            .multiPart("x-amz-meta-source", "camera")
+            .multiPart("x-amz-meta-owner", "test-user")
+            .multiPart("file", "with-metadata.txt", fileContent.getBytes(StandardCharsets.UTF_8), "text/plain")
+        .when()
+            .post("/" + BUCKET)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .head("/" + BUCKET + "/" + key)
+        .then()
+            .statusCode(200)
+            .header("x-amz-meta-source", equalTo("camera"))
+            .header("x-amz-meta-owner", equalTo("test-user"));
+    }
+
+    @Test
     @Order(100)
     void cleanupBucket() {
         // Delete all objects
@@ -487,6 +521,7 @@ class S3PresignedPostIntegrationTest {
         given().delete("/" + BUCKET + "/uploads/within-range.txt");
         given().delete("/" + BUCKET + "/uploads/prefix-test.txt");
         given().delete("/" + BUCKET + "/uploads/capital-p-ok.txt");
+        given().delete("/" + BUCKET + "/uploads/with-metadata.txt");
 
         given()
         .when()


### PR DESCRIPTION
## Summary

Fixes presigned POST uploads dropping user metadata. The `x-amz-meta-*` form fields were parsed but never passed to the storage layer.

Closes #707

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was:
- Presigned POST uploads with `x-amz-meta-*` form fields returned 204 but stored the object with empty metadata
- Standard `PutObject` with metadata headers worked correctly (only presigned POST was broken)

The root cause was `S3Controller.doHandlePresignedPost()` passing `null` as the metadata parameter to `s3Service.putObject()` instead of extracting metadata from the parsed form fields. The fix extracts fields with the `x-amz-meta-` prefix and passes them through.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)