### PR TITLE
fix(sqs,sns): conformance gaps surfaced by .NET SDK sweep (#768)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,12 @@
             <artifactId>rds</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- AWS SDK SQS client to validate MD5/wire compatibility -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -40,6 +40,7 @@ public class SnsService {
 
     private static final Logger LOG = Logger.getLogger(SnsService.class);
     private static final Duration FIFO_DEDUP_WINDOW = Duration.ofMinutes(5);
+    private static final int MAX_PUBLISH_SIZE = 262_144;
     private static final List<String> PENDING_CONFIRMATION_PROTOCOLS =
             List.of("http", "https", "email", "email-json", "sms");
 
@@ -288,6 +289,12 @@ public class SnsService {
             throw new AwsException("InvalidParameter", "Message is required.", 400);
         }
 
+        int payloadSize = computePublishSize(message, subject, messageAttributes);
+        if (payloadSize > MAX_PUBLISH_SIZE) {
+            throw new AwsException("InvalidParameterException",
+                    "Invalid parameter: Message too long", 400);
+        }
+
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));
         String dedupId = messageDeduplicationId;
         if (isFifo) {
@@ -353,6 +360,21 @@ public class SnsService {
         String topicStoreKey = topicKey(region, topicArn);
         Topic topic = topicStore.get(topicStoreKey)
                 .orElseThrow(() -> new AwsException("NotFound", "Topic does not exist.", 404));
+
+        int batchSize = 0;
+        for (Map<String, Object> entry : entries) {
+            String message = (String) entry.get("Message");
+            String subject = (String) entry.get("Subject");
+            @SuppressWarnings("unchecked")
+            Map<String, MessageAttributeValue> attrs =
+                    (Map<String, MessageAttributeValue>) entry.get("MessageAttributes");
+            batchSize += computePublishSize(message, subject, attrs);
+        }
+        if (batchSize > MAX_PUBLISH_SIZE) {
+            throw new AwsException("BatchRequestTooLong",
+                    "Batch requests cannot be longer than " + MAX_PUBLISH_SIZE + " bytes.", 400);
+        }
+
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));
         List<String[]> successful = new ArrayList<>();
         List<String[]> failed = new ArrayList<>();
@@ -764,6 +786,32 @@ public class SnsService {
         if (arn.startsWith("http")) return arn;
         try { AwsArnUtils.parse(arn); } catch (IllegalArgumentException e) { return arn; }
         return AwsArnUtils.arnToQueueUrl(arn, baseUrl);
+    }
+
+    private static int computePublishSize(String message, String subject,
+                                          Map<String, MessageAttributeValue> attributes) {
+        int total = message == null ? 0 : message.getBytes(StandardCharsets.UTF_8).length;
+        if (subject != null) {
+            total += subject.getBytes(StandardCharsets.UTF_8).length;
+        }
+        if (attributes != null) {
+            for (Map.Entry<String, MessageAttributeValue> entry : attributes.entrySet()) {
+                total += entry.getKey().getBytes(StandardCharsets.UTF_8).length;
+                MessageAttributeValue value = entry.getValue();
+                if (value == null) {
+                    continue;
+                }
+                if (value.getDataType() != null) {
+                    total += value.getDataType().getBytes(StandardCharsets.UTF_8).length;
+                }
+                if (value.getBinaryValue() != null) {
+                    total += value.getBinaryValue().length;
+                } else if (value.getStringValue() != null) {
+                    total += value.getStringValue().getBytes(StandardCharsets.UTF_8).length;
+                }
+            }
+        }
+        return total;
     }
 
     private static String sha256(String message) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -115,10 +115,12 @@ class GuardedMessageQueue {
     private void claimFifo(int maxMessages, int effectiveTimeout,
                            int maxReceiveCount, String deadLetterTargetArn,
                            List<Message> claimed, List<Message> dlqCandidates) {
-        Set<String> groupsWithInFlight;
-        Set<String> groupsDelivered = new HashSet<>();
-
-        groupsWithInFlight =
+        // Cross-call group locking: a group that already has an in-flight
+        // message from a previous ReceiveMessage call is blocked until that
+        // message is deleted or its visibility expires. Within a single call
+        // we may return multiple messages from the same group (preserving
+        // insertion order), up to MaxNumberOfMessages.
+        Set<String> groupsWithInFlight =
                 messages.stream().filter(msg -> !msg.isVisible() && msg.getMessageGroupId() != null)
                         .map(Message::getMessageGroupId).collect(Collectors.toSet());
 
@@ -128,12 +130,8 @@ class GuardedMessageQueue {
 
             String groupId = msg.getMessageGroupId();
             if (groupId != null && groupsWithInFlight.contains(groupId)) continue;
-            if (groupId != null && groupsDelivered.contains(groupId)) continue;
 
-            if (tryClaim(msg, effectiveTimeout, maxReceiveCount, deadLetterTargetArn, claimed, dlqCandidates)
-                    && groupId != null) {
-                groupsDelivered.add(groupId);
-            }
+            tryClaim(msg, effectiveTimeout, maxReceiveCount, deadLetterTargetArn, claimed, dlqCandidates);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -86,6 +86,9 @@ class GuardedMessageQueue {
                              String deadLetterTargetArn, List<Message> claimed,
                              List<Message> dlqCandidates) {
         msg.setReceiveCount(msg.getReceiveCount() + 1);
+        if (msg.getFirstReceiveTimestamp() == null) {
+            msg.setFirstReceiveTimestamp(Instant.now());
+        }
 
         if (maxReceiveCount > 0 && deadLetterTargetArn != null
                 && msg.getReceiveCount() > maxReceiveCount) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -57,10 +57,38 @@ public class SqsJsonHandler {
             case "ListDeadLetterSourceQueues" -> handleListDeadLetterSourceQueues(request, region);
             case "StartMessageMoveTask" -> handleStartMessageMoveTask(request, region);
             case "ListMessageMoveTasks" -> handleListMessageMoveTasks(request, region);
+            case "AddPermission" -> handleAddPermission(request, region);
+            case "RemovePermission" -> handleRemovePermission(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
         };
+    }
+
+    private Response handleAddPermission(JsonNode request, String region) {
+        String queueUrl = request.path("QueueUrl").asText(null);
+        String label = request.path("Label").asText(null);
+        List<String> accountIds = jsonNodeToList(request.path("AWSAccountIds"));
+        List<String> actions = jsonNodeToList(request.path("Actions"));
+        sqsService.addPermission(queueUrl, label, accountIds, actions, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleRemovePermission(JsonNode request, String region) {
+        String queueUrl = request.path("QueueUrl").asText(null);
+        String label = request.path("Label").asText(null);
+        sqsService.removePermission(queueUrl, label, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private List<String> jsonNodeToList(JsonNode node) {
+        List<String> values = new ArrayList<>();
+        if (node != null && node.isArray()) {
+            for (JsonNode item : node) {
+                values.add(item.asText());
+            }
+        }
+        return values;
     }
 
     private Response handleCreateQueue(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -81,6 +81,42 @@ public class SqsJsonHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    private void writeSystemAttributesJson(ObjectNode msgNode, Message msg,
+                                           java.util.Set<String> requested, String senderId) {
+        if (requested.isEmpty()) {
+            return;
+        }
+        boolean all = requested.contains("All");
+        ObjectNode attrs = objectMapper.createObjectNode();
+        if ((all || requested.contains("SenderId")) && senderId != null) {
+            attrs.put("SenderId", senderId);
+        }
+        if (all || requested.contains("SentTimestamp")) {
+            attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
+        }
+        if (all || requested.contains("ApproximateReceiveCount")) {
+            attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
+        }
+        if ((all || requested.contains("ApproximateFirstReceiveTimestamp"))
+                && msg.getFirstReceiveTimestamp() != null) {
+            attrs.put("ApproximateFirstReceiveTimestamp",
+                    String.valueOf(msg.getFirstReceiveTimestamp().toEpochMilli()));
+        }
+        if (msg.getMessageGroupId() != null && (all || requested.contains("MessageGroupId"))) {
+            attrs.put("MessageGroupId", msg.getMessageGroupId());
+        }
+        if (msg.getSequenceNumber() > 0 && (all || requested.contains("SequenceNumber"))) {
+            attrs.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
+        }
+        if (msg.getMessageDeduplicationId() != null
+                && (all || requested.contains("MessageDeduplicationId"))) {
+            attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
+        }
+        if (!attrs.isEmpty()) {
+            msgNode.set("Attributes", attrs);
+        }
+    }
+
     private List<String> jsonNodeToList(JsonNode node) {
         List<String> values = new ArrayList<>();
         if (node != null && node.isArray()) {
@@ -199,8 +235,13 @@ public class SqsJsonHandler {
         int visibilityTimeout = request.path("VisibilityTimeout").asInt(-1);
         int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(0);
 
+        java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
+        requestedAttrs.addAll(jsonNodeToList(request.path("AttributeNames")));
+        requestedAttrs.addAll(jsonNodeToList(request.path("MessageSystemAttributeNames")));
+
         List<Message> messages = sqsService.receiveMessage(queueUrl, maxMessages,
                 visibilityTimeout, waitTimeSeconds, region);
+        String senderId = sqsService.senderIdFor(queueUrl);
 
         ObjectNode response = objectMapper.createObjectNode();
         // Match AWS: omit the Messages field entirely when no messages are
@@ -220,18 +261,7 @@ public class SqsJsonHandler {
             }
             msgNode.put("Body", msg.getBody());
 
-            ObjectNode attrs = msgNode.putObject("Attributes");
-            attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
-            attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
-            if (msg.getMessageGroupId() != null) {
-                attrs.put("MessageGroupId", msg.getMessageGroupId());
-            }
-            if (msg.getSequenceNumber() > 0) {
-                attrs.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
-            }
-            if (msg.getMessageDeduplicationId() != null) {
-                attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
-            }
+            writeSystemAttributesJson(msgNode, msg, requestedAttrs, senderId);
 
             if (msg.getMessageAttributes() != null && !msg.getMessageAttributes().isEmpty()) {
                 ObjectNode msgAttrs = msgNode.putObject("MessageAttributes");

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -203,6 +203,12 @@ public class SqsJsonHandler {
                 visibilityTimeout, waitTimeSeconds, region);
 
         ObjectNode response = objectMapper.createObjectNode();
+        // Match AWS: omit the Messages field entirely when no messages are
+        // available, so SDK clients with InitializeCollections=false see null
+        // instead of an empty list.
+        if (messages.isEmpty()) {
+            return Response.ok(response).build();
+        }
         ArrayNode messagesArray = response.putArray("Messages");
         for (Message msg : messages) {
             ObjectNode msgNode = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -79,6 +79,46 @@ public class SqsQueryHandler {
         return Response.ok(AwsQueryResponse.envelopeNoResult("RemovePermission", null)).build();
     }
 
+    private static void writeSystemAttributesXml(XmlBuilder xml, Message msg,
+                                                 java.util.Set<String> requested, String senderId) {
+        if (requested.isEmpty()) {
+            return;
+        }
+        boolean all = requested.contains("All");
+        if (all || requested.contains("SenderId")) {
+            if (senderId != null) {
+                xml.start("Attribute").elem("Name", "SenderId")
+                        .elem("Value", senderId).end("Attribute");
+            }
+        }
+        if (all || requested.contains("SentTimestamp")) {
+            xml.start("Attribute").elem("Name", "SentTimestamp")
+                    .elem("Value", String.valueOf(msg.getSentTimestamp().toEpochMilli())).end("Attribute");
+        }
+        if (all || requested.contains("ApproximateReceiveCount")) {
+            xml.start("Attribute").elem("Name", "ApproximateReceiveCount")
+                    .elem("Value", String.valueOf(msg.getReceiveCount())).end("Attribute");
+        }
+        if (all || requested.contains("ApproximateFirstReceiveTimestamp")) {
+            if (msg.getFirstReceiveTimestamp() != null) {
+                xml.start("Attribute").elem("Name", "ApproximateFirstReceiveTimestamp")
+                        .elem("Value", String.valueOf(msg.getFirstReceiveTimestamp().toEpochMilli())).end("Attribute");
+            }
+        }
+        if (msg.getMessageGroupId() != null && (all || requested.contains("MessageGroupId"))) {
+            xml.start("Attribute").elem("Name", "MessageGroupId")
+                    .elem("Value", msg.getMessageGroupId()).end("Attribute");
+        }
+        if (msg.getSequenceNumber() > 0 && (all || requested.contains("SequenceNumber"))) {
+            xml.start("Attribute").elem("Name", "SequenceNumber")
+                    .elem("Value", String.valueOf(msg.getSequenceNumber())).end("Attribute");
+        }
+        if (msg.getMessageDeduplicationId() != null && (all || requested.contains("MessageDeduplicationId"))) {
+            xml.start("Attribute").elem("Name", "MessageDeduplicationId")
+                    .elem("Value", msg.getMessageDeduplicationId()).end("Attribute");
+        }
+    }
+
     private List<String> collectIndexed(MultivaluedMap<String, String> params, String prefix) {
         List<String> values = new ArrayList<>();
         for (int i = 1; ; i++) {
@@ -192,7 +232,12 @@ public class SqsQueryHandler {
         int visibilityTimeout = getIntParam(params, "VisibilityTimeout", -1);
         int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", 0);
 
+        java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
+        requestedAttrs.addAll(collectIndexed(params, "AttributeName."));
+        requestedAttrs.addAll(collectIndexed(params, "MessageSystemAttributeName."));
+
         List<Message> messages = sqsService.receiveMessage(queueUrl, maxMessages, visibilityTimeout, waitTimeSeconds, region);
+        String senderId = sqsService.senderIdFor(queueUrl);
 
         var xml = new XmlBuilder();
         for (Message msg : messages) {
@@ -203,23 +248,8 @@ public class SqsQueryHandler {
             if (msg.getMd5OfMessageAttributes() != null) {
                 xml.elem("MD5OfMessageAttributes", msg.getMd5OfMessageAttributes());
             }
-            xml.elem("Body", msg.getBody())
-               .start("Attribute").elem("Name", "ApproximateReceiveCount")
-                 .elem("Value", String.valueOf(msg.getReceiveCount())).end("Attribute")
-               .start("Attribute").elem("Name", "SentTimestamp")
-                 .elem("Value", String.valueOf(msg.getSentTimestamp().toEpochMilli())).end("Attribute");
-            if (msg.getMessageGroupId() != null) {
-                xml.start("Attribute").elem("Name", "MessageGroupId")
-                   .elem("Value", msg.getMessageGroupId()).end("Attribute");
-            }
-            if (msg.getSequenceNumber() > 0) {
-                xml.start("Attribute").elem("Name", "SequenceNumber")
-                   .elem("Value", String.valueOf(msg.getSequenceNumber())).end("Attribute");
-            }
-            if (msg.getMessageDeduplicationId() != null) {
-                xml.start("Attribute").elem("Name", "MessageDeduplicationId")
-                   .elem("Value", msg.getMessageDeduplicationId()).end("Attribute");
-            }
+            xml.elem("Body", msg.getBody());
+            writeSystemAttributesXml(xml, msg, requestedAttrs, senderId);
             if (msg.getMessageAttributes() != null && !msg.getMessageAttributes().isEmpty()) {
                 for (var entry : msg.getMessageAttributes().entrySet()) {
                     xml.start("MessageAttribute")

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -56,9 +56,37 @@ public class SqsQueryHandler {
             case "ListDeadLetterSourceQueues" -> handleListDeadLetterSourceQueues(params, region);
             case "StartMessageMoveTask" -> handleStartMessageMoveTask(params, region);
             case "ListMessageMoveTasks" -> handleListMessageMoveTasks(params, region);
+            case "AddPermission" -> handleAddPermission(params, region);
+            case "RemovePermission" -> handleRemovePermission(params, region);
             default -> AwsQueryResponse.error("UnsupportedOperation",
                     "Operation " + action + " is not supported by SQS.", AwsNamespaces.SQS, 400);
         };
+    }
+
+    private Response handleAddPermission(MultivaluedMap<String, String> params, String region) {
+        String queueUrl = getParam(params, "QueueUrl");
+        String label = getParam(params, "Label");
+        List<String> accountIds = collectIndexed(params, "AWSAccountId.");
+        List<String> actions = collectIndexed(params, "ActionName.");
+        sqsService.addPermission(queueUrl, label, accountIds, actions, region);
+        return Response.ok(AwsQueryResponse.envelopeNoResult("AddPermission", null)).build();
+    }
+
+    private Response handleRemovePermission(MultivaluedMap<String, String> params, String region) {
+        String queueUrl = getParam(params, "QueueUrl");
+        String label = getParam(params, "Label");
+        sqsService.removePermission(queueUrl, label, region);
+        return Response.ok(AwsQueryResponse.envelopeNoResult("RemovePermission", null)).build();
+    }
+
+    private List<String> collectIndexed(MultivaluedMap<String, String> params, String prefix) {
+        List<String> values = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String v = getParam(params, prefix + i);
+            if (v == null) break;
+            values.add(v);
+        }
+        return values;
     }
 
     private Response handleCreateQueue(MultivaluedMap<String, String> params, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -968,6 +968,17 @@ public class SqsService {
         return new java.util.LinkedHashMap<>(queue.getTags());
     }
 
+    /**
+     * SQS reports SenderId as the principal that called SendMessage. Floci
+     * has no per-call IAM context, so it falls back to the account that owns
+     * the queue (parsed from the queue URL when present, otherwise the
+     * configured default).
+     */
+    public String senderIdFor(String queueUrl) {
+        String fromUrl = accountFromQueueUrl(queueUrl);
+        return fromUrl != null ? fromUrl : regionResolver.getAccountId();
+    }
+
     private static String regionKey(String region, String queueUrl) {
         return region + "::" + extractQueuePath(queueUrl);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -406,10 +406,22 @@ public class SqsService {
             Instant previous = dedupMap.putIfAbsent(dedupId, expiry);
             persistDedup(storageKey);
             if (previous != null && Instant.now().isBefore(previous)) {
-                // Duplicate within window — return the original message idempotently
+                // Duplicate within window — keep the original messageId and
+                // sequenceNumber but compute response MD5s from this request's
+                // body and attributes, otherwise SDK clients (which validate
+                // MD5 against what they sent) reject the response.
                 Message existing = getOrCreateQueue(storageKey).findByDeduplicationId(dedupId);
                 if (existing != null) {
-                    return existing;
+                    Message response = new Message(body);
+                    response.setMessageId(existing.getMessageId());
+                    response.setMessageGroupId(messageGroupId);
+                    response.setMessageDeduplicationId(dedupId);
+                    response.setSequenceNumber(existing.getSequenceNumber());
+                    if (messageAttributes != null && !messageAttributes.isEmpty()) {
+                        response.getMessageAttributes().putAll(messageAttributes);
+                        response.updateMd5OfMessageAttributes();
+                    }
+                    return response;
                 }
             }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -11,6 +11,10 @@ import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.model.Message;
 import io.github.hectorvent.floci.services.sqs.model.Queue;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -788,6 +792,132 @@ public class SqsService {
         }
         queueStore.put(storageKey, queue);
         LOG.infov("Untagged queue: {0}", queueUrl);
+    }
+
+    private static final ObjectMapper POLICY_MAPPER = new ObjectMapper();
+
+    public void addPermission(String queueUrl, String label, List<String> awsAccountIds,
+                              List<String> actionNames, String region) {
+        if (label == null || label.isEmpty()) {
+            throw new AwsException("InvalidParameterValue", "Value for parameter Label is invalid.", 400);
+        }
+        if (awsAccountIds == null || awsAccountIds.isEmpty()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter AWSAccountIds.", 400);
+        }
+        if (actionNames == null || actionNames.isEmpty()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter Actions.", 400);
+        }
+
+        String storageKey = regionKey(region, queueUrl);
+        Queue queue = queueStore.get(storageKey)
+                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
+                        "The specified queue does not exist.", 400));
+
+        ObjectNode policy = parsePolicyOrEmpty(queue.getAttributes().get("Policy"));
+        ArrayNode statements = ensureStatementArray(policy);
+
+        for (JsonNode stmt : statements) {
+            if (label.equals(stmt.path("Sid").asText(null))) {
+                throw new AwsException("InvalidParameterValue",
+                        "Value " + label + " for parameter Label is invalid. " +
+                                "Reason: Already exists.", 400);
+            }
+        }
+
+        ObjectNode statement = POLICY_MAPPER.createObjectNode();
+        statement.put("Sid", label);
+        statement.put("Effect", "Allow");
+        ObjectNode principal = statement.putObject("Principal");
+        ArrayNode awsArns = principal.putArray("AWS");
+        for (String accountId : awsAccountIds) {
+            awsArns.add("arn:aws:iam::" + accountId + ":root");
+        }
+        ArrayNode actions = statement.putArray("Action");
+        for (String action : actionNames) {
+            actions.add("SQS:" + action);
+        }
+        statement.put("Resource", regionResolver.buildArn("sqs", region, queue.getQueueName()));
+        statements.add(statement);
+
+        queue.getAttributes().put("Policy", policy.toString());
+        queue.setLastModifiedTimestamp(Instant.now());
+        queueStore.put(storageKey, queue);
+        LOG.infov("Added permission {0} to queue {1}", label, queueUrl);
+    }
+
+    public void removePermission(String queueUrl, String label, String region) {
+        if (label == null || label.isEmpty()) {
+            throw new AwsException("InvalidParameterValue", "Value for parameter Label is invalid.", 400);
+        }
+
+        String storageKey = regionKey(region, queueUrl);
+        Queue queue = queueStore.get(storageKey)
+                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
+                        "The specified queue does not exist.", 400));
+
+        ObjectNode policy = parsePolicyOrEmpty(queue.getAttributes().get("Policy"));
+        ArrayNode statements = ensureStatementArray(policy);
+
+        int removeIndex = -1;
+        for (int i = 0; i < statements.size(); i++) {
+            if (label.equals(statements.get(i).path("Sid").asText(null))) {
+                removeIndex = i;
+                break;
+            }
+        }
+        if (removeIndex < 0) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value " + label + " for parameter Label is invalid. " +
+                            "Reason: can't find label on existing policy.", 400);
+        }
+        statements.remove(removeIndex);
+
+        if (statements.isEmpty()) {
+            queue.getAttributes().remove("Policy");
+        } else {
+            queue.getAttributes().put("Policy", policy.toString());
+        }
+        queue.setLastModifiedTimestamp(Instant.now());
+        queueStore.put(storageKey, queue);
+        LOG.infov("Removed permission {0} from queue {1}", label, queueUrl);
+    }
+
+    private static ObjectNode parsePolicyOrEmpty(String raw) {
+        if (raw == null || raw.isBlank()) {
+            ObjectNode policy = POLICY_MAPPER.createObjectNode();
+            policy.put("Version", "2012-10-17");
+            policy.putArray("Statement");
+            return policy;
+        }
+        try {
+            JsonNode parsed = POLICY_MAPPER.readTree(raw);
+            if (parsed instanceof ObjectNode obj) {
+                if (!obj.has("Version")) {
+                    obj.put("Version", "2012-10-17");
+                }
+                return obj;
+            }
+        } catch (Exception e) {
+            LOG.warnv("Failed to parse existing queue Policy; replacing with fresh document");
+        }
+        ObjectNode policy = POLICY_MAPPER.createObjectNode();
+        policy.put("Version", "2012-10-17");
+        policy.putArray("Statement");
+        return policy;
+    }
+
+    private static ArrayNode ensureStatementArray(ObjectNode policy) {
+        JsonNode existing = policy.get("Statement");
+        if (existing instanceof ArrayNode arr) {
+            return arr;
+        }
+        ArrayNode arr = policy.putArray("Statement");
+        if (existing instanceof ObjectNode singleStatement) {
+            arr.add(singleStatement);
+        }
+        return arr;
     }
 
     public Map<String, String> listQueueTags(String queueUrl, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -358,9 +358,12 @@ public class SqsService {
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
                         "The specified queue does not exist.", 400));
 
-        if (body.length() > maxMessageSize) {
+        int queueMaxMessageSize = parseMaxMessageSize(queue.getAttributes().get("MaximumMessageSize"));
+        int totalSize = computeMessageSize(body, messageAttributes);
+        if (totalSize > queueMaxMessageSize) {
             throw new AwsException("InvalidParameterValue",
-                    "Message body must be shorter than " + maxMessageSize + " bytes.", 400);
+                    "One or more parameters are invalid. " +
+                            "Reason: Message must be shorter than " + queueMaxMessageSize + " bytes.", 400);
         }
 
         int queueDelaySeconds = parseDelaySecondsAttribute(queue.getAttributes().get("DelaySeconds"));
@@ -447,6 +450,43 @@ public class SqsService {
         LOG.tracev("Sent message {0} to queue {1} body={2} attributes={3}",
                 message.getMessageId(), queueUrl, body, message.getMessageAttributes());
         return message;
+    }
+
+    private int parseMaxMessageSize(String value) {
+        if (value != null && !value.isEmpty()) {
+            try {
+                int parsed = Integer.parseInt(value);
+                if (parsed >= 1024 && parsed <= 1048576) {
+                    return parsed;
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return maxMessageSize;
+    }
+
+    /**
+     * Total wire-level message size, in bytes, matching AWS SQS accounting:
+     * UTF-8 body bytes + per-attribute (name UTF-8 + type UTF-8 + value bytes).
+     */
+    private static int computeMessageSize(String body, Map<String, MessageAttributeValue> attributes) {
+        int total = body == null ? 0 : body.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        if (attributes == null || attributes.isEmpty()) {
+            return total;
+        }
+        for (Map.Entry<String, MessageAttributeValue> entry : attributes.entrySet()) {
+            total += entry.getKey().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            MessageAttributeValue value = entry.getValue();
+            if (value.getDataType() != null) {
+                total += value.getDataType().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            }
+            if (value.getBinaryValue() != null) {
+                total += value.getBinaryValue().length;
+            } else if (value.getStringValue() != null) {
+                total += value.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            }
+        }
+        return total;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -17,6 +17,7 @@ public class Message {
     private String body;
     private Map<String, MessageAttributeValue> messageAttributes;
     private Instant sentTimestamp;
+    private Instant firstReceiveTimestamp;
     private int receiveCount;
     private String md5OfBody;
     private String md5OfMessageAttributes;
@@ -56,6 +57,9 @@ public class Message {
 
     public Instant getSentTimestamp() { return sentTimestamp; }
     public void setSentTimestamp(Instant sentTimestamp) { this.sentTimestamp = sentTimestamp; }
+
+    public Instant getFirstReceiveTimestamp() { return firstReceiveTimestamp; }
+    public void setFirstReceiveTimestamp(Instant firstReceiveTimestamp) { this.firstReceiveTimestamp = firstReceiveTimestamp; }
 
     public int getReceiveCount() { return receiveCount; }
     public void setReceiveCount(int receiveCount) { this.receiveCount = receiveCount; }

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -221,6 +221,41 @@ class SnsServiceTest {
     }
 
     @Test
+    void publish_messageExceedsSizeLimit_throwsInvalidParameterException() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String tooBig = "x".repeat(262_145);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publish(topic.getTopicArn(), null, tooBig, null, REGION));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertTrue(ex.getMessage().toLowerCase().contains("too long"));
+    }
+
+    @Test
+    void publish_messagePlusAttributesExceedsLimit_throws() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String body = "x".repeat(262_100);
+        Map<String, io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue> attrs = Map.of(
+                "longAttribute", new io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue(
+                        "y".repeat(200), "String"));
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publish(topic.getTopicArn(), null, null, body, null, attrs, REGION));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+    }
+
+    @Test
+    void publishBatch_totalSizeExceedsLimit_throwsBatchRequestTooLong() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String halfMeg = "x".repeat(130_000);
+        List<Map<String, Object>> entries = List.of(
+                Map.of("Id", "1", "Message", halfMeg),
+                Map.of("Id", "2", "Message", halfMeg),
+                Map.of("Id", "3", "Message", halfMeg));
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publishBatch(topic.getTopicArn(), entries, REGION));
+        assertEquals("BatchRequestTooLong", ex.getErrorCode());
+    }
+
+    @Test
     void subscriptionsConfirmed_countsCorrectly() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue1", REGION, Map.of());

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -167,7 +167,10 @@ class GuardedMessageQueueTest {
     // --- FIFO ---
 
     @Test
-    void fifoClaimRespectsGroupOrdering() {
+    void fifoClaimReturnsMultipleMessagesPerGroupWithinSingleCall() {
+        // AWS FIFO: a single ReceiveMessage may return multiple messages from
+        // the same MessageGroupId, preserving insertion order. The cross-call
+        // group lock applies only against future calls.
         Message g1m1 = new Message("g1-msg1");
         g1m1.setMessageGroupId("group1");
         Message g1m2 = new Message("g1-msg2");
@@ -179,13 +182,14 @@ class GuardedMessageQueueTest {
         queue.addMessage(g1m2);
         queue.addMessage(g2m1);
 
-        // Should get first from each group
         var first = queue.claimVisibleMessages(10, 30, true, -1, null);
-        assertEquals(2, first.claimed().size());
+        assertEquals(3, first.claimed().size(),
+                "Single FIFO ReceiveMessage should return all visible messages up to MaxNumberOfMessages");
         assertEquals("g1-msg1", first.claimed().get(0).getBody());
-        assertEquals("g2-msg1", first.claimed().get(1).getBody());
+        assertEquals("g1-msg2", first.claimed().get(1).getBody());
+        assertEquals("g2-msg1", first.claimed().get(2).getBody());
 
-        // Both groups blocked
+        // All groups now have in-flight messages — second call returns empty
         var second = queue.claimVisibleMessages(10, 30, true, -1, null);
         assertTrue(second.claimed().isEmpty());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
@@ -111,6 +111,7 @@ class SqsFifoIntegrationTest {
             .formParam("Action", "ReceiveMessage")
             .formParam("QueueUrl", queueUrl)
             .formParam("MaxNumberOfMessages", "10")
+            .formParam("AttributeName.1", "All")
         .when()
             .post("/")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -174,6 +174,38 @@ class SqsJsonProtocolTest {
 
     @Test
     @Order(7)
+    void receiveMessageOnEmptyQueueOmitsMessagesField() {
+        // AWS omits the Messages field entirely when no messages are available.
+        // The .NET SDK with InitializeCollections=false then leaves the
+        // response collection as null. Floci previously returned "Messages": []
+        // which broke parity tests asserting null.
+        String emptyQueueName = QUEUE_NAME + "-empty";
+        String createBody = "{\"QueueName\":\"" + emptyQueueName + "\"}";
+        String emptyQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body(createBody)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        String body = "{\"QueueUrl\":\"" + emptyQueueUrl + "\",\"MaxNumberOfMessages\":1}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body(body)
+        .when()
+            .post("/" + ACCOUNT_ID + "/" + emptyQueueName)
+        .then()
+            .statusCode(200)
+            .body("$", not(hasKey("Messages")));
+    }
+
+    @Test
+    @Order(8)
     void deleteQueueViaQueueUrlPath() {
         String body = "{\"QueueUrl\":\"" + queueUrl + "\"}";
 

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -174,6 +174,64 @@ class SqsJsonProtocolTest {
 
     @Test
     @Order(7)
+    void receiveMessage_messageSystemAttributeNamesFiltersOutput() {
+        String filterQueueName = QUEUE_NAME + "-filter";
+        String filterQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\":\"" + filterQueueName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\",\"MessageBody\":\"hi\"}")
+        .when().post("/").then().statusCode(200);
+
+        // Empty filter: no system attributes returned
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages", hasSize(1))
+            .body("Messages[0]", not(hasKey("Attributes")));
+
+        // Only SenderId requested: returns only SenderId
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[\"SenderId\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes", not(hasKey("SentTimestamp")))
+            .body("Messages[0].Attributes", not(hasKey("ApproximateReceiveCount")));
+
+        // All: returns SenderId, SentTimestamp, ApproximateReceiveCount,
+        // ApproximateFirstReceiveTimestamp
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[\"All\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes.SentTimestamp", notNullValue())
+            .body("Messages[0].Attributes.ApproximateReceiveCount", notNullValue())
+            .body("Messages[0].Attributes.ApproximateFirstReceiveTimestamp", notNullValue());
+    }
+
+    @Test
+    @Order(7)
     void receiveMessageOnEmptyQueueOmitsMessagesField() {
         // AWS omits the Messages field entirely when no messages are available.
         // The .NET SDK with InitializeCollections=false then leaves the

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsSdkMd5IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsSdkMd5IntegrationTest.java
@@ -1,0 +1,201 @@
+package io.github.hectorvent.floci.services.sqs;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Validates that the AWS SDK Java accepts the MD5OfMessageAttributes
+ * Floci returns for both standard and FIFO queues. The SDK validates
+ * MD5 client-side and throws when the response checksum doesn't match
+ * its own canonical recomputation, so a successful SendMessage is
+ * proof of wire-level MD5 parity.
+ */
+@QuarkusTest
+class SqsSdkMd5IntegrationTest {
+
+    @Inject
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    int testPort;
+
+    private SqsClient sqs;
+
+    @BeforeEach
+    void setUp() {
+        sqs = SqsClient.builder()
+                .endpointOverride(URI.create("http://localhost:" + testPort))
+                .region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("test", "test")))
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (sqs != null) {
+            sqs.close();
+        }
+    }
+
+    @Test
+    void standardQueue_sendMessageWithAttributes_sdkAcceptsMd5() {
+        String queueName = "md5-std-" + UUID.randomUUID();
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName).build()).queueUrl();
+
+        var attrs = Map.of(
+                "trace-id", MessageAttributeValue.builder()
+                        .dataType("String").stringValue("abc-123").build(),
+                "priority", MessageAttributeValue.builder()
+                        .dataType("Number").stringValue("42").build());
+
+        assertDoesNotThrow(() -> {
+            var resp = sqs.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .messageBody("hello standard")
+                    .messageAttributes(attrs)
+                    .build());
+            assertNotNull(resp.md5OfMessageAttributes());
+        });
+    }
+
+    @Test
+    void fifoQueue_sendMessageWithAttributes_sdkAcceptsMd5() {
+        String queueName = "md5-fifo-" + UUID.randomUUID() + ".fifo";
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName)
+                .attributes(Map.of(
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_QUEUE, "true",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true"))
+                .build()).queueUrl();
+
+        var attrs = Map.of(
+                "trace-id", MessageAttributeValue.builder()
+                        .dataType("String").stringValue("abc-123").build(),
+                "priority", MessageAttributeValue.builder()
+                        .dataType("Number").stringValue("42").build());
+
+        assertDoesNotThrow(() -> {
+            var resp = sqs.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .messageBody("hello fifo")
+                    .messageGroupId("g1")
+                    .messageAttributes(attrs)
+                    .build());
+            assertNotNull(resp.md5OfMessageAttributes());
+        });
+    }
+
+    @Test
+    void fifoQueue_dedupReplay_sdkAcceptsMd5OnSecondSend() {
+        // Within the 5-minute dedup window, a second SendMessage with the
+        // same MessageDeduplicationId must return MD5s computed from the
+        // CURRENT request body and attributes (not the original message's
+        // cached MD5s), otherwise the SDK throws MD5 mismatch when the two
+        // sends differ at all.
+        String queueName = "md5-dedup-" + UUID.randomUUID() + ".fifo";
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName)
+                .attributes(Map.of(
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_QUEUE, "true"))
+                .build()).queueUrl();
+
+        var firstAttrs = Map.of(
+                "k", MessageAttributeValue.builder().dataType("String").stringValue("v1").build());
+        var secondAttrs = Map.of(
+                "k", MessageAttributeValue.builder().dataType("String").stringValue("v2").build());
+
+        sqs.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl).messageBody("body-1").messageGroupId("g1")
+                .messageDeduplicationId("same-dedup")
+                .messageAttributes(firstAttrs).build());
+
+        // Duplicate within window with different attributes/body — SDK will
+        // throw "MD5 hash mismatch" if Floci returns the cached first MD5.
+        assertDoesNotThrow(() -> sqs.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl).messageBody("body-2").messageGroupId("g1")
+                .messageDeduplicationId("same-dedup")
+                .messageAttributes(secondAttrs).build()));
+    }
+
+    @Test
+    void fifoQueue_binaryAttribute_sdkAcceptsMd5() {
+        String queueName = "md5-fifo-bin-" + UUID.randomUUID() + ".fifo";
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName)
+                .attributes(Map.of(
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_QUEUE, "true",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true"))
+                .build()).queueUrl();
+
+        var attrs = Map.of(
+                "blob", MessageAttributeValue.builder()
+                        .dataType("Binary")
+                        .binaryValue(software.amazon.awssdk.core.SdkBytes.fromByteArray(new byte[]{1, 2, 3, 4, 5}))
+                        .build());
+
+        assertDoesNotThrow(() -> sqs.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl).messageBody("binary").messageGroupId("g1")
+                .messageAttributes(attrs).build()));
+    }
+
+    @Test
+    void fifoQueue_customTypeName_sdkAcceptsMd5() {
+        String queueName = "md5-fifo-custom-" + UUID.randomUUID() + ".fifo";
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName)
+                .attributes(Map.of(
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_QUEUE, "true",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true"))
+                .build()).queueUrl();
+
+        var attrs = Map.of(
+                "priority", MessageAttributeValue.builder()
+                        .dataType("Number.int").stringValue("42").build());
+
+        assertDoesNotThrow(() -> sqs.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl).messageBody("custom").messageGroupId("g1")
+                .messageAttributes(attrs).build()));
+    }
+
+    @Test
+    void highThroughputFifoQueue_sendMessageWithAttributes_sdkAcceptsMd5() {
+        String queueName = "md5-fair-" + UUID.randomUUID() + ".fifo";
+        String queueUrl = sqs.createQueue(CreateQueueRequest.builder()
+                .queueName(queueName)
+                .attributes(Map.of(
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_QUEUE, "true",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.CONTENT_BASED_DEDUPLICATION, "true",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.DEDUPLICATION_SCOPE, "messageGroup",
+                        software.amazon.awssdk.services.sqs.model.QueueAttributeName.FIFO_THROUGHPUT_LIMIT, "perMessageGroupId"))
+                .build()).queueUrl();
+
+        var attrs = Map.of(
+                "key", MessageAttributeValue.builder()
+                        .dataType("String").stringValue("value").build());
+
+        assertDoesNotThrow(() -> sqs.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody("hello fair")
+                .messageGroupId("g1")
+                .messageAttributes(attrs)
+                .build()));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.model.Message;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import io.github.hectorvent.floci.services.sqs.model.Queue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -437,6 +438,41 @@ class SqsServiceTest {
         service.purgeQueue(queue.getQueueUrl());
         assertTrue(dedupStore.keys().isEmpty(),
                 "Dedup store must be empty after purge with clearFifoDeduplicationCacheOnPurge=true");
+    }
+
+    @Test
+    void sendMessage_usesQueueMaximumMessageSizeAttribute() {
+        Queue queue = sqsService.createQueue("big-queue",
+                Map.of("MaximumMessageSize", "524288"));
+        String halfMeg = "x".repeat(300_000);
+
+        assertDoesNotThrow(() -> sqsService.sendMessage(queue.getQueueUrl(), halfMeg, 0),
+                "Body within the queue's MaximumMessageSize must be accepted");
+    }
+
+    @Test
+    void sendMessage_oversize_errorReportsQueueLimit() {
+        Queue queue = sqsService.createQueue("limited-queue",
+                Map.of("MaximumMessageSize", "2048"));
+        String oversized = "x".repeat(3000);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> sqsService.sendMessage(queue.getQueueUrl(), oversized, 0));
+        assertTrue(ex.getMessage().contains("2048"),
+                "Error message must reference the queue's configured MaximumMessageSize, got: " + ex.getMessage());
+    }
+
+    @Test
+    void sendMessage_attributesCountTowardsLimit() {
+        Queue queue = sqsService.createQueue("attr-limit-queue",
+                Map.of("MaximumMessageSize", "2048"));
+        String body = "x".repeat(2040);
+        Map<String, MessageAttributeValue> attrs = Map.of(
+                "key", new MessageAttributeValue("value", "String"));
+
+        // Body alone fits; body + attributes exceed the 2048 byte limit.
+        assertThrows(AwsException.class,
+                () -> sqsService.sendMessage(queue.getQueueUrl(), body, 0, null, null, attrs, "us-east-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -440,6 +440,84 @@ class SqsServiceTest {
     }
 
     @Test
+    void addPermission_appendsLabelledStatementToPolicy() {
+        Queue queue = sqsService.createQueue("perm-queue", null);
+        sqsService.addPermission(queue.getQueueUrl(), "share",
+                List.of("111122223333"), List.of("SendMessage", "ReceiveMessage"), "us-east-1");
+
+        String policy = sqsService.getQueueAttributes(queue.getQueueUrl(),
+                List.of("Policy"), "us-east-1").get("Policy");
+        assertNotNull(policy, "Policy attribute must be set after AddPermission");
+        assertTrue(policy.contains("\"Sid\":\"share\""));
+        assertTrue(policy.contains("arn:aws:iam::111122223333:root"));
+        assertTrue(policy.contains("SQS:SendMessage"));
+        assertTrue(policy.contains("SQS:ReceiveMessage"));
+    }
+
+    @Test
+    void addPermission_duplicateLabel_throws() {
+        Queue queue = sqsService.createQueue("perm-queue", null);
+        sqsService.addPermission(queue.getQueueUrl(), "share",
+                List.of("111122223333"), List.of("SendMessage"), "us-east-1");
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.addPermission(queue.getQueueUrl(), "share",
+                        List.of("444455556666"), List.of("ReceiveMessage"), "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void addPermission_queueDoesNotExist_throws() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.addPermission(BASE_URL + "/000000000000/missing", "share",
+                        List.of("111122223333"), List.of("SendMessage"), "us-east-1"));
+        assertEquals("AWS.SimpleQueueService.NonExistentQueue", ex.getErrorCode());
+    }
+
+    @Test
+    void removePermission_removesLabelledStatement() {
+        Queue queue = sqsService.createQueue("perm-queue", null);
+        sqsService.addPermission(queue.getQueueUrl(), "a",
+                List.of("111122223333"), List.of("SendMessage"), "us-east-1");
+        sqsService.addPermission(queue.getQueueUrl(), "b",
+                List.of("444455556666"), List.of("ReceiveMessage"), "us-east-1");
+
+        sqsService.removePermission(queue.getQueueUrl(), "a", "us-east-1");
+
+        String policy = sqsService.getQueueAttributes(queue.getQueueUrl(),
+                List.of("Policy"), "us-east-1").get("Policy");
+        assertNotNull(policy);
+        assertFalse(policy.contains("\"Sid\":\"a\""));
+        assertTrue(policy.contains("\"Sid\":\"b\""));
+    }
+
+    @Test
+    void removePermission_lastStatement_removesPolicyAttribute() {
+        Queue queue = sqsService.createQueue("perm-queue", null);
+        sqsService.addPermission(queue.getQueueUrl(), "only",
+                List.of("111122223333"), List.of("SendMessage"), "us-east-1");
+        sqsService.removePermission(queue.getQueueUrl(), "only", "us-east-1");
+
+        String policy = sqsService.getQueueAttributes(queue.getQueueUrl(),
+                List.of("Policy"), "us-east-1").get("Policy");
+        assertNull(policy, "Policy must be removed when last statement is dropped");
+    }
+
+    @Test
+    void removePermission_unknownLabel_throws() {
+        Queue queue = sqsService.createQueue("perm-queue", null);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.removePermission(queue.getQueueUrl(), "ghost", "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void removePermission_queueDoesNotExist_throws() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.removePermission(BASE_URL + "/000000000000/missing", "share", "us-east-1"));
+        assertEquals("AWS.SimpleQueueService.NonExistentQueue", ex.getErrorCode());
+    }
+
+    @Test
     void purgeQueueWithClearFifoDelegatesToSnsForFifoDedupOnSubscribedTopics() {
         final var sns = mock(SnsService.class);
         final var service = new SqsService(

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -277,27 +277,25 @@ class SqsServiceTest {
     }
 
     @Test
-    void fifoQueueReceiveRespectsGroupOrdering() {
+    void fifoQueueReceiveReturnsMultipleMessagesPerGroupInOrder() {
+        // AWS FIFO: a single ReceiveMessage call may return multiple messages
+        // from the same MessageGroupId (in order), up to MaxNumberOfMessages.
+        // The group lock only blocks subsequent ReceiveMessage calls.
         Queue queue = sqsService.createQueue("test.fifo", null);
         sqsService.sendMessage(queue.getQueueUrl(), "g1-msg1", 0, "group1", "d1");
         sqsService.sendMessage(queue.getQueueUrl(), "g1-msg2", 0, "group1", "d2");
         sqsService.sendMessage(queue.getQueueUrl(), "g2-msg1", 0, "group2", "d3");
 
-        // First receive: should get one message per group (first from each)
         List<Message> first = sqsService.receiveMessage(queue.getQueueUrl(), 10, 30, 0);
-        assertEquals(2, first.size());
+        assertEquals(3, first.size(),
+                "Single FIFO ReceiveMessage should drain all visible messages up to MaxNumberOfMessages");
         assertEquals("g1-msg1", first.get(0).getBody());
-        assertEquals("g2-msg1", first.get(1).getBody());
+        assertEquals("g1-msg2", first.get(1).getBody());
+        assertEquals("g2-msg1", first.get(2).getBody());
 
-        // Second receive: group1 and group2 both have in-flight messages, so nothing returned
+        // Both groups are now in-flight; second call returns empty.
         List<Message> second = sqsService.receiveMessage(queue.getQueueUrl(), 10, 30, 0);
         assertTrue(second.isEmpty());
-
-        // Delete the group1 message, then receive again — should get g1-msg2
-        sqsService.deleteMessage(queue.getQueueUrl(), first.get(0).getReceiptHandle());
-        List<Message> third = sqsService.receiveMessage(queue.getQueueUrl(), 10, 30, 0);
-        assertEquals(1, third.size());
-        assertEquals("g1-msg2", third.get(0).getBody());
     }
 
     @Test
@@ -438,6 +436,21 @@ class SqsServiceTest {
         service.purgeQueue(queue.getQueueUrl());
         assertTrue(dedupStore.keys().isEmpty(),
                 "Dedup store must be empty after purge with clearFifoDeduplicationCacheOnPurge=true");
+    }
+
+    @Test
+    void fifoQueue_groupLockBlocksAcrossCallsButNotWithin() {
+        Queue queue = sqsService.createQueue("group-lock.fifo", null);
+        for (int i = 1; i <= 5; i++) {
+            sqsService.sendMessage(queue.getQueueUrl(), "msg" + i, 0, "g1", "d" + i);
+        }
+
+        // First call drains all five from the single group.
+        List<Message> first = sqsService.receiveMessage(queue.getQueueUrl(), 10, 30, 0);
+        assertEquals(5, first.size());
+
+        // Second call returns nothing because g1 is in-flight.
+        assertTrue(sqsService.receiveMessage(queue.getQueueUrl(), 10, 30, 0).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the seven SQS/SNS conformance gaps from #768. Each fix is an independent commit so reviewers can read or revert them individually; happy to split into separate PRs if preferred.

| # | Section in #768 | Commit |
|---|---|---|
| 1 | §7 AddPermission / RemovePermission | `fix(sqs): implement AddPermission and RemovePermission` |
| 2 | §1 Empty `Messages` array | `fix(sqs): omit Messages field from empty ReceiveMessage JSON response` |
| 3 | §3 `SendMessage` size limit | `fix(sqs): honor MaximumMessageSize attribute on SendMessage` |
| 4 | §6 SNS Publish/PublishBatch size enforcement | `fix(sns): enforce message size limits on Publish and PublishBatch` |
| 5 | §2 `MessageSystemAttributeNames` filter | `fix(sqs): honor AttributeNames/MessageSystemAttributeNames on ReceiveMessage` |
| 6 | §5 FIFO/fair receive cap | `fix(sqs): FIFO ReceiveMessage returns multiple messages per group per call` |
| 7 | §4 FIFO MD5 mismatch | `fix(sqs): return MD5 of current request on FIFO dedup replay` |

The MD5 bug (§4) turned out to be a different root cause than the issue speculated. The canonical attribute encoding was already correct (verified against AWS SDK Java); the actual problem was the FIFO dedup-replay path returning the **original** message's cached MD5 instead of recomputing for the current request — so any second send within the dedup window with different body or attributes failed client-side MD5 validation. AWS itself recomputes MD5s on dedup replay while keeping the original `MessageId` / `SequenceNumber`; Floci now does the same.

## Test plan

- [x] `./mvnw test -Dtest='*Sqs*,*Sns*,EventBridgeFifoSqsIntegrationTest,PipesPollerIntegrationTest'` — 213 tests pass
- [x] New SDK-driven integration test (`SqsSdkMd5IntegrationTest`) using `software.amazon.awssdk:sqs` at test scope covers standard, FIFO, high-throughput FIFO, binary attributes, custom type names, and dedup-replay MD5 round-trips
- [x] New service- and protocol-level tests added for each fix (AddPermission/RemovePermission policy management, empty-queue Messages omission, MaximumMessageSize accounting incl. attributes, SNS Publish/PublishBatch size limits, SystemAttributeNames filtering, FIFO multi-per-group receive)
- [x] Two existing tests updated where they asserted previously buggy "one per group per call" FIFO semantics

## Notes

- New test-scope dependency: `software.amazon.awssdk:sqs` (managed by the existing AWS SDK BOM, so no version bump).
- A new `firstReceiveTimestamp` field was added to the `Message` model to back `ApproximateFirstReceiveTimestamp`. Pre-existing persisted queues will read it as `null` and emit the attribute only after the next receive — no migration needed.
- SenderId is derived from the account ID in the queue URL (falling back to the configured default), consistent with the per-account isolation introduced in #753.