### PR TITLE
fix(s3): use queue ARN region when delivering notifications to SQS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1626,7 +1626,7 @@ public class S3Service {
         for (QueueNotification qn : config.getQueueConfigurations()) {
             if (qn.events().stream().anyMatch(p -> matchesEvent(p, eventName)) && qn.matchesKey(key)) {
                 try {
-                    sqsService.sendMessage(sqsUrlFromArn(qn.queueArn()), eventJson, 0);
+                    sqsService.sendMessage(sqsUrlFromArn(qn.queueArn()), eventJson, 0, extractRegionFromArn(qn.queueArn()));
                     LOG.debugv("Fired S3 event {0} to SQS {1}", eventName, qn.queueArn());
                 } catch (Exception e) {
                     LOG.warnv("Failed to deliver S3 event to SQS {0}: {1}", qn.queueArn(), e.getMessage());

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1343,6 +1343,72 @@ class S3IntegrationTest {
 
     @Test
     @Order(94)
+    void notificationDeliveredToQueueInDifferentRegion() {
+        String sqsAuth = "Credential=AKID/20260507/ap-southeast-2/s3/aws4_request";
+
+        String queueUrl = given()
+            .header("Authorization", sqsAuth)
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "notif-test-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            given()
+                .contentType("application/xml")
+                .queryParam("notification", "")
+                .body("""
+                    <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <QueueConfiguration>
+                            <Id>sqs-notif</Id>
+                            <Queue>arn:aws:sqs:ap-southeast-2:000000000000:notif-test-queue</Queue>
+                            <Event>s3:ObjectCreated:*</Event>
+                        </QueueConfiguration>
+                    </NotificationConfiguration>
+                """)
+            .when()
+                .put("/notif-test-bucket")
+            .then()
+                .statusCode(200);
+
+            given()
+                .contentType("text/plain")
+                .body("hello")
+            .when()
+                .put("/notif-test-bucket/file.txt")
+            .then()
+                .statusCode(200);
+
+            given()
+                .header("Authorization", sqsAuth)
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", queueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(
+                    "ReceiveMessageResponse.ReceiveMessageResult.Message.Body",
+                    allOf(containsString("notif-test-bucket"), containsString("file.txt"))
+                );
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", sqsAuth)
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", queueUrl)
+                .post("/");
+        }
+    }
+
+    @Test
+    @Order(95)
     void cleanupNotificationBucket() {
         given().delete("/notif-test-bucket");
     }


### PR DESCRIPTION
## Summary

Use queue ARN region when sending S3 bucket notifications to SQS.

Closes #717.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`S3Service.fireNotifications()` looked up the destination SQS queue using `regionResolver.getDefaultRegion()`. Since SQS stores queues keyed by `<region>::<queueUrl>`, any queue created in a different region wasn't found, and the event was silently dropped with a warn log: `Failed to deliver S3 event to SQS ...: The specified queue does not exist.`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
