### PR TITLE
feat(cognito): add UpdateGroup and ListUsersInGroup actions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -78,6 +78,8 @@ public class CognitoJsonHandler {
             case "GetGroup" -> handleGetGroup(request);
             case "ListGroups" -> handleListGroups(request);
             case "DeleteGroup" -> handleDeleteGroup(request);
+            case "UpdateGroup" -> handleUpdateGroup(request);
+            case "ListUsersInGroup" -> handleListUsersInGroup(request);
             case "AdminAddUserToGroup" -> handleAdminAddUserToGroup(request);
             case "AdminRemoveUserFromGroup" -> handleAdminRemoveUserFromGroup(request);
             case "AdminListGroupsForUser" -> handleAdminListGroupsForUser(request);
@@ -696,6 +698,29 @@ public class CognitoJsonHandler {
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode items = response.putArray("Groups");
         groups.forEach(g -> items.add(groupToNode(g)));
+        return Response.ok(response).build();
+    }
+
+    private Response handleUpdateGroup(JsonNode request) {
+        String userPoolId = request.path("UserPoolId").asText();
+        String groupName = request.path("GroupName").asText();
+        String description = request.has("Description") ? request.path("Description").asText() : null;
+        JsonNode precNode = request.path("Precedence");
+        Integer precedence = precNode.isMissingNode() || precNode.isNull() ? null : precNode.asInt();
+        String roleArn = request.has("RoleArn") ? request.path("RoleArn").asText() : null;
+        CognitoGroup group = service.updateGroup(userPoolId, groupName, description, precedence, roleArn);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("Group", groupToNode(group));
+        return Response.ok(response).build();
+    }
+
+    private Response handleListUsersInGroup(JsonNode request) {
+        String userPoolId = request.path("UserPoolId").asText();
+        String groupName = request.path("GroupName").asText();
+        List<CognitoUser> users = service.listUsersInGroup(userPoolId, groupName);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode items = response.putArray("Users");
+        users.forEach(u -> items.add(userToNode(u)));
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -659,6 +659,25 @@ public class CognitoService {
         LOG.infov("Deleted Cognito group: {0} from pool {1}", groupName, userPoolId);
     }
 
+    public CognitoGroup updateGroup(String userPoolId, String groupName, String description,
+                                     Integer precedence, String roleArn) {
+        CognitoGroup group = getGroup(userPoolId, groupName);
+        if (description != null) group.setDescription(description);
+        if (precedence != null) group.setPrecedence(precedence);
+        if (roleArn != null) group.setRoleArn(roleArn);
+        group.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        groupStore.put(groupKey(userPoolId, groupName), group);
+        LOG.infov("Updated Cognito group: {0} in pool {1}", groupName, userPoolId);
+        return group;
+    }
+
+    public List<CognitoUser> listUsersInGroup(String userPoolId, String groupName) {
+        CognitoGroup group = getGroup(userPoolId, groupName);
+        return group.getUserNames().stream()
+                .flatMap(username -> userStore.get(userKey(userPoolId, username)).stream())
+                .toList();
+    }
+
     public void adminAddUserToGroup(String userPoolId, String groupName, String username) {
         CognitoGroup group = getGroup(userPoolId, groupName);
         CognitoUser user = adminGetUser(userPoolId, username);

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -372,6 +372,105 @@ class CognitoIntegrationTest {
                 .statusCode(404);
     }
 
+    // ── UpdateGroup & ListUsersInGroup ────────────────────────────────
+
+    @Test
+    @Order(21)
+    void updateGroup() throws Exception {
+        // Create a group to update
+        cognitoJson("CreateGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors",
+                  "Description": "Original description",
+                  "Precedence": 10
+                }
+                """.formatted(poolId));
+
+        // Update the group
+        JsonNode resp = cognitoJson("UpdateGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors",
+                  "Description": "Updated description",
+                  "Precedence": 5,
+                  "RoleArn": "arn:aws:iam::000000000000:role/editors-role"
+                }
+                """.formatted(poolId));
+
+        JsonNode group = resp.path("Group");
+        assertEquals("editors", group.path("GroupName").asText());
+        assertEquals("Updated description", group.path("Description").asText());
+        assertEquals(5, group.path("Precedence").asInt());
+        assertEquals("arn:aws:iam::000000000000:role/editors-role", group.path("RoleArn").asText());
+
+        // Verify via GetGroup
+        JsonNode getResp = cognitoJson("GetGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors"
+                }
+                """.formatted(poolId));
+        assertEquals("Updated description", getResp.path("Group").path("Description").asText());
+        assertEquals(5, getResp.path("Group").path("Precedence").asInt());
+    }
+
+    @Test
+    @Order(22)
+    void listUsersInGroup() throws Exception {
+        // Add user to editors group
+        cognitoAction("AdminAddUserToGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors",
+                  "Username": "%s"
+                }
+                """.formatted(poolId, username))
+                .then().statusCode(200);
+
+        // List users in group
+        JsonNode resp = cognitoJson("ListUsersInGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors"
+                }
+                """.formatted(poolId));
+
+        assertEquals(1, resp.path("Users").size());
+        assertEquals(username, resp.path("Users").get(0).path("Username").asText());
+    }
+
+    @Test
+    @Order(23)
+    void listUsersInGroupEmpty() throws Exception {
+        // Remove user and verify empty list
+        cognitoAction("AdminRemoveUserFromGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors",
+                  "Username": "%s"
+                }
+                """.formatted(poolId, username))
+                .then().statusCode(200);
+
+        JsonNode resp = cognitoJson("ListUsersInGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors"
+                }
+                """.formatted(poolId));
+        assertEquals(0, resp.path("Users").size());
+
+        // Cleanup
+        cognitoAction("DeleteGroup", """
+                {
+                  "UserPoolId": "%s",
+                  "GroupName": "editors"
+                }
+                """.formatted(poolId))
+                .then().statusCode(200);
+    }
+
     // ── Issue #228: AccessToken contains client_id ─────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Adds two missing Cognito Group actions: `UpdateGroup` and `ListUsersInGroup`.

- **`UpdateGroup`** — Modify a group's `Description`, `Precedence`, and `RoleArn`. The existing Group CRUD had Create/Get/List/Delete but no Update.
- **`ListUsersInGroup`** — Return all users belonging to a specific group. The `CognitoGroup` model already tracked `userNames
