### PR TITLE
fix(sns): enforce message size limits on Publish and PublishBatch

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -228,10 +228,12 @@ public class SnsJsonHandler {
 
                 JsonNode attrsNode = entryNode.path("MessageAttributes");
                 if (attrsNode.isObject()) {
-                    Map<String, String> messageAttributes = new HashMap<>();
-                    attrsNode.fields().forEachRemaining(field ->
-                        messageAttributes.put(field.getKey(), field.getValue().path("StringValue").asText())
-                    );
+                    Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
+                    attrsNode.fields().forEachRemaining(field -> {
+                        String dataType = field.getValue().path("DataType").asText("String");
+                        String stringValue = field.getValue().path("StringValue").asText();
+                        messageAttributes.put(field.getKey(), new MessageAttributeValue(stringValue, dataType));
+                    });
                     entry.put("MessageAttributes", messageAttributes);
                 }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -40,6 +40,7 @@ public class SnsService {
 
     private static final Logger LOG = Logger.getLogger(SnsService.class);
     private static final Duration FIFO_DEDUP_WINDOW = Duration.ofMinutes(5);
+    private static final int MAX_PUBLISH_SIZE = 262_144;
     private static final List<String> PENDING_CONFIRMATION_PROTOCOLS =
             List.of("http", "https", "email", "email-json", "sms");
 
@@ -288,6 +289,12 @@ public class SnsService {
             throw new AwsException("InvalidParameter", "Message is required.", 400);
         }
 
+        int payloadSize = computePublishSize(message, subject, messageAttributes);
+        if (payloadSize > MAX_PUBLISH_SIZE) {
+            throw new AwsException("InvalidParameterException",
+                    "Invalid parameter: Message too long", 400);
+        }
+
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));
         String dedupId = messageDeduplicationId;
         if (isFifo) {
@@ -353,6 +360,21 @@ public class SnsService {
         String topicStoreKey = topicKey(region, topicArn);
         Topic topic = topicStore.get(topicStoreKey)
                 .orElseThrow(() -> new AwsException("NotFound", "Topic does not exist.", 404));
+
+        int batchSize = 0;
+        for (Map<String, Object> entry : entries) {
+            String message = (String) entry.get("Message");
+            String subject = (String) entry.get("Subject");
+            @SuppressWarnings("unchecked")
+            Map<String, MessageAttributeValue> attrs =
+                    (Map<String, MessageAttributeValue>) entry.get("MessageAttributes");
+            batchSize += computePublishSize(message, subject, attrs);
+        }
+        if (batchSize > MAX_PUBLISH_SIZE) {
+            throw new AwsException("BatchRequestTooLong",
+                    "Batch requests cannot be longer than " + MAX_PUBLISH_SIZE + " bytes.", 400);
+        }
+
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));
         List<String[]> successful = new ArrayList<>();
         List<String[]> failed = new ArrayList<>();
@@ -764,6 +786,32 @@ public class SnsService {
         if (arn.startsWith("http")) return arn;
         try { AwsArnUtils.parse(arn); } catch (IllegalArgumentException e) { return arn; }
         return AwsArnUtils.arnToQueueUrl(arn, baseUrl);
+    }
+
+    private static int computePublishSize(String message, String subject,
+                                          Map<String, MessageAttributeValue> attributes) {
+        int total = message == null ? 0 : message.getBytes(StandardCharsets.UTF_8).length;
+        if (subject != null) {
+            total += subject.getBytes(StandardCharsets.UTF_8).length;
+        }
+        if (attributes != null) {
+            for (Map.Entry<String, MessageAttributeValue> entry : attributes.entrySet()) {
+                total += entry.getKey().getBytes(StandardCharsets.UTF_8).length;
+                MessageAttributeValue value = entry.getValue();
+                if (value == null) {
+                    continue;
+                }
+                if (value.getDataType() != null) {
+                    total += value.getDataType().getBytes(StandardCharsets.UTF_8).length;
+                }
+                if (value.getBinaryValue() != null) {
+                    total += value.getBinaryValue().length;
+                } else if (value.getStringValue() != null) {
+                    total += value.getStringValue().getBytes(StandardCharsets.UTF_8).length;
+                }
+            }
+        }
+        return total;
     }
 
     private static String sha256(String message) {

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -272,6 +272,12 @@ public class SnsService {
     public String publish(String topicArn, String targetArn, String phoneNumber, String message,
                           String subject, Map<String, MessageAttributeValue> messageAttributes,
                           String messageGroupId, String messageDeduplicationId, String region) {
+        int payloadSize = computePublishSize(message, subject, messageAttributes);
+        if (payloadSize > MAX_PUBLISH_SIZE) {
+            throw new AwsException("InvalidParameterException",
+                    "Invalid parameter: Message too long", 400);
+        }
+
         // Send SMS
         if (phoneNumber != null) {
             return UUID.randomUUID().toString();
@@ -287,12 +293,6 @@ public class SnsService {
                 .orElseThrow(() -> new AwsException("NotFound", "Topic does not exist.", 404));
         if (message == null || message.isBlank()) {
             throw new AwsException("InvalidParameter", "Message is required.", 400);
-        }
-
-        int payloadSize = computePublishSize(message, subject, messageAttributes);
-        if (payloadSize > MAX_PUBLISH_SIZE) {
-            throw new AwsException("InvalidParameterException",
-                    "Invalid parameter: Message too long", 400);
         }
 
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -221,6 +221,41 @@ class SnsServiceTest {
     }
 
     @Test
+    void publish_messageExceedsSizeLimit_throwsInvalidParameterException() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String tooBig = "x".repeat(262_145);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publish(topic.getTopicArn(), null, tooBig, null, REGION));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertTrue(ex.getMessage().toLowerCase().contains("too long"));
+    }
+
+    @Test
+    void publish_messagePlusAttributesExceedsLimit_throws() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String body = "x".repeat(262_100);
+        Map<String, io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue> attrs = Map.of(
+                "longAttribute", new io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue(
+                        "y".repeat(200), "String"));
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publish(topic.getTopicArn(), null, null, body, null, attrs, REGION));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+    }
+
+    @Test
+    void publishBatch_totalSizeExceedsLimit_throwsBatchRequestTooLong() {
+        Topic topic = snsService.createTopic("size-topic", null, null, REGION);
+        String halfMeg = "x".repeat(130_000);
+        List<Map<String, Object>> entries = List.of(
+                Map.of("Id", "1", "Message", halfMeg),
+                Map.of("Id", "2", "Message", halfMeg),
+                Map.of("Id", "3", "Message", halfMeg));
+        AwsException ex = assertThrows(AwsException.class, () ->
+                snsService.publishBatch(topic.getTopicArn(), entries, REGION));
+        assertEquals("BatchRequestTooLong", ex.getErrorCode());
+    }
+
+    @Test
     void subscriptionsConfirmed_countsCorrectly() {
         Topic topic = snsService.createTopic("my-topic", null, null, REGION);
         snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue1", REGION, Map.of());


### PR DESCRIPTION
Closes #778.

## Summary

Real AWS SNS rejects oversized publish payloads:

- `Publish`: message + Subject + message attributes must not exceed 262144 bytes, otherwise `InvalidParameterException` with `Invalid parameter: Message too long`.
- `PublishBatch`: total bytes across all entries (message + Subject + attributes per entry) must not exceed 262144, otherwise `BatchRequestTooLong`.

Floci was silently accepting both, which broke the .NET conformance tests asserting these limits. Size accounting matches AWS: UTF-8 bytes for message and subject, plus per-attribute (name + type + value) bytes, with the binary-value byte length used directly for Binary attributes.

## Test plan

- [x] `./mvnw test -Dtest=SnsServiceTest` — three new tests cover the per-message limit, message + attributes combined limit, and per-batch limit (each asserts the correct error code).