### PR TITLE
fix(sqs): honor AttributeNames/MessageSystemAttributeNames on ReceiveMessage

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -86,6 +86,9 @@ class GuardedMessageQueue {
                              String deadLetterTargetArn, List<Message> claimed,
                              List<Message> dlqCandidates) {
         msg.setReceiveCount(msg.getReceiveCount() + 1);
+        if (msg.getFirstReceiveTimestamp() == null) {
+            msg.setFirstReceiveTimestamp(Instant.now());
+        }
 
         if (maxReceiveCount > 0 && deadLetterTargetArn != null
                 && msg.getReceiveCount() > maxReceiveCount) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -81,6 +81,42 @@ public class SqsJsonHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    private void writeSystemAttributesJson(ObjectNode msgNode, Message msg,
+                                           java.util.Set<String> requested, String senderId) {
+        if (requested.isEmpty()) {
+            return;
+        }
+        boolean all = requested.contains("All");
+        ObjectNode attrs = objectMapper.createObjectNode();
+        if ((all || requested.contains("SenderId")) && senderId != null) {
+            attrs.put("SenderId", senderId);
+        }
+        if (all || requested.contains("SentTimestamp")) {
+            attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
+        }
+        if (all || requested.contains("ApproximateReceiveCount")) {
+            attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
+        }
+        if ((all || requested.contains("ApproximateFirstReceiveTimestamp"))
+                && msg.getFirstReceiveTimestamp() != null) {
+            attrs.put("ApproximateFirstReceiveTimestamp",
+                    String.valueOf(msg.getFirstReceiveTimestamp().toEpochMilli()));
+        }
+        if (msg.getMessageGroupId() != null && (all || requested.contains("MessageGroupId"))) {
+            attrs.put("MessageGroupId", msg.getMessageGroupId());
+        }
+        if (msg.getSequenceNumber() > 0 && (all || requested.contains("SequenceNumber"))) {
+            attrs.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
+        }
+        if (msg.getMessageDeduplicationId() != null
+                && (all || requested.contains("MessageDeduplicationId"))) {
+            attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
+        }
+        if (!attrs.isEmpty()) {
+            msgNode.set("Attributes", attrs);
+        }
+    }
+
     private List<String> jsonNodeToList(JsonNode node) {
         List<String> values = new ArrayList<>();
         if (node != null && node.isArray()) {
@@ -199,8 +235,13 @@ public class SqsJsonHandler {
         int visibilityTimeout = request.path("VisibilityTimeout").asInt(-1);
         int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(0);
 
+        java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
+        requestedAttrs.addAll(jsonNodeToList(request.path("AttributeNames")));
+        requestedAttrs.addAll(jsonNodeToList(request.path("MessageSystemAttributeNames")));
+
         List<Message> messages = sqsService.receiveMessage(queueUrl, maxMessages,
                 visibilityTimeout, waitTimeSeconds, region);
+        String senderId = sqsService.senderIdFor(queueUrl);
 
         ObjectNode response = objectMapper.createObjectNode();
         // Match AWS: omit the Messages field entirely when no messages are
@@ -220,18 +261,7 @@ public class SqsJsonHandler {
             }
             msgNode.put("Body", msg.getBody());
 
-            ObjectNode attrs = msgNode.putObject("Attributes");
-            attrs.put("ApproximateReceiveCount", String.valueOf(msg.getReceiveCount()));
-            attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
-            if (msg.getMessageGroupId() != null) {
-                attrs.put("MessageGroupId", msg.getMessageGroupId());
-            }
-            if (msg.getSequenceNumber() > 0) {
-                attrs.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
-            }
-            if (msg.getMessageDeduplicationId() != null) {
-                attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
-            }
+            writeSystemAttributesJson(msgNode, msg, requestedAttrs, senderId);
 
             if (msg.getMessageAttributes() != null && !msg.getMessageAttributes().isEmpty()) {
                 ObjectNode msgAttrs = msgNode.putObject("MessageAttributes");

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -79,6 +79,46 @@ public class SqsQueryHandler {
         return Response.ok(AwsQueryResponse.envelopeNoResult("RemovePermission", null)).build();
     }
 
+    private static void writeSystemAttributesXml(XmlBuilder xml, Message msg,
+                                                 java.util.Set<String> requested, String senderId) {
+        if (requested.isEmpty()) {
+            return;
+        }
+        boolean all = requested.contains("All");
+        if (all || requested.contains("SenderId")) {
+            if (senderId != null) {
+                xml.start("Attribute").elem("Name", "SenderId")
+                        .elem("Value", senderId).end("Attribute");
+            }
+        }
+        if (all || requested.contains("SentTimestamp")) {
+            xml.start("Attribute").elem("Name", "SentTimestamp")
+                    .elem("Value", String.valueOf(msg.getSentTimestamp().toEpochMilli())).end("Attribute");
+        }
+        if (all || requested.contains("ApproximateReceiveCount")) {
+            xml.start("Attribute").elem("Name", "ApproximateReceiveCount")
+                    .elem("Value", String.valueOf(msg.getReceiveCount())).end("Attribute");
+        }
+        if (all || requested.contains("ApproximateFirstReceiveTimestamp")) {
+            if (msg.getFirstReceiveTimestamp() != null) {
+                xml.start("Attribute").elem("Name", "ApproximateFirstReceiveTimestamp")
+                        .elem("Value", String.valueOf(msg.getFirstReceiveTimestamp().toEpochMilli())).end("Attribute");
+            }
+        }
+        if (msg.getMessageGroupId() != null && (all || requested.contains("MessageGroupId"))) {
+            xml.start("Attribute").elem("Name", "MessageGroupId")
+                    .elem("Value", msg.getMessageGroupId()).end("Attribute");
+        }
+        if (msg.getSequenceNumber() > 0 && (all || requested.contains("SequenceNumber"))) {
+            xml.start("Attribute").elem("Name", "SequenceNumber")
+                    .elem("Value", String.valueOf(msg.getSequenceNumber())).end("Attribute");
+        }
+        if (msg.getMessageDeduplicationId() != null && (all || requested.contains("MessageDeduplicationId"))) {
+            xml.start("Attribute").elem("Name", "MessageDeduplicationId")
+                    .elem("Value", msg.getMessageDeduplicationId()).end("Attribute");
+        }
+    }
+
     private List<String> collectIndexed(MultivaluedMap<String, String> params, String prefix) {
         List<String> values = new ArrayList<>();
         for (int i = 1; ; i++) {
@@ -192,7 +232,12 @@ public class SqsQueryHandler {
         int visibilityTimeout = getIntParam(params, "VisibilityTimeout", -1);
         int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", 0);
 
+        java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
+        requestedAttrs.addAll(collectIndexed(params, "AttributeName."));
+        requestedAttrs.addAll(collectIndexed(params, "MessageSystemAttributeName."));
+
         List<Message> messages = sqsService.receiveMessage(queueUrl, maxMessages, visibilityTimeout, waitTimeSeconds, region);
+        String senderId = sqsService.senderIdFor(queueUrl);
 
         var xml = new XmlBuilder();
         for (Message msg : messages) {
@@ -203,23 +248,8 @@ public class SqsQueryHandler {
             if (msg.getMd5OfMessageAttributes() != null) {
                 xml.elem("MD5OfMessageAttributes", msg.getMd5OfMessageAttributes());
             }
-            xml.elem("Body", msg.getBody())
-               .start("Attribute").elem("Name", "ApproximateReceiveCount")
-                 .elem("Value", String.valueOf(msg.getReceiveCount())).end("Attribute")
-               .start("Attribute").elem("Name", "SentTimestamp")
-                 .elem("Value", String.valueOf(msg.getSentTimestamp().toEpochMilli())).end("Attribute");
-            if (msg.getMessageGroupId() != null) {
-                xml.start("Attribute").elem("Name", "MessageGroupId")
-                   .elem("Value", msg.getMessageGroupId()).end("Attribute");
-            }
-            if (msg.getSequenceNumber() > 0) {
-                xml.start("Attribute").elem("Name", "SequenceNumber")
-                   .elem("Value", String.valueOf(msg.getSequenceNumber())).end("Attribute");
-            }
-            if (msg.getMessageDeduplicationId() != null) {
-                xml.start("Attribute").elem("Name", "MessageDeduplicationId")
-                   .elem("Value", msg.getMessageDeduplicationId()).end("Attribute");
-            }
+            xml.elem("Body", msg.getBody());
+            writeSystemAttributesXml(xml, msg, requestedAttrs, senderId);
             if (msg.getMessageAttributes() != null && !msg.getMessageAttributes().isEmpty()) {
                 for (var entry : msg.getMessageAttributes().entrySet()) {
                     xml.start("MessageAttribute")

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -975,6 +975,17 @@ public class SqsService {
         return new java.util.LinkedHashMap<>(queue.getTags());
     }
 
+    /**
+     * SQS reports SenderId as the principal that called SendMessage. Floci
+     * has no per-call IAM context, so it falls back to the account that owns
+     * the queue (parsed from the queue URL when present, otherwise the
+     * configured default).
+     */
+    public String senderIdFor(String queueUrl) {
+        String fromUrl = accountFromQueueUrl(queueUrl);
+        return fromUrl != null ? fromUrl : regionResolver.getAccountId();
+    }
+
     private static String regionKey(String region, String queueUrl) {
         return region + "::" + extractQueuePath(queueUrl);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -978,8 +978,9 @@ public class SqsService {
     /**
      * SQS reports SenderId as the principal that called SendMessage. Floci
      * has no per-call IAM context, so it falls back to the account that owns
-     * the queue (parsed from the queue URL when present, otherwise the
-     * configured default).
+     * the queue (parsed from the queue URL when present), otherwise the
+     * account from the current request context, otherwise the configured
+     * default account.
      */
     public String senderIdFor(String queueUrl) {
         String fromUrl = accountFromQueueUrl(queueUrl);

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -17,6 +17,7 @@ public class Message {
     private String body;
     private Map<String, MessageAttributeValue> messageAttributes;
     private Instant sentTimestamp;
+    private Instant firstReceiveTimestamp;
     private int receiveCount;
     private String md5OfBody;
     private String md5OfMessageAttributes;
@@ -56,6 +57,9 @@ public class Message {
 
     public Instant getSentTimestamp() { return sentTimestamp; }
     public void setSentTimestamp(Instant sentTimestamp) { this.sentTimestamp = sentTimestamp; }
+
+    public Instant getFirstReceiveTimestamp() { return firstReceiveTimestamp; }
+    public void setFirstReceiveTimestamp(Instant firstReceiveTimestamp) { this.firstReceiveTimestamp = firstReceiveTimestamp; }
 
     public int getReceiveCount() { return receiveCount; }
     public void setReceiveCount(int receiveCount) { this.receiveCount = receiveCount; }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
@@ -111,6 +111,7 @@ class SqsFifoIntegrationTest {
             .formParam("Action", "ReceiveMessage")
             .formParam("QueueUrl", queueUrl)
             .formParam("MaxNumberOfMessages", "10")
+            .formParam("AttributeName.1", "All")
         .when()
             .post("/")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -468,4 +468,68 @@ class SqsIntegrationTest {
             .body(containsString("QueueDoesNotExist"))
             .body(not(containsString("AWS.SimpleQueueService.NonExistentQueue")));
     }
+
+    @Test
+    void receiveMessage_queryProtocol_attributeNameFiltersSystemAttributes() {
+        String filterQueueName = "query-attr-filter-queue";
+        String filterQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", filterQueueName)
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "SendMessage")
+                .formParam("QueueUrl", filterQueueUrl)
+                .formParam("MessageBody", "hi")
+            .when().post("/").then().statusCode(200);
+
+            // No AttributeName.N requested: response must contain no <Attribute> entries
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", filterQueueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+                .formParam("VisibilityTimeout", "0")
+            .when().post("/").then().statusCode(200)
+                .body(containsString("<Message>"))
+                .body(not(containsString("<Attribute>")));
+
+            // AttributeName.1=SenderId: only SenderId present, no SentTimestamp / ApproximateReceiveCount
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", filterQueueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+                .formParam("VisibilityTimeout", "0")
+                .formParam("AttributeName.1", "SenderId")
+            .when().post("/").then().statusCode(200)
+                .body(containsString("<Name>SenderId</Name>"))
+                .body(not(containsString("<Name>SentTimestamp</Name>")))
+                .body(not(containsString("<Name>ApproximateReceiveCount</Name>")));
+
+            // MessageSystemAttributeName.1=All: full system-attribute set returned
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", filterQueueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+                .formParam("VisibilityTimeout", "0")
+                .formParam("MessageSystemAttributeName.1", "All")
+            .when().post("/").then().statusCode(200)
+                .body(containsString("<Name>SenderId</Name>"))
+                .body(containsString("<Name>SentTimestamp</Name>"))
+                .body(containsString("<Name>ApproximateReceiveCount</Name>"))
+                .body(containsString("<Name>ApproximateFirstReceiveTimestamp</Name>"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", filterQueueUrl)
+            .when().post("/");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -260,6 +260,33 @@ class SqsJsonProtocolTest {
             .body("Messages[0].Attributes.SentTimestamp", notNullValue())
             .body("Messages[0].Attributes.ApproximateReceiveCount", notNullValue())
             .body("Messages[0].Attributes.ApproximateFirstReceiveTimestamp", notNullValue());
+
+        // Legacy AttributeNames parameter (pre-2023 SDKs): SenderId-only filter
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"AttributeNames\":[\"SenderId\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes", not(hasKey("SentTimestamp")))
+            .body("Messages[0].Attributes", not(hasKey("ApproximateReceiveCount")));
+
+        // Legacy AttributeNames=["All"]: same expansion as MessageSystemAttributeNames
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"AttributeNames\":[\"All\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes.SentTimestamp", notNullValue())
+            .body("Messages[0].Attributes.ApproximateReceiveCount", notNullValue())
+            .body("Messages[0].Attributes.ApproximateFirstReceiveTimestamp", notNullValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -205,6 +205,64 @@ class SqsJsonProtocolTest {
     }
 
     @Test
+    @Order(7)
+    void receiveMessage_messageSystemAttributeNamesFiltersOutput() {
+        String filterQueueName = QUEUE_NAME + "-filter";
+        String filterQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\":\"" + filterQueueName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\",\"MessageBody\":\"hi\"}")
+        .when().post("/").then().statusCode(200);
+
+        // Empty filter: no system attributes returned
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages", hasSize(1))
+            .body("Messages[0]", not(hasKey("Attributes")));
+
+        // Only SenderId requested: returns only SenderId
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[\"SenderId\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes", not(hasKey("SentTimestamp")))
+            .body("Messages[0].Attributes", not(hasKey("ApproximateReceiveCount")));
+
+        // All: returns SenderId, SentTimestamp, ApproximateReceiveCount,
+        // ApproximateFirstReceiveTimestamp
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + filterQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[\"All\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.SenderId", equalTo(ACCOUNT_ID))
+            .body("Messages[0].Attributes.SentTimestamp", notNullValue())
+            .body("Messages[0].Attributes.ApproximateReceiveCount", notNullValue())
+            .body("Messages[0].Attributes.ApproximateFirstReceiveTimestamp", notNullValue());
+    }
+
+    @Test
     @Order(8)
     void deleteQueueViaQueueUrlPath() {
         String body = "{\"QueueUrl\":\"" + queueUrl + "\"}";


### PR DESCRIPTION
Closes #774.

## Summary

`ReceiveMessage` previously emitted a fixed set of system attributes (`ApproximateReceiveCount`, `SentTimestamp`, plus FIFO fields when present) regardless of what the caller asked for. AWS instead returns exactly the attributes the request selects:

- empty list → no system attributes
- `["SenderId"]` → only `SenderId`
- `["All"]` → `SenderId`, `SentTimestamp`, `ApproximateReceiveCount`, `ApproximateFirstReceiveTimestamp` (and FIFO `MessageGroupId`, `SequenceNumber`, `MessageDeduplicationId` when applicable)

Both the legacy `AttributeName.N` / `AttributeNames` parameter and the modern `MessageSystemAttributeName.N` / `MessageSystemAttributeNames` parameter are honored.

`SenderId` derives from the account ID parsed from the queue URL (falling back to the configured default account), matching the multi-tenancy isolation introduced in #753. A new `firstReceiveTimestamp` field on `Message` backs `ApproximateFirstReceiveTimestamp` and is set on first claim.

## Test plan

- [x] `./mvnw test -Dtest=SqsJsonProtocolTest` — new `receiveMessage_messageSystemAttributeNamesFiltersOutput` covers empty filter, single-name filter, and `All`.
- [x] Existing FIFO integration test updated to pass `AttributeName.1=All` where it previously relied on the unfiltered default.