### PR TITLE
fix(cloudformation): provision AWS::ApiGateway::Authorizer and wire Method.AuthorizerId

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -155,6 +155,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
                 case "AWS::ApiGateway::RestApi" -> provisionApiGatewayRestApi(resource, properties, engine, region, accountId, stackName);
                 case "AWS::ApiGateway::Resource" -> provisionApiGatewayResource(resource, properties, engine, region);
+                case "AWS::ApiGateway::Authorizer" -> provisionApiGatewayAuthorizer(resource, properties, engine, region);
                 case "AWS::ApiGateway::Method" -> provisionApiGatewayMethod(resource, properties, engine, region);
                 case "AWS::ApiGateway::Deployment" -> provisionApiGatewayDeployment(resource, properties, engine, region);
                 case "AWS::ApiGateway::Stage" -> provisionApiGatewayStage(resource, properties, engine, region);
@@ -1399,6 +1400,22 @@ public class CloudFormationResourceProvisioner {
         r.setPhysicalId(res.getId());
     }
 
+    private void provisionApiGatewayAuthorizer(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                               String region) {
+        String apiId = resolveOptional(props, "RestApiId", engine);
+        Map<String, Object> req = new HashMap<>();
+        req.put("name", resolveOptional(props, "Name", engine));
+        req.put("type", resolveOptional(props, "Type", engine));
+        req.put("authorizerUri", resolveOptional(props, "AuthorizerUri", engine));
+        req.put("identitySource", resolveOptional(props, "IdentitySource", engine));
+        String ttl = resolveOptional(props, "AuthorizerResultTtlInSeconds", engine);
+        if (ttl != null) {
+            req.put("authorizerResultTtlInSeconds", ttl);
+        }
+        var authorizer = apiGatewayService.createAuthorizer(region, apiId, req);
+        r.setPhysicalId(authorizer.getId());
+    }
+
     private void provisionApiGatewayMethod(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                            String region) {
         String apiId = resolveOptional(props, "RestApiId", engine);
@@ -1407,6 +1424,10 @@ public class CloudFormationResourceProvisioner {
 
         Map<String, Object> req = new HashMap<>();
         req.put("authorizationType", resolveOrDefault(props, "AuthorizationType", engine, "NONE"));
+        String authorizerId = resolveOptional(props, "AuthorizerId", engine);
+        if (authorizerId != null) {
+            req.put("authorizerId", authorizerId);
+        }
 
         apiGatewayService.putMethod(region, apiId, resourceId, httpMethod, req);
         r.setPhysicalId(apiId + "-" + resourceId + "-" + httpMethod);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -60,6 +60,23 @@ class CloudFormationIntegrationTest {
         return xml.substring(start, end);
     }
 
+    private static String physicalIdByLogicalId(String xml, String logicalId) {
+        String memberOpen = "<member>";
+        String memberClose = "</member>";
+        String logicalMarker = "<LogicalResourceId>" + logicalId + "</LogicalResourceId>";
+        int logicalIdx = xml.indexOf(logicalMarker);
+        assertThat("logical id '" + logicalId + "' present in DescribeStackResources output",
+                logicalIdx, not(equalTo(-1)));
+        int memberStart = xml.lastIndexOf(memberOpen, logicalIdx);
+        int memberEnd = xml.indexOf(memberClose, logicalIdx);
+        String member = xml.substring(memberStart, memberEnd);
+        String physicalOpen = "<PhysicalResourceId>";
+        String physicalClose = "</PhysicalResourceId>";
+        int pStart = member.indexOf(physicalOpen) + physicalOpen.length();
+        int pEnd = member.indexOf(physicalClose, pStart);
+        return member.substring(pStart, pEnd);
+    }
+
     @Test
     void createStack_withS3AndSqs() {
         String template = """
@@ -3337,6 +3354,420 @@ class CloudFormationIntegrationTest {
             .post("/")
         .then()
             .statusCode(400);
+    }
+
+    // ── Issue #788: AWS::ApiGateway::Authorizer support + Method.AuthorizerId wiring ───
+
+    @Test
+    void createStack_withApiGatewayAuthorizer_createsAuthorizerResource() {
+        // Regression test for issue #788: CFN previously fell through the default
+        // stub branch for AWS::ApiGateway::Authorizer, so the resource never reached
+        // ApiGatewayService and `get-authorizers` returned an empty list.
+        String stackName = "cfn-apigw-auth-create-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {
+                    "Name": "cfn-apigw-auth-create-api"
+                  }
+                },
+                "MyAuthorizer": {
+                  "Type": "AWS::ApiGateway::Authorizer",
+                  "Properties": {
+                    "Name": "MyTokenAuth",
+                    "Type": "TOKEN",
+                    "RestApiId": {"Ref": "RestApi"},
+                    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:my-auth/invocations",
+                    "IdentitySource": "method.request.header.Authorization"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String authorizerId = physicalIdByLogicalId(resourcesXml, "MyAuthorizer");
+
+        // PhysicalResourceId must be the ApiGatewayService-issued authorizer id, not the logical name.
+        assertThat(authorizerId, matchesRegex("^[A-Za-z0-9]+$"));
+        assertThat(authorizerId, not(equalTo("MyAuthorizer")));
+
+        // The authorizer must be retrievable from the standard REST endpoint.
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/authorizers")
+        .then()
+            .statusCode(200)
+            .body("item.size()", equalTo(1))
+            .body("item[0].id", equalTo(authorizerId))
+            .body("item[0].name", equalTo("MyTokenAuth"))
+            .body("item[0].type", equalTo("TOKEN"));
+    }
+
+    @Test
+    void createStack_withApiGatewayMethod_wiresAuthorizerIdViaRef() {
+        // Core scenario from issue #788: `AuthorizationType: CUSTOM` plus
+        // `AuthorizerId: !Ref MyAuthorizer` must produce a method whose
+        // authorizerId points to the actual authorizer resource. Before the fix,
+        // authorizerId was null on the method and the API behaved as `NONE`.
+        String stackName = "cfn-apigw-auth-method-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {
+                    "Name": "cfn-apigw-auth-method-api"
+                  }
+                },
+                "ApiResource": {
+                  "Type": "AWS::ApiGateway::Resource",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ParentId": {"Fn::GetAtt": ["RestApi", "RootResourceId"]},
+                    "PathPart": "secured"
+                  }
+                },
+                "TokenAuthorizer": {
+                  "Type": "AWS::ApiGateway::Authorizer",
+                  "Properties": {
+                    "Name": "MyTokenAuth",
+                    "Type": "TOKEN",
+                    "RestApiId": {"Ref": "RestApi"},
+                    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:my-auth/invocations",
+                    "IdentitySource": "method.request.header.Authorization",
+                    "AuthorizerResultTtlInSeconds": 0
+                  }
+                },
+                "SecuredMethod": {
+                  "Type": "AWS::ApiGateway::Method",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ResourceId": {"Ref": "ApiResource"},
+                    "HttpMethod": "GET",
+                    "AuthorizationType": "CUSTOM",
+                    "AuthorizerId": {"Ref": "TokenAuthorizer"}
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String resourceId = physicalIdByLogicalId(resourcesXml, "ApiResource");
+        String authorizerId = physicalIdByLogicalId(resourcesXml, "TokenAuthorizer");
+
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET")
+        .then()
+            .statusCode(200)
+            .body("httpMethod", equalTo("GET"))
+            .body("authorizationType", equalTo("CUSTOM"))
+            .body("authorizerId", equalTo(authorizerId));
+    }
+
+    @Test
+    void createStack_withApiGatewayAuthorizer_preservesAllFields() {
+        // Reviewer-defence: every CFN-supported property on AWS::ApiGateway::Authorizer
+        // round-trips through GET /restapis/{apiId}/authorizers, not just the Name.
+        // Catches future regressions where a new field is added to the CFN handler
+        // but not threaded into the service request map.
+        String stackName = "cfn-apigw-auth-fields-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {"Name": "cfn-apigw-auth-fields-api"}
+                },
+                "TokenAuth": {
+                  "Type": "AWS::ApiGateway::Authorizer",
+                  "Properties": {
+                    "Name": "FieldsTokenAuth",
+                    "Type": "TOKEN",
+                    "RestApiId": {"Ref": "RestApi"},
+                    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:fields-auth/invocations",
+                    "IdentitySource": "method.request.header.X-Auth",
+                    "AuthorizerResultTtlInSeconds": 120
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String authorizerId = physicalIdByLogicalId(resourcesXml, "TokenAuth");
+
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/authorizers/" + authorizerId)
+        .then()
+            .statusCode(200)
+            .body("id", equalTo(authorizerId))
+            .body("name", equalTo("FieldsTokenAuth"))
+            .body("type", equalTo("TOKEN"))
+            .body("authorizerUri", containsString("function:fields-auth"))
+            .body("identitySource", equalTo("method.request.header.X-Auth"))
+            .body("authorizerResultTtlInSeconds", equalTo(120));
+    }
+
+    @Test
+    void createStack_withApiGatewayMethod_withoutAuthorizerId_authorizerIdRemainsNull() {
+        // Backwards-compat: methods that omit AuthorizerId must NOT acquire one
+        // accidentally (e.g. from a stale loop variable or default value). A
+        // NONE-auth method whose authorizerId surfaces in GET is a contract leak
+        // for SDK clients.
+        String stackName = "cfn-apigw-method-noauth-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {"Name": "cfn-apigw-method-noauth-api"}
+                },
+                "PublicResource": {
+                  "Type": "AWS::ApiGateway::Resource",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ParentId": {"Fn::GetAtt": ["RestApi", "RootResourceId"]},
+                    "PathPart": "public"
+                  }
+                },
+                "PublicMethod": {
+                  "Type": "AWS::ApiGateway::Method",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ResourceId": {"Ref": "PublicResource"},
+                    "HttpMethod": "GET",
+                    "AuthorizationType": "NONE"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String resourceId = physicalIdByLogicalId(resourcesXml, "PublicResource");
+
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET")
+        .then()
+            .statusCode(200)
+            .body("authorizationType", equalTo("NONE"))
+            .body("authorizerId", nullValue());
+    }
+
+    @Test
+    void createStack_withMultipleAuthorizers_eachWiredToOwnMethod() {
+        // Multi-authorizer isolation: two authorizers + two methods, each method
+        // must end up wired to the correct authorizer id. Prevents future
+        // regressions where a shared local would leak across iterations of the
+        // resource provisioning loop.
+        String stackName = "cfn-apigw-multi-auth-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {"Name": "cfn-apigw-multi-auth-api"}
+                },
+                "FirstResource": {
+                  "Type": "AWS::ApiGateway::Resource",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ParentId": {"Fn::GetAtt": ["RestApi", "RootResourceId"]},
+                    "PathPart": "first"
+                  }
+                },
+                "SecondResource": {
+                  "Type": "AWS::ApiGateway::Resource",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ParentId": {"Fn::GetAtt": ["RestApi", "RootResourceId"]},
+                    "PathPart": "second"
+                  }
+                },
+                "FirstAuth": {
+                  "Type": "AWS::ApiGateway::Authorizer",
+                  "Properties": {
+                    "Name": "FirstAuth",
+                    "Type": "TOKEN",
+                    "RestApiId": {"Ref": "RestApi"},
+                    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:first-auth/invocations",
+                    "IdentitySource": "method.request.header.Authorization"
+                  }
+                },
+                "SecondAuth": {
+                  "Type": "AWS::ApiGateway::Authorizer",
+                  "Properties": {
+                    "Name": "SecondAuth",
+                    "Type": "TOKEN",
+                    "RestApiId": {"Ref": "RestApi"},
+                    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:second-auth/invocations",
+                    "IdentitySource": "method.request.header.X-Token"
+                  }
+                },
+                "FirstMethod": {
+                  "Type": "AWS::ApiGateway::Method",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ResourceId": {"Ref": "FirstResource"},
+                    "HttpMethod": "GET",
+                    "AuthorizationType": "CUSTOM",
+                    "AuthorizerId": {"Ref": "FirstAuth"}
+                  }
+                },
+                "SecondMethod": {
+                  "Type": "AWS::ApiGateway::Method",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "ResourceId": {"Ref": "SecondResource"},
+                    "HttpMethod": "POST",
+                    "AuthorizationType": "CUSTOM",
+                    "AuthorizerId": {"Ref": "SecondAuth"}
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String firstResource = physicalIdByLogicalId(resourcesXml, "FirstResource");
+        String secondResource = physicalIdByLogicalId(resourcesXml, "SecondResource");
+        String firstAuth = physicalIdByLogicalId(resourcesXml, "FirstAuth");
+        String secondAuth = physicalIdByLogicalId(resourcesXml, "SecondAuth");
+
+        assertThat(firstAuth, not(equalTo(secondAuth)));
+
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/resources/" + firstResource + "/methods/GET")
+        .then()
+            .statusCode(200)
+            .body("authorizationType", equalTo("CUSTOM"))
+            .body("authorizerId", equalTo(firstAuth));
+
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/resources/" + secondResource + "/methods/POST")
+        .then()
+            .statusCode(200)
+            .body("authorizationType", equalTo("CUSTOM"))
+            .body("authorizerId", equalTo(secondAuth));
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes #788.

`CloudFormationResourceProvisioner` had no `case` for `AWS::ApiGateway::Authorizer`, so the resource fell through the default stub branch and never reached `ApiGatewayService`. Stacks reported `CREATE_COMPLETE`, but `apigateway get-authorizers --rest-api-id <api-id>` came back with an empty list. On top of that, `provisionApiGatewayMethod` did not read `AuthorizerId` from the template, so any `CUSTOM` / `COGNITO_USER_POOLS` method created via CFN was registered with `authorizerId: null`. Net effect: a CloudFormation-managed TOKEN authorizer flow silently degraded to `AuthorizationType: NONE`.

**Reproduces with** (from issue #788):

```text
authorizers:           []
authorizerExists:      false
method.authorizationType: CUSTOM
method.authorizerId:   null
methodHasAuthorizerId: false
broken:                true
```

After the fix, the authorizer is created server-side, `Ref` on the authorizer resource resolves to its real id, the method carries `authorizerId` pointing at that id, and the OOTB AWS CLI / SDK flow works against Floci.

## What changed

- New `case "AWS::ApiGateway::Authorizer"` in `CloudFormationResourceProvisioner` plus a dedicated `provisionApiGatewayAuthorizer` method that maps the CFN PascalCase properties (`Name`, `Type`, `RestApiId`, `AuthorizerUri`, `IdentitySource`, `AuthorizerResultTtlInSeconds`) onto the existing `ApiGatewayService.createAuthorizer` camelCase request shape. The created authorizer's id is stored as the resource's `PhysicalResourceId`, so `!Ref MyAuthorizer` resolves correctly.
- `provisionApiGatewayMethod` now reads `AuthorizerId` (optional) and forwards it to `ApiGatewayService.putMethod`, which already supports the field.
- No service-layer changes — `ApiGatewayService` already exposes `createAuthorizer` and `putMethod(authorizerId)` for the direct REST path. This PR closes the gap for CloudFormation-driven flows only.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Both `AWS::ApiGateway::Authorizer` and `AWS::ApiGateway::Method.AuthorizerId` are part of the public CloudFormation schema for API Gateway REST APIs. Real AWS surfaces the authorizer via `apigateway get-authorizers` and `get-method --authorization-type CUSTOM` after the stack creates. Floci already supports both via the direct REST endpoints (`POST /restapis/{apiId}/authorizers`, `PUT /restapis/{apiId}/resources/{resourceId}/methods/{httpMethod}`); this PR ensures the AWS SDK / CDK / Terraform behave identically against Floci regardless of how the authorizer was registered.

## Checklist

- [x] `./mvnw test` passes locally (targeted suite `CloudFormationIntegrationTest + ApiGatewayIntegrationTest`: 90/90)
- [x] New or updated integration test added — five regression tests in `CloudFormationIntegrationTest`:
    - `createStack_withApiGatewayAuthorizer_createsAuthorizerResource` — basic `AWS::ApiGateway::Authorizer` provisioning surfaces via `get-authorizers`
    - `createStack_withApiGatewayMethod_wiresAuthorizerIdViaRef` — the core scenario from the issue: `AuthorizationType: CUSTOM` + `AuthorizerId: !Ref MyAuth` → `get-method` returns the resolved id
    - `createStack_withApiGatewayAuthorizer_preservesAllFields` — every CFN-supported property round-trips (`Type`, `AuthorizerUri`, `IdentitySource`, `AuthorizerResultTtlInSeconds`)
    - `createStack_withApiGatewayMethod_withoutAuthorizerId_authorizerIdRemainsNull` — backwards-compat: methods that omit `AuthorizerId` do not acquire one
    - `createStack_withMultipleAuthorizers_eachWiredToOwnMethod` — multi-authorizer isolation, prevents future cross-iteration leaks
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## TDD verification (red-then-green)

To prove the new tests catch the real bug, the test file was applied alone on `main` (without the prod fix in `CloudFormationResourceProvisioner`):

- **RED check** — tests on `main`, prod fix stashed: **4 / 5 new tests fail**, exactly as predicted by the bug:
  - `createStack_withApiGatewayAuthorizer_createsAuthorizerResource` — `get-authorizers` returns empty list
  - `createStack_withApiGatewayMethod_wiresAuthorizerIdViaRef` — method `authorizerId` is `null`
  - `createStack_withApiGatewayAuthorizer_preservesAllFields` — authorizer never created, `404` on `GET /authorizers/{id}`
  - `createStack_withMultipleAuthorizers_eachWiredToOwnMethod` — same as above, both authorizers missing
  - `createStack_withApiGatewayMethod_withoutAuthorizerId_authorizerIdRemainsNull` — **passes on red** (intentional: backwards-compat guard, asserts the absence of behaviour change for methods that never set `AuthorizerId`)

- **GREEN check** — tests on this branch with the prod fix applied: **5 / 5 new tests pass**.

So 4 tests prove the fix moves the needle, and 1 guards against a future regression.
