### PR TITLE
fix(sqs): SQS tags set at CreateQueue not returned by ListQueueTags

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/sqs.bats
+++ b/compatibility-tests/sdk-test-awscli/test/sqs.bats
@@ -84,3 +84,18 @@ teardown() {
     assert_success
     QUEUE_URL=""
 }
+
+@test "SQS: tags set at CreateQueue are returned by ListQueueTags" {
+    # Regression test for https://github.com/floci-io/floci/issues/699
+    run aws_cmd sqs create-queue --queue-name "$QUEUE_NAME" --tags "k1=v1,k2=v2"
+    assert_success
+    QUEUE_URL=$(json_get "$output" '.QueueUrl')
+    [ -n "$QUEUE_URL" ]
+
+    run aws_cmd sqs list-queue-tags --queue-url "$QUEUE_URL"
+    assert_success
+    v1=$(json_get "$output" '.Tags.k1')
+    v2=$(json_get "$output" '.Tags.k2')
+    [ "$v1" = "v1" ]
+    [ "$v2" = "v2" ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -66,7 +66,11 @@ public class SqsJsonHandler {
     private Response handleCreateQueue(JsonNode request, String region) {
         String queueName = request.path("QueueName").asText(null);
         Map<String, String> attributes = jsonNodeToMap(request.path("Attributes"));
-        Queue queue = sqsService.createQueue(queueName, attributes, region);
+        // Botocore sends "tags" (lowercase) for CreateQueue but "Tags" (uppercase) for TagQueue.
+        // Merge both to handle any client regardless of casing.
+        Map<String, String> tags = new HashMap<>(jsonNodeToMap(request.path("Tags")));
+        tags.putAll(jsonNodeToMap(request.path("tags")));
+        Queue queue = sqsService.createQueue(queueName, attributes, tags, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         response.put("QueueUrl", queue.getQueueUrl());

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -64,7 +64,8 @@ public class SqsQueryHandler {
     private Response handleCreateQueue(MultivaluedMap<String, String> params, String region) {
         String queueName = getParam(params, "QueueName");
         Map<String, String> attributes = extractAttributes(params);
-        Queue queue = sqsService.createQueue(queueName, attributes, region);
+        Map<String, String> tags = extractTags(params);
+        Queue queue = sqsService.createQueue(queueName, attributes, tags, region);
 
         String result = new XmlBuilder().elem("QueueUrl", queue.getQueueUrl()).build();
         return Response.ok(AwsQueryResponse.envelope("CreateQueue", null, result)).build();
@@ -437,6 +438,17 @@ public class SqsQueryHandler {
             attributes.put(name, value);
         }
         return attributes;
+    }
+
+    private Map<String, String> extractTags(MultivaluedMap<String, String> params) {
+        Map<String, String> tags = new HashMap<>();
+        for (int i = 1; ; i++) {
+            String key = getParam(params, "Tag." + i + ".Key");
+            String value = getParam(params, "Tag." + i + ".Value");
+            if (key == null) break;
+            tags.put(key, value);
+        }
+        return tags;
     }
 
     Response xmlErrorResponse(String code, String message, int status) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -153,10 +153,14 @@ public class SqsService {
     }
 
     public Queue createQueue(String queueName, Map<String, String> attributes) {
-        return createQueue(queueName, attributes, regionResolver.getDefaultRegion());
+        return createQueue(queueName, attributes, null, regionResolver.getDefaultRegion());
     }
 
     public Queue createQueue(String queueName, Map<String, String> attributes, String region) {
+        return createQueue(queueName, attributes, null, region);
+    }
+
+    public Queue createQueue(String queueName, Map<String, String> attributes, Map<String, String> tags, String region) {
 
         boolean fifoRequested = attributes != null && "true".equalsIgnoreCase(attributes.get("FifoQueue"));
         boolean hasFifoSuffix = queueName != null && queueName.endsWith(".fifo");
@@ -198,6 +202,9 @@ public class SqsService {
         Queue queue = new Queue(queueName, queueUrl);
         if (attributes != null) {
             queue.getAttributes().putAll(attributes);
+        }
+        if (tags != null) {
+            queue.getTags().putAll(tags);
         }
         // Set default attributes
         queue.getAttributes().putIfAbsent("VisibilityTimeout", String.valueOf(defaultVisibilityTimeout));

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -251,6 +251,52 @@ class SqsIntegrationTest {
     }
 
     @Test
+    void createQueue_withTags_tagsReturnedByListQueueTags() {
+        // Regression test for https://github.com/floci-io/floci/issues/699
+        // Tags supplied at CreateQueue time must be visible via ListQueueTags.
+        String taggedQueueName = "tagged-queue-integration-test";
+
+        // Extract the queue URL from the CreateQueue response — don't hard-code the port
+        String taggedQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", taggedQueueName)
+            .formParam("Tag.1.Key", "k1")
+            .formParam("Tag.1.Value", "v1")
+            .formParam("Tag.2.Key", "k2")
+            .formParam("Tag.2.Value", "v2")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(taggedQueueName))
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListQueueTags")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("k1"))
+            .body(containsString("v1"))
+            .body(containsString("k2"))
+            .body(containsString("v2"));
+
+        // cleanup
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedAction() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -49,6 +49,20 @@ class SqsServiceTest {
     }
 
     @Test
+    void createQueueWithTags_tagsReturnedByListQueueTags() {
+        // Regression test for https://github.com/floci-io/floci/issues/699
+        // Tags supplied at CreateQueue time must be visible via ListQueueTags.
+        Map<String, String> tags = Map.of("k1", "v1", "k2", "v2");
+        Queue queue = sqsService.createQueue("tagged-queue", null, tags, "us-east-1");
+        String queueUrl = queue.getQueueUrl();
+
+        Map<String, String> returned = sqsService.listQueueTags(queueUrl, "us-east-1");
+        assertEquals(2, returned.size(), "ListQueueTags must return all tags set during CreateQueue");
+        assertEquals("v1", returned.get("k1"));
+        assertEquals("v2", returned.get("k2"));
+    }
+
+    @Test
     void deleteQueue() {
         Queue queue = sqsService.createQueue("test-queue", null);
         sqsService.deleteQueue(queue.getQueueUrl());


### PR DESCRIPTION
## Summary

Tags passed to `CreateQueue` were silently dropped in both the Query and JSON protocol handlers — neither extracted the `Tags` parameter before calling `sqsService.createQueue()`. As a result, `ListQueueTags` always returned an empty map for queues created with tags.

Closes #699

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** Tags supplied via `--tags` in `CreateQueue` were not persisted. `ListQueueTags` returned `{}` regardless of what was passed at creation time.

**Fixed behavior:** Tags are now extracted from both protocol handlers and stored on the queue at creation time. `ListQueueTags` correctly returns them.

**Protocol note:** Botocore sends `"tags"` (lowercase) for `CreateQueue` but `"Tags"` (uppercase) for `TagQueue`. The JSON handler now merges both fields to handle any client regardless of casing.

Verified with AWS CLI v2 (`sqs create-queue --tags`) and the Query protocol (`Tag.N.Key` / `Tag.N.Value` form params).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
