### PR TITLE
chore(docker): ship awslocal wrapper in the -compat image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!bin/awslocal
 !docker/entrypoint.sh
 !docker/localstack-parity.sh
 !pom.xml

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -27,4 +27,7 @@ export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
 export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
 export AWS_DEFAULT_REGION="${_REGION}"
 
-exec aws "$@"
+# Pass --endpoint-url explicitly: a few SDKs/services (notably SQS in older
+# botocore) silently bypass AWS_ENDPOINT_URL via service-specific endpoint
+# resolvers, sending the call to public AWS instead of Floci.
+exec aws --endpoint-url "${_ENDPOINT}" "$@"

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -13,4 +13,7 @@ RUN microdnf install -y --nodocs python3 python3-pip \
     && microdnf clean all \
     && rm -rf /root/.cache/pip
 
+COPY bin/awslocal /usr/local/bin/awslocal
+RUN chmod +x /usr/local/bin/awslocal
+
 USER 1001


### PR DESCRIPTION
Closes #744.

`bin/awslocal` was added to the repo in #638 but never made it into any published image:
1. `Dockerfile.compat` doesn't `COPY` it.
2. `.dockerignore` is allow-list style and `bin/awslocal` isn't allow-listed — even with the `COPY`, the build fails with `file not found in build context`.

This PR adds both lines. After it, existing LocalStack init scripts using `awslocal …` work unchanged on the `-compat` image.

In response to Copilot's review, the second commit (`e033318`) also patches `bin/awslocal` itself to `exec aws --endpoint-url "${_ENDPOINT}" "$@"`. Setting `AWS_ENDPOINT_URL` alone is not sufficient — the bundled `botocore/1.42.97` silently bypasses it for SQS, so the wrapper didn't actually hard-pin the endpoint (which is `awslocal`'s whole job). Injected before `"$@"` so a user-supplied `--endpoint-url` still wins.

Does **not** close #745 — `aws` (without the wrapper) on the same image still bypasses to public AWS for SQS. Out of scope here.

### Verification

Built locally; on the resulting image:

- `awslocal sqs create-queue` ✅ — was `InvalidClientTokenId` (escape to public AWS) before `e033318`
- `awslocal kinesis create-stream`, `awslocal s3 mb` ✅
- `awslocal env` subcommand unchanged
- `awslocal --endpoint-url http://does-not-resolve:9999 sts …` hits the user URL — last-flag-wins preserved

### Type

- [x] Docs / chore (commit 1: `chore(docker):` — packaging) and `fix:` (commit 2: `fix(awslocal):` — wrapper now actually hard-pins). Happy to split into two PRs if you'd prefer.

### Checklist

- [ ] `./mvnw test` — N/A, no Java/Maven path touched. Skipped deliberately.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)