### PR TITLE
fix(stepfunctions): honour TimeoutSeconds on Parallel state

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -829,9 +829,26 @@ public class AslExecutor {
             futures.add(executor.submit(() -> executeBranch(startAt, branchStates, capturedInput, sm, topLevelQueryLanguage, context)));
         }
 
+        int timeoutSeconds = stateDef.path("TimeoutSeconds").asInt(0);
+        long deadlineNanos = timeoutSeconds > 0
+                ? System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
+                : Long.MAX_VALUE;
+
         ArrayNode results = objectMapper.createArrayNode();
         for (Future<JsonNode> future : futures) {
-            results.add(future.get(60, TimeUnit.SECONDS));
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0) {
+                futures.forEach(f -> f.cancel(true));
+                throw new FailStateException("States.Timeout",
+                        "Parallel state timed out after " + timeoutSeconds + " seconds");
+            }
+            try {
+                results.add(future.get(remainingNanos, TimeUnit.NANOSECONDS));
+            } catch (java.util.concurrent.TimeoutException e) {
+                futures.forEach(f -> f.cancel(true));
+                throw new FailStateException("States.Timeout",
+                        "Parallel state timed out after " + timeoutSeconds + " seconds");
+            }
         }
 
         if (jsonata) {


### PR DESCRIPTION
## Summary

The `Parallel` state executor was using a hardcoded 60-second deadline per branch future instead of reading the optional `TimeoutSeconds` field from the state definition. This caused executions with long-running branches to fail prematurely, and ignored any `TimeoutSeconds` value set by the caller.

Closes — (no existing issue; opening alongside this PR)

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

AWS Step Functions supports a `TimeoutSeconds` field on the `Parallel` state (same as `Task`). When set, execution is terminated with `States.Timeout` if all branches do not complete within that duration. When absent, AWS imposes no timeout.

**Incorrect behavior:** a hardcoded 60 s `future.get(60, TimeUnit.SECONDS)` was applied per-future regardless of the state definition.  
**Correct behavior:** compute a single wall-clock deadline from `TimeoutSeconds` before collecting results, decrement it across futures, and cancel remaining branches + throw `States.Timeout` on expiry. When `TimeoutSeconds` is absent, futures are awaited without a deadline.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)