### PR TITLE
refactor: use HexFormat for digest encoding

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +52,8 @@ public class SnsService {
     private final String baseUrl;
     private final ObjectMapper objectMapper;
     private final Map<String, Instant> fifoDeduplicationCache = new ConcurrentHashMap<>();
-
+    private static final HexFormat HEX = HexFormat.of();
+    
     @Inject
     public SnsService(StorageFactory storageFactory, EmulatorConfig config,
                       RegionResolver regionResolver, SqsService sqsService,
@@ -768,13 +770,9 @@ public class SnsService {
 
     private static String sha256(String message) {
         try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
+        	MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] hash = md.digest(message.getBytes(StandardCharsets.UTF_8));
-            var sb = new StringBuilder();
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
+            return HEX.formatHex(hash);
         } catch (NoSuchAlgorithmException e) {
             return UUID.randomUUID().toString();
         }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -35,6 +35,7 @@ public class SqsService {
     private final ConcurrentHashMap<String, RedrivePolicy> redrivePolicyCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Instant>> deduplicationCache = new ConcurrentHashMap<>();
     private final AtomicLong sequenceCounter = new AtomicLong(0);
+    private static final HexFormat HEX = HexFormat.of();
 
     private record RedrivePolicy(int maxReceiveCount, String deadLetterTargetArn) {
     }
@@ -483,11 +484,7 @@ public class SqsService {
         try {
             var md = java.security.MessageDigest.getInstance("MD5");
             byte[] digest = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            var sb = new StringBuilder();
-            for (byte b : digest) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
+            return HEX.formatHex(digest);
         } catch (java.security.NoSuchAlgorithmException e) {
             return "";
         }


### PR DESCRIPTION
## Summary

Replaces manual byte-to-hex conversion using `StringBuilder` and `String.format("%02x", ...)` with the standard JDK `HexFormat` API.

This keeps the same lowercase/no-delimiter hex output while making the digest encoding code simpler and more readable.

## Why

Floci targets modern Java, so `HexFormat` is available and is a better fit for byte-to-hex conversion than manually formatting each byte.

## Testing

- [x] `./mvnw clean package -DskipTests`
- [x] `./mvnw test -Dtest=ApiGatewayAuthorizerContextIntegrationTest`
- [x] `./mvnw test`

Full test result:

```text
Tests run: 4118, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS