### PR TITLE
fix(s3): strip charset parameter from XML response Content-Type

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilter.java
@@ -2,52 +2,19 @@ package io.github.hectorvent.floci.services.s3;
 
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
 
 /**
- * Removes the {@code charset} parameter from {@code application/xml} and
- * {@code text/xml} response {@code Content-Type} headers.
- *
- * <p>Quarkus REST (RESTEasy Reactive) automatically appends
- * {@code ;charset=UTF-8} to text-like media types declared via
- * {@code @Produces(MediaType.APPLICATION_XML)} or
- * {@code Response.ok(...).type(MediaType.APPLICATION_XML)}. Production Amazon
- * S3 returns {@code Content-Type: application/xml} without any {@code charset}
- * parameter for every XML response — see the response examples in the AWS S3
- * API Reference (ListBuckets, ListObjects, GetBucketAcl, etc.).
- *
- * <p>Some AWS SDKs and ecosystem tools parse the response media type strictly
- * and treat the extra {@code charset} parameter as a deviation from the
- * documented wire format, so Floci normalises the header to match the real
- * service.
- *
- * <p><strong>Scope.</strong> The handler only rewrites when the base media
- * type is {@code application/xml} or {@code text/xml}, so non-XML responses
- * (JSON 1.1, REST JSON, binary object bodies) are passed through untouched.
- * The same correction is in fact valid for every XML-based AWS protocol
- * (Query: SQS / SNS / IAM / STS, REST XML: S3), so the provider is registered
- * globally and lives in the S3 package because S3 is where the discrepancy
- * was originally reported.
- *
- * <p><strong>Why a request filter + Vert.x headers-end handler.</strong>
- * For Quarkus REST resource methods that return {@code Response.ok(entity).build()}
- * without an explicit {@code .type(...)} — which is the common pattern across
- * {@link S3Controller} — neither {@link
- * jakarta.ws.rs.container.ContainerResponseFilter} nor {@link
- * jakarta.ws.rs.ext.WriterInterceptor} sees a non-null media type, because
- * Quarkus REST's optimised write path resolves the {@code Content-Type}
- * (including the framework-added charset) outside the standard
- * {@code MessageBodyWriter} pipeline. The earliest hook at which the final
- * {@code Content-Type} is observable and still mutable is Vert.x's
- * {@link RoutingContext#addHeadersEndHandler}, which fires immediately before
- * the HTTP response headers are written to the wire. Registering the handler
- * from a {@link ContainerRequestFilter} guarantees it is installed once per
- * request, before any response processing begins.
+ * Strips the {@code charset} parameter from {@code application/xml} and
+ * {@code text/xml} response Content-Type headers so they match the real AWS
+ * XML protocol wire format.
  */
 @Provider
+@ApplicationScoped
 public class S3ContentTypeCharsetFilter implements ContainerRequestFilter {
 
     @Inject
@@ -61,7 +28,7 @@ public class S3ContentTypeCharsetFilter implements ContainerRequestFilter {
             String ct = rc.response().headers().get("Content-Type");
             if (ct == null) return;
             int semi = ct.indexOf(';');
-            if (semi <= 0) return;
+            if (semi < 0) return;
             String base = ct.substring(0, semi).trim();
             if ("application/xml".equalsIgnoreCase(base) || "text/xml".equalsIgnoreCase(base)) {
                 rc.response().headers().set("Content-Type", base);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilter.java
@@ -1,0 +1,71 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Removes the {@code charset} parameter from {@code application/xml} and
+ * {@code text/xml} response {@code Content-Type} headers.
+ *
+ * <p>Quarkus REST (RESTEasy Reactive) automatically appends
+ * {@code ;charset=UTF-8} to text-like media types declared via
+ * {@code @Produces(MediaType.APPLICATION_XML)} or
+ * {@code Response.ok(...).type(MediaType.APPLICATION_XML)}. Production Amazon
+ * S3 returns {@code Content-Type: application/xml} without any {@code charset}
+ * parameter for every XML response — see the response examples in the AWS S3
+ * API Reference (ListBuckets, ListObjects, GetBucketAcl, etc.).
+ *
+ * <p>Some AWS SDKs and ecosystem tools parse the response media type strictly
+ * and treat the extra {@code charset} parameter as a deviation from the
+ * documented wire format, so Floci normalises the header to match the real
+ * service.
+ *
+ * <p><strong>Scope.</strong> The handler only rewrites when the base media
+ * type is {@code application/xml} or {@code text/xml}, so non-XML responses
+ * (JSON 1.1, REST JSON, binary object bodies) are passed through untouched.
+ * The same correction is in fact valid for every XML-based AWS protocol
+ * (Query: SQS / SNS / IAM / STS, REST XML: S3), so the provider is registered
+ * globally and lives in the S3 package because S3 is where the discrepancy
+ * was originally reported.
+ *
+ * <p><strong>Why a request filter + Vert.x headers-end handler.</strong>
+ * For Quarkus REST resource methods that return {@code Response.ok(entity).build()}
+ * without an explicit {@code .type(...)} — which is the common pattern across
+ * {@link S3Controller} — neither {@link
+ * jakarta.ws.rs.container.ContainerResponseFilter} nor {@link
+ * jakarta.ws.rs.ext.WriterInterceptor} sees a non-null media type, because
+ * Quarkus REST's optimised write path resolves the {@code Content-Type}
+ * (including the framework-added charset) outside the standard
+ * {@code MessageBodyWriter} pipeline. The earliest hook at which the final
+ * {@code Content-Type} is observable and still mutable is Vert.x's
+ * {@link RoutingContext#addHeadersEndHandler}, which fires immediately before
+ * the HTTP response headers are written to the wire. Registering the handler
+ * from a {@link ContainerRequestFilter} guarantees it is installed once per
+ * request, before any response processing begins.
+ */
+@Provider
+public class S3ContentTypeCharsetFilter implements ContainerRequestFilter {
+
+    @Inject
+    CurrentVertxRequest currentVertxRequest;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        RoutingContext rc = currentVertxRequest.getCurrent();
+        if (rc == null) return;
+        rc.addHeadersEndHandler(v -> {
+            String ct = rc.response().headers().get("Content-Type");
+            if (ct == null) return;
+            int semi = ct.indexOf(';');
+            if (semi <= 0) return;
+            String base = ct.substring(0, semi).trim();
+            if ("application/xml".equalsIgnoreCase(base) || "text/xml".equalsIgnoreCase(base)) {
+                rc.response().headers().set("Content-Type", base);
+            }
+        });
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilterTest.java
@@ -5,13 +5,11 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 /**
- * Verifies that S3 XML responses match the production wire format:
- * {@code Content-Type: application/xml} with no {@code charset} parameter.
- *
- * <p>Quarkus REST would otherwise append {@code ;charset=UTF-8}, but real AWS
- * S3 never does — see the response examples in the AWS S3 API Reference.
+ * Verifies S3 XML responses match the real AWS wire format
+ * ({@code Content-Type: application/xml}, no {@code charset} parameter).
  */
 @QuarkusTest
 class S3ContentTypeCharsetFilterTest {
@@ -28,15 +26,21 @@ class S3ContentTypeCharsetFilterTest {
 
     @Test
     void noSuchBucketErrorContentTypeHasNoCharset() {
-        // GET on a non-existent bucket returns an XML error body, which must
-        // also be charset-free. Using a missing bucket (instead of duplicate
-        // PUT) avoids region-dependent behaviour: PUT to an existing bucket
-        // returns 200 in us-east-1 and 409 elsewhere.
         given()
         .when()
             .get("/charset-test-missing-bucket-xyz")
         .then()
             .statusCode(404)
             .header("Content-Type", equalTo("application/xml"));
+    }
+
+    @Test
+    void jsonResponseContentTypeUntouched() {
+        given()
+        .when()
+            .get("/_floci/health")
+        .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/json"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ContentTypeCharsetFilterTest.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that S3 XML responses match the production wire format:
+ * {@code Content-Type: application/xml} with no {@code charset} parameter.
+ *
+ * <p>Quarkus REST would otherwise append {@code ;charset=UTF-8}, but real AWS
+ * S3 never does — see the response examples in the AWS S3 API Reference.
+ */
+@QuarkusTest
+class S3ContentTypeCharsetFilterTest {
+
+    @Test
+    void listBucketsContentTypeHasNoCharset() {
+        given()
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .header("Content-Type", equalTo("application/xml"));
+    }
+
+    @Test
+    void noSuchBucketErrorContentTypeHasNoCharset() {
+        // GET on a non-existent bucket returns an XML error body, which must
+        // also be charset-free. Using a missing bucket (instead of duplicate
+        // PUT) avoids region-dependent behaviour: PUT to an existing bucket
+        // returns 200 in us-east-1 and 409 elsewhere.
+        given()
+        .when()
+            .get("/charset-test-missing-bucket-xyz")
+        .then()
+            .statusCode(404)
+            .header("Content-Type", equalTo("application/xml"));
+    }
+}


### PR DESCRIPTION
## Summary

Real AWS S3 returns `Content-Type: application/xml` for every XML response, but Quarkus REST automatically appends `;charset=UTF-8` to text-like media types declared via `@Produces(APPLICATION_XML)`. Some SDKs treat the extra parameter as a wire-format deviation.

A `ContainerRequestFilter` registers a Vert.x `addHeadersEndHandler` that strips the charset just before HTTP headers hit the wire. The hook is necessary because for `Response.ok(entity).build()` (the common pattern in S3Controller), Quarkus REST's optimised write path bypasses both `ContainerResponseFilter` and `WriterInterceptor` — they see `getMediaType() == null`.

Test: `S3ContentTypeCharsetFilterTest` covers ListBuckets (200) and NoSuchBucket (404).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: Floci was returning `Content-Type: application/xml;charset=UTF-8` on every S3 XML response (ListBuckets, ListObjects, GetBucketAcl, …), while real AWS S3 returns `Content-Type: application/xml` with no parameters — see the response examples throughout the AWS S3 API Reference. Permissive clients (AWS SDK for Java v2, AWS CLI) tolerate the extra parameter, but strict parsers and tools that compare the response media type literally treat it as a deviation from the documented wire format.

After the fix: `Content-Type: application/xml` (no parameters), matching the documented response examples byte-for-byte. JSON-based AWS protocols (REST JSON, JSON 1.1) are intentionally untouched — the filter only rewrites `application/xml` and `text/xml`.

Upstream: Quarkus REST does not expose a switch to disable the auto-charset on text-like media types; see [quarkusio/quarkus#25295](https://github.com/quarkusio/quarkus/issues/25295) for the maintainers' position. Rewriting the header at the Vert.x layer is the only reliable fix.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
