### PR TITLE
fix(api-gateway): resolve sibling {proxy+} collision with longest-prefix matching

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1195,29 +1195,27 @@ public class ApiGatewayExecuteController {
                 }
             }
         }
-        // 3. Proxy+ wildcard — {proxy+} matches any remaining path
-        // Pick the proxy+ resource whose parent path is the longest prefix of requestPath
+        // 3. Proxy+ wildcard — {proxy+} matches longest parent prefix
+        // Requires at least one path segment after the parent prefix (except root /{proxy+})
         ApiGatewayResource best = null;
         int bestLen = -1;
         for (ApiGatewayResource r : resources) {
-            if (r.getPathPart() == null || !r.getPathPart().contains("{")) continue;
-            String path = r.getPath();
-            if (path == null) continue;
-            // Parent path is everything before the last / (i.e. strip /{proxy+})
-            int lastSlash = path.lastIndexOf('/');
-            String parent = lastSlash > 0 ? path.substring(0, lastSlash) : "/";
-            if ("/".equals(parent)) {
-                // Root /{proxy+} — fallback if nothing more specific matches
+            if (r.getPath() == null || !r.getPath().contains("{proxy+}")) continue;
+            String parentPrefix = r.getPath().substring(0, r.getPath().indexOf("{proxy+}"));
+            // Root /{proxy+} matches everything including /
+            if ("/".equals(parentPrefix)) {
                 if (best == null) {
                     best = r;
                     bestLen = 0;
                 }
                 continue;
             }
-            String prefix = parent.endsWith("/") ? parent : parent + "/";
-            if (requestPath.startsWith(prefix) && parent.length() > bestLen) {
+            // Non-root proxy+ requires at least one char after the prefix
+            if (requestPath.startsWith(parentPrefix)
+                    && requestPath.length() > parentPrefix.length()
+                    && parentPrefix.length() > bestLen) {
                 best = r;
-                bestLen = parent.length();
+                bestLen = parentPrefix.length();
             }
         }
         return best;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1180,7 +1180,7 @@ public class ApiGatewayExecuteController {
      * Finds the best-matching resource for {@code requestPath}.
      * Priority: exact match > template path match (e.g. /items/{id}) > proxy+ wildcard.
      */
-    private ApiGatewayResource matchResource(List<ApiGatewayResource> resources, String requestPath) {
+    ApiGatewayResource matchResource(List<ApiGatewayResource> resources, String requestPath) {
         // 1. Exact match
         for (ApiGatewayResource r : resources) {
             if (requestPath.equals(r.getPath())) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1196,12 +1196,31 @@ public class ApiGatewayExecuteController {
             }
         }
         // 3. Proxy+ wildcard — {proxy+} matches any remaining path
+        // Pick the proxy+ resource whose parent path is the longest prefix of requestPath
+        ApiGatewayResource best = null;
+        int bestLen = -1;
         for (ApiGatewayResource r : resources) {
-            if (r.getPathPart() != null && r.getPathPart().contains("{")) {
-                return r;
+            if (r.getPathPart() == null || !r.getPathPart().contains("{")) continue;
+            String path = r.getPath();
+            if (path == null) continue;
+            // Parent path is everything before the last / (i.e. strip /{proxy+})
+            int lastSlash = path.lastIndexOf('/');
+            String parent = lastSlash > 0 ? path.substring(0, lastSlash) : "/";
+            if ("/".equals(parent)) {
+                // Root /{proxy+} — fallback if nothing more specific matches
+                if (best == null) {
+                    best = r;
+                    bestLen = 0;
+                }
+                continue;
+            }
+            String prefix = parent.endsWith("/") ? parent : parent + "/";
+            if (requestPath.startsWith(prefix) && parent.length() > bestLen) {
+                best = r;
+                bestLen = parent.length();
             }
         }
-        return null;
+        return best;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
@@ -60,10 +60,19 @@ class ApiGatewayProxyMatchTest {
         List<ApiGatewayResource> resources = List.of(authProxy, productsProxy);
 
         assertSame(authProxy, ctrl.matchResource(resources, "/auth/login"));
-        assertSame(authProxy, ctrl.matchResource(resources, "/auth/"));
         assertSame(productsProxy, ctrl.matchResource(resources, "/products/123"));
         assertSame(productsProxy, ctrl.matchResource(resources, "/products/abc/def"));
         assertNull(ctrl.matchResource(resources, "/other"));
+    }
+
+    @Test
+    void emptyProxySegmentDoesNotMatchNonRootProxy() {
+        ApiGatewayResource authProxy = resource("r1", "root", "{proxy+}", "/auth/{proxy+}");
+        ApiGatewayResource productsProxy = resource("r2", "root", "{proxy+}", "/products/{proxy+}");
+
+        assertNull(ctrl.matchResource(List.of(authProxy), "/auth/"));
+        assertNull(ctrl.matchResource(List.of(authProxy, productsProxy), "/auth/"));
+        assertNull(ctrl.matchResource(List.of(authProxy, productsProxy), "/products/"));
     }
 
     @Test
@@ -105,7 +114,7 @@ class ApiGatewayProxyMatchTest {
 
         assertSame(apiV1Proxy, ctrl.matchResource(resources, "/api/v1/users"));
         assertSame(apiProxy, ctrl.matchResource(resources, "/api/v2"));
-        assertSame(apiProxy, ctrl.matchResource(resources, "/api/"));
+        assertNull(ctrl.matchResource(resources, "/api/"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
@@ -1,0 +1,118 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.github.hectorvent.floci.services.apigateway.model.ApiGatewayResource;
+import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2Service;
+import io.github.hectorvent.floci.services.apigatewayv2.websocket.WebSocketConnectionManager;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApiGatewayProxyMatchTest {
+
+    @Mock ApiGatewayService apiGatewayService;
+    @Mock ApiGatewayV2Service apiGatewayV2Service;
+    @Mock LambdaService lambdaService;
+    @Mock VtlTemplateEngine vtlEngine;
+    @Mock AwsServiceRouter serviceRouter;
+    @Mock WebSocketConnectionManager webSocketConnectionManager;
+
+    private ApiGatewayExecuteController ctrl;
+
+    @BeforeEach
+    void setUp() {
+        ctrl = new ApiGatewayExecuteController(apiGatewayService, apiGatewayV2Service, lambdaService,
+                new RegionResolver("us-east-1", "000000000000"),
+                new ObjectMapper(), vtlEngine, serviceRouter, webSocketConnectionManager);
+    }
+
+    private ApiGatewayResource resource(String id, String parentId, String pathPart, String path) {
+        ApiGatewayResource r = new ApiGatewayResource();
+        r.setId(id);
+        r.setParentId(parentId);
+        r.setPathPart(pathPart);
+        r.setPath(path);
+        return r;
+    }
+
+    @Test
+    void rootProxyMatchesEverything() {
+        ApiGatewayResource rootProxy = resource("r1", "root", "{proxy+}", "/{proxy+}");
+
+        assertSame(rootProxy, ctrl.matchResource(List.of(rootProxy), "/anything"));
+        assertSame(rootProxy, ctrl.matchResource(List.of(rootProxy), "/"));
+        assertSame(rootProxy, ctrl.matchResource(List.of(rootProxy), "/a/b/c"));
+    }
+
+    @Test
+    void siblingProxyRoutesToCorrectParent() {
+        ApiGatewayResource authProxy = resource("r1", "root", "{proxy+}", "/auth/{proxy+}");
+        ApiGatewayResource productsProxy = resource("r2", "root", "{proxy+}", "/products/{proxy+}");
+        List<ApiGatewayResource> resources = List.of(authProxy, productsProxy);
+
+        assertSame(authProxy, ctrl.matchResource(resources, "/auth/login"));
+        assertSame(authProxy, ctrl.matchResource(resources, "/auth/"));
+        assertSame(productsProxy, ctrl.matchResource(resources, "/products/123"));
+        assertSame(productsProxy, ctrl.matchResource(resources, "/products/abc/def"));
+        assertNull(ctrl.matchResource(resources, "/other"));
+    }
+
+    @Test
+    void rootProxyFallbackWhenNoSpecificMatch() {
+        ApiGatewayResource rootProxy = resource("r0", "root", "{proxy+}", "/{proxy+}");
+        ApiGatewayResource authProxy = resource("r1", "root", "{proxy+}", "/auth/{proxy+}");
+        List<ApiGatewayResource> resources = List.of(rootProxy, authProxy);
+
+        assertSame(authProxy, ctrl.matchResource(resources, "/auth/login"));
+        assertSame(rootProxy, ctrl.matchResource(resources, "/other"));
+        assertSame(rootProxy, ctrl.matchResource(resources, "/"));
+    }
+
+    @Test
+    void exactMatchTakesPriorityOverProxy() {
+        ApiGatewayResource exact = resource("r1", "root", "login", "/auth/login");
+        ApiGatewayResource authProxy = resource("r2", "root", "{proxy+}", "/auth/{proxy+}");
+        List<ApiGatewayResource> resources = List.of(authProxy, exact);
+
+        assertSame(exact, ctrl.matchResource(resources, "/auth/login"));
+        assertSame(authProxy, ctrl.matchResource(resources, "/auth/register"));
+    }
+
+    @Test
+    void templatePathTakesPriorityOverProxy() {
+        ApiGatewayResource itemDetail = resource("r1", "root", "{id}", "/items/{id}");
+        ApiGatewayResource itemsProxy = resource("r2", "root", "{proxy+}", "/items/{proxy+}");
+        List<ApiGatewayResource> resources = List.of(itemsProxy, itemDetail);
+
+        assertSame(itemDetail, ctrl.matchResource(resources, "/items/123"));
+        assertSame(itemsProxy, ctrl.matchResource(resources, "/items/123/sub"));
+    }
+
+    @Test
+    void longestParentPrefixWins() {
+        ApiGatewayResource apiProxy = resource("r1", "root", "{proxy+}", "/api/{proxy+}");
+        ApiGatewayResource apiV1Proxy = resource("r2", "root", "{proxy+}", "/api/v1/{proxy+}");
+        List<ApiGatewayResource> resources = List.of(apiV1Proxy, apiProxy);
+
+        assertSame(apiV1Proxy, ctrl.matchResource(resources, "/api/v1/users"));
+        assertSame(apiProxy, ctrl.matchResource(resources, "/api/v2"));
+        assertSame(apiProxy, ctrl.matchResource(resources, "/api/"));
+    }
+
+    @Test
+    void noMatchReturnsNull() {
+        ApiGatewayResource authProxy = resource("r1", "root", "{proxy+}", "/auth/{proxy+}");
+
+        assertNull(ctrl.matchResource(List.of(authProxy), "/"));
+        assertNull(ctrl.matchResource(List.of(authProxy), "/other/path"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes sibling `{proxy+}` resource collision in API Gateway REST API. When multiple `{proxy+}` resources existed under different parent paths (e.g., `/auth/{proxy+}` and `/products/{proxy+}`), the first one registered matched **all** requests regardless of the parent path prefix. Now the `{proxy+}` resource whose parent path is the **longest prefix** of the request path is selected, matching real AWS behaviour.

Also fixes an empty proxy segment edge case: requests like `/auth/` against `/auth/{proxy+}` now correctly return null (404) instead of matching, since `{proxy+}` requires at least one path segment after the prefix. Root `/{proxy+}` still matches `/` as a special case.

Closes #792

## Changes

**`ApiGatewayExecuteController.java`** — replaced the naive first-match proxy+ fallback with a longest-parent-prefix strategy using `substring` before `{proxy+}` for cleaner parent extraction:

- Picks the `{proxy+}` whose parent prefix is the longest match of `requestPath`
- Non-root proxy+ requires at least one char after the prefix (rejects empty segments like `/auth/`)
- Root `/{proxy+}` remains as a special-case fallback matching all paths including `/`
- Non-proxy+ template paths (e.g., `/items/{id}`) are unaffected

## New tests

8 focused unit tests added in **`ApiGatewayProxyMatchTest.java`** covering:

| Test | Scenario |
|------|----------|
| `rootProxyMatchesEverything` | Single `/{proxy+}` matches all paths including `/` |
| `siblingProxyRoutesToCorrectParent` | `/auth/{proxy+}` vs `/products/{proxy+}` routes correctly |
| `emptyProxySegmentDoesNotMatchNonRootProxy` | `/auth/` vs `/auth/{proxy+}` returns null |
| `rootProxyFallbackWhenNoSpecificMatch` | Root `/{proxy+}` catches unmatched paths |
| `exactMatchTakesPriorityOverProxy` | Exact path `/auth/login` beats `/auth/{proxy+}` |
| `templatePathTakesPriorityOverProxy` | `/items/{id}` beats `/items/{proxy+}` for single-segment |
| `longestParentPrefixWins` | `/api/v1/{proxy+}` beats `/api/{proxy+}` for `/api/v1/...` |
| `noMatchReturnsNull` | No proxy+ matches returns null |

## AWS Compatibility

Matches real AWS API Gateway behaviour:
- `POST /auth/login` → `/auth/{proxy+}` ✅
- `GET /products/123` → `/products/{proxy+}` ✅
- `DELETE /products/123` → `/products/{proxy+}` ✅
- `POST /` → `/{proxy+}` (fallback) ✅
- `GET /auth/` → 404 (empty proxy segment) ✅

## Checklist

- [X] `./mvnw test` passes locally (all tests green)
- [X] 8 new unit tests added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)