### PR TITLE
feat(cognito): support AdminCreateUser MessageAction=RESEND

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -263,12 +263,15 @@ public class CognitoJsonHandler {
         request.path("UserAttributes").forEach(a -> attrs.put(a.path("Name").asText(), a.path("Value").asText()));
         String tempPassword = request.path("TemporaryPassword").isMissingNode() ? null
                 : request.path("TemporaryPassword").asText(null);
+        String messageAction = request.path("MessageAction").isMissingNode() ? null
+                : request.path("MessageAction").asText(null);
 
         CognitoUser user = service.adminCreateUser(
                 request.path("UserPoolId").asText(),
                 request.path("Username").asText(),
                 attrs,
-                tempPassword
+                tempPassword,
+                messageAction
         );
         ObjectNode response = objectMapper.createObjectNode();
         response.set("User", userToNode(user));

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -437,8 +437,41 @@ public class CognitoService {
 
     public CognitoUser adminCreateUser(String userPoolId, String username, Map<String, String> attributes,
                                        String temporaryPassword) {
+        return adminCreateUser(userPoolId, username, attributes, temporaryPassword, null);
+    }
+
+    /**
+     * AdminCreateUser with optional MessageAction.
+     *
+     * <p>{@code messageAction = "RESEND"} resends the invitation for an existing
+     * user in {@code FORCE_CHANGE_PASSWORD} status without recreating it; floci
+     * has no email transport, so this only refreshes {@code lastModifiedDate}.
+     * {@code "SUPPRESS"} or {@code null} retain the default create behavior.</p>
+     */
+    public CognitoUser adminCreateUser(String userPoolId,
+                                       String username,
+                                       Map<String, String> attributes,
+                                       String temporaryPassword,
+                                       String messageAction) {
         describeUserPool(userPoolId);
         String key = userKey(userPoolId, username);
+        boolean resend = "RESEND".equalsIgnoreCase(messageAction);
+
+        if (resend) {
+            CognitoUser existing = userStore.get(key)
+                    .orElseThrow(() -> new AwsException("UserNotFoundException", "User not found", 404));
+            if (!"FORCE_CHANGE_PASSWORD".equals(existing.getUserStatus())) {
+                final String userStateExceptionMessage = """
+                        User is in %s state and cannot be resent an invitation.
+                        """.formatted(existing.getUserStatus());
+                throw new AwsException("UnsupportedUserStateException", userStateExceptionMessage, 400);
+            }
+            existing.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+            userStore.put(key, existing);
+            LOG.infov("Resent invitation for user {0} in pool {1}", username, userPoolId);
+            return existing;
+        }
+
         if (userStore.get(key).isPresent()) {
             throw new AwsException("UsernameExistsException", "User already exists", 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -15,7 +13,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -993,6 +990,39 @@ class CognitoIntegrationTest {
                 .formParam("client_secret", oauthClientSecret)
         .when()
                 .post("/cognito-idp/oauth2/token");
+    }
+
+    @Test
+    @Order(91)
+    void adminCreateUserWithMessageActionResendRefreshesExistingUser() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                { "PoolName": "ResendPool" }
+                """);
+        String resendPoolId = poolResponse.path("UserPool").path("Id").asText();
+        String resendUser = "resend-" + UUID.randomUUID();
+
+        cognitoAction("AdminCreateUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s",
+                  "TemporaryPassword": "TempPass1!",
+                  "UserAttributes": [ { "Name": "email", "Value": "resend@example.com" } ]
+                }
+                """.formatted(resendPoolId, resendUser))
+                .then()
+                .statusCode(200);
+
+        JsonNode resent = cognitoJson("AdminCreateUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s",
+                  "MessageAction": "RESEND",
+                  "UserAttributes": [ { "Name": "email", "Value": "resend@example.com" } ]
+                }
+                """.formatted(resendPoolId, resendUser));
+
+        assertEquals("FORCE_CHANGE_PASSWORD",
+                resent.path("User").path("UserStatus").asText());
     }
 
     private static Response cognitoAction(String action, String body) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -525,6 +525,50 @@ class CognitoServiceTest {
     }
 
     @Test
+    void adminCreateUserResendRefreshesExistingForceChangePasswordUser() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        CognitoUser created = service.adminCreateUser(pool.getId(),
+                "alice",
+                Map.of("email", "alice@example.com"),
+                "TempPass1!");
+
+        // Backdate lastModifiedDate so RESEND's refresh is unambiguously observable
+        // without relying on wall-clock sleep (lastModifiedDate has 1s precision).
+        long backdated = (System.currentTimeMillis() / 1000L) - 60;
+        created.setLastModifiedDate(backdated);
+
+        CognitoUser resent = service.adminCreateUser(pool.getId(), "alice",
+                Map.of("email", "alice@example.com"), null, "RESEND");
+
+        assertEquals(created.getAttributes().get("sub"), resent.getAttributes().get("sub"),
+                "RESEND must not recreate the user");
+        assertEquals("FORCE_CHANGE_PASSWORD", resent.getUserStatus());
+        assertTrue(resent.getLastModifiedDate() > backdated,
+                "RESEND should refresh lastModifiedDate");
+    }
+
+    @Test
+    void adminCreateUserResendThrowsUserNotFoundForMissingUser() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.adminCreateUser(pool.getId(), "ghost",
+                        Map.of("email", "g@example.com"), null, "RESEND"));
+        assertEquals("UserNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void adminCreateUserResendThrowsUnsupportedStateForConfirmedUser() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), "TempPass1!");
+        service.adminSetUserPassword(pool.getId(), "bob", "Permanent1!", true);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.adminCreateUser(pool.getId(), "bob",
+                        Map.of("email", "bob@example.com"), null, "RESEND"));
+        assertEquals("UnsupportedUserStateException", ex.getErrorCode());
+    }
+
+    @Test
     void signUpAutoGeneratesSub() {
         UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         UserPoolClient client = service.createUserPoolClient(pool.getId(), "test-client",


### PR DESCRIPTION
## Summary

Adds support for `MessageAction=RESEND` in `AdminCreateUser`.

- Parse `MessageAction` in `CognitoJsonHandler#handleAdminCreateUser`.
- Add a new 5-arg `CognitoService#adminCreateUser` overload that accepts `MessageAction`.
- Preserve the existing 4-arg `adminCreateUser` signature by delegating to the new overload.
- Handle `RESEND` for `FORCE_CHANGE_PASSWORD` users by refreshing `lastModifiedDate` and returning the existing user instead of throwing `UsernameExistsException`.
- Treat `RESEND` as a no-op invitation refresh because Floci does not have email transport.
- Keep `RESEND` behavior consistent with other notification-bearing APIs in the emulator.
- Throw `UserNotFoundException` when `RESEND` is requested for a missing user.
- Throw `UnsupportedUserStateException` when `RESEND` is requested for a `CONFIRMED` user.
- Align `RESEND` error behavior with real AWS Cognito.
- Add 3 unit tests in `CognitoServiceTest`.
- Add 1 wire-level test in `CognitoIntegrationTest`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Adds `AdminCreateUser` support for `MessageAction=RESEND`.

The new behavior matches AWS Cognito:

- `RESEND` for an existing `FORCE_CHANGE_PASSWORD` user returns the existing user and refreshes `lastModifiedDate`.
- `RESEND` for a missing user throws `UserNotFoundException`.
- `RESEND` for a `CONFIRMED` user throws `UnsupportedUserStateException`.

Because Floci does not have email transport, `RESEND` is treated as a no-op invitation refresh, consistent with other notification-bearing APIs in the emulator.

## Checklist

- [x] `./mvnw test` passes locally -> except ElastiCacheIntegrationTest has 10 pre-existing failures on main caused by a local socket bind issue (Can't assign requested address) which is unrelated to this change.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)