### PR TITLE
fix(sqs): honor MaximumMessageSize attribute on SendMessage

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -449,16 +449,14 @@ public class SqsService {
     }
 
     private int parseMaxMessageSize(String value) {
-        if (value != null && !value.isEmpty()) {
-            try {
-                int parsed = Integer.parseInt(value);
-                if (parsed >= 1024 && parsed <= 1048576) {
-                    return parsed;
-                }
-            } catch (NumberFormatException ignored) {
-            }
+        if (value == null || value.isEmpty()) {
+            return maxMessageSize;
         }
-        return maxMessageSize;
+        try {
+            return Math.min(1048576, Math.max(1024, Integer.parseInt(value)));
+        } catch (NumberFormatException ignored) {
+            return maxMessageSize;
+        }
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -354,9 +354,12 @@ public class SqsService {
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
                         "The specified queue does not exist.", 400));
 
-        if (body.length() > maxMessageSize) {
+        int queueMaxMessageSize = parseMaxMessageSize(queue.getAttributes().get("MaximumMessageSize"));
+        int totalSize = computeMessageSize(body, messageAttributes);
+        if (totalSize > queueMaxMessageSize) {
             throw new AwsException("InvalidParameterValue",
-                    "Message body must be shorter than " + maxMessageSize + " bytes.", 400);
+                    "One or more parameters are invalid. " +
+                            "Reason: Message must be shorter than " + queueMaxMessageSize + " bytes.", 400);
         }
 
         int queueDelaySeconds = parseDelaySecondsAttribute(queue.getAttributes().get("DelaySeconds"));
@@ -443,6 +446,43 @@ public class SqsService {
         LOG.tracev("Sent message {0} to queue {1} body={2} attributes={3}",
                 message.getMessageId(), queueUrl, body, message.getMessageAttributes());
         return message;
+    }
+
+    private int parseMaxMessageSize(String value) {
+        if (value != null && !value.isEmpty()) {
+            try {
+                int parsed = Integer.parseInt(value);
+                if (parsed >= 1024 && parsed <= 1048576) {
+                    return parsed;
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return maxMessageSize;
+    }
+
+    /**
+     * Total wire-level message size, in bytes, matching AWS SQS accounting:
+     * UTF-8 body bytes + per-attribute (name UTF-8 + type UTF-8 + value bytes).
+     */
+    private static int computeMessageSize(String body, Map<String, MessageAttributeValue> attributes) {
+        int total = body == null ? 0 : body.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+        if (attributes == null || attributes.isEmpty()) {
+            return total;
+        }
+        for (Map.Entry<String, MessageAttributeValue> entry : attributes.entrySet()) {
+            total += entry.getKey().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            MessageAttributeValue value = entry.getValue();
+            if (value.getDataType() != null) {
+                total += value.getDataType().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            }
+            if (value.getBinaryValue() != null) {
+                total += value.getBinaryValue().length;
+            } else if (value.getStringValue() != null) {
+                total += value.getStringValue().getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            }
+        }
+        return total;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -444,9 +444,9 @@ class SqsServiceTest {
     void sendMessage_usesQueueMaximumMessageSizeAttribute() {
         Queue queue = sqsService.createQueue("big-queue",
                 Map.of("MaximumMessageSize", "524288"));
-        String halfMeg = "x".repeat(300_000);
+        String body = "x".repeat(300_000);
 
-        assertDoesNotThrow(() -> sqsService.sendMessage(queue.getQueueUrl(), halfMeg, 0),
+        assertDoesNotThrow(() -> sqsService.sendMessage(queue.getQueueUrl(), body, 0),
                 "Body within the queue's MaximumMessageSize must be accepted");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.model.Message;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import io.github.hectorvent.floci.services.sqs.model.Queue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -437,6 +438,41 @@ class SqsServiceTest {
         service.purgeQueue(queue.getQueueUrl());
         assertTrue(dedupStore.keys().isEmpty(),
                 "Dedup store must be empty after purge with clearFifoDeduplicationCacheOnPurge=true");
+    }
+
+    @Test
+    void sendMessage_usesQueueMaximumMessageSizeAttribute() {
+        Queue queue = sqsService.createQueue("big-queue",
+                Map.of("MaximumMessageSize", "524288"));
+        String halfMeg = "x".repeat(300_000);
+
+        assertDoesNotThrow(() -> sqsService.sendMessage(queue.getQueueUrl(), halfMeg, 0),
+                "Body within the queue's MaximumMessageSize must be accepted");
+    }
+
+    @Test
+    void sendMessage_oversize_errorReportsQueueLimit() {
+        Queue queue = sqsService.createQueue("limited-queue",
+                Map.of("MaximumMessageSize", "2048"));
+        String oversized = "x".repeat(3000);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> sqsService.sendMessage(queue.getQueueUrl(), oversized, 0));
+        assertTrue(ex.getMessage().contains("2048"),
+                "Error message must reference the queue's configured MaximumMessageSize, got: " + ex.getMessage());
+    }
+
+    @Test
+    void sendMessage_attributesCountTowardsLimit() {
+        Queue queue = sqsService.createQueue("attr-limit-queue",
+                Map.of("MaximumMessageSize", "2048"));
+        String body = "x".repeat(2040);
+        Map<String, MessageAttributeValue> attrs = Map.of(
+                "key", new MessageAttributeValue("value", "String"));
+
+        // Body alone fits; body + attributes exceed the 2048 byte limit.
+        assertThrows(AwsException.class,
+                () -> sqsService.sendMessage(queue.getQueueUrl(), body, 0, null, null, attrs, "us-east-1"));
     }
 
     @Test


### PR DESCRIPTION
Closes #775.

## Summary

`SendMessage` previously enforced a hard-coded 256 KiB limit regardless of the queue's `MaximumMessageSize` attribute, and the error text always referenced 262144 bytes. Two behavioral problems:

- Queues created with `MaximumMessageSize=1048576` still rejected payloads over 256 KiB.
- The size check only inspected the message body (in chars), not body bytes plus message attribute name/type/value bytes — the formula AWS uses to compute total message size.

Both are now fixed: `SendMessage` reads the queue's `MaximumMessageSize` attribute (clamped to AWS's 1024..1048576 range), computes total size as UTF-8 body bytes + per-attribute (name + type + value) bytes, and reports the queue's configured limit in the error message.

## Test plan

- [x] `./mvnw test -Dtest=SqsServiceTest` — three new tests cover larger-than-default `MaximumMessageSize`, error message containing the queue's configured limit, and attributes counting toward the limit.