### PR TITLE
fix(tests): Enhance ElastiCache test reliability and optimize thread …

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
@@ -14,6 +14,12 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +35,15 @@ public class ElastiCacheContainerManager {
 
     private static final Logger LOG = Logger.getLogger(ElastiCacheContainerManager.class);
     private static final int BACKEND_PORT = 6379;
+
+    /**
+     * Docker can publish a host port before Valkey inside the container is listening. Without a probe,
+     * the auth proxy may connect, forward PING, and block on PONG until the client times out.
+     */
+    private static final int BACKEND_READY_DEADLINE_MS = 60_000;
+    private static final int BACKEND_READY_RETRY_MS = 100;
+    private static final int BACKEND_PROBE_CONNECT_MS = 2_000;
+    private static final byte[] RESP_PING = "*1\r\n$4\r\nPING\r\n".getBytes(StandardCharsets.UTF_8);
 
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
@@ -100,7 +115,64 @@ public class ElastiCacheContainerManager {
                 info.containerId(), logGroup, logStream, region, "elasticache:" + groupId);
         handle.setLogStream(logHandle);
 
+        waitForBackendReady(groupId, endpoint.host(), endpoint.port());
+
         return handle;
+    }
+
+    private static void waitForBackendReady(String groupId, String host, int port) {
+        long deadline = System.currentTimeMillis() + BACKEND_READY_DEADLINE_MS;
+        int attempt = 0;
+        while (System.currentTimeMillis() < deadline) {
+            attempt++;
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress(host, port), BACKEND_PROBE_CONNECT_MS);
+                s.setTcpNoDelay(true);
+                s.setSoTimeout(BACKEND_PROBE_CONNECT_MS);
+                OutputStream out = s.getOutputStream();
+                out.write(RESP_PING);
+                out.flush();
+                String line = readAsciiLineCrLf(s.getInputStream());
+                if (line.startsWith("+PONG")) {
+                    if (attempt > 1) {
+                        LOG.infov("ElastiCache backend ready for group {0} after {1} probe attempt(s)", groupId, attempt);
+                    }
+                    return;
+                }
+                if (LOG.isDebugEnabled()) {
+                    LOG.debugv("ElastiCache backend probe for group {0}: unexpected line {1}", groupId, line);
+                }
+            } catch (IOException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debugv("ElastiCache backend probe for group {0} attempt {1}: {2}", groupId, attempt, e.getMessage());
+                }
+            }
+            try {
+                Thread.sleep(BACKEND_READY_RETRY_MS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for ElastiCache backend " + groupId, ie);
+            }
+        }
+        throw new RuntimeException(
+                "ElastiCache backend for group " + groupId + " did not become ready on " + host + ":" + port
+                        + " within " + BACKEND_READY_DEADLINE_MS + "ms");
+    }
+
+    private static String readAsciiLineCrLf(InputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int b;
+        while ((b = in.read()) != -1) {
+            if (b == '\r') {
+                int next = in.read();
+                if (next != '\n') {
+                    throw new IOException("Expected \\n after \\r in RESP line");
+                }
+                break;
+            }
+            sb.append((char) b);
+        }
+        return sb.toString();
     }
 
     public void stop(ElastiCacheContainerHandle handle) {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
@@ -159,10 +159,15 @@ public class ElastiCacheAuthProxy {
         };
     }
 
+    /**
+     * Relay I/O runs on platform daemon threads (not virtual threads). A parent virtual thread
+     * from {@code handleConnection} blocks in {@code join} here; scheduling nested virtual-thread
+     * relays under load can stall delivery of backend responses (e.g. PING/PONG) to the client.
+     */
     private void bridge(Socket client, Socket backend) {
-        Thread t1 = Thread.ofVirtual().name("ec-relay-c2b-" + groupId)
+        Thread t1 = Thread.ofPlatform().daemon(true).name("ec-relay-c2b-" + groupId)
                 .start(() -> relay(client, backend));
-        Thread t2 = Thread.ofVirtual().name("ec-relay-b2c-" + groupId)
+        Thread t2 = Thread.ofPlatform().daemon(true).name("ec-relay-b2c-" + groupId)
                 .start(() -> relay(backend, client));
         try {
             t1.join();

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -14,11 +14,11 @@ import java.util.List;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -36,6 +36,11 @@ class ElastiCacheIntegrationTest {
     private static final String GROUP_AUTH_TOKEN = "group-auth-token";
     private static final String CROSS_GROUP_ID = "it-ec-group-cross";
     private static final String CROSS_GROUP_AUTH_TOKEN = "cross-group-token";
+
+    /** Per-read timeout; ElastiCache tests talk to Docker-backed Valkey and can stall under load. */
+    private static final int SOCKET_TIMEOUT_MS = 10_000;
+    /** Retries only when no bytes were read yet for the line (safe: no partial-line corruption). */
+    private static final int READ_LINE_MAX_ATTEMPTS = 3;
 
     private static int firstProxyPort;
     private static int crossGroupPort;
@@ -345,7 +350,7 @@ class ElastiCacheIntegrationTest {
 
     private static Socket openSocket(int port) throws IOException {
         Socket socket = new Socket("localhost", port);
-        socket.setSoTimeout(5000);
+        socket.setSoTimeout(SOCKET_TIMEOUT_MS);
         return socket;
     }
 
@@ -363,11 +368,40 @@ class ElastiCacheIntegrationTest {
     }
 
     private static String readLine(Socket socket) throws IOException {
+        for (int attempt = 1; attempt <= READ_LINE_MAX_ATTEMPTS; attempt++) {
+            try {
+                return readLineOnce(socket);
+            } catch (SocketTimeoutException e) {
+                if (attempt == READ_LINE_MAX_ATTEMPTS) {
+                    throw new IOException(
+                            "Redis response timed out after " + READ_LINE_MAX_ATTEMPTS + " attempts ("
+                                    + SOCKET_TIMEOUT_MS + "ms read timeout each). "
+                                    + "Confirm Docker is running, Valkey containers are healthy (docker ps), "
+                                    + "and the host is not CPU/memory starved; re-run this test in isolation if needed.",
+                            e);
+                }
+            }
+        }
+        throw new AssertionError("unreachable");
+    }
+
+    private static String readLineOnce(Socket socket) throws IOException {
         InputStream in = socket.getInputStream();
         byte[] buffer = new byte[256];
         int offset = 0;
         while (offset < buffer.length) {
-            int read = in.read();
+            int read;
+            try {
+                read = in.read();
+            } catch (SocketTimeoutException e) {
+                if (offset == 0) {
+                    throw e;
+                }
+                throw new IOException(
+                        "Incomplete Redis line (" + offset + " bytes) before read timeout; proxy or backend "
+                                + "returned partial data.",
+                        e);
+            }
             if (read == -1) {
                 break;
             }


### PR DESCRIPTION

## Summary

Introduced configurable socket timeout and retry logic in integration tests to handle stalling under load. Updated relay threads in the proxy to use platform daemon threads, preventing scheduling issues and improving response delivery in high-load scenarios. These changes improve test robustness and backend-client communication stability.

Closes #757 

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
