### PR TITLE
feat(transcribe): add AWS Transcribe service support

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -301,6 +301,7 @@ public interface EmulatorConfig {
         TransferServiceConfig transfer();
         TextractServiceConfig textract();
         PricingServiceConfig pricing();
+        TranscribeServiceConfig transcribe();
     }
 
     interface TransferServiceConfig {
@@ -652,6 +653,11 @@ public interface EmulatorConfig {
          * {@code <path>/price-lists/<service>.json} are read in preference to the classpath copy.
          */
         Optional<String> snapshotPath();
+    }
+
+    interface TranscribeServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface EcrServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.glue.GlueJsonHandler;
 import io.github.hectorvent.floci.services.resourcegroupstagging.ResourceGroupsTaggingJsonHandler;
 import io.github.hectorvent.floci.services.pricing.PricingJsonHandler;
 import io.github.hectorvent.floci.services.textract.TextractJsonHandler;
+import io.github.hectorvent.floci.services.transcribe.TranscribeJsonHandler;
 import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2JsonHandler;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsHandler;
 import io.github.hectorvent.floci.services.cognito.CognitoJsonHandler;
@@ -68,6 +69,7 @@ public class AwsJson11Controller {
     private final TransferHandler transferHandler;
     private final TextractJsonHandler textractJsonHandler;
     private final PricingJsonHandler pricingJsonHandler;
+    private final TranscribeJsonHandler transcribeJsonHandler;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -88,7 +90,8 @@ public class AwsJson11Controller {
                                Ec2MessagesJsonHandler ec2MessagesJsonHandler,
                                TransferHandler transferHandler,
                                TextractJsonHandler textractJsonHandler,
-                               PricingJsonHandler pricingJsonHandler) {
+                               PricingJsonHandler pricingJsonHandler,
+                               TranscribeJsonHandler transcribeJsonHandler) {
         this.objectMapper = objectMapper;
         this.catalog = catalog;
         this.regionResolver = regionResolver;
@@ -113,6 +116,7 @@ public class AwsJson11Controller {
         this.transferHandler = transferHandler;
         this.textractJsonHandler = textractJsonHandler;
         this.pricingJsonHandler = pricingJsonHandler;
+        this.transcribeJsonHandler = transcribeJsonHandler;
     }
 
     @POST
@@ -162,6 +166,7 @@ public class AwsJson11Controller {
                 case "transfer" -> transferHandler.handle(action, request, region);
                 case "textract" -> textractJsonHandler.handle(action, request, region);
                 case "pricing" -> pricingJsonHandler.handle(action, request, region);
+                case "transcribe" -> transcribeJsonHandler.handle(action, request, region);
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -247,7 +247,11 @@ public class ResolvedServiceCatalog {
                 descriptor("pricing", "pricing", config.services().pricing().enabled(), true,
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
-                        Set.of("AWSPriceListService."), Set.of("pricing", "api.pricing"), Set.of(), Set.of())
+                        Set.of("AWSPriceListService."), Set.of("pricing", "api.pricing"), Set.of(), Set.of()),
+                descriptor("transcribe", "transcribe", config.services().transcribe().enabled(), true,
+                        null, null, 5000L, null, ServiceProtocol.JSON,
+                        protocols(ServiceProtocol.JSON),
+                        Set.of("Transcribe."), Set.of("transcribe"), Set.of(), Set.of())
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeJsonHandler.java
@@ -1,0 +1,128 @@
+package io.github.hectorvent.floci.services.transcribe;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.services.transcribe.model.TranscriptionJob;
+import io.github.hectorvent.floci.services.transcribe.model.VocabularyInfo;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+
+/**
+ * JSON 1.1 handler for Amazon Transcribe API operations.
+ * Dispatches X-Amz-Target: Transcribe.* actions to {@link TranscribeService}.
+ *
+ * @see <a href="https://docs.aws.amazon.com/transcribe/latest/APIReference/Welcome.html">Transcribe API</a>
+ */
+@ApplicationScoped
+public class TranscribeJsonHandler {
+
+    private static final Logger LOG = Logger.getLogger(TranscribeJsonHandler.class);
+
+    private final TranscribeService transcribeService;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public TranscribeJsonHandler(TranscribeService transcribeService, ObjectMapper objectMapper) {
+        this.transcribeService = transcribeService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        LOG.debugv("Transcribe action: {0}", action);
+        return switch (action) {
+            case "StartTranscriptionJob" -> {
+                TranscriptionJob job = transcribeService.startTranscriptionJob(
+                        getStringField(request, "TranscriptionJobName"),
+                        getMediaFileUri(request),
+                        getStringField(request, "LanguageCode"),
+                        getStringField(request, "MediaFormat"));
+                yield Response.ok(Map.of("TranscriptionJob", job)).build();
+            }
+            case "GetTranscriptionJob" -> {
+                TranscriptionJob job = transcribeService.getTranscriptionJob(
+                        getStringField(request, "TranscriptionJobName"));
+                yield Response.ok(Map.of("TranscriptionJob", job)).build();
+            }
+            case "ListTranscriptionJobs" -> {
+                var result = transcribeService.listTranscriptionJobs(
+                        getStringField(request, "Status"),
+                        getStringField(request, "JobNameContains"),
+                        getIntField(request, "MaxResults"));
+                ObjectNode root = objectMapper.createObjectNode();
+                if (result.status() != null) {
+                    root.put("Status", result.status());
+                }
+                root.set("TranscriptionJobSummaries",
+                        objectMapper.valueToTree(result.summaries()));
+                if (result.nextToken() != null) {
+                    root.put("NextToken", result.nextToken());
+                }
+                yield Response.ok(root).build();
+            }
+            case "DeleteTranscriptionJob" -> {
+                transcribeService.deleteTranscriptionJob(
+                        getStringField(request, "TranscriptionJobName"));
+                yield Response.ok(objectMapper.createObjectNode()).build();
+            }
+            case "CreateVocabulary" -> {
+                VocabularyInfo vocab = transcribeService.createVocabulary(
+                        getStringField(request, "VocabularyName"),
+                        getStringField(request, "LanguageCode"));
+                yield Response.ok(vocab).build();
+            }
+            case "GetVocabulary" -> {
+                VocabularyInfo vocab = transcribeService.getVocabulary(
+                        getStringField(request, "VocabularyName"));
+                yield Response.ok(vocab).build();
+            }
+            case "ListVocabularies" -> {
+                var result = transcribeService.listVocabularies(
+                        getStringField(request, "StateEquals"),
+                        getStringField(request, "NameContains"),
+                        getIntField(request, "MaxResults"));
+                ObjectNode root = objectMapper.createObjectNode();
+                if (result.status() != null) {
+                    root.put("Status", result.status());
+                }
+                root.set("Vocabularies", objectMapper.valueToTree(result.vocabularies()));
+                if (result.nextToken() != null) {
+                    root.put("NextToken", result.nextToken());
+                }
+                yield Response.ok(root).build();
+            }
+            case "DeleteVocabulary" -> {
+                transcribeService.deleteVocabulary(
+                        getStringField(request, "VocabularyName"));
+                yield Response.ok(objectMapper.createObjectNode()).build();
+            }
+            default -> Response.status(400)
+                    .entity(new AwsErrorResponse("UnknownOperationException",
+                            "Unknown operation: Transcribe." + action))
+                    .build();
+        };
+    }
+
+    private String getStringField(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        return (value != null && !value.isNull()) ? value.asText() : null;
+    }
+
+    private String getMediaFileUri(JsonNode request) {
+        if (request == null) return null;
+        JsonNode media = request.path("Media");
+        if (media.isMissingNode()) return null;
+        JsonNode uri = media.get("MediaFileUri");
+        return (uri != null && !uri.isNull()) ? uri.asText() : null;
+    }
+
+    private Integer getIntField(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        return (value != null && !value.isNull()) ? value.asInt() : null;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeService.java
@@ -1,0 +1,152 @@
+package io.github.hectorvent.floci.services.transcribe;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.transcribe.model.TranscriptionJob;
+import io.github.hectorvent.floci.services.transcribe.model.TranscriptionJobSummary;
+import io.github.hectorvent.floci.services.transcribe.model.VocabularyInfo;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Stub for Amazon Transcribe. Jobs transition to COMPLETED and vocabularies
+ * to READY immediately. No real transcription is performed.
+ *
+ * @see <a href="https://docs.aws.amazon.com/transcribe/latest/APIReference/Welcome.html">Transcribe API</a>
+ */
+@ApplicationScoped
+public class TranscribeService {
+
+    private final ConcurrentHashMap<String, TranscriptionJob> transcriptionJobs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, VocabularyInfo> vocabularies = new ConcurrentHashMap<>();
+
+    public TranscriptionJob startTranscriptionJob(String jobName, String mediaFileUri,
+                                                  String languageCode, String mediaFormat) {
+        requireNonBlank(jobName, "TranscriptionJobName");
+        requireNonBlank(mediaFileUri, "Media.MediaFileUri");
+        if (transcriptionJobs.containsKey(jobName)) {
+            throw new AwsException("ConflictException",
+                    "The requested job name already exists. Use a different job name.", 400);
+        }
+
+        long now = Instant.now().getEpochSecond();
+        TranscriptionJob job = new TranscriptionJob(
+                jobName,
+                "COMPLETED",
+                languageCode != null ? languageCode : "en-US",
+                mediaFormat != null ? mediaFormat : "mp4",
+                48000,
+                new TranscriptionJob.Media(mediaFileUri),
+                new TranscriptionJob.Transcript("s3://floci-transcribe-output/" + jobName + ".json"),
+                now, now, now);
+
+        transcriptionJobs.put(jobName, job);
+        return job;
+    }
+
+    public TranscriptionJob getTranscriptionJob(String jobName) {
+        requireNonBlank(jobName, "TranscriptionJobName");
+        TranscriptionJob job = transcriptionJobs.get(jobName);
+        if (job == null) {
+            throw new AwsException("NotFoundException",
+                    "The requested job couldn't be found. Check the job name and try your request again.", 400);
+        }
+        return job;
+    }
+
+    public ListTranscriptionJobsResult listTranscriptionJobs(String statusFilter, String jobNameContains,
+                                                             Integer maxResults) {
+        int limit = maxResults != null ? Math.min(maxResults, 100) : 100;
+
+        List<TranscriptionJobSummary> filtered = transcriptionJobs.values().stream()
+                .filter(j -> statusFilter == null || statusFilter.equals(j.transcriptionJobStatus()))
+                .filter(j -> jobNameContains == null || j.transcriptionJobName().contains(jobNameContains))
+                .sorted(Comparator.comparing(TranscriptionJob::transcriptionJobName))
+                .map(TranscriptionJobSummary::from)
+                .toList();
+
+        List<TranscriptionJobSummary> page = filtered.subList(0, Math.min(limit, filtered.size()));
+        String nextToken = page.size() < filtered.size()
+                ? page.get(page.size() - 1).transcriptionJobName() : null;
+
+        return new ListTranscriptionJobsResult(page, statusFilter, nextToken);
+    }
+
+    public void deleteTranscriptionJob(String jobName) {
+        requireNonBlank(jobName, "TranscriptionJobName");
+        if (transcriptionJobs.remove(jobName) == null) {
+            throw new AwsException("BadRequestException",
+                    "The requested job couldn't be found. Check the job name and try your request again.", 400);
+        }
+    }
+
+    public VocabularyInfo createVocabulary(String vocabularyName, String languageCode) {
+        requireNonBlank(vocabularyName, "VocabularyName");
+        requireNonBlank(languageCode, "LanguageCode");
+        if (vocabularies.containsKey(vocabularyName)) {
+            throw new AwsException("ConflictException",
+                    "The requested vocabulary name already exists. Use a different vocabulary name.", 400);
+        }
+
+        VocabularyInfo vocab = new VocabularyInfo(
+                vocabularyName, languageCode, "READY", Instant.now().getEpochSecond());
+        vocabularies.put(vocabularyName, vocab);
+        return vocab;
+    }
+
+    public VocabularyInfo getVocabulary(String vocabularyName) {
+        requireNonBlank(vocabularyName, "VocabularyName");
+        VocabularyInfo vocab = vocabularies.get(vocabularyName);
+        if (vocab == null) {
+            throw new AwsException("NotFoundException",
+                    "The requested vocabulary couldn't be found. Check the vocabulary name and try your request again.",
+                    400);
+        }
+        return vocab;
+    }
+
+    public ListVocabulariesResult listVocabularies(String stateEquals, String nameContains,
+                                                   Integer maxResults) {
+        int limit = maxResults != null ? Math.min(maxResults, 100) : 100;
+
+        List<VocabularyInfo> filtered = vocabularies.values().stream()
+                .filter(v -> stateEquals == null || stateEquals.equals(v.vocabularyState()))
+                .filter(v -> nameContains == null || v.vocabularyName().contains(nameContains))
+                .sorted(Comparator.comparing(VocabularyInfo::vocabularyName))
+                .toList();
+
+        List<VocabularyInfo> page = filtered.subList(0, Math.min(limit, filtered.size()));
+        String nextToken = page.size() < filtered.size()
+                ? page.get(page.size() - 1).vocabularyName() : null;
+
+        return new ListVocabulariesResult(page, stateEquals, nextToken);
+    }
+
+    public void deleteVocabulary(String vocabularyName) {
+        requireNonBlank(vocabularyName, "VocabularyName");
+        if (vocabularies.remove(vocabularyName) == null) {
+            throw new AwsException("NotFoundException",
+                    "The requested vocabulary couldn't be found. Check the vocabulary name and try your request again.",
+                    400);
+        }
+    }
+
+    private void requireNonBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value null at '" + fieldName
+                            + "' failed to satisfy constraint: Member must not be null",
+                    400);
+        }
+    }
+
+    public record ListTranscriptionJobsResult(
+            List<TranscriptionJobSummary> summaries, String status, String nextToken) {}
+
+    public record ListVocabulariesResult(
+            List<VocabularyInfo> vocabularies, String status, String nextToken) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/model/TranscriptionJob.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/model/TranscriptionJob.java
@@ -1,0 +1,32 @@
+package io.github.hectorvent.floci.services.transcribe.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TranscriptionJob(
+        @JsonProperty("TranscriptionJobName") String transcriptionJobName,
+        @JsonProperty("TranscriptionJobStatus") String transcriptionJobStatus,
+        @JsonProperty("LanguageCode") String languageCode,
+        @JsonProperty("MediaFormat") String mediaFormat,
+        @JsonProperty("MediaSampleRateHertz") Integer mediaSampleRateHertz,
+        @JsonProperty("Media") Media media,
+        @JsonProperty("Transcript") Transcript transcript,
+        @JsonProperty("CreationTime") Long creationTime,
+        @JsonProperty("StartTime") Long startTime,
+        @JsonProperty("CompletionTime") Long completionTime
+) {
+    @RegisterForReflection
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Media(
+            @JsonProperty("MediaFileUri") String mediaFileUri
+    ) {}
+
+    @RegisterForReflection
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Transcript(
+            @JsonProperty("TranscriptFileUri") String transcriptFileUri
+    ) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/model/TranscriptionJobSummary.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/model/TranscriptionJobSummary.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.transcribe.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TranscriptionJobSummary(
+        @JsonProperty("TranscriptionJobName") String transcriptionJobName,
+        @JsonProperty("TranscriptionJobStatus") String transcriptionJobStatus,
+        @JsonProperty("LanguageCode") String languageCode,
+        @JsonProperty("CreationTime") Long creationTime,
+        @JsonProperty("StartTime") Long startTime,
+        @JsonProperty("CompletionTime") Long completionTime
+) {
+    public static TranscriptionJobSummary from(TranscriptionJob job) {
+        return new TranscriptionJobSummary(
+                job.transcriptionJobName(),
+                job.transcriptionJobStatus(),
+                job.languageCode(),
+                job.creationTime(),
+                job.startTime(),
+                job.completionTime());
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/model/VocabularyInfo.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/model/VocabularyInfo.java
@@ -1,0 +1,14 @@
+package io.github.hectorvent.floci.services.transcribe.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record VocabularyInfo(
+        @JsonProperty("VocabularyName") String vocabularyName,
+        @JsonProperty("LanguageCode") String languageCode,
+        @JsonProperty("VocabularyState") String vocabularyState,
+        @JsonProperty("LastModifiedTime") Long lastModifiedTime
+) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -260,3 +260,5 @@ floci:
       enabled: true
     pricing:
       enabled: true
+    transcribe:
+      enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/transcribe/TranscribeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/transcribe/TranscribeIntegrationTest.java
@@ -1,0 +1,453 @@
+package io.github.hectorvent.floci.services.transcribe;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for the Amazon Transcribe stub.
+ * Protocol: JSON 1.1 — Content-Type: application/x-amz-json-1.1, X-Amz-Target: Transcribe.&lt;Action&gt;
+ */
+@QuarkusTest
+class TranscribeIntegrationTest {
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/transcribe/aws4_request";
+
+    // ── StartTranscriptionJob ────────────────────────────────────────────────
+
+    @Test
+    void startTranscriptionJob_returnsCompletedJob() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-start",
+                 "Media":{"MediaFileUri":"s3://my-bucket/audio.mp3"},
+                 "LanguageCode":"en-US","MediaFormat":"mp3"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TranscriptionJob.TranscriptionJobName", equalTo("test-job-start"))
+            .body("TranscriptionJob.TranscriptionJobStatus", equalTo("COMPLETED"))
+            .body("TranscriptionJob.LanguageCode", equalTo("en-US"))
+            .body("TranscriptionJob.MediaFormat", equalTo("mp3"))
+            .body("TranscriptionJob.Media.MediaFileUri", equalTo("s3://my-bucket/audio.mp3"))
+            .body("TranscriptionJob.Transcript.TranscriptFileUri", notNullValue())
+            .body("TranscriptionJob.CreationTime", notNullValue())
+            .body("TranscriptionJob.CompletionTime", notNullValue());
+    }
+
+    @Test
+    void startTranscriptionJob_defaultLanguageCode() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-defaults",
+                 "Media":{"MediaFileUri":"s3://bucket/audio.wav"}}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TranscriptionJob.LanguageCode", equalTo("en-US"))
+            .body("TranscriptionJob.MediaFormat", equalTo("mp4"));
+    }
+
+    @Test
+    void startTranscriptionJob_duplicateName_returnsConflict() {
+        String body = """
+            {"TranscriptionJobName":"test-job-dup",
+             "Media":{"MediaFileUri":"s3://bucket/audio.wav"}}""";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConflictException"));
+    }
+
+    @Test
+    void startTranscriptionJob_missingJobName_returnsBadRequest() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"Media":{"MediaFileUri":"s3://bucket/audio.wav"}}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    void startTranscriptionJob_missingMedia_returnsBadRequest() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-no-media"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    // ── GetTranscriptionJob ──────────────────────────────────────────────────
+
+    @Test
+    void getTranscriptionJob_returnsJobDetails() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-get",
+                 "Media":{"MediaFileUri":"s3://bucket/audio.wav"},
+                 "LanguageCode":"fr-FR"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-get"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TranscriptionJob.TranscriptionJobName", equalTo("test-job-get"))
+            .body("TranscriptionJob.TranscriptionJobStatus", equalTo("COMPLETED"))
+            .body("TranscriptionJob.LanguageCode", equalTo("fr-FR"));
+    }
+
+    @Test
+    void getTranscriptionJob_notFound_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"nonexistent-job"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    // ── ListTranscriptionJobs ────────────────────────────────────────────────
+
+    @Test
+    void listTranscriptionJobs_returnsJobs() {
+        for (String name : new String[]{"list-job-a", "list-job-b"}) {
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+                .header("Authorization", AUTH_HEADER)
+                .body("{\"TranscriptionJobName\":\"" + name
+                        + "\",\"Media\":{\"MediaFileUri\":\"s3://b/a.wav\"}}")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.ListTranscriptionJobs")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"JobNameContains":"list-job-"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TranscriptionJobSummaries", hasSize(greaterThanOrEqualTo(2)))
+            .body("TranscriptionJobSummaries.TranscriptionJobName",
+                    hasItems("list-job-a", "list-job-b"));
+    }
+
+    // ── DeleteTranscriptionJob ───────────────────────────────────────────────
+
+    @Test
+    void deleteTranscriptionJob_removesJob() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.StartTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-delete",
+                 "Media":{"MediaFileUri":"s3://b/a.wav"}}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.DeleteTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-delete"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"test-job-delete"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    void deleteTranscriptionJob_notFound_returnsBadRequest() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.DeleteTranscriptionJob")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TranscriptionJobName":"nonexistent-delete"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    // ── CreateVocabulary ─────────────────────────────────────────────────────
+
+    @Test
+    void createVocabulary_returnsReadyVocabulary() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-create","LanguageCode":"en-US"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("VocabularyName", equalTo("test-vocab-create"))
+            .body("LanguageCode", equalTo("en-US"))
+            .body("VocabularyState", equalTo("READY"))
+            .body("LastModifiedTime", notNullValue());
+    }
+
+    @Test
+    void createVocabulary_duplicateName_returnsConflict() {
+        String body = """
+            {"VocabularyName":"test-vocab-dup","LanguageCode":"en-US"}""";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConflictException"));
+    }
+
+    // ── GetVocabulary ────────────────────────────────────────────────────────
+
+    @Test
+    void getVocabulary_returnsVocabularyDetails() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-get","LanguageCode":"de-DE"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-get"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("VocabularyName", equalTo("test-vocab-get"))
+            .body("LanguageCode", equalTo("de-DE"))
+            .body("VocabularyState", equalTo("READY"));
+    }
+
+    @Test
+    void getVocabulary_notFound_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"nonexistent-vocab"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    // ── ListVocabularies ─────────────────────────────────────────────────────
+
+    @Test
+    void listVocabularies_returnsAll() {
+        for (String name : new String[]{"list-vocab-a", "list-vocab-b"}) {
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+                .header("Authorization", AUTH_HEADER)
+                .body("{\"VocabularyName\":\"" + name + "\",\"LanguageCode\":\"en-US\"}")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.ListVocabularies")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"NameContains":"list-vocab-"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Vocabularies", hasSize(greaterThanOrEqualTo(2)))
+            .body("Vocabularies.VocabularyName", hasItems("list-vocab-a", "list-vocab-b"));
+    }
+
+    // ── DeleteVocabulary ─────────────────────────────────────────────────────
+
+    @Test
+    void deleteVocabulary_removesVocabulary() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.CreateVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-delete","LanguageCode":"en-US"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.DeleteVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-delete"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.GetVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"test-vocab-delete"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    void deleteVocabulary_notFound_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.DeleteVocabulary")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"VocabularyName":"nonexistent-vocab-del"}""")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    // ── Unknown operation ────────────────────────────────────────────────────
+
+    @Test
+    void unknownAction_returnsUnknownOperationError() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "Transcribe.FakeAction")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("UnknownOperationException"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add stub implementation for AWS Transcribe with 8 API actions: `StartTranscriptionJob`, `GetTranscriptionJob`, `ListTranscriptionJobs`, `DeleteTranscriptionJob`, `CreateVocabulary`, `GetVocabulary`, `ListVocabularies`, `DeleteVocabulary`
- JSON 1.1 protocol (`X-Amz-Target: Transcribe.*`), in-memory `ConcurrentHashMap` storage, following the existing service patterns
- 18 integration tests covering happy paths, validation errors, conflicts, and unknown operations

Closes #820

## Test plan

- [x] `TranscribeIntegrationTest` — 18/18 tests pass
- [x] Verified with Apache Camel `camel-aws2-transcribe` integration tests against local Docker image