### PR TITLE
feat(eventbridge): add TestEventPattern action

### DIFF
--- a/docs/services/eventbridge.md
+++ b/docs/services/eventbridge.md
@@ -21,6 +21,7 @@
 | `RemoveTargets` | Remove targets from a rule |
 | `ListTargetsByRule` | List targets for a rule |
 | `PutEvents` | Publish custom events to an event bus |
+| `TestEventPattern` | Test whether a sample event matches a given pattern (no targets fired) |
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -64,6 +64,7 @@ public class EventBridgeHandler {
                 case "RemoveTargets" -> handleRemoveTargets(request, region);
                 case "ListTargetsByRule" -> handleListTargetsByRule(request, region);
                 case "PutEvents" -> handlePutEvents(request, region);
+                case "TestEventPattern" -> handleTestEventPattern(request);
                 case "ListTagsForResource" -> handleListTagsForResource(request, region);
                 case "TagResource" -> handleTagResource(request, region);
                 case "UntagResource" -> handleUntagResource(request, region);
@@ -312,6 +313,15 @@ public class EventBridgeHandler {
             entry.forEach(node::put);
             resultEntries.add(node);
         }
+        return Response.ok(response).build();
+    }
+
+    private Response handleTestEventPattern(JsonNode request) {
+        String eventPattern = request.path("EventPattern").asText(null);
+        String event = request.path("Event").asText(null);
+        boolean result = eventBridgeService.testEventPattern(eventPattern, event);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Result", result);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -628,6 +628,49 @@ public class EventBridgeService {
 
     // ──────────────────────────── Pattern Matching ────────────────────────────
 
+    /**
+     * Tests whether a sample event matches a given event pattern, without firing any
+     * targets. Mirrors the AWS {@code TestEventPattern} API: callers pass the full event
+     * envelope (lowercase {@code source} / {@code detail-type} / {@code detail} /
+     * {@code resources}) as JSON; we adapt it to the internal entry shape and delegate
+     * to {@link #matchesPattern(Map, String)}.
+     */
+    public boolean testEventPattern(String eventPattern, String eventJson) {
+        if (eventJson == null || eventJson.isBlank()) {
+            throw new AwsException("InvalidEventPatternException", "Event is required.", 400);
+        }
+        if (eventPattern != null && !eventPattern.isBlank()) {
+            try {
+                objectMapper.readTree(eventPattern);
+            } catch (Exception e) {
+                throw new AwsException("InvalidEventPatternException",
+                        "Event pattern is not valid JSON: " + e.getMessage(), 400);
+            }
+        }
+        JsonNode event;
+        try {
+            event = objectMapper.readTree(eventJson);
+        } catch (Exception e) {
+            throw new AwsException("InvalidEventPatternException",
+                    "Event is not valid JSON: " + e.getMessage(), 400);
+        }
+        Map<String, Object> entry = new HashMap<>();
+        if (event.hasNonNull("source")) {
+            entry.put("Source", event.get("source").asText());
+        }
+        if (event.hasNonNull("detail-type")) {
+            entry.put("DetailType", event.get("detail-type").asText());
+        }
+        if (event.hasNonNull("detail")) {
+            JsonNode detail = event.get("detail");
+            entry.put("Detail", detail.isTextual() ? detail.asText() : detail.toString());
+        }
+        if (event.hasNonNull("resources") && event.get("resources").isArray()) {
+            entry.put("Resources", event.get("resources"));
+        }
+        return matchesPattern(entry, eventPattern);
+    }
+
     boolean matchesPattern(Map<String, Object> event, String eventPattern) {
         if (eventPattern == null || eventPattern.isBlank()) {
             return true;

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -636,16 +636,17 @@ public class EventBridgeService {
      * to {@link #matchesPattern(Map, String)}.
      */
     public boolean testEventPattern(String eventPattern, String eventJson) {
+        if (eventPattern == null || eventPattern.isBlank()) {
+            throw new AwsException("InvalidEventPatternException", "EventPattern is required.", 400);
+        }
         if (eventJson == null || eventJson.isBlank()) {
             throw new AwsException("InvalidEventPatternException", "Event is required.", 400);
         }
-        if (eventPattern != null && !eventPattern.isBlank()) {
-            try {
-                objectMapper.readTree(eventPattern);
-            } catch (Exception e) {
-                throw new AwsException("InvalidEventPatternException",
-                        "Event pattern is not valid JSON: " + e.getMessage(), 400);
-            }
+        try {
+            objectMapper.readTree(eventPattern);
+        } catch (Exception e) {
+            throw new AwsException("InvalidEventPatternException",
+                    "Event pattern is not valid JSON: " + e.getMessage(), 400);
         }
         JsonNode event;
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -655,6 +655,10 @@ public class EventBridgeService {
             throw new AwsException("InvalidEventPatternException",
                     "Event is not valid JSON: " + e.getMessage(), 400);
         }
+        if (event == null || !event.isObject()) {
+            throw new AwsException("InvalidEventPatternException",
+                    "Event must be a JSON object.", 400);
+        }
         Map<String, Object> entry = new HashMap<>();
         if (event.hasNonNull("source")) {
             entry.put("Source", event.get("source").asText());
@@ -668,6 +672,12 @@ public class EventBridgeService {
         }
         if (event.hasNonNull("resources") && event.get("resources").isArray()) {
             entry.put("Resources", event.get("resources"));
+        }
+        if (event.hasNonNull("account")) {
+            entry.put("Account", event.get("account").asText());
+        }
+        if (event.hasNonNull("region")) {
+            entry.put("Region", event.get("region").asText());
         }
         return matchesPattern(entry, eventPattern);
     }
@@ -694,14 +704,20 @@ public class EventBridgeService {
             }
             JsonNode accountField = pattern.get("account");
             if (accountField != null && accountField.isArray()) {
-                String eventAccount = regionResolver.getAccountId();
+                // Prefer the entry's Account (set by TestEventPattern from the
+                // supplied event envelope); fall back to the caller's account
+                // for PutEvents rule dispatch, where the event always belongs
+                // to the caller.
+                String eventAccount = (String) event.getOrDefault(
+                        "Account", regionResolver.getAccountId());
                 if (!matchesArrayField(accountField, eventAccount)) {
                     return false;
                 }
             }
             JsonNode regionField = pattern.get("region");
             if (regionField != null && regionField.isArray()) {
-                String eventRegion = regionResolver.getDefaultRegion();
+                String eventRegion = (String) event.getOrDefault(
+                        "Region", regionResolver.getDefaultRegion());
                 if (!matchesArrayField(regionField, eventRegion)) {
                     return false;
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -1,0 +1,162 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class EventBridgeTestEventPatternIntegrationTest {
+
+    private static final String EVENT_BRIDGE_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String TARGET = "AWSEvents.TestEventPattern";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void sourceMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void sourceNoMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}",
+                    "Event": "{\\"source\\":\\"com.otherapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailTypeMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"],\\"detail-type\\":[\\"OrderPlaced\\"]}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailNestedMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"status\\":[\\"PAID\\"]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"status\\":\\"PAID\\"}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void prefixFilterMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[{\\"prefix\\":\\"com.\\"}]}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void emptyPatternMatchesAnything() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void malformedPatternRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{not-json}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void missingEventRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -110,7 +110,9 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
-    void emptyPatternMatchesAnything() {
+    void emptyPatternRejected() {
+        // AWS spec: EventPattern is required; an empty string must be rejected
+        // rather than treated as a match-all wildcard.
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)
             .header("X-Amz-Target", TARGET)
@@ -123,8 +125,23 @@ class EventBridgeTestEventPatternIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(200)
-            .body("Result", equalTo(true));
+            .statusCode(400);
+    }
+
+    @Test
+    void missingPatternRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -129,6 +129,129 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
+    void accountMatchFromEventEnvelope() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"account\\":[\\"999999999999\\"]}",
+                    "Event": "{\\"source\\":\\"x\\",\\"detail-type\\":\\"y\\",\\"account\\":\\"999999999999\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void accountNoMatchFromEventEnvelope() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"account\\":[\\"999999999999\\"]}",
+                    "Event": "{\\"source\\":\\"x\\",\\"detail-type\\":\\"y\\",\\"account\\":\\"111111111111\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void regionMatchFromEventEnvelope() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"region\\":[\\"eu-west-1\\"]}",
+                    "Event": "{\\"source\\":\\"x\\",\\"detail-type\\":\\"y\\",\\"region\\":\\"eu-west-1\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void regionNoMatchFromEventEnvelope() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"region\\":[\\"eu-west-1\\"]}",
+                    "Event": "{\\"source\\":\\"x\\",\\"detail-type\\":\\"y\\",\\"region\\":\\"us-east-1\\",\\"detail\\":{}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void arrayEventRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}",
+                    "Event": "[]"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void scalarEventRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}",
+                    "Event": "true"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void nullLiteralEventRejected() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"source\\":[\\"com.myapp\\"]}",
+                    "Event": "null"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
     void missingPatternRejected() {
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)


### PR DESCRIPTION
## Summary

Implements the EventBridge `TestEventPattern` API so callers can check whether a sample event matches an event pattern without firing any targets.

- New public `EventBridgeService#testEventPattern(eventPattern, eventJson)` adapts the AWS event envelope (lowercase `source` / `detail-type` / `detail` / `resources`) into the internal entry shape and delegates to the existing `matchesPattern()` helper — the same matcher used by `PutEvents` for rule dispatch. No new pattern-matching logic is introduced.
- `TestEventPattern` case wired into `EventBridgeHandler`'s switch.
- Returns `{"Result": <bool>}` on success; throws `InvalidEventPatternException` (HTTP 400) on malformed pattern or missing event.
- Docs table in `docs/services/eventbridge.md` updated.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Action name (`TestEventPattern`), request shape (`EventPattern` + `Event` fields), response shape (`{"Result": <bool>}`), and error code (`InvalidEventPatternException`) all per the [AWS EventBridge TestEventPattern reference](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_TestEventPattern.html).

Verified end-to-end via 8 integration tests hitting the running emulator over HTTP. 
SDK verified end-to-end with `boto3 1.43.6`:

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`EventBridgeTestEventPatternIntegrationTest`, 8 cases)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)