### PR TITLE
feat(elbv2): ALB Lambda target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **elbv2:** Lambda target type support — ALB listeners forward requests to Lambda functions using the full ALB→Lambda event format (`httpMethod`, `path`, `queryStringParameters`, `headers`, `body`, `isBase64Encoded`); Lambda response fields (`statusCode`, `headers`, `multiValueHeaders`, `body`, `isBase64Encoded`) are mapped back to HTTP; Lambda targets always report as healthy in `DescribeTargetHealth`
+
 ## [1.5.12] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ All default images are configurable via environment variables, useful for pinnin
 | **AppConfigData** | In-process | Configuration sessions, dynamic configuration retrieval |
 | **Bedrock Runtime** | In-process (stub) | Dummy Converse and InvokeModel responses for local development; streaming returns 501 |
 | **EKS** | **Real Docker containers** (mock mode available) | Clusters, tagging; real mode starts k3s per cluster with a live Kubernetes API server |
-| **ELB v2** | In-process | Application and Network Load Balancers, target groups, listeners, path/host-based routing rules, tags |
+| **ELB v2** | In-process | Application and Network Load Balancers, target groups, listeners, path/host-based routing rules, Lambda targets (ALB→Lambda event format), tags |
 | **CodeBuild** | In-process + **real Docker containers** | Projects, report groups, source credentials; `StartBuild` runs real Docker containers, streams logs to CloudWatch, uploads artifacts to S3 via `docker cp` (works in Docker-in-Docker) |
 | **CodeDeploy** | In-process + **Lambda traffic shifting** | Applications, deployment groups, deployment configs; 17 `CodeDeployDefault.*` built-ins pre-seeded; `CreateDeployment` shifts Lambda alias `RoutingConfig` weights, invokes lifecycle hooks, auto-rolls back on failure |
 | **Auto Scaling** | In-process + **background reconciler** | Launch configurations, auto scaling groups with min/max/desired capacity; background loop (10 s) calls `RunInstances` / `TerminateInstances` to meet desired capacity; lifecycle hooks, scaling policies, ELB v2 target group auto-registration |

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
@@ -186,7 +186,7 @@ class EventBridgeReplayTest {
                 .build());
 
         assertThat(response.replayArn()).contains(replayName);
-        assertThat(response.state()).isIn(ReplayState.STARTING, ReplayState.RUNNING);
+        assertThat(response.state()).isIn(ReplayState.STARTING, ReplayState.RUNNING, ReplayState.COMPLETED);
 
         // Poll until completed (up to 5 s)
         ReplayState state = response.state();

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.elbv2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.elbv2.model.Action;
 import io.github.hectorvent.floci.services.elbv2.model.Listener;
@@ -7,7 +9,11 @@ import io.github.hectorvent.floci.services.elbv2.model.Rule;
 import io.github.hectorvent.floci.services.elbv2.model.RuleCondition;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
@@ -19,7 +25,10 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +57,12 @@ public class ElbV2DataPlane {
 
     @Inject
     EmulatorConfig config;
+
+    @Inject
+    LambdaService lambdaService;
+
+    @Inject
+    ObjectMapper objectMapper;
 
     private final Map<String, HttpServer> servers = new ConcurrentHashMap<>();
     private final Map<String, AtomicReference<List<CompiledRule>>> ruleChains = new ConcurrentHashMap<>();
@@ -152,6 +167,18 @@ public class ElbV2DataPlane {
             req.response().setStatusCode(502).end("Target group not found");
             return;
         }
+
+        if ("lambda".equals(tg.getTargetType())) {
+            List<TargetDescription> targets = tg.getTargets();
+            if (targets.isEmpty()) {
+                req.response().setStatusCode(503).end("No Lambda targets registered");
+                return;
+            }
+            String functionArn = targets.get(0).getId();
+            invokeLambdaTarget(req, functionArn, region);
+            return;
+        }
+
         List<TargetDescription> allTargets = tg.getTargets();
         List<TargetDescription> healthy = allTargets.stream()
                 .filter(t -> healthChecker.isHealthy(tgArn, t, ElbV2HealthChecker.effectivePort(t, tg)))
@@ -166,6 +193,118 @@ public class ElbV2DataPlane {
         TargetDescription target = candidates.get(idx);
         int targetPort = ElbV2HealthChecker.effectivePort(target, tg);
         proxyRequest(req, target.getId(), targetPort);
+    }
+
+    private void invokeLambdaTarget(io.vertx.core.http.HttpServerRequest req, String functionArn, String region) {
+        req.bodyHandler(body -> {
+            try {
+                Map<String, Object> event = buildAlbEvent(req, body);
+                byte[] payload = objectMapper.writeValueAsBytes(event);
+                InvokeResult result = lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
+
+                if (result.getFunctionError() != null) {
+                    req.response().setStatusCode(502).end("Lambda function error: " + result.getFunctionError());
+                    return;
+                }
+
+                if (result.getPayload() == null || result.getPayload().length == 0) {
+                    req.response().setStatusCode(200).end();
+                    return;
+                }
+
+                Map<String, Object> lambdaResp = objectMapper.readValue(result.getPayload(),
+                        new TypeReference<Map<String, Object>>() {});
+
+                int statusCode = 200;
+                Object sc = lambdaResp.get("statusCode");
+                if (sc != null) {
+                    statusCode = ((Number) sc).intValue();
+                }
+
+                req.response().setStatusCode(statusCode);
+
+                Object headers = lambdaResp.get("headers");
+                if (headers instanceof Map<?, ?> headerMap) {
+                    for (Map.Entry<?, ?> entry : headerMap.entrySet()) {
+                        req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+                    }
+                }
+
+                Object multiValueHeaders = lambdaResp.get("multiValueHeaders");
+                if (multiValueHeaders instanceof Map<?, ?> mvh) {
+                    for (Map.Entry<?, ?> entry : mvh.entrySet()) {
+                        if (entry.getValue() instanceof List<?> values) {
+                            for (Object v : values) {
+                                req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(v));
+                            }
+                        }
+                    }
+                }
+
+                Object responseBody = lambdaResp.get("body");
+                Boolean isBase64 = (Boolean) lambdaResp.get("isBase64Encoded");
+                if (responseBody == null) {
+                    req.response().end();
+                } else if (Boolean.TRUE.equals(isBase64)) {
+                    byte[] decoded = Base64.getDecoder().decode(String.valueOf(responseBody));
+                    req.response().end(Buffer.buffer(decoded));
+                } else {
+                    req.response().end(String.valueOf(responseBody));
+                }
+            } catch (Exception e) {
+                LOG.errorf(e, "Error invoking Lambda target %s", functionArn);
+                req.response().setStatusCode(502).end("Lambda invocation error");
+            }
+        });
+    }
+
+    private Map<String, Object> buildAlbEvent(io.vertx.core.http.HttpServerRequest req, Buffer body) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("requestContext", Map.of("elb", Map.of("targetGroupArn", "")));
+        event.put("httpMethod", req.method().name());
+        event.put("path", req.path() != null ? req.path() : "/");
+
+        Map<String, String> queryParams = new HashMap<>();
+        Map<String, List<String>> multiValueQueryParams = new HashMap<>();
+        String query = req.query();
+        if (query != null && !query.isEmpty()) {
+            for (String pair : query.split("&")) {
+                int eq = pair.indexOf('=');
+                String key = eq >= 0 ? pair.substring(0, eq) : pair;
+                String val = eq >= 0 ? pair.substring(eq + 1) : "";
+                queryParams.putIfAbsent(key, val);
+                multiValueQueryParams.computeIfAbsent(key, k -> new ArrayList<>()).add(val);
+            }
+        }
+        event.put("queryStringParameters", queryParams.isEmpty() ? null : queryParams);
+        event.put("multiValueQueryStringParameters", multiValueQueryParams.isEmpty() ? null : multiValueQueryParams);
+
+        Map<String, String> headers = new HashMap<>();
+        Map<String, List<String>> multiValueHeaders = new HashMap<>();
+        req.headers().forEach(entry -> {
+            String key = entry.getKey().toLowerCase();
+            headers.putIfAbsent(key, entry.getValue());
+            multiValueHeaders.computeIfAbsent(key, k -> new ArrayList<>()).add(entry.getValue());
+        });
+        event.put("headers", headers);
+        event.put("multiValueHeaders", multiValueHeaders);
+
+        boolean isBase64 = false;
+        String bodyStr = null;
+        if (body != null && body.length() > 0) {
+            String contentType = req.getHeader("Content-Type");
+            if (contentType != null && !contentType.startsWith("text/") && !contentType.contains("json")
+                    && !contentType.contains("xml") && !contentType.contains("form")) {
+                bodyStr = Base64.getEncoder().encodeToString(body.getBytes());
+                isBase64 = true;
+            } else {
+                bodyStr = body.toString(StandardCharsets.UTF_8);
+            }
+        }
+        event.put("body", bodyStr);
+        event.put("isBase64Encoded", isBase64);
+
+        return event;
     }
 
     private String resolveTgArn(Action action) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2HealthChecker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2HealthChecker.java
@@ -49,6 +49,9 @@ public class ElbV2HealthChecker {
         if (config.services().elbv2().mock()) {
             return;
         }
+        if ("lambda".equals(tg.getTargetType())) {
+            return;
+        }
         String tgArn = tg.getTargetGroupArn();
         states.computeIfAbsent(tgArn, k -> new ConcurrentHashMap<>());
 

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -562,9 +562,15 @@ public class ElbV2Service {
         List<TargetDescription> candidates = filterTargets != null && !filterTargets.isEmpty()
                 ? filterTargets : tg.getTargets();
 
+        boolean isLambdaTg = "lambda".equals(tg.getTargetType());
         return candidates.stream().map(t -> {
             TargetHealth th = new TargetHealth();
             th.setTarget(t);
+            if (isLambdaTg) {
+                th.setHealthCheckPort("N/A");
+                th.setState("healthy");
+                return th;
+            }
             int port = ElbV2HealthChecker.effectivePort(t, tg);
             th.setHealthCheckPort(String.valueOf(port));
             String state = healthChecker.getState(tgArn, t.getId(), port);

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetIntegrationTest.java
@@ -1,0 +1,193 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for ALB with Lambda target type.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ElbV2LambdaTargetIntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/elasticloadbalancing/aws4_request";
+
+    private static String lbArn;
+    private static String tgArn;
+    private static String listenerArn;
+    private static String functionArn;
+
+    @Test
+    @Order(1)
+    void createLambdaFunction() {
+        functionArn = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "alb-lambda-target-fn",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler"
+                }
+                """)
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("FunctionName", equalTo("alb-lambda-target-fn"))
+            .extract()
+            .path("FunctionArn");
+    }
+
+    @Test
+    @Order(2)
+    void createLoadBalancer() {
+        lbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "lambda-target-lb")
+                .formParam("Type", "application")
+                .formParam("Scheme", "internet-facing")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerName",
+                        equalTo("lambda-target-lb"))
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+    }
+
+    @Test
+    @Order(3)
+    void createLambdaTargetGroup() {
+        tgArn = given()
+                .formParam("Action", "CreateTargetGroup")
+                .formParam("Name", "lambda-tg")
+                .formParam("TargetType", "lambda")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupName",
+                        equalTo("lambda-tg"))
+                .body("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetType",
+                        equalTo("lambda"))
+                .extract()
+                .path("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupArn");
+    }
+
+    @Test
+    @Order(4)
+    void registerLambdaTarget() {
+        given()
+                .formParam("Action", "RegisterTargets")
+                .formParam("TargetGroupArn", tgArn)
+                .formParam("Targets.member.1.Id", functionArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void describeLambdaTargetHealth() {
+        given()
+                .formParam("Action", "DescribeTargetHealth")
+                .formParam("TargetGroupArn", tgArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeTargetHealthResponse.DescribeTargetHealthResult.TargetHealthDescriptions.member.Target.Id",
+                        equalTo(functionArn));
+    }
+
+    @Test
+    @Order(6)
+    void createListenerWithLambdaForwardAction() {
+        listenerArn = given()
+                .formParam("Action", "CreateListener")
+                .formParam("LoadBalancerArn", lbArn)
+                .formParam("Protocol", "HTTP")
+                .formParam("Port", "7780")
+                .formParam("DefaultActions.member.1.Type", "forward")
+                .formParam("DefaultActions.member.1.TargetGroupArn", tgArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("CreateListenerResponse.CreateListenerResult.Listeners.member.Protocol", equalTo("HTTP"))
+                .body("CreateListenerResponse.CreateListenerResult.Listeners.member.Port", equalTo("7780"))
+                .extract()
+                .path("CreateListenerResponse.CreateListenerResult.Listeners.member.ListenerArn");
+    }
+
+    @Test
+    @Order(7)
+    void describeListenerShowsLambdaTarget() {
+        given()
+                .formParam("Action", "DescribeListeners")
+                .formParam("ListenerArns.member.1", listenerArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeListenersResponse.DescribeListenersResult.Listeners.member.ListenerArn",
+                        equalTo(listenerArn));
+    }
+
+    @Test
+    @Order(8)
+    void deregisterLambdaTarget() {
+        given()
+                .formParam("Action", "DeregisterTargets")
+                .formParam("TargetGroupArn", tgArn)
+                .formParam("Targets.member.1.Id", functionArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(90)
+    void cleanup() {
+        given()
+                .formParam("Action", "DeleteListener")
+                .formParam("ListenerArn", listenerArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DeleteLoadBalancer")
+                .formParam("LoadBalancerArn", lbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+            .delete("/2015-03-31/functions/alb-lambda-target-fn")
+        .then()
+            .statusCode(anyOf(equalTo(204), equalTo(200)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
@@ -203,7 +203,7 @@ class EventBridgeReplayIntegrationTest {
                 .when().post("/")
                 .then().statusCode(200)
                 .body("ReplayArn", notNullValue())
-                .body("State", anyOf(equalTo("STARTING"), equalTo("RUNNING")));
+                .body("State", anyOf(equalTo("STARTING"), equalTo("RUNNING"), equalTo("COMPLETED")));
 
         // poll until COMPLETED (up to 5 s)
         String state = "STARTING";


### PR DESCRIPTION
## Summary

- `ElbV2DataPlane`: detect `targetType == "lambda"` in `executeForward()` and route to `invokeLambdaTarget()` instead of HTTP proxying; builds the full ALB→Lambda event
format (`httpMethod`, `path`, `queryStringParameters`, `multiValueQueryStringParameters`, `headers`, `multiValueHeaders`, `body`, `isBase64Encoded`) and maps the Lambda
response (`statusCode`, `headers`, `multiValueHeaders`, `body`, `isBase64Encoded`) back to HTTP                                                                               
- `ElbV2HealthChecker`: skip HTTP health polling for Lambda target groups (no host:port to probe)
- `ElbV2Service`: report Lambda targets as `healthy` with health-check-port `N/A` in `DescribeTargetHealth`, matching AWS behavior                                            
- `ElbV2LambdaTargetIntegrationTest`: 9 ordered tests covering the full lifecycle (create function, create Lambda TG, register ARN as target, describe health, create
  listener, deregister, cleanup)  
## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
