### PR TITLE
fix(eventbridge): persist and forward SqsParameters.MessageGroupId for FIFO SQS targets (#722)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.eventbridge.model.Replay;
 import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
+import io.github.hectorvent.floci.services.eventbridge.model.SqsParameters;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -207,6 +208,15 @@ public class EventBridgeHandler {
                     String template = transformerNode.path("InputTemplate").asText(null);
                     target.setInputTransformer(new InputTransformer(pathsMap, template));
                 }
+                JsonNode sqsParamsNode = t.path("SqsParameters");
+                if (!sqsParamsNode.isMissingNode() && sqsParamsNode.isObject()) {
+                    String messageGroupId = sqsParamsNode.path("MessageGroupId").asText(null);
+                    if (messageGroupId != null) {
+                        SqsParameters sqsParameters = new SqsParameters();
+                        sqsParameters.setMessageGroupId(messageGroupId);
+                        target.setSqsParameters(sqsParameters);
+                    }
+                }
                 targets.add(target);
             }
         }
@@ -260,6 +270,9 @@ public class EventBridgeHandler {
                 if (t.getInputTransformer().getInputTemplate() != null) {
                     transformerNode.put("InputTemplate", t.getInputTransformer().getInputTemplate());
                 }
+            }
+            if (t.getSqsParameters() != null && t.getSqsParameters().getMessageGroupId() != null) {
+                node.putObject("SqsParameters").put("MessageGroupId", t.getSqsParameters().getMessageGroupId());
             }
             targetsArray.add(node);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
@@ -59,7 +59,9 @@ public class EventBridgeInvoker {
                 LOG.debugv("EventBridge delivered to Lambda: {0}", arn);
             } else if (arn.contains(":sqs:")) {
                 String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
-                sqsService.sendMessage(queueUrl, payload, 0);
+                String messageGroupId = target.getSqsParameters() != null
+                        ? target.getSqsParameters().getMessageGroupId() : null;
+                sqsService.sendMessage(queueUrl, payload, 0, messageGroupId, null);
                 LOG.debugv("EventBridge delivered to SQS: {0}", arn);
             } else if (arn.contains(":sns:")) {
                 String topicRegion = extractRegionFromArn(arn, region);

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/SqsParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/SqsParameters.java
@@ -1,0 +1,16 @@
+package io.github.hectorvent.floci.services.eventbridge.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SqsParameters {
+
+    private String messageGroupId;
+
+    public SqsParameters() {}
+
+    public String getMessageGroupId() { return messageGroupId; }
+    public void setMessageGroupId(String messageGroupId) { this.messageGroupId = messageGroupId; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Target.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Target.java
@@ -12,6 +12,7 @@ public class Target {
     private String input;
     private String inputPath;
     private InputTransformer inputTransformer;
+    private SqsParameters sqsParameters;
 
     public Target() {}
 
@@ -36,4 +37,7 @@ public class Target {
 
     public InputTransformer getInputTransformer() { return inputTransformer; }
     public void setInputTransformer(InputTransformer inputTransformer) { this.inputTransformer = inputTransformer; }
+
+    public SqsParameters getSqsParameters() { return sqsParameters; }
+    public void setSqsParameters(SqsParameters sqsParameters) { this.sqsParameters = sqsParameters; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeFifoSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeFifoSqsIntegrationTest.java
@@ -1,0 +1,209 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeFifoSqsIntegrationTest {
+
+    private static final String EB_CT  = "application/x-amz-json-1.1";
+    private static final String SQS_CT = "application/x-amz-json-1.0";
+
+    private static String fifoQueueUrl;
+    private static String fifoQueueArn;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createFifoQueue() {
+        fifoQueueUrl = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("""
+                        {
+                          "QueueName": "eb-fifo-target-test.fifo",
+                          "Attributes": {
+                            "FifoQueue": "true",
+                            "ContentBasedDeduplication": "true"
+                          }
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+
+        fifoQueueArn = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + fifoQueueUrl + "\",\"AttributeNames\":[\"All\"]}")
+                .when().post("/0000000000/eb-fifo-target-test.fifo")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+    }
+
+    @Test
+    @Order(2)
+    void createRuleAndPutTargetWithSqsParameters() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                        {
+                          "Name": "fifo-sqs-rule",
+                          "EventBusName": "default",
+                          "EventPattern": "{\\"source\\":[\\"test.fifo\\"]}"
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutTargets")
+                .body("""
+                        {
+                          "Rule": "fifo-sqs-rule",
+                          "EventBusName": "default",
+                          "Targets": [{
+                            "Id": "FifoTarget",
+                            "Arn": "%s",
+                            "SqsParameters": {
+                              "MessageGroupId": "test-group-1"
+                            }
+                          }]
+                        }
+                        """.formatted(fifoQueueArn))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+    }
+
+    @Test
+    @Order(3)
+    void listTargetsByRuleReturnsSqsParameters() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+                .body("{\"Rule\":\"fifo-sqs-rule\",\"EventBusName\":\"default\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Targets", hasSize(1))
+                .body("Targets[0].Id", equalTo("FifoTarget"))
+                .body("Targets[0].SqsParameters.MessageGroupId", equalTo("test-group-1"));
+    }
+
+    @Test
+    @Order(4)
+    void putEventsDeliversToFifoQueue() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutEvents")
+                .body("""
+                        {
+                          "Entries": [{
+                            "EventBusName": "default",
+                            "Source": "test.fifo",
+                            "DetailType": "FifoTest",
+                            "Detail": "{\\"msg\\":\\"hello-fifo\\"}"
+                          }]
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+    }
+
+    @Test
+    @Order(5)
+    void messageArrivesInFifoQueue() {
+        given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + fifoQueueUrl + "\",\"MaxNumberOfMessages\":1,\"AttributeNames\":[\"All\"]}")
+                .when().post("/0000000000/eb-fifo-target-test.fifo")
+                .then().statusCode(200)
+                .body("Messages", hasSize(1))
+                .body("Messages[0].Attributes.MessageGroupId", equalTo("test-group-1"));
+    }
+
+    @Test
+    @Order(6)
+    void standardSqsTargetWithoutSqsParametersStillWorks() {
+        String stdQueueUrl = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"eb-fifo-test-std-queue\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+
+        String stdQueueArn = given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + stdQueueUrl + "\",\"AttributeNames\":[\"All\"]}")
+                .when().post("/0000000000/eb-fifo-test-std-queue")
+                .then().statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                        {
+                          "Name": "std-sqs-rule",
+                          "EventBusName": "default",
+                          "EventPattern": "{\\"source\\":[\\"test.std\\"]}"
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutTargets")
+                .body("""
+                        {
+                          "Rule": "std-sqs-rule",
+                          "EventBusName": "default",
+                          "Targets": [{"Id": "StdTarget", "Arn": "%s"}]
+                        }
+                        """.formatted(stdQueueArn))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.PutEvents")
+                .body("""
+                        {
+                          "Entries": [{
+                            "EventBusName": "default",
+                            "Source": "test.std",
+                            "DetailType": "StdTest",
+                            "Detail": "{\\"msg\\":\\"hello-std\\"}"
+                          }]
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+
+        given()
+                .contentType(SQS_CT)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + stdQueueUrl + "\",\"MaxNumberOfMessages\":1}")
+                .when().post("/0000000000/eb-fifo-test-std-queue")
+                .then().statusCode(200)
+                .body("Messages", hasSize(1));
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes EventBridge FIFO SQS target delivery — `SqsParameters.MessageGroupId` was silently dropped on `PutTargets` because the handler only extracted known fields manually; the missing field caused every `PutEvents` delivery to a FIFO queue to fail with "The request must contain the parameter MessageGroupId.
- `SqsParameters` is now read from the request, persisted with the target, returned by `ListTargetsByRule`, and forwarded to `SqsService.sendMessage()` at delivery time
- Standard SQS targets (no `SqsParameters`) are unaffected — `messageGroupId` is `null` and the existing `sendMessage` overload handles it correctly

Fixes #722

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
