### PR TITLE
fix(cloudwatch-logs): implement PutSubscriptionFilter and DescribeSub…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogEvent;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogGroup;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogStream;
+import io.github.hectorvent.floci.services.cloudwatch.logs.model.SubscriptionFilter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -48,6 +49,9 @@ public class CloudWatchLogsHandler {
             case "ListTagsForResource" -> handleListTagsForResource(request, region);
             case "TagResource" -> handleTagResource(request, region);
             case "UntagResource" -> handleUntagResource(request, region);
+            case "PutSubscriptionFilter" -> handlePutSubscriptionFilter(request, region);
+            case "DescribeSubscriptionFilters" -> handleDescribeSubscriptionFilters(request, region);
+            case "DeleteSubscriptionFilter" -> handleDeleteSubscriptionFilter(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -254,6 +258,54 @@ public class CloudWatchLogsHandler {
         List<String> tagKeys = new ArrayList<>();
         request.path("tagKeys").forEach(k -> tagKeys.add(k.asText()));
         logsService.untagLogGroup(groupName, tagKeys, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handlePutSubscriptionFilter(JsonNode request, String region) {
+        String logGroupName = request.path("logGroupName").asText();
+        String filterName = request.path("filterName").asText();
+        String filterPattern = request.path("filterPattern").asText();
+        String destinationArn = request.path("destinationArn").asText();
+        String distribution = request.has("distribution") ? request.path("distribution").asText(null) : null;
+
+        logsService.putSubscriptionFilter(logGroupName, filterName, filterPattern, destinationArn, distribution, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleDescribeSubscriptionFilters(JsonNode request, String region) {
+        String logGroupName = request.path("logGroupName").asText();
+        String filterNamePrefix = request.path("filterNamePrefix").asText(null);
+        String nextToken = request.has("nextToken") ? request.path("nextToken").asText(null) : null;
+        int limit = request.path("limit").asInt(0);
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult result =
+                logsService.describeSubscriptionFilters(logGroupName, filterNamePrefix, nextToken, limit, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode filtersArray = objectMapper.createArrayNode();
+        for (SubscriptionFilter f : result.subscriptionFilters()) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("filterName", f.getFilterName());
+            node.put("logGroupName", f.getLogGroupName());
+            node.put("filterPattern", f.getFilterPattern());
+            node.put("destinationArn", f.getDestinationArn());
+            if (f.getDistribution() != null) {
+                node.put("distribution", f.getDistribution());
+            }
+            node.put("creationTime", f.getCreationTime());
+            filtersArray.add(node);
+        }
+        response.set("subscriptionFilters", filtersArray);
+        if (result.nextToken() != null) {
+            response.put("nextToken", result.nextToken());
+        }
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteSubscriptionFilter(JsonNode request, String region) {
+        String logGroupName = request.path("logGroupName").asText();
+        String filterName = request.path("filterName").asText();
+        logsService.deleteSubscriptionFilter(logGroupName, filterName, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -368,19 +368,15 @@ public class CloudWatchLogsService {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "The specified log group does not exist: " + logGroupName, 400));
 
-        String filterKey = subscriptionFilterKey(region, logGroupName, filterName);
-        if (subscriptionFilterStore.get(filterKey).isPresent()) {
-            throw new AwsException("LimitExceededException",
-                    "The specified subscription filter already exists: " + filterName, 400);
-        }
-
         SubscriptionFilter filter = new SubscriptionFilter();
         filter.setFilterName(filterName);
         filter.setLogGroupName(logGroupName);
-        filter.setFilterPattern(filterPattern);
+        filter.setFilterPattern(filterPattern != null ? filterPattern : "");
         filter.setDestinationArn(destinationArn);
-        filter.setDistribution(distribution);
+        filter.setDistribution(distribution != null ? distribution : "ByLogStream");
         filter.setCreationTime(System.currentTimeMillis());
+
+        String filterKey = subscriptionFilterKey(region, logGroupName, filterName);
         subscriptionFilterStore.put(filterKey, filter);
         LOG.infov("Created subscription filter: {0} on log group: {1}", filterName, logGroupName);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogEvent;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogGroup;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogStream;
+import io.github.hectorvent.floci.services.cloudwatch.logs.model.SubscriptionFilter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -28,6 +29,7 @@ public class CloudWatchLogsService {
     private final StorageBackend<String, LogGroup> groupStore;
     private final StorageBackend<String, LogStream> streamStore;
     private final StorageBackend<String, LogEvent> eventStore;
+    private final StorageBackend<String, SubscriptionFilter> subscriptionFilterStore;
     private final RegionResolver regionResolver;
     private final int maxEventsPerQuery;
 
@@ -42,6 +44,8 @@ public class CloudWatchLogsService {
                         new TypeReference<>() {}),
                 storageFactory.create("cloudwatchlogs", "cwlogs-events.json",
                         new TypeReference<>() {}),
+                storageFactory.create("cloudwatchlogs", "cwlogs-subscription-filters.json",
+                        new TypeReference<>() {}),
                 config.services().cloudwatchlogs().maxEventsPerQuery(),
                 regionResolver
         );
@@ -50,11 +54,13 @@ public class CloudWatchLogsService {
     CloudWatchLogsService(StorageBackend<String, LogGroup> groupStore,
                            StorageBackend<String, LogStream> streamStore,
                            StorageBackend<String, LogEvent> eventStore,
+                           StorageBackend<String, SubscriptionFilter> subscriptionFilterStore,
                            int maxEventsPerQuery,
                            RegionResolver regionResolver) {
         this.groupStore = groupStore;
         this.streamStore = streamStore;
         this.eventStore = eventStore;
+        this.subscriptionFilterStore = subscriptionFilterStore;
         this.maxEventsPerQuery = maxEventsPerQuery;
         this.regionResolver = regionResolver;
     }
@@ -353,6 +359,80 @@ public class CloudWatchLogsService {
         return new FilteredLogEventsResult(result, nextToken);
     }
 
+    // ──────────────────────────── Subscription Filters ────────────────────────────
+
+    public void putSubscriptionFilter(String logGroupName, String filterName, String filterPattern,
+                                       String destinationArn, String distribution, String region) {
+        String groupKey = groupKey(region, logGroupName);
+        groupStore.get(groupKey)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified log group does not exist: " + logGroupName, 400));
+
+        String filterKey = subscriptionFilterKey(region, logGroupName, filterName);
+        if (subscriptionFilterStore.get(filterKey).isPresent()) {
+            throw new AwsException("LimitExceededException",
+                    "The specified subscription filter already exists: " + filterName, 400);
+        }
+
+        SubscriptionFilter filter = new SubscriptionFilter();
+        filter.setFilterName(filterName);
+        filter.setLogGroupName(logGroupName);
+        filter.setFilterPattern(filterPattern);
+        filter.setDestinationArn(destinationArn);
+        filter.setDistribution(distribution);
+        filter.setCreationTime(System.currentTimeMillis());
+        subscriptionFilterStore.put(filterKey, filter);
+        LOG.infov("Created subscription filter: {0} on log group: {1}", filterName, logGroupName);
+    }
+
+    public record DescribeSubscriptionFiltersResult(List<SubscriptionFilter> subscriptionFilters, String nextToken) {}
+
+    public DescribeSubscriptionFiltersResult describeSubscriptionFilters(String logGroupName, String filterNamePrefix,
+                                                                          String nextToken, int limit, String region) {
+        String groupKey = groupKey(region, logGroupName);
+        groupStore.get(groupKey)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified log group does not exist: " + logGroupName, 400));
+
+        String prefix = subscriptionFilterKeyPrefix(region, logGroupName);
+        List<SubscriptionFilter> all = subscriptionFilterStore.scan(k -> {
+            if (!k.startsWith(prefix)) return false;
+            if (filterNamePrefix == null || filterNamePrefix.isBlank()) return true;
+            String name = k.substring(prefix.length());
+            return name.startsWith(filterNamePrefix);
+        });
+        all.sort(Comparator.comparing(SubscriptionFilter::getFilterName));
+
+        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
+        int offset = 0;
+        if (nextToken != null && !nextToken.isBlank()) {
+            try {
+                offset = Integer.parseInt(nextToken);
+            } catch (NumberFormatException e) {
+                offset = 0;
+            }
+        }
+
+        int end = Math.min(offset + maxResults, all.size());
+        List<SubscriptionFilter> page = all.subList(offset, end);
+        String token = end < all.size() ? String.valueOf(end) : null;
+        return new DescribeSubscriptionFiltersResult(page, token);
+    }
+
+    public void deleteSubscriptionFilter(String logGroupName, String filterName, String region) {
+        String groupKey = groupKey(region, logGroupName);
+        groupStore.get(groupKey)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified log group does not exist: " + logGroupName, 400));
+
+        String filterKey = subscriptionFilterKey(region, logGroupName, filterName);
+        subscriptionFilterStore.get(filterKey)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified subscription filter does not exist: " + filterName, 400));
+        subscriptionFilterStore.delete(filterKey);
+        LOG.infov("Deleted subscription filter: {0} on log group: {1}", filterName, logGroupName);
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private void deleteEventsForStream(String region, String groupName, String streamName) {
@@ -391,6 +471,14 @@ public class CloudWatchLogsService {
                                     long timestamp, String uuid) {
         return region + "::" + groupName + "::" + streamName + "::"
                 + String.format("%015d", timestamp) + "::" + uuid;
+    }
+
+    private static String subscriptionFilterKeyPrefix(String region, String logGroupName) {
+        return region + "::" + logGroupName + "::filter::";
+    }
+
+    private static String subscriptionFilterKey(String region, String logGroupName, String filterName) {
+        return region + "::" + logGroupName + "::filter::" + filterName;
     }
 
     private static long toLong(Object value, long defaultValue) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/SubscriptionFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/SubscriptionFilter.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.cloudwatch.logs.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SubscriptionFilter {
+
+    private String filterName;
+    private String logGroupName;
+    private String filterPattern;
+    private String destinationArn;
+    private String distribution;
+    private long creationTime;
+
+    public SubscriptionFilter() {}
+
+    public String getFilterName() { return filterName; }
+    public void setFilterName(String filterName) { this.filterName = filterName; }
+
+    public String getLogGroupName() { return logGroupName; }
+    public void setLogGroupName(String logGroupName) { this.logGroupName = logGroupName; }
+
+    public String getFilterPattern() { return filterPattern; }
+    public void setFilterPattern(String filterPattern) { this.filterPattern = filterPattern; }
+
+    public String getDestinationArn() { return destinationArn; }
+    public void setDestinationArn(String destinationArn) { this.destinationArn = destinationArn; }
+
+    public String getDistribution() { return distribution; }
+    public void setDistribution(String distribution) { this.distribution = distribution; }
+
+    public long getCreationTime() { return creationTime; }
+    public void setCreationTime(long creationTime) { this.creationTime = creationTime; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -356,8 +356,17 @@ class CloudWatchLogsServiceTest {
         assertEquals("/app/logs", f.getLogGroupName());
         assertEquals("ERROR", f.getFilterPattern());
         assertEquals("arn:aws:lambda:us-east-1:000000000000:function:test", f.getDestinationArn());
-        assertNull(f.getDistribution());
+        assertEquals("ByLogStream", f.getDistribution());
         assertTrue(f.getCreationTime() > 0);
+    }
+
+    @Test
+    void putSubscriptionFilterDefaultsDistribution() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.putSubscriptionFilter("/app/logs", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
+
+        SubscriptionFilter f = service.describeSubscriptionFilters("/app/logs", null, null, 50, REGION).subscriptionFilters().getFirst();
+        assertEquals("ByLogStream", f.getDistribution());
     }
 
     @Test
@@ -367,11 +376,17 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
-    void putSubscriptionFilterDuplicateThrows() {
+    void putSubscriptionFilterUpsertsDuplicate() {
         service.createLogGroup("/app/logs", null, null, REGION);
         service.putSubscriptionFilter("/app/logs", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
-        assertThrows(AwsException.class, () ->
-                service.putSubscriptionFilter("/app/logs", "my-filter", "WARN", "arn:aws:lambda:us-east-1:000000000000:function:other", null, REGION));
+        // Upsert: calling with same name overwrites
+        service.putSubscriptionFilter("/app/logs", "my-filter", "WARN", "arn:aws:lambda:us-east-1:000000000000:function:other", null, REGION);
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult result =
+                service.describeSubscriptionFilters("/app/logs", null, null, 50, REGION);
+        assertEquals(1, result.subscriptionFilters().size());
+        assertEquals("WARN", result.subscriptionFilters().getFirst().getFilterPattern());
+        assertEquals("arn:aws:lambda:us-east-1:000000000000:function:other", result.subscriptionFilters().getFirst().getDestinationArn());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogEvent;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogGroup;
 import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogStream;
+import io.github.hectorvent.floci.services.cloudwatch.logs.model.SubscriptionFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,7 @@ class CloudWatchLogsServiceTest {
     @BeforeEach
     void setUp() {
         service = new CloudWatchLogsService(
+                new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
@@ -245,6 +247,7 @@ class CloudWatchLogsServiceTest {
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
                 2,
                 new RegionResolver("us-east-1", "000000000000")
         );
@@ -336,6 +339,92 @@ class CloudWatchLogsServiceTest {
         assertEquals("msg-4", result.events().get(2).getMessage());
         assertEquals("b/2", result.nextBackwardToken());
         assertEquals("f/5", result.nextForwardToken());
+    }
+
+    // ──────────────────────────── Subscription Filters ────────────────────────────
+
+    @Test
+    void putSubscriptionFilter() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.putSubscriptionFilter("/app/logs", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult result =
+                service.describeSubscriptionFilters("/app/logs", null, null, 50, REGION);
+        assertEquals(1, result.subscriptionFilters().size());
+        SubscriptionFilter f = result.subscriptionFilters().getFirst();
+        assertEquals("my-filter", f.getFilterName());
+        assertEquals("/app/logs", f.getLogGroupName());
+        assertEquals("ERROR", f.getFilterPattern());
+        assertEquals("arn:aws:lambda:us-east-1:000000000000:function:test", f.getDestinationArn());
+        assertNull(f.getDistribution());
+        assertTrue(f.getCreationTime() > 0);
+    }
+
+    @Test
+    void putSubscriptionFilterWithoutLogGroupThrows() {
+        assertThrows(AwsException.class, () ->
+                service.putSubscriptionFilter("/missing", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION));
+    }
+
+    @Test
+    void putSubscriptionFilterDuplicateThrows() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.putSubscriptionFilter("/app/logs", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.putSubscriptionFilter("/app/logs", "my-filter", "WARN", "arn:aws:lambda:us-east-1:000000000000:function:other", null, REGION));
+    }
+
+    @Test
+    void describeSubscriptionFiltersWithPrefix() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.putSubscriptionFilter("/app/logs", "alpha-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:a", null, REGION);
+        service.putSubscriptionFilter("/app/logs", "beta-filter", "WARN", "arn:aws:lambda:us-east-1:000000000000:function:b", null, REGION);
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult result =
+                service.describeSubscriptionFilters("/app/logs", "alpha", null, 50, REGION);
+        assertEquals(1, result.subscriptionFilters().size());
+        assertEquals("alpha-filter", result.subscriptionFilters().getFirst().getFilterName());
+    }
+
+    @Test
+    void describeSubscriptionFiltersWithoutLogGroupThrows() {
+        assertThrows(AwsException.class, () ->
+                service.describeSubscriptionFilters("/missing", null, null, 50, REGION));
+    }
+
+    @Test
+    void describeSubscriptionFiltersPagination() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        for (int i = 0; i < 5; i++) {
+            service.putSubscriptionFilter("/app/logs", "filter-" + i, "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
+        }
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult page1 =
+                service.describeSubscriptionFilters("/app/logs", null, null, 2, REGION);
+        assertEquals(2, page1.subscriptionFilters().size());
+        assertNotNull(page1.nextToken());
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult page2 =
+                service.describeSubscriptionFilters("/app/logs", null, page1.nextToken(), 2, REGION);
+        assertEquals(2, page2.subscriptionFilters().size());
+    }
+
+    @Test
+    void deleteSubscriptionFilter() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.putSubscriptionFilter("/app/logs", "my-filter", "ERROR", "arn:aws:lambda:us-east-1:000000000000:function:test", null, REGION);
+        service.deleteSubscriptionFilter("/app/logs", "my-filter", REGION);
+
+        CloudWatchLogsService.DescribeSubscriptionFiltersResult result =
+                service.describeSubscriptionFilters("/app/logs", null, null, 50, REGION);
+        assertTrue(result.subscriptionFilters().isEmpty());
+    }
+
+    @Test
+    void deleteSubscriptionFilterNotFoundThrows() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.deleteSubscriptionFilter("/app/logs", "nonexistent", REGION));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements `PutSubscriptionFilter`, `DescribeSubscriptionFilters`, and `DeleteSubscriptionFilter` for the CloudWatch Logs service. Previously these operations returned `UnsupportedOperation` (HTTP 400), blocking the common pattern of forwarding log events from a log group to a destination Lambda / Kinesis / Firehose.

Closes #795

## Changes

### New files
- **`SubscriptionFilter.java`** — domain model with fields: `filterName`, `logGroupName`, `filterPattern`, `destinationArn`, `distribution`, `creationTime`. Follows existing model conventions (`@RegisterForReflection`, `@JsonIgnoreProperties`).

### Modified files
- **`CloudWatchLogsService.java`** — added 4th `StorageBackend` for subscription filters; implemented `putSubscriptionFilter`, `describeSubscriptionFilters` (with `filterNamePrefix` and `nextToken`-based pagination, limit 50 per AWS spec), and `deleteSubscriptionFilter`. All three validate the log group exists before operating.
- **`CloudWatchLogsHandler.java`** — added three switch cases (`PutSubscriptionFilter`, `DescribeSubscriptionFilters`, `DeleteSubscriptionFilter`) with corresponding handler methods that parse the JSON 1.1 request and build the AWS-standard response.
- **`CloudWatchLogsServiceTest.java`** — 8 new unit tests covering create, describe with prefix, pagination, duplicate detection, missing log group validation, delete, and delete-not-found.

## AWS Compatibility

Verified against the [PutSubscriptionFilter](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutSubscriptionFilter.html) and [DescribeSubscriptionFilters](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeSubscriptionFilters.html) API reference.

- `PutSubscriptionFilter` returns HTTP 200 with `{}` (matches real AWS behaviour)
- `DescribeSubscriptionFilters` returns `{"subscriptionFilters": [...], "nextToken": "..."}` with the expected field names and pagination
- `DeleteSubscriptionFilter` returns HTTP 200 with `{}`

## Out of scope (deferred)

- Filter pattern evaluation on `PutLogEvents` and actual event delivery to destination ARN (Lambda invoke / Kinesis PutRecord with the `awslogs` gzipped+base64 payload format). This can be addressed in a follow-up.

## Checklist

- [X] `./mvnw test` passes locally (32/32 tests pass)
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)