### PR TITLE
fix(sqs): omit Messages field from empty ReceiveMessage JSON response

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/pipes.bats
+++ b/compatibility-tests/sdk-test-awscli/test/pipes.bats
@@ -301,6 +301,6 @@ target_arn() {
     out=$(aws_cmd sqs receive-message \
         --queue-url "$TARGET_QUEUE_URL" \
         --max-number-of-messages 1)
-    msgs=$(echo "$out" | jq '.Messages // [] | length')
+    msgs=$(echo "${out:-"{}"}" | jq '.Messages // [] | length')
     [ "$msgs" = "0" ]
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -175,6 +175,12 @@ public class SqsJsonHandler {
                 visibilityTimeout, waitTimeSeconds, region);
 
         ObjectNode response = objectMapper.createObjectNode();
+        // Match AWS: omit the Messages field entirely when no messages are
+        // available, so SDK clients with InitializeCollections=false see null
+        // instead of an empty list.
+        if (messages.isEmpty()) {
+            return Response.ok(response).build();
+        }
         ArrayNode messagesArray = response.putArray("Messages");
         for (Message msg : messages) {
             ObjectNode msgNode = objectMapper.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -174,6 +174,38 @@ class SqsJsonProtocolTest {
 
     @Test
     @Order(7)
+    void receiveMessageOnEmptyQueueOmitsMessagesField() {
+        // AWS omits the Messages field entirely when no messages are available.
+        // The .NET SDK with InitializeCollections=false then leaves the
+        // response collection as null. Floci previously returned "Messages": []
+        // which broke parity tests asserting null.
+        String emptyQueueName = QUEUE_NAME + "-empty";
+        String createBody = "{\"QueueName\":\"" + emptyQueueName + "\"}";
+        String emptyQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body(createBody)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        String body = "{\"QueueUrl\":\"" + emptyQueueUrl + "\",\"MaxNumberOfMessages\":1}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body(body)
+        .when()
+            .post("/" + ACCOUNT_ID + "/" + emptyQueueName)
+        .then()
+            .statusCode(200)
+            .body("$", not(hasKey("Messages")));
+    }
+
+    @Test
+    @Order(8)
     void deleteQueueViaQueueUrlPath() {
         String body = "{\"QueueUrl\":\"" + queueUrl + "\"}";
 


### PR DESCRIPTION
Closes #773.

## Summary

Real AWS SQS omits the `Messages` field entirely from the `ReceiveMessage` JSON response when no messages are available. With the modern AWS SDK default `AWSConfigs.InitializeCollections = false`, the SDK leaves the collection as `null` in that case. Floci was emitting `"Messages": []`, so the SDK deserialized to a non-null empty list and broke parity tests asserting `null` (including the `StartMessageMoveTask*` family).

## Test plan

- [x] `./mvnw test -Dtest=SqsJsonProtocolTest` — new `receiveMessageOnEmptyQueueOmitsMessagesField` asserts `Messages` key is absent from the empty-queue response.
- [x] All other SQS/SNS tests pass (no behavior change for the non-empty case).