### PR TITLE
fix(cloudformation): preserve Targets[].SqsParameters on AWS::Events::Rule

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
+import io.github.hectorvent.floci.services.eventbridge.model.SqsParameters;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
@@ -1176,7 +1177,17 @@ public class CloudFormationResourceProvisioner {
                 String input = resolved.path("Input").asText(null);
                 String inputPath = resolved.path("InputPath").asText(null);
                 if (targetId != null && targetArn != null) {
-                    targets.add(new Target(targetId, targetArn, input, inputPath));
+                    Target target = new Target(targetId, targetArn, input, inputPath);
+                    JsonNode sqsParamsNode = resolved.path("SqsParameters");
+                    if (!sqsParamsNode.isMissingNode() && sqsParamsNode.isObject()) {
+                        String messageGroupId = sqsParamsNode.path("MessageGroupId").asText(null);
+                        if (messageGroupId != null) {
+                            SqsParameters sqsParameters = new SqsParameters();
+                            sqsParameters.setMessageGroupId(messageGroupId);
+                            target.setSqsParameters(sqsParameters);
+                        }
+                    }
+                    targets.add(target);
                 }
             }
             if (!targets.isEmpty()) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -2224,6 +2224,363 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_withEventBridgeRule_preservesSqsParametersMessageGroupId() {
+        // Regression test for issue #787: CFN provisioner dropped Targets[].SqsParameters,
+        // making FIFO SQS delivery fail with "The request must contain the parameter MessageGroupId".
+        // The same target works when registered via direct events PutTargets, proving the
+        // EventBridge API path supports the field — only the CFN translator was missing it.
+        String template = """
+            {
+              "Resources": {
+                "FifoQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-eb-fifo-target.fifo",
+                    "FifoQueue": true,
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "FifoRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-fifo-rule",
+                    "EventPattern": {
+                      "source": ["cfn.fifo.test"]
+                    },
+                    "Targets": [
+                      {
+                        "Id": "FifoQueueTarget",
+                        "Arn": {"Fn::GetAtt": ["FifoQueue", "Arn"]},
+                        "SqsParameters": {"MessageGroupId": "group-1"}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-fifo-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eb-fifo-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-eb-fifo-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets[0].Id", equalTo("FifoQueueTarget"))
+            .body("Targets[0].Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:cfn-eb-fifo-target.fifo"))
+            .body("Targets[0].SqsParameters.MessageGroupId", equalTo("group-1"));
+    }
+
+    @Test
+    void createStack_withEventBridgeRule_fifoDeliveryEndToEnd() {
+        // Functional regression for issue #787: not only must the field round-trip
+        // through ListTargetsByRule, an event published via PutEvents must actually
+        // be delivered to the FIFO queue. Without MessageGroupId, SQS rejects with
+        // "The request must contain the parameter MessageGroupId" and the message
+        // never lands. We verify delivery + that MessageGroupId surfaces on the
+        // received SQS attribute.
+        String template = """
+            {
+              "Resources": {
+                "FifoQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-eb-fifo-e2e.fifo",
+                    "FifoQueue": true,
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "FifoRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-fifo-e2e-rule",
+                    "EventPattern": {
+                      "source": ["cfn.fifo.e2e"]
+                    },
+                    "Targets": [
+                      {
+                        "Id": "FifoQueueTarget",
+                        "Arn": {"Fn::GetAtt": ["FifoQueue", "Arn"]},
+                        "SqsParameters": {"MessageGroupId": "e2e-group"}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-fifo-e2e-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Match the issue #787 reproducer: re-apply ContentBasedDeduplication via
+        // SetQueueAttributes to control for a separate Floci CFN→SQS bug where
+        // FIFO queue attributes do not always propagate from the template. This
+        // test focuses solely on the EventBridge target SqsParameters wiring.
+        String queueUrl = "http://localhost:4566/000000000000/cfn-eb-fifo-e2e.fifo";
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SetQueueAttributes")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("Attribute.1.Name", "ContentBasedDeduplication")
+            .formParam("Attribute.1.Value", "true")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.PutEvents")
+            .body("""
+                {
+                  "Entries": [
+                    {
+                      "Source": "cfn.fifo.e2e",
+                      "DetailType": "poc",
+                      "Detail": "{\\"marker\\":\\"cfn-fifo-e2e\\"}"
+                    }
+                  ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("FailedEntryCount", equalTo(0));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+            .formParam("WaitTimeSeconds", "1")
+            .formParam("AttributeName.1", "All")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Body>"))
+            .body(containsString("cfn-fifo-e2e"))
+            .body(containsString("<Name>MessageGroupId</Name>"))
+            .body(containsString("<Value>e2e-group</Value>"));
+    }
+
+    @Test
+    void createStack_withEventBridgeRule_targetWithoutSqsParameters_omitsField() {
+        // Backwards-compat: targets that have no SqsParameters in the CFN template
+        // must NOT acquire one in the materialised target. Real AWS omits the field
+        // entirely from ListTargetsByRule when none was supplied at PutTargets time;
+        // we mirror that to avoid SDK clients seeing a phantom (null) container.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "cfn-eb-no-sqs-params-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "PlainRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-no-sqs-params-rule",
+                    "EventPattern": {"source": ["cfn.no.sqs.params"]},
+                    "Targets": [
+                      {
+                        "Id": "PlainTarget",
+                        "Arn": "arn:aws:sqs:us-east-1:000000000000:cfn-eb-no-sqs-params-queue"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-no-sqs-params-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-eb-no-sqs-params-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets[0].Id", equalTo("PlainTarget"))
+            .body("Targets[0].SqsParameters", nullValue());
+    }
+
+    @Test
+    void createStack_withEventBridgeRule_emptySqsParametersBlock_isIgnored() {
+        // Edge case mirroring the direct PutTargets handler (EventBridgeHandler line 211-219):
+        // an SqsParameters object that is present but does not carry a MessageGroupId
+        // produces NO SqsParameters on the target. We do not coerce empty input into a
+        // half-populated object — that would mask user mistakes.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "cfn-eb-empty-sqs-params-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "EmptyParamsRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-empty-sqs-params-rule",
+                    "EventPattern": {"source": ["cfn.empty.sqs.params"]},
+                    "Targets": [
+                      {
+                        "Id": "EmptyParamsTarget",
+                        "Arn": "arn:aws:sqs:us-east-1:000000000000:cfn-eb-empty-sqs-params-queue",
+                        "SqsParameters": {}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-empty-sqs-params-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-eb-empty-sqs-params-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets[0].Id", equalTo("EmptyParamsTarget"))
+            .body("Targets[0].SqsParameters", nullValue());
+    }
+
+    @Test
+    void createStack_withEventBridgeRule_mixedTargets_preservesPerTargetSqsParameters() {
+        // Reviewer-defence test: a single rule with two FIFO targets — only one carrying
+        // SqsParameters — must keep them on the right target and leave the other untouched.
+        // Catches future regressions where the field would leak across iterations of the
+        // Targets[] loop (e.g. via a hoisted local variable).
+        String template = """
+            {
+              "Resources": {
+                "QueueA": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-eb-mixed-a.fifo",
+                    "FifoQueue": true,
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "QueueB": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-eb-mixed-b.fifo",
+                    "FifoQueue": true,
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "MixedRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-eb-mixed-rule",
+                    "EventPattern": {"source": ["cfn.mixed.targets"]},
+                    "Targets": [
+                      {
+                        "Id": "TargetWithGroup",
+                        "Arn": {"Fn::GetAtt": ["QueueA", "Arn"]},
+                        "SqsParameters": {"MessageGroupId": "group-A"}
+                      },
+                      {
+                        "Id": "TargetWithoutGroup",
+                        "Arn": {"Fn::GetAtt": ["QueueB", "Arn"]}
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eb-mixed-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-eb-mixed-rule\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Targets.find { it.Id == 'TargetWithGroup' }.SqsParameters.MessageGroupId", equalTo("group-A"))
+            .body("Targets.find { it.Id == 'TargetWithoutGroup' }.SqsParameters", nullValue());
+    }
+
+    @Test
     void createStack_dependencyOrdering_refBeforeTarget() {
         String template = """
             {


### PR DESCRIPTION
## Summary

Fixes #787.

`CloudFormationResourceProvisioner.provisionEventBridgeRule` only read `Id`, `Arn`, `Input`, and `InputPath` from each target node, dropping `SqsParameters`. As a result, CloudFormation-managed EventBridge targets pointing at FIFO SQS queues lost their `MessageGroupId` and SQS rejected delivery with:

> `The request must contain the parameter MessageGroupId.`

The direct `events:PutTargets` API path already parses `SqsParameters.MessageGroupId` (`EventBridgeHandler.java:211-219`) and `EventBridgeInvoker` already uses it to set the SQS `MessageGroupId` on delivery (`EventBridgeInvoker.java:62-64`). Only the CFN translator was out of sync. The fix mirrors the existing handler's logic so CFN-managed targets behave identically to direct ones — same code shape, same null-safety, same opt-in semantics.

**Reproduces with** (from issue #787):

```text
cloudFormationTargetHasMessageGroupId: false
cloudFormationDelivered:               false
directPutTargetsHasMessageGroupId:     true
directPutTargetsDelivered:             true
```

After the fix, the CFN-materialised target carries `SqsParameters.MessageGroupId` and FIFO delivery succeeds end-to-end.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

`AWS::Events::Rule.Targets[].SqsParameters` is part of the public CloudFormation schema for EventBridge rules. Real AWS exposes it on `events:ListTargetsByRule` after the stack creates and forwards the `MessageGroupId` to FIFO SQS targets. Floci already supported the field through the direct `events:PutTargets` path; this PR closes the gap for CloudFormation-driven flows so the AWS SDK / AWS CLI behave identically against Floci regardless of how the target was registered.

## Checklist

- [x] `./mvnw test` passes locally (CFN suite: 57/57; targeted CFN + EventBridge + SqsFifo run: 183/183)
- [x] New or updated integration test added — five regression tests in `CloudFormationIntegrationTest`:
    - `createStack_withEventBridgeRule_preservesSqsParametersMessageGroupId` — round-trip via `ListTargetsByRule`
    - `createStack_withEventBridgeRule_fifoDeliveryEndToEnd` — full `PutEvents` → SQS receive, asserts `MessageGroupId` attribute
    - `createStack_withEventBridgeRule_targetWithoutSqsParameters_omitsField` — backwards-compat (no phantom `SqsParameters` on plain targets)
    - `createStack_withEventBridgeRule_emptySqsParametersBlock_isIgnored` — empty `SqsParameters: {}` mirrors the direct handler's behaviour (no half-populated object)
    - `createStack_withEventBridgeRule_mixedTargets_preservesPerTargetSqsParameters` — multi-target isolation, prevents future leak across `Targets[]` iterations
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)

## TDD verification (red-then-green)

To prove the new tests catch the real bug, the test file was applied alone on `main` (without the prod fix in `CloudFormationResourceProvisioner.provisionEventBridgeRule`):

- **RED check** — tests on `main`, prod fix stashed: **3 / 5 new tests fail**, exactly as predicted by the bug:
  - `createStack_withEventBridgeRule_preservesSqsParametersMessageGroupId` — `ListTargetsByRule` does not return `SqsParameters`
  - `createStack_withEventBridgeRule_fifoDeliveryEndToEnd` — `PutEvents` triggers no FIFO delivery, `ReceiveMessage` returns nothing (no `MessageGroupId` attribute)
  - `createStack_withEventBridgeRule_mixedTargets_preservesPerTargetSqsParameters` — both targets surface without `SqsParameters`
  - `createStack_withEventBridgeRule_targetWithoutSqsParameters_omitsField` — **passes on red** (intentional: backwards-compat guard, asserts that targets that never set `SqsParameters` continue to surface without one)
  - `createStack_withEventBridgeRule_emptySqsParametersBlock_isIgnored` — **passes on red** (intentional: edge-case guard mirroring `EventBridgeHandler.java:211-219` — an empty `SqsParameters: {}` produces no `SqsParameters` on the target)

- **GREEN check** — tests on this branch with the prod fix applied: **5 / 5 new tests pass**.

So 3 tests prove the fix moves the needle, and 2 guard against future regressions on edge cases that already behave correctly today.
