### PR TITLE
feat(ce): add Cost Explorer service

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ All default images are configurable via environment variables — useful for pin
 | **Transfer Family** | In-process | Server lifecycle (`CreateServer` / `DeleteServer` / `StartServer` / `StopServer` / `UpdateServer`), user management, SSH public key import, and tagging |
 | **Textract** | In-process (stub) | API-compatible stubs for all operations; dummy block data with realistic shape and metadata; async job simulation with immediate SUCCEEDED status |
 | **Pricing (Price List Service)** | In-process + bundled static snapshot | `DescribeServices`, `GetAttributeValues`, `GetProducts`, `ListPriceLists`, `GetPriceListFileUrl`; pagination; filesystem override via `FLOCI_SERVICES_PRICING_SNAPSHOT_PATH` |
+| **Cost Explorer** | In-process; cost synthesized from Floci resource state × Pricing snapshot | `GetCostAndUsage` (full `Filter`/`GroupBy`/`Metrics`/`RECORD_TYPE`), `GetCostAndUsageWithResources`, `GetDimensionValues`, `GetTags`, RI/SP coverage+utilization stubs; CDI-discovered `ResourceUsageEnumerator` SPI for new services to emit cost lines without touching CE |
 
 ---
 

--- a/docs/services/ce.md
+++ b/docs/services/ce.md
@@ -1,0 +1,126 @@
+# Cost Explorer (`ce:*`)
+
+**Protocol:** JSON 1.1
+**Header:** `X-Amz-Target: AWSInsightsIndexService.<Action>`
+**Endpoint prefix:** `ce`
+
+Floci synthesizes Cost Explorer responses from its own resource state,
+multiplied by the bundled AWS Pricing snapshot served by the
+[Pricing service](pricing.md). Costs reflect what's running in Floci right now,
+so any test that mutates resources (e.g. creates a bucket, runs an instance)
+sees those changes in the next `GetCostAndUsage` call.
+
+## Supported Operations
+
+| Operation | Notes |
+|-----------|-------|
+| `GetCostAndUsage` | Full `TimePeriod` / `Granularity` / `Filter` / `GroupBy` / `Metrics` support |
+| `GetCostAndUsageWithResources` | Same shape as `GetCostAndUsage`; for resource-level breakdown, group by `Type=DIMENSION,Key=RESOURCE_ID` |
+| `GetDimensionValues` | Returns dimension values present in the synthesized data set |
+| `GetTags` | Returns tag keys / values across enumerated resources |
+| `GetReservationCoverage` | Stub — returns zeroed totals; full RI math lands in a follow-up PR |
+| `GetReservationUtilization` | Stub — returns zeroed totals |
+| `GetSavingsPlansCoverage` | Stub — returns empty list |
+| `GetSavingsPlansUtilization` | Stub — returns zeroed totals |
+| `GetCostCategories` | Stub — returns empty list (cost-category management not yet emulated) |
+
+## Cost synthesis model
+
+Each Floci service that wants to participate in cost reporting ships a
+{@code @ApplicationScoped} bean implementing `ResourceUsageEnumerator`
+(in `core/common/`). Cost Explorer auto-discovers these via CDI — adding a new
+service with cost data needs zero changes to `CostExplorerService`.
+
+The bundled enumerators cover:
+
+| Service | Priced unit | Source |
+|---------|-------------|--------|
+| `AmazonEC2` | `BoxUsage:<instanceType>` × hours | `Ec2Service.describeInstances` |
+| `AmazonS3` | `TimedStorage-Standard` × GB-month | `S3Service.listBuckets` + `listObjects` |
+| `AWSLambda` | `AWS-Lambda-Requests` (zero quantity, catalog only) | `LambdaService.listFunctions` |
+| Other Floci services (DDB, SQS, SNS, …) | catalog only, zero quantity | `UnpricedServicesEnumerator` |
+
+Unpriced services emit zero-quantity catalog rows so they remain visible in
+`GetDimensionValues SERVICE` responses without contributing billed cost.
+
+## `RECORD_TYPE` semantics
+
+`GROUP_BY=RECORD_TYPE` distinguishes:
+
+| Record type | When emitted |
+|-------------|--------------|
+| `Usage` | All synthesized usage rows (always present) |
+| `Credit` | When `FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY > 0` (see below) |
+| `Tax` / `Refund` / `DiscountedUsage` / `SavingsPlan*` | Reserved for future PRs; not currently emitted |
+
+### Synthetic credit injection
+
+Set `FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY` (default `0.0`) to emit a monthly
+`Credit` row that offsets `min(creditUsd, monthly Usage cost)`. Useful for
+exercising any code path that computes net cost (gross usage − credits) without
+having to build credit fixtures by hand.
+
+```yaml
+floci:
+  services:
+    ce:
+      credit-usd-monthly: 100.0
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_CE_ENABLED` | `true` | Enable or disable the service |
+| `FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY` | `0.0` | Synthetic monthly credit, applied as a `Credit` `RECORD_TYPE` row |
+
+## Examples
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+
+aws ce get-cost-and-usage \
+  --time-period Start=2026-01-01,End=2026-02-01 \
+  --granularity MONTHLY \
+  --metrics UnblendedCost \
+  --group-by Type=DIMENSION,Key=SERVICE
+
+aws ce get-dimension-values \
+  --time-period Start=2026-01-01,End=2026-02-01 \
+  --dimension SERVICE
+```
+
+```python
+import boto3
+
+ce = boto3.client(
+    "ce",
+    endpoint_url="http://localhost:4566",
+    region_name="us-east-1",
+)
+
+resp = ce.get_cost_and_usage(
+    TimePeriod={"Start": "2026-01-01", "End": "2026-02-01"},
+    Granularity="MONTHLY",
+    Metrics=["UnblendedCost"],
+    GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
+    Filter={
+        "Not": {"Dimensions": {"Key": "SERVICE", "Values": ["AmazonRDS"]}}
+    },
+)
+for result in resp["ResultsByTime"]:
+    for group in result["Groups"]:
+        print(group["Keys"], group["Metrics"]["UnblendedCost"]["Amount"])
+```
+
+## Out of Scope
+
+- Forecasting (`GetCostForecast`, `GetUsageForecast`).
+- Right-sizing recommendations (`GetRightsizingRecommendation`).
+- Anomaly detection management (`GetAnomalies`, `*AnomalyMonitor`, `*AnomalySubscription`) — separate PR planned per #791.
+- Real Reservation / Savings Plan utilization math — currently zeroed stubs.
+- Cost category management (`CreateCostCategoryDefinition` / `*Definition` / `ListCostCategoryDefinitions`).
+- Resource-level granularity beyond what `GetCostAndUsageWithResources` exposes today.

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -302,6 +302,7 @@ public interface EmulatorConfig {
         TextractServiceConfig textract();
         PricingServiceConfig pricing();
         TranscribeServiceConfig transcribe();
+        CostExplorerServiceConfig ce();
     }
 
     interface TransferServiceConfig {
@@ -658,6 +659,20 @@ public interface EmulatorConfig {
     interface TranscribeServiceConfig {
         @WithDefault("true")
         boolean enabled();
+    }
+
+    interface CostExplorerServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * Synthetic monthly USD credit applied as a {@code Credit} {@code RECORD_TYPE}
+         * row in {@code GetCostAndUsage} responses. The emitted credit is capped at
+         * the synthesized monthly usage so net cost never goes below zero.
+         * Defaults to zero (no credit emitted).
+         */
+        @WithDefault("0.0")
+        double creditUsdMonthly();
     }
 
     interface EcrServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ecs.EcsJsonHandler;
 import io.github.hectorvent.floci.services.firehose.FirehoseJsonHandler;
 import io.github.hectorvent.floci.services.glue.GlueJsonHandler;
 import io.github.hectorvent.floci.services.resourcegroupstagging.ResourceGroupsTaggingJsonHandler;
+import io.github.hectorvent.floci.services.ce.CostExplorerJsonHandler;
 import io.github.hectorvent.floci.services.pricing.PricingJsonHandler;
 import io.github.hectorvent.floci.services.textract.TextractJsonHandler;
 import io.github.hectorvent.floci.services.transcribe.TranscribeJsonHandler;
@@ -70,6 +71,7 @@ public class AwsJson11Controller {
     private final TextractJsonHandler textractJsonHandler;
     private final PricingJsonHandler pricingJsonHandler;
     private final TranscribeJsonHandler transcribeJsonHandler;
+    private final CostExplorerJsonHandler costExplorerJsonHandler;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -91,7 +93,8 @@ public class AwsJson11Controller {
                                TransferHandler transferHandler,
                                TextractJsonHandler textractJsonHandler,
                                PricingJsonHandler pricingJsonHandler,
-                               TranscribeJsonHandler transcribeJsonHandler) {
+                               TranscribeJsonHandler transcribeJsonHandler,
+                               CostExplorerJsonHandler costExplorerJsonHandler) {
         this.objectMapper = objectMapper;
         this.catalog = catalog;
         this.regionResolver = regionResolver;
@@ -117,6 +120,7 @@ public class AwsJson11Controller {
         this.textractJsonHandler = textractJsonHandler;
         this.pricingJsonHandler = pricingJsonHandler;
         this.transcribeJsonHandler = transcribeJsonHandler;
+        this.costExplorerJsonHandler = costExplorerJsonHandler;
     }
 
     @POST
@@ -167,6 +171,7 @@ public class AwsJson11Controller {
                 case "textract" -> textractJsonHandler.handle(action, request, region);
                 case "pricing" -> pricingJsonHandler.handle(action, request, region);
                 case "transcribe" -> transcribeJsonHandler.handle(action, request, region);
+                case "ce" -> costExplorerJsonHandler.handle(action, request, region);
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -251,7 +251,11 @@ public class ResolvedServiceCatalog {
                 descriptor("transcribe", "transcribe", config.services().transcribe().enabled(), true,
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
-                        Set.of("Transcribe."), Set.of("transcribe"), Set.of(), Set.of())
+                        Set.of("Transcribe."), Set.of("transcribe"), Set.of(), Set.of()),
+                descriptor("ce", "ce", config.services().ce().enabled(), true,
+                        null, null, 5000L, null, ServiceProtocol.JSON,
+                        protocols(ServiceProtocol.JSON),
+                        Set.of("AWSInsightsIndexService."), Set.of("ce"), Set.of(), Set.of())
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResourceUsageEnumerator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResourceUsageEnumerator.java
@@ -1,0 +1,48 @@
+package io.github.hectorvent.floci.core.common;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+
+/**
+ * SPI for any Floci service that wants to participate in Cost Explorer / CUR
+ * cost-and-usage reporting.
+ * <p>
+ * Implementations are discovered by CDI. Drop a class annotated
+ * {@code @ApplicationScoped} that implements this interface anywhere on the
+ * classpath; Cost Explorer auto-injects it via {@code Instance<>}. There is no
+ * central registration step.
+ *
+ * <p>An implementation enumerates the resource state held by its service and
+ * emits one {@link UsageLine} per (resource, region, usage-type, day) cell that
+ * was active during the requested period. Lines for unpriced services should
+ * still be emitted with {@code quantity = 0} — that keeps the service visible
+ * in {@code GetDimensionValues}({@code SERVICE}) responses without contributing
+ * to billed cost.
+ *
+ * <p>Implementations should be cheap to call repeatedly: Cost Explorer invokes
+ * {@link #enumerate} per request and does not cache across calls. Implementations
+ * are responsible for honoring {@code region} themselves; the caller does not
+ * pre-filter.
+ *
+ * <p><b>Usage-type contract:</b> future enumerators should emit AWS-native usage
+ * types (e.g. {@code BoxUsage:t3.micro}, {@code TimedStorage-Standard},
+ * {@code AWS-Lambda-Requests}) that match the {@code usagetype} attribute carried
+ * on the corresponding product offer in the Pricing snapshot. The fallback
+ * synthesis path in {@code PricingRateLookup} is compatibility-only for
+ * incomplete external snapshots supplied via
+ * {@code FLOCI_SERVICES_PRICING_SNAPSHOT_PATH} that omit {@code usagetype}; new
+ * code should not rely on it.
+ */
+public interface ResourceUsageEnumerator {
+
+    /**
+     * Returns the usage rows for {@code [periodStart, periodEnd)} in {@code region}.
+     * The boundaries are half-open: {@code periodStart} inclusive, {@code periodEnd}
+     * exclusive. Both are UTC instants aligned to a day boundary by the caller.
+     *
+     * <p>The stream is consumed eagerly by Cost Explorer; implementations may
+     * return a closed stream once exhausted. Empty stream is valid (and is the
+     * default for services with no resources in {@code region}).
+     */
+    Stream<UsageLine> enumerate(Instant periodStart, Instant periodEnd, String region);
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/UsageLine.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/UsageLine.java
@@ -1,0 +1,57 @@
+package io.github.hectorvent.floci.core.common;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * One synthesized cost-and-usage row, before Cost Explorer pricing or grouping.
+ * <p>
+ * Each Floci service that wants to participate in cost reporting emits these via
+ * an {@link ResourceUsageEnumerator} bean. Cost Explorer ({@code services/ce})
+ * and CUR / BCM Data Exports consume the same stream.
+ * <p>
+ * Fields map to the AWS CE / CUR dimensions:
+ * <ul>
+ *   <li>{@link #service()} — {@code Dimension.SERVICE} (e.g. {@code AmazonEC2})</li>
+ *   <li>{@link #region()} — {@code Dimension.REGION}</li>
+ *   <li>{@link #usageType()} — {@code Dimension.USAGE_TYPE}</li>
+ *   <li>{@link #recordType()} — {@code Dimension.RECORD_TYPE}
+ *       (one of {@code Usage}, {@code Credit}, {@code Tax}, {@code Refund},
+ *       {@code DiscountedUsage},
+ *       {@code SavingsPlanCoveredUsage}, {@code SavingsPlanNegation},
+ *       {@code SavingsPlanUpfrontFee}, {@code SavingsPlanRecurringFee})</li>
+ *   <li>{@link #operation()} — {@code Dimension.OPERATION}</li>
+ *   <li>{@link #linkedAccountId()} — {@code Dimension.LINKED_ACCOUNT}</li>
+ *   <li>{@link #resourceId()} — populated when the request asks for resource-level data</li>
+ *   <li>{@link #tags()} — resource tags surfaced into the {@code TAG} group key namespace</li>
+ *   <li>{@link #quantity()} — usage quantity in {@link #usageUnit()} (e.g. {@code Hrs}, {@code GB-Mo})</li>
+ *   <li>{@link #periodStart()} / {@link #periodEnd()} — half-open day window</li>
+ * </ul>
+ *
+ * <p>This is a wire-neutral model. The Cost Explorer service maps it to
+ * {@code GetCostAndUsage} responses; the CUR service maps it to Parquet rows.
+ */
+public record UsageLine(
+        Instant periodStart,
+        Instant periodEnd,
+        String service,
+        String region,
+        String usageType,
+        String operation,
+        String recordType,
+        String linkedAccountId,
+        String resourceId,
+        Map<String, String> tags,
+        double quantity,
+        String usageUnit) {
+
+    public static final String RECORD_TYPE_USAGE = "Usage";
+    public static final String RECORD_TYPE_CREDIT = "Credit";
+    public static final String RECORD_TYPE_TAX = "Tax";
+    public static final String RECORD_TYPE_REFUND = "Refund";
+    public static final String RECORD_TYPE_DISCOUNTED_USAGE = "DiscountedUsage";
+    public static final String RECORD_TYPE_SP_COVERED_USAGE = "SavingsPlanCoveredUsage";
+    public static final String RECORD_TYPE_SP_NEGATION = "SavingsPlanNegation";
+    public static final String RECORD_TYPE_SP_UPFRONT_FEE = "SavingsPlanUpfrontFee";
+    public static final String RECORD_TYPE_SP_RECURRING_FEE = "SavingsPlanRecurringFee";
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerJsonHandler.java
@@ -1,0 +1,47 @@
+package io.github.hectorvent.floci.services.ce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+/**
+ * JSON 1.1 handler for AWS Cost Explorer operations.
+ * Dispatches {@code X-Amz-Target: AWSInsightsIndexService.*} actions to
+ * {@link CostExplorerService}.
+ *
+ * @see <a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Operations_AWS_Cost_Explorer_Service.html">AWS Cost Explorer API</a>
+ */
+@ApplicationScoped
+public class CostExplorerJsonHandler {
+
+    private static final Logger LOG = Logger.getLogger(CostExplorerJsonHandler.class);
+
+    private final CostExplorerService service;
+
+    @Inject
+    public CostExplorerJsonHandler(CostExplorerService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        LOG.debugv("CostExplorer action: {0}", action);
+        return switch (action) {
+            case "GetCostAndUsage" -> Response.ok(service.getCostAndUsage(request, region)).build();
+            case "GetCostAndUsageWithResources" -> Response.ok(service.getCostAndUsageWithResources(request, region)).build();
+            case "GetDimensionValues" -> Response.ok(service.getDimensionValues(request, region)).build();
+            case "GetTags" -> Response.ok(service.getTags(request, region)).build();
+            case "GetReservationCoverage" -> Response.ok(service.getReservationCoverage()).build();
+            case "GetReservationUtilization" -> Response.ok(service.getReservationUtilization()).build();
+            case "GetSavingsPlansCoverage" -> Response.ok(service.getSavingsPlansCoverage()).build();
+            case "GetSavingsPlansUtilization" -> Response.ok(service.getSavingsPlansUtilization()).build();
+            case "GetCostCategories" -> Response.ok(service.getCostCategories(request)).build();
+            default -> Response.status(400)
+                    .entity(new AwsErrorResponse("UnknownOperationException",
+                            "Unknown operation: AWSInsightsIndexService." + action))
+                    .build();
+        };
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerService.java
@@ -1,0 +1,318 @@
+package io.github.hectorvent.floci.services.ce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ResourceUsageEnumerator;
+import io.github.hectorvent.floci.core.common.UsageLine;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * AWS Cost Explorer (`ce:*`) emulation.
+ * <p>
+ * Synthesizes cost and usage from Floci's own resource state, multiplied by
+ * the AWS Pricing snapshot served by {@code services/pricing}. Discovery of
+ * which services contribute to cost is handled by CDI: every
+ * {@code @ApplicationScoped} bean implementing
+ * {@link ResourceUsageEnumerator} is auto-injected here, so adding a new
+ * Floci service with cost reporting needs no change to this class.
+ *
+ * @see <a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_Operations_AWS_Cost_Explorer_Service.html">AWS Cost Explorer API</a>
+ */
+@ApplicationScoped
+public class CostExplorerService {
+
+    private static final Logger LOG = Logger.getLogger(CostExplorerService.class);
+
+    private final ObjectMapper objectMapper;
+    private final Instance<ResourceUsageEnumerator> enumerators;
+    private final PricingRateLookup rateLookup;
+    private final GroupAggregator aggregator;
+    private final double monthlyCreditUsd;
+
+    @Inject
+    public CostExplorerService(ObjectMapper objectMapper,
+                                Instance<ResourceUsageEnumerator> enumerators,
+                                PricingRateLookup rateLookup,
+                                EmulatorConfig config) {
+        this(objectMapper, enumerators, rateLookup, config.services().ce().creditUsdMonthly());
+    }
+
+    CostExplorerService(ObjectMapper objectMapper,
+                         Instance<ResourceUsageEnumerator> enumerators,
+                         PricingRateLookup rateLookup,
+                         double monthlyCreditUsd) {
+        this.objectMapper = objectMapper;
+        this.enumerators = enumerators;
+        this.rateLookup = rateLookup;
+        this.aggregator = new GroupAggregator(objectMapper);
+        this.monthlyCreditUsd = monthlyCreditUsd;
+    }
+
+    public ObjectNode getCostAndUsage(JsonNode request, String defaultRegion) {
+        return runCostAndUsage(request, defaultRegion);
+    }
+
+    /**
+     * Returns the same shape as {@link #getCostAndUsage} for now. Floci's
+     * resource-level data is already surfaced through the {@code RESOURCE_ID}
+     * dimension, so a caller that wants resource breakdown can issue
+     * {@code GetCostAndUsage} with {@code GroupBy=[{Type:DIMENSION,Key:RESOURCE_ID}]}.
+     * A separate emit path that returns inline resource attributions can land
+     * later if a consumer needs it.
+     */
+    public ObjectNode getCostAndUsageWithResources(JsonNode request, String defaultRegion) {
+        return runCostAndUsage(request, defaultRegion);
+    }
+
+    private ObjectNode runCostAndUsage(JsonNode request, String defaultRegion) {
+        TimeWindow window = parseTimeWindow(request);
+        TimeBucketing.Granularity granularity = TimeBucketing.parseGranularity(
+                request.path("Granularity").asText(null));
+        Set<String> metrics = GroupAggregator.parseMetrics(request.path("Metrics"));
+        if (metrics.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'Metrics' failed to satisfy constraint: Member must contain at least 1 element.", 400);
+        }
+        List<GroupAggregator.GroupBy> groupBys = GroupAggregator.parseGroupBy(request.path("GroupBy"));
+        JsonNode filter = request.has("Filter") ? request.get("Filter") : null;
+
+        List<UsageLine> all = collectLines(window.start(), window.end(), defaultRegion);
+        // Apply filter once across the full window so the same set is reused
+        // per bucket (lines are emitted per request scope, no cross-bucket leakage).
+        List<UsageLine> filtered = new ArrayList<>();
+        for (UsageLine line : all) {
+            if (FilterExpressionEvaluator.matches(filter, line)) {
+                filtered.add(line);
+            }
+        }
+
+        CostSynthesizer synthesizer = new CostSynthesizer(rateLookup);
+        if (monthlyCreditUsd > 0) {
+            CreditLineEmitter creditEmitter = new CreditLineEmitter(monthlyCreditUsd);
+            List<UsageLine> credits = creditEmitter.emit(filtered.stream(), synthesizer).toList();
+            for (UsageLine credit : credits) {
+                if (FilterExpressionEvaluator.matches(filter, credit)) {
+                    filtered.add(credit);
+                }
+            }
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode resultsByTime = response.putArray("ResultsByTime");
+        for (TimeBucketing.Bucket bucket : TimeBucketing.split(window.start(), window.end(), granularity)) {
+            List<UsageLine> bucketLines = new ArrayList<>();
+            for (UsageLine line : filtered) {
+                if (overlaps(line, bucket)) {
+                    bucketLines.add(scaleToBucket(line, bucket));
+                }
+            }
+            resultsByTime.add(aggregator.buildResultByTime(bucket.start(), bucket.end(),
+                    bucketLines, groupBys, metrics, synthesizer));
+        }
+        ArrayNode groupDefinitions = response.putArray("GroupDefinitions");
+        for (GroupAggregator.GroupBy gb : groupBys) {
+            ObjectNode def = groupDefinitions.addObject();
+            def.put("Type", gb.type());
+            def.put("Key", gb.key());
+        }
+        response.putArray("DimensionValueAttributes");
+        return response;
+    }
+
+    public ObjectNode getDimensionValues(JsonNode request, String defaultRegion) {
+        TimeWindow window = parseTimeWindow(request);
+        String dimension = request.path("Dimension").asText(null);
+        if (dimension == null || dimension.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'Dimension' failed to satisfy constraint: Member must not be null.", 400);
+        }
+        String search = request.path("SearchString").asText(null);
+        JsonNode filter = request.has("Filter") ? request.get("Filter") : null;
+
+        Set<String> values = new TreeSet<>();
+        for (UsageLine line : collectLines(window.start(), window.end(), defaultRegion)) {
+            if (!FilterExpressionEvaluator.matches(filter, line)) {
+                continue;
+            }
+            String v = FilterExpressionEvaluator.dimensionValue(dimension, line);
+            if (v != null && !v.isEmpty() && (search == null || v.contains(search))) {
+                values.add(v);
+            }
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode arr = response.putArray("DimensionValues");
+        for (String v : values) {
+            ObjectNode entry = arr.addObject();
+            entry.put("Value", v);
+        }
+        response.put("ReturnSize", values.size());
+        response.put("TotalSize", values.size());
+        return response;
+    }
+
+    public ObjectNode getTags(JsonNode request, String defaultRegion) {
+        TimeWindow window = parseTimeWindow(request);
+        String tagKey = request.path("TagKey").asText(null);
+        String search = request.path("SearchString").asText(null);
+        JsonNode filter = request.has("Filter") ? request.get("Filter") : null;
+
+        Set<String> values = new TreeSet<>();
+        Set<String> keys = new TreeSet<>();
+        for (UsageLine line : collectLines(window.start(), window.end(), defaultRegion)) {
+            if (!FilterExpressionEvaluator.matches(filter, line)) {
+                continue;
+            }
+            if (line.tags() == null) {
+                continue;
+            }
+            for (Map.Entry<String, String> tag : line.tags().entrySet()) {
+                keys.add(tag.getKey());
+                if (tagKey != null && !tagKey.isEmpty()) {
+                    if (tagKey.equals(tag.getKey())
+                            && (search == null || tag.getValue().contains(search))) {
+                        values.add(tag.getValue());
+                    }
+                }
+            }
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode arr = response.putArray("Tags");
+        Set<String> emit = (tagKey == null || tagKey.isEmpty()) ? keys : values;
+        for (String v : emit) {
+            arr.add(v);
+        }
+        response.put("ReturnSize", emit.size());
+        response.put("TotalSize", emit.size());
+        return response;
+    }
+
+    public ObjectNode getReservationCoverage() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("CoveragesByTime");
+        ObjectNode total = response.putObject("Total");
+        ObjectNode coverageHours = total.putObject("CoverageHours");
+        coverageHours.put("OnDemandHours", "0");
+        coverageHours.put("ReservedHours", "0");
+        coverageHours.put("TotalRunningHours", "0");
+        coverageHours.put("CoverageHoursPercentage", "0");
+        return response;
+    }
+
+    public ObjectNode getReservationUtilization() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("UtilizationsByTime");
+        ObjectNode total = response.putObject("Total");
+        total.put("UtilizationPercentage", "0");
+        total.put("UtilizationPercentageInUnits", "0");
+        total.put("PurchasedHours", "0");
+        total.put("PurchasedUnits", "0");
+        total.put("TotalActualHours", "0");
+        total.put("TotalActualUnits", "0");
+        total.put("UnusedHours", "0");
+        total.put("UnusedUnits", "0");
+        total.put("OnDemandCostOfRIHoursUsed", "0");
+        total.put("NetRISavings", "0");
+        total.put("TotalPotentialRISavings", "0");
+        total.put("AmortizedUpfrontFee", "0");
+        total.put("AmortizedRecurringFee", "0");
+        total.put("TotalAmortizedFee", "0");
+        total.put("RICostForUnusedHours", "0");
+        total.put("RealizedSavings", "0");
+        total.put("UnrealizedSavings", "0");
+        return response;
+    }
+
+    public ObjectNode getSavingsPlansCoverage() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("SavingsPlansCoverages");
+        return response;
+    }
+
+    public ObjectNode getSavingsPlansUtilization() {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("SavingsPlansUtilizationsByTime");
+        ObjectNode total = response.putObject("Total");
+        ObjectNode utilization = total.putObject("Utilization");
+        utilization.put("TotalCommitment", "0");
+        utilization.put("UsedCommitment", "0");
+        utilization.put("UnusedCommitment", "0");
+        utilization.put("UtilizationPercentage", "0");
+        return response;
+    }
+
+    public ObjectNode getCostCategories(JsonNode request) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("CostCategoryNames");
+        response.putArray("CostCategoryValues");
+        response.put("ReturnSize", 0);
+        response.put("TotalSize", 0);
+        return response;
+    }
+
+    private List<UsageLine> collectLines(Instant start, Instant end, String region) {
+        List<UsageLine> all = new ArrayList<>();
+        for (ResourceUsageEnumerator enumerator : enumerators) {
+            try {
+                enumerator.enumerate(start, end, region).forEach(all::add);
+            } catch (Exception e) {
+                LOG.warnv(e, "Enumerator {0} failed", enumerator.getClass().getSimpleName());
+            }
+        }
+        return all;
+    }
+
+    private TimeWindow parseTimeWindow(JsonNode request) {
+        JsonNode tp = request.path("TimePeriod");
+        if (!tp.isObject() || tp.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'TimePeriod' failed to satisfy constraint: Member must not be null.", 400);
+        }
+        Instant start = TimeBucketing.parseDate(tp.path("Start").asText(null), "TimePeriod.Start");
+        Instant end = TimeBucketing.parseDate(tp.path("End").asText(null), "TimePeriod.End");
+        return new TimeWindow(start, end);
+    }
+
+    private static boolean overlaps(UsageLine line, TimeBucketing.Bucket bucket) {
+        return line.periodStart().isBefore(bucket.end()) && line.periodEnd().isAfter(bucket.start());
+    }
+
+    /**
+     * Returns a copy of {@code line} with quantity scaled to the fraction of the
+     * line's window that falls inside {@code bucket}. Keeps daily/hourly outputs
+     * proportional when the request window doesn't align to the line's day.
+     */
+    private static UsageLine scaleToBucket(UsageLine line, TimeBucketing.Bucket bucket) {
+        Instant overlapStart = line.periodStart().isAfter(bucket.start()) ? line.periodStart() : bucket.start();
+        Instant overlapEnd = line.periodEnd().isBefore(bucket.end()) ? line.periodEnd() : bucket.end();
+        long lineSeconds = Math.max(1, line.periodEnd().getEpochSecond() - line.periodStart().getEpochSecond());
+        long overlapSeconds = Math.max(0, overlapEnd.getEpochSecond() - overlapStart.getEpochSecond());
+        double factor = overlapSeconds / (double) lineSeconds;
+        return new UsageLine(
+                bucket.start(), bucket.end(),
+                line.service(), line.region(), line.usageType(), line.operation(),
+                line.recordType(), line.linkedAccountId(), line.resourceId(),
+                line.tags(),
+                line.quantity() * factor,
+                line.usageUnit());
+    }
+
+    private record TimeWindow(Instant start, Instant end) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/CostSynthesizer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/CostSynthesizer.java
@@ -1,0 +1,76 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.UsageLine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Multiplies a {@link UsageLine} by the matching unit price from
+ * {@link PricingRateLookup} to produce per-metric cost amounts.
+ * <p>
+ * AWS exposes five cost metrics — {@code UnblendedCost}, {@code BlendedCost},
+ * {@code AmortizedCost}, {@code NetUnblendedCost}, {@code NetAmortizedCost} —
+ * plus {@code UsageQuantity} and {@code NormalizedUsageAmount}. Floci has no
+ * commitment math, so all five cost metrics return the same value.
+ */
+class CostSynthesizer {
+
+    private final PricingRateLookup rates;
+    private final Map<String, Map<String, Double>> rateCache = new HashMap<>();
+
+    CostSynthesizer(PricingRateLookup rates) {
+        this.rates = rates;
+    }
+
+    /** Returns a metric-name -> {amount, unit} map for the given line. */
+    Map<String, MetricValue> compute(UsageLine line) {
+        double cost;
+        double quantity;
+        String quantityUnit;
+        if (isUsdDenominated(line)) {
+            // Credit / Refund / SavingsPlan upfront and recurring fees arrive
+            // already denominated in USD. Treat the line quantity as the cost
+            // amount directly; do not multiply by a per-unit rate. UsageQuantity
+            // is reported as zero because AWS does not surface a separate usage
+            // unit for these record types.
+            cost = line.quantity();
+            quantity = 0.0;
+            quantityUnit = line.usageUnit() == null ? "USD" : line.usageUnit();
+        } else {
+            cost = line.quantity() * lookupRate(line);
+            quantity = line.quantity();
+            quantityUnit = line.usageUnit();
+        }
+        Map<String, MetricValue> metrics = new HashMap<>();
+        metrics.put("UnblendedCost", new MetricValue(cost, "USD"));
+        metrics.put("BlendedCost", new MetricValue(cost, "USD"));
+        metrics.put("AmortizedCost", new MetricValue(cost, "USD"));
+        metrics.put("NetUnblendedCost", new MetricValue(cost, "USD"));
+        metrics.put("NetAmortizedCost", new MetricValue(cost, "USD"));
+        metrics.put("UsageQuantity", new MetricValue(quantity, quantityUnit));
+        metrics.put("NormalizedUsageAmount", new MetricValue(quantity, quantityUnit));
+        return metrics;
+    }
+
+    private static boolean isUsdDenominated(UsageLine line) {
+        String rt = line.recordType();
+        if (rt == null) {
+            return false;
+        }
+        return UsageLine.RECORD_TYPE_CREDIT.equals(rt)
+                || UsageLine.RECORD_TYPE_REFUND.equals(rt)
+                || UsageLine.RECORD_TYPE_TAX.equals(rt)
+                || UsageLine.RECORD_TYPE_SP_UPFRONT_FEE.equals(rt)
+                || UsageLine.RECORD_TYPE_SP_RECURRING_FEE.equals(rt);
+    }
+
+    private double lookupRate(UsageLine line) {
+        Map<String, Double> svc = rateCache.computeIfAbsent(
+                line.service() + "|" + line.region(),
+                key -> rates.ratesFor(line.service(), line.region()));
+        return svc.getOrDefault(line.usageType(), 0.0);
+    }
+
+    record MetricValue(double amount, String unit) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/CreditLineEmitter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/CreditLineEmitter.java
@@ -1,0 +1,104 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.UsageLine;
+
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Emits a synthetic {@code Credit} {@code RECORD_TYPE} line per calendar month
+ * covered by the request, sized at {@code -min(creditUsd, monthly Usage)} so net
+ * cost never goes below zero.
+ * <p>
+ * Configured by {@code FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY}. When zero, no
+ * credit lines are emitted.
+ */
+final class CreditLineEmitter {
+
+    private final double monthlyCreditUsd;
+
+    CreditLineEmitter(double monthlyCreditUsd) {
+        this.monthlyCreditUsd = monthlyCreditUsd;
+    }
+
+    /**
+     * Returns a stream of credit lines, one per (region, month) pair where
+     * {@code lines} contains usage in that region and month.
+     * Each credit line carries a quantity equal to {@code -monthlyCreditUsd}
+     * capped at the monthly usage cost, with {@code USD} as the unit.
+     * <p>
+     * Each input usage line may span an arbitrary window — enumerators emit one
+     * line for the whole request period — so the line's cost is split across
+     * every calendar month its window touches, weighted by the second-overlap
+     * with each month, before per-month credits are computed.
+     */
+    Stream<UsageLine> emit(Stream<UsageLine> lines, CostSynthesizer synthesizer) {
+        if (monthlyCreditUsd <= 0) {
+            return Stream.empty();
+        }
+        Map<String, Double> usageCostByKey = new HashMap<>();
+        Map<String, Instant[]> windowByKey = new HashMap<>();
+        Map<String, String> regionByKey = new HashMap<>();
+        Map<String, String> accountByKey = new HashMap<>();
+        lines.forEach(line -> {
+            if (!UsageLine.RECORD_TYPE_USAGE.equals(line.recordType())) {
+                return;
+            }
+            double totalCost = synthesizer.compute(line).get("UnblendedCost").amount();
+            if (totalCost == 0.0) {
+                return;
+            }
+            long lineSeconds = Math.max(1, line.periodEnd().getEpochSecond() - line.periodStart().getEpochSecond());
+
+            YearMonth ym = YearMonth.from(line.periodStart().atOffset(ZoneOffset.UTC));
+            Instant cursor = line.periodStart();
+            while (cursor.isBefore(line.periodEnd())) {
+                Instant monthStart = ym.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+                Instant monthEnd = ym.plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+                Instant overlapStart = cursor.isAfter(monthStart) ? cursor : monthStart;
+                Instant overlapEnd = line.periodEnd().isBefore(monthEnd) ? line.periodEnd() : monthEnd;
+                long overlapSeconds = Math.max(0, overlapEnd.getEpochSecond() - overlapStart.getEpochSecond());
+                if (overlapSeconds > 0) {
+                    double monthCost = totalCost * (overlapSeconds / (double) lineSeconds);
+                    String key = line.region() + "|" + ym;
+                    usageCostByKey.merge(key, monthCost, Double::sum);
+                    YearMonth captured = ym;
+                    windowByKey.computeIfAbsent(key, k -> new Instant[] {
+                            captured.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant(),
+                            captured.plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant() });
+                    regionByKey.put(key, line.region());
+                    accountByKey.put(key, line.linkedAccountId());
+                }
+                cursor = monthEnd;
+                ym = ym.plusMonths(1);
+            }
+        });
+
+        List<UsageLine> credits = new ArrayList<>();
+        for (Map.Entry<String, Double> entry : usageCostByKey.entrySet()) {
+            String key = entry.getKey();
+            double appliedCredit = Math.min(monthlyCreditUsd, entry.getValue());
+            if (appliedCredit <= 0) {
+                continue;
+            }
+            Instant[] window = windowByKey.get(key);
+            credits.add(new UsageLine(
+                    window[0], window[1],
+                    "Credits", regionByKey.get(key),
+                    "Credit-Promotional", "ApplyPromoCredit",
+                    UsageLine.RECORD_TYPE_CREDIT,
+                    accountByKey.get(key),
+                    null,
+                    Map.of(),
+                    -appliedCredit,
+                    "USD"));
+        }
+        return credits.stream();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/FilterExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/FilterExpressionEvaluator.java
@@ -1,0 +1,139 @@
+package io.github.hectorvent.floci.services.ce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.UsageLine;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Recursive evaluator for the AWS Cost Explorer {@code Expression} filter shape:
+ * {@code {And, Or, Not, Dimensions, Tags, CostCategories}}.
+ * <p>
+ * MatchOptions supported:
+ * <ul>
+ *   <li>{@code EQUALS} — exact equality (default)</li>
+ *   <li>{@code CASE_SENSITIVE} — paired with EQUALS, AWS treats it as the default</li>
+ *   <li>{@code CASE_INSENSITIVE} — case-insensitive equality</li>
+ * </ul>
+ * Other AWS match options (e.g. {@code STARTS_WITH}, {@code GREATER_THAN_OR_EQUAL})
+ * are accepted in the request but treated as EQUALS for now; full coverage can land
+ * in a follow-up PR.
+ */
+final class FilterExpressionEvaluator {
+
+    static boolean matches(JsonNode expression, UsageLine line) {
+        if (expression == null || expression.isNull() || expression.isMissingNode()) {
+            return true;
+        }
+        JsonNode and = expression.path("And");
+        if (and.isArray() && !and.isEmpty()) {
+            for (JsonNode child : and) {
+                if (!matches(child, line)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        JsonNode or = expression.path("Or");
+        if (or.isArray() && !or.isEmpty()) {
+            for (JsonNode child : or) {
+                if (matches(child, line)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        JsonNode not = expression.path("Not");
+        if (not.isObject() && !not.isEmpty()) {
+            return !matches(not, line);
+        }
+        JsonNode dimensions = expression.path("Dimensions");
+        if (dimensions.isObject() && !dimensions.isEmpty()) {
+            return matchDimensions(dimensions, line);
+        }
+        JsonNode tags = expression.path("Tags");
+        if (tags.isObject() && !tags.isEmpty()) {
+            return matchTags(tags, line);
+        }
+        JsonNode costCategories = expression.path("CostCategories");
+        if (costCategories.isObject() && !costCategories.isEmpty()) {
+            // No cost categories defined — never matches.
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean matchDimensions(JsonNode node, UsageLine line) {
+        String key = node.path("Key").asText(null);
+        if (key == null || key.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Dimensions filter requires a Key.", 400);
+        }
+        Set<String> values = readValues(node.path("Values"));
+        Set<String> matchOptions = readValues(node.path("MatchOptions"));
+        boolean caseInsensitive = matchOptions.contains("CASE_INSENSITIVE");
+        String actual = dimensionValue(key, line);
+        return valueMatches(actual, values, caseInsensitive);
+    }
+
+    private static boolean matchTags(JsonNode node, UsageLine line) {
+        String key = node.path("Key").asText(null);
+        if (key == null || key.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Tags filter requires a Key.", 400);
+        }
+        Set<String> values = readValues(node.path("Values"));
+        Set<String> matchOptions = readValues(node.path("MatchOptions"));
+        boolean caseInsensitive = matchOptions.contains("CASE_INSENSITIVE");
+        String actual = line.tags() == null ? null : line.tags().get(key);
+        return valueMatches(actual, values, caseInsensitive);
+    }
+
+    private static boolean valueMatches(String actual, Set<String> values, boolean caseInsensitive) {
+        if (values.isEmpty()) {
+            return actual != null;
+        }
+        if (actual == null) {
+            return false;
+        }
+        if (caseInsensitive) {
+            for (String v : values) {
+                if (v.equalsIgnoreCase(actual)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return values.contains(actual);
+    }
+
+    /** Maps a Cost Explorer dimension name to the equivalent {@link UsageLine} field. */
+    static String dimensionValue(String dimension, UsageLine line) {
+        return switch (dimension) {
+            case "SERVICE", "SERVICE_CODE" -> line.service();
+            case "REGION" -> line.region();
+            case "USAGE_TYPE" -> line.usageType();
+            case "OPERATION" -> line.operation();
+            case "RECORD_TYPE" -> line.recordType();
+            case "LINKED_ACCOUNT", "PAYER_ACCOUNT", "LINKED_ACCOUNT_NAME" -> line.linkedAccountId();
+            case "RESOURCE_ID" -> line.resourceId();
+            default -> null;
+        };
+    }
+
+    private static Set<String> readValues(JsonNode arr) {
+        Set<String> out = new HashSet<>();
+        if (arr.isArray()) {
+            for (JsonNode v : arr) {
+                if (!v.isNull() && !v.asText().isEmpty()) {
+                    out.add(v.asText());
+                }
+            }
+        }
+        return out;
+    }
+
+    private FilterExpressionEvaluator() {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/GroupAggregator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/GroupAggregator.java
@@ -1,0 +1,143 @@
+package io.github.hectorvent.floci.services.ce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.UsageLine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Aggregates per-bucket usage lines into the AWS Cost Explorer
+ * {@code ResultsByTime[].Groups} / {@code ResultsByTime[].Total} shape.
+ */
+final class GroupAggregator {
+
+    private final ObjectMapper objectMapper;
+
+    GroupAggregator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Builds a single {@code ResultByTime} entry covering {@code [bucketStart, bucketEnd)}
+     * from the provided lines (already filtered + costed).
+     */
+    ObjectNode buildResultByTime(java.time.Instant bucketStart, java.time.Instant bucketEnd,
+                                  List<UsageLine> lines, List<GroupBy> groupBys, Set<String> metrics,
+                                  CostSynthesizer synthesizer) {
+        ObjectNode result = objectMapper.createObjectNode();
+        ObjectNode timePeriod = result.putObject("TimePeriod");
+        timePeriod.put("Start", bucketStart.toString());
+        timePeriod.put("End", bucketEnd.toString());
+
+        // Group key -> metric name -> running total
+        Map<List<String>, Map<String, Double>> groupAmounts = new LinkedHashMap<>();
+        Map<List<String>, Map<String, String>> groupUnits = new HashMap<>();
+        Map<String, Double> totalAmounts = new HashMap<>();
+        Map<String, String> totalUnits = new HashMap<>();
+
+        for (UsageLine line : lines) {
+            Map<String, CostSynthesizer.MetricValue> computed = synthesizer.compute(line);
+            for (String metric : metrics) {
+                CostSynthesizer.MetricValue mv = computed.get(metric);
+                if (mv == null) {
+                    continue;
+                }
+                totalAmounts.merge(metric, mv.amount(), Double::sum);
+                totalUnits.putIfAbsent(metric, mv.unit() == null ? "" : mv.unit());
+                if (!groupBys.isEmpty()) {
+                    List<String> key = groupKey(groupBys, line);
+                    groupAmounts.computeIfAbsent(key, k -> new HashMap<>())
+                            .merge(metric, mv.amount(), Double::sum);
+                    groupUnits.computeIfAbsent(key, k -> new HashMap<>())
+                            .putIfAbsent(metric, mv.unit() == null ? "" : mv.unit());
+                }
+            }
+        }
+
+        ObjectNode totalNode = result.putObject("Total");
+        for (Map.Entry<String, Double> entry : totalAmounts.entrySet()) {
+            ObjectNode m = totalNode.putObject(entry.getKey());
+            m.put("Amount", formatAmount(entry.getValue()));
+            m.put("Unit", totalUnits.getOrDefault(entry.getKey(), ""));
+        }
+
+        ArrayNode groups = result.putArray("Groups");
+        for (Map.Entry<List<String>, Map<String, Double>> entry : groupAmounts.entrySet()) {
+            ObjectNode group = groups.addObject();
+            ArrayNode keys = group.putArray("Keys");
+            for (String k : entry.getKey()) {
+                keys.add(k);
+            }
+            ObjectNode m = group.putObject("Metrics");
+            for (Map.Entry<String, Double> me : entry.getValue().entrySet()) {
+                ObjectNode mv = m.putObject(me.getKey());
+                mv.put("Amount", formatAmount(me.getValue()));
+                mv.put("Unit", groupUnits.get(entry.getKey()).getOrDefault(me.getKey(), ""));
+            }
+        }
+        result.put("Estimated", false);
+        return result;
+    }
+
+    private static List<String> groupKey(List<GroupBy> groupBys, UsageLine line) {
+        List<String> out = new ArrayList<>(groupBys.size());
+        for (GroupBy gb : groupBys) {
+            out.add(switch (gb.type()) {
+                case "DIMENSION" -> {
+                    String v = FilterExpressionEvaluator.dimensionValue(gb.key(), line);
+                    yield v == null ? "" : v;
+                }
+                case "TAG" -> line.tags() == null ? "" : line.tags().getOrDefault(gb.key(), "");
+                case "COST_CATEGORY" -> "";
+                default -> throw new AwsException("ValidationException",
+                        "Unsupported GroupBy.Type: " + gb.type(), 400);
+            });
+        }
+        return out;
+    }
+
+    static List<GroupBy> parseGroupBy(JsonNode node) {
+        List<GroupBy> out = new ArrayList<>();
+        if (!node.isArray()) {
+            return out;
+        }
+        for (JsonNode entry : node) {
+            String type = entry.path("Type").asText("DIMENSION");
+            String key = entry.path("Key").asText(null);
+            if (key == null || key.isEmpty()) {
+                throw new AwsException("ValidationException",
+                        "GroupBy entries must include a Key.", 400);
+            }
+            out.add(new GroupBy(type, key));
+        }
+        return out;
+    }
+
+    static Set<String> parseMetrics(JsonNode node) {
+        Set<String> out = new java.util.LinkedHashSet<>();
+        if (node.isArray()) {
+            for (JsonNode v : node) {
+                if (!v.isNull() && !v.asText().isEmpty()) {
+                    out.add(v.asText());
+                }
+            }
+        }
+        return out;
+    }
+
+    static String formatAmount(double amount) {
+        // AWS returns amounts as decimal strings.
+        return String.format(java.util.Locale.ROOT, "%.10f", amount);
+    }
+
+    record GroupBy(String type, String key) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/PricingRateLookup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/PricingRateLookup.java
@@ -1,0 +1,134 @@
+package io.github.hectorvent.floci.services.ce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.pricing.PricingService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Looks up unit prices from the bundled {@link PricingService} snapshot.
+ * Used by {@link CostSynthesizer} to attach a USD rate to each
+ * {@link io.github.hectorvent.floci.core.common.UsageLine}.
+ *
+ * <p>Maps a {@code (serviceCode, regionCode, usageType)} key to {@code USD per unit}.
+ * Cache is sized per {@code (serviceCode, regionCode)} pair on first hit and reused
+ * for the lifetime of the request — the snapshot itself is read-only.
+ */
+@ApplicationScoped
+public class PricingRateLookup {
+
+    private static final Logger LOG = Logger.getLogger(PricingRateLookup.class);
+
+    private final PricingService pricing;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public PricingRateLookup(PricingService pricing, ObjectMapper objectMapper) {
+        this.pricing = pricing;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Returns USD-per-unit for {@code usageType} under {@code (serviceCode, regionCode)}.
+     * Returns {@code 0.0} when no matching offer exists in the snapshot.
+     */
+    public double rate(String serviceCode, String regionCode, String usageType) {
+        return ratesFor(serviceCode, regionCode).getOrDefault(usageType, 0.0);
+    }
+
+    /** Returns the full {@code usageType -> USD/unit} map for a (service, region) pair. */
+    public Map<String, Double> ratesFor(String serviceCode, String regionCode) {
+        Map<String, Double> result = new HashMap<>();
+        try {
+            ObjectNode response = pricing.getProducts(
+                    serviceCode,
+                    List.of(new PricingService.FilterSpec("TERM_MATCH", "regionCode", regionCode)),
+                    null,
+                    null,
+                    1000);
+            JsonNode priceList = response.path("PriceList");
+            if (!priceList.isArray()) {
+                return result;
+            }
+            for (JsonNode entry : priceList) {
+                JsonNode product;
+                try {
+                    product = objectMapper.readTree(entry.asText());
+                } catch (Exception e) {
+                    continue;
+                }
+                String usageType = product.path("product").path("attributes").path("usagetype").asText(null);
+                if (usageType == null || usageType.isEmpty()) {
+                    // Fallback for user-supplied snapshots that don't include
+                    // a usagetype attribute. The bundled fixtures populate it
+                    // directly, so this path applies only to externally provided
+                    // snapshots via FLOCI_SERVICES_PRICING_SNAPSHOT_PATH.
+                    usageType = synthesizeUsageType(product, serviceCode);
+                }
+                if (usageType == null) {
+                    continue;
+                }
+                double rate = extractOnDemandRate(product.path("terms"));
+                if (rate > 0) {
+                    result.merge(usageType, rate, Double::max);
+                }
+            }
+        } catch (Exception e) {
+            LOG.warnv(e, "Pricing rate lookup failed for {0}/{1}", serviceCode, regionCode);
+        }
+        return result;
+    }
+
+    /**
+     * Returns a synthesized usage-type key for a product offer that doesn't carry
+     * the {@code usagetype} attribute. Compatibility-only fallback for incomplete
+     * external snapshots; bundled fixtures populate {@code usagetype} directly,
+     * and future enumerators should emit AWS-native usage types that match the
+     * snapshot's real {@code usagetype} attribute rather than relying on this
+     * synthesis path.
+     */
+    private static String synthesizeUsageType(JsonNode product, String serviceCode) {
+        JsonNode attrs = product.path("product").path("attributes");
+        return switch (serviceCode) {
+            case "AmazonEC2" -> "BoxUsage:" + attrs.path("instanceType").asText("");
+            case "AmazonS3" -> "TimedStorage-" + attrs.path("volumeType").asText("");
+            case "AWSLambda" -> attrs.path("group").asText("AWS-Lambda-Requests");
+            default -> null;
+        };
+    }
+
+    private static double extractOnDemandRate(JsonNode terms) {
+        JsonNode onDemand = terms.path("OnDemand");
+        if (!onDemand.isObject()) {
+            return 0.0;
+        }
+        java.util.Iterator<java.util.Map.Entry<String, JsonNode>> termIter = onDemand.fields();
+        while (termIter.hasNext()) {
+            JsonNode dimensions = termIter.next().getValue().path("priceDimensions");
+            if (!dimensions.isObject()) {
+                continue;
+            }
+            java.util.Iterator<java.util.Map.Entry<String, JsonNode>> dimIter = dimensions.fields();
+            while (dimIter.hasNext()) {
+                JsonNode dim = dimIter.next().getValue();
+                String usd = dim.path("pricePerUnit").path("USD").asText("0");
+                try {
+                    double v = Double.parseDouble(usd);
+                    if (v > 0) {
+                        return v;
+                    }
+                } catch (NumberFormatException ignored) {
+                    // skip malformed entries
+                }
+            }
+        }
+        return 0.0;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/TimeBucketing.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/TimeBucketing.java
@@ -1,0 +1,141 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits a Cost Explorer {@code TimePeriod} into AWS-shaped granularity buckets.
+ * <p>
+ * AWS truncates {@code Start}/{@code End} to whole-day boundaries for DAILY
+ * and HOURLY, and to the first day of the month for MONTHLY. The window is
+ * half-open: {@code Start} inclusive, {@code End} exclusive.
+ */
+final class TimeBucketing {
+
+    enum Granularity { HOURLY, DAILY, MONTHLY }
+
+    static Granularity parseGranularity(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'Granularity' failed to satisfy constraint: Member must not be null.", 400);
+        }
+        return switch (value) {
+            case "HOURLY" -> Granularity.HOURLY;
+            case "DAILY" -> Granularity.DAILY;
+            case "MONTHLY" -> Granularity.MONTHLY;
+            default -> throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + value + "' at 'Granularity' failed to satisfy constraint: Member must satisfy enum value set: [DAILY, MONTHLY, HOURLY]", 400);
+        };
+    }
+
+    static Instant parseDate(String value, String field) {
+        if (value == null || value.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at '" + field + "' failed to satisfy constraint: Member must not be null.", 400);
+        }
+        // AWS accepts "YYYY-MM-DD" (most common) and ISO-8601 timestamps.
+        try {
+            return LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant();
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+        try {
+            return OffsetDateTime.parse(value).toInstant();
+        } catch (DateTimeParseException ignored) {
+            // fall through
+        }
+        try {
+            return LocalDateTime.parse(value).toInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException e) {
+            throw new AwsException("ValidationException",
+                    field + " must be a YYYY-MM-DD date or ISO-8601 timestamp.", 400);
+        }
+    }
+
+    /** A half-open [start, end) bucket aligned to the requested granularity. */
+    record Bucket(Instant start, Instant end) {}
+
+    static List<Bucket> split(Instant start, Instant end, Granularity granularity) {
+        if (!end.isAfter(start)) {
+            throw new AwsException("DataUnavailableException",
+                    "End date must be after Start date.", 400);
+        }
+        // Truncate Start down and End up to the granularity boundary so every
+        // emitted bucket aligns to the period AWS would return.
+        Instant alignedStart = floor(start, granularity);
+        Instant alignedEnd = ceil(end, granularity);
+        return switch (granularity) {
+            case HOURLY -> splitHourly(alignedStart, alignedEnd);
+            case DAILY -> splitDaily(alignedStart, alignedEnd);
+            case MONTHLY -> splitMonthly(alignedStart, alignedEnd);
+        };
+    }
+
+    private static Instant floor(Instant instant, Granularity granularity) {
+        return switch (granularity) {
+            case HOURLY -> instant.truncatedTo(java.time.temporal.ChronoUnit.HOURS);
+            case DAILY -> instant.truncatedTo(java.time.temporal.ChronoUnit.DAYS);
+            case MONTHLY -> YearMonth.from(instant.atOffset(ZoneOffset.UTC))
+                    .atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        };
+    }
+
+    private static Instant ceil(Instant instant, Granularity granularity) {
+        Instant floored = floor(instant, granularity);
+        if (floored.equals(instant)) {
+            return instant;
+        }
+        return switch (granularity) {
+            case HOURLY -> floored.plusSeconds(3600);
+            case DAILY -> floored.plus(java.time.Duration.ofDays(1));
+            case MONTHLY -> YearMonth.from(floored.atOffset(ZoneOffset.UTC))
+                    .plusMonths(1).atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        };
+    }
+
+    private static List<Bucket> splitHourly(Instant start, Instant end) {
+        List<Bucket> out = new ArrayList<>();
+        Instant cursor = start;
+        while (cursor.isBefore(end)) {
+            Instant next = cursor.plusSeconds(3600);
+            out.add(new Bucket(cursor, next.isAfter(end) ? end : next));
+            cursor = next;
+        }
+        return out;
+    }
+
+    private static List<Bucket> splitDaily(Instant start, Instant end) {
+        List<Bucket> out = new ArrayList<>();
+        Instant cursor = start;
+        while (cursor.isBefore(end)) {
+            Instant next = cursor.plus(java.time.Duration.ofDays(1));
+            out.add(new Bucket(cursor, next.isAfter(end) ? end : next));
+            cursor = next;
+        }
+        return out;
+    }
+
+    private static List<Bucket> splitMonthly(Instant start, Instant end) {
+        List<Bucket> out = new ArrayList<>();
+        YearMonth ym = YearMonth.from(start.atOffset(ZoneOffset.UTC));
+        Instant cursor = start;
+        while (cursor.isBefore(end)) {
+            ym = ym.plusMonths(1);
+            Instant next = ym.atDay(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+            out.add(new Bucket(cursor, next.isAfter(end) ? end : next));
+            cursor = next;
+        }
+        return out;
+    }
+
+    private TimeBucketing() {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/Ec2UsageEnumerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/Ec2UsageEnumerator.java
@@ -1,0 +1,100 @@
+package io.github.hectorvent.floci.services.ce.enumerator;
+
+import io.github.hectorvent.floci.core.common.ResourceUsageEnumerator;
+import io.github.hectorvent.floci.core.common.UsageLine;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Enumerates running EC2 instances as Cost Explorer usage lines.
+ * Emits one {@code Hrs} line per instance per region, sized to the requested period.
+ */
+@ApplicationScoped
+public class Ec2UsageEnumerator implements ResourceUsageEnumerator {
+
+    static final String SERVICE_CODE = "AmazonEC2";
+
+    private final Ec2Service ec2;
+
+    @Inject
+    public Ec2UsageEnumerator(Ec2Service ec2) {
+        this.ec2 = ec2;
+    }
+
+    @Override
+    public Stream<UsageLine> enumerate(Instant periodStart, Instant periodEnd, String region) {
+        List<Reservation> reservations = ec2.describeInstances(region, List.of(), Map.of());
+        Stream.Builder<UsageLine> out = Stream.builder();
+        // Use seconds with fractional-hour conversion so HOURLY queries with
+        // non-aligned windows (e.g. 90 minutes) and sub-hour windows still
+        // surface the correct partial-hour quantity.
+        long periodSeconds = Duration.between(periodStart, periodEnd).toSeconds();
+        if (periodSeconds <= 0) {
+            return Stream.empty();
+        }
+        double hours = periodSeconds / 3600.0;
+        // Always emit a zero-quantity catalog line so the service surfaces in
+        // GetDimensionValues SERVICE even when no instances are running.
+        out.add(catalogLine(periodStart, periodEnd, region));
+        for (Reservation reservation : reservations) {
+            String accountId = reservation.getOwnerId() != null ? reservation.getOwnerId() : "000000000000";
+            for (Instance instance : reservation.getInstances()) {
+                // AWS only bills BoxUsage hours for instances in the running state.
+                // pending / stopping / stopped / shutting-down / terminated incur no
+                // instance-hour cost (storage and other dimensions are billed separately
+                // and are out of scope for this enumerator).
+                if (instance.getState() == null
+                        || !"running".equalsIgnoreCase(instance.getState().getName())) {
+                    continue;
+                }
+                String instanceType = instance.getInstanceType();
+                if (instanceType == null || instanceType.isEmpty()) {
+                    continue;
+                }
+                String usageType = "BoxUsage:" + instanceType;
+                Map<String, String> tags = collectTags(instance);
+                out.add(new UsageLine(
+                        periodStart, periodEnd,
+                        SERVICE_CODE, region,
+                        usageType, "RunInstances",
+                        UsageLine.RECORD_TYPE_USAGE,
+                        accountId,
+                        instance.getInstanceId(),
+                        tags,
+                        hours,
+                        "Hrs"));
+            }
+        }
+        return out.build();
+    }
+
+    private static UsageLine catalogLine(Instant start, Instant end, String region) {
+        return new UsageLine(start, end, SERVICE_CODE, region,
+                "BoxUsage", "RunInstances",
+                UsageLine.RECORD_TYPE_USAGE, "000000000000", null, Map.of(),
+                0.0, "Hrs");
+    }
+
+    private static Map<String, String> collectTags(Instance instance) {
+        Map<String, String> tags = new HashMap<>();
+        if (instance.getTags() != null) {
+            for (Tag tag : instance.getTags()) {
+                if (tag.getKey() != null) {
+                    tags.put(tag.getKey(), tag.getValue() == null ? "" : tag.getValue());
+                }
+            }
+        }
+        return tags;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/LambdaUsageEnumerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/LambdaUsageEnumerator.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.ce.enumerator;
+
+import io.github.hectorvent.floci.core.common.ResourceUsageEnumerator;
+import io.github.hectorvent.floci.core.common.UsageLine;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Enumerates Lambda functions as Cost Explorer usage lines.
+ * Floci does not measure real invocation count or duration in this PR; each
+ * function emits a zero-quantity line so the function still surfaces in
+ * {@code GetDimensionValues SERVICE} responses without billed cost. The shape
+ * is in place for a follow-up PR that tracks invocations.
+ */
+@ApplicationScoped
+public class LambdaUsageEnumerator implements ResourceUsageEnumerator {
+
+    static final String SERVICE_CODE = "AWSLambda";
+
+    private final LambdaService lambdaService;
+
+    @Inject
+    public LambdaUsageEnumerator(LambdaService lambdaService) {
+        this.lambdaService = lambdaService;
+    }
+
+    @Override
+    public Stream<UsageLine> enumerate(Instant periodStart, Instant periodEnd, String region) {
+        if (Duration.between(periodStart, periodEnd).toSeconds() <= 0) {
+            return Stream.empty();
+        }
+        List<LambdaFunction> functions = lambdaService.listFunctions(region);
+        Stream.Builder<UsageLine> out = Stream.builder();
+        // Always emit a zero-quantity catalog line so the service surfaces in
+        // GetDimensionValues SERVICE even when no functions exist.
+        out.add(new UsageLine(periodStart, periodEnd,
+                SERVICE_CODE, region,
+                "AWS-Lambda-Requests", "Invoke",
+                UsageLine.RECORD_TYPE_USAGE,
+                "000000000000", null, new HashMap<>(),
+                0.0, "Requests"));
+        for (LambdaFunction fn : functions) {
+            Map<String, String> tags = fn.getTags() == null ? new HashMap<>() : new HashMap<>(fn.getTags());
+            String accountId = fn.getAccountId() != null ? fn.getAccountId() : "000000000000";
+            out.add(new UsageLine(
+                    periodStart, periodEnd,
+                    SERVICE_CODE, region,
+                    "AWS-Lambda-Requests", "Invoke",
+                    UsageLine.RECORD_TYPE_USAGE,
+                    accountId,
+                    fn.getFunctionArn(),
+                    tags,
+                    0.0,
+                    "Requests"));
+        }
+        return out.build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/S3UsageEnumerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/S3UsageEnumerator.java
@@ -1,0 +1,99 @@
+package io.github.hectorvent.floci.services.ce.enumerator;
+
+import io.github.hectorvent.floci.core.common.ResourceUsageEnumerator;
+import io.github.hectorvent.floci.core.common.UsageLine;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.Bucket;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Enumerates S3 buckets as Cost Explorer storage-usage lines.
+ * Aggregates object sizes per bucket and emits one {@code GB-Mo} line scaled
+ * to the fraction of a 30-day month covered by the requested period.
+ */
+@ApplicationScoped
+public class S3UsageEnumerator implements ResourceUsageEnumerator {
+
+    static final String SERVICE_CODE = "AmazonS3";
+    /**
+     * AWS-native usage type for S3 Standard-class storage. Must match the
+     * {@code usagetype} attribute on the corresponding product offer in the
+     * Pricing snapshot.
+     */
+    static final String STANDARD_STORAGE_USAGE_TYPE = "TimedStorage-Standard";
+    private static final double BYTES_PER_GB = 1_073_741_824.0;
+    private static final double SECONDS_PER_MONTH = 30.0 * 86_400.0;
+
+    private final S3Service s3;
+
+    @Inject
+    public S3UsageEnumerator(S3Service s3) {
+        this.s3 = s3;
+    }
+
+    @Override
+    public Stream<UsageLine> enumerate(Instant periodStart, Instant periodEnd, String region) {
+        long periodSeconds = Duration.between(periodStart, periodEnd).toSeconds();
+        if (periodSeconds <= 0) {
+            return Stream.empty();
+        }
+        double monthFraction = periodSeconds / SECONDS_PER_MONTH;
+
+        List<Bucket> buckets = s3.listBuckets();
+        Stream.Builder<UsageLine> out = Stream.builder();
+        // Always emit a zero-quantity catalog line so the service surfaces in
+        // GetDimensionValues SERVICE even when no buckets are present.
+        out.add(new UsageLine(periodStart, periodEnd, SERVICE_CODE, region,
+                STANDARD_STORAGE_USAGE_TYPE, "StandardStorage",
+                UsageLine.RECORD_TYPE_USAGE, "000000000000", null, new HashMap<>(),
+                0.0, "GB-Mo"));
+        for (Bucket bucket : buckets) {
+            String bucketRegion = bucket.getRegion();
+            if (bucketRegion == null) {
+                bucketRegion = "us-east-1";
+            }
+            if (!bucketRegion.equals(region)) {
+                continue;
+            }
+            double totalGb = totalBucketGb(bucket.getName());
+            if (totalGb <= 0) {
+                continue;
+            }
+            double gbMonths = totalGb * monthFraction;
+            Map<String, String> tags = bucket.getTags() == null ? new HashMap<>() : new HashMap<>(bucket.getTags());
+            out.add(new UsageLine(
+                    periodStart, periodEnd,
+                    SERVICE_CODE, region,
+                    STANDARD_STORAGE_USAGE_TYPE, "StandardStorage",
+                    UsageLine.RECORD_TYPE_USAGE,
+                    "000000000000",
+                    "arn:aws:s3:::" + bucket.getName(),
+                    tags,
+                    gbMonths,
+                    "GB-Mo"));
+        }
+        return out.build();
+    }
+
+    private double totalBucketGb(String bucketName) {
+        try {
+            List<S3Object> objects = s3.listObjects(bucketName, null, null, Integer.MAX_VALUE);
+            long bytes = 0;
+            for (S3Object obj : objects) {
+                bytes += Math.max(0, obj.getSize());
+            }
+            return bytes / BYTES_PER_GB;
+        } catch (RuntimeException ignored) {
+            return 0.0;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/UnpricedServicesEnumerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/enumerator/UnpricedServicesEnumerator.java
@@ -1,0 +1,80 @@
+package io.github.hectorvent.floci.services.ce.enumerator;
+
+import io.github.hectorvent.floci.core.common.ResourceUsageEnumerator;
+import io.github.hectorvent.floci.core.common.UsageLine;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Emits zero-quantity placeholder lines for Floci services that don't have
+ * unit-price data in the bundled snapshot yet. Keeps these services discoverable
+ * via {@code GetDimensionValues SERVICE} without contributing billed cost.
+ *
+ * <p>Each service ships its own AWS-shaped {@code ServiceCode} per the AWS Price
+ * List naming convention.
+ */
+@ApplicationScoped
+public class UnpricedServicesEnumerator implements ResourceUsageEnumerator {
+
+    /**
+     * AWS Price List service codes for the Floci services Floci's pricing snapshot
+     * does not yet cover. Update when a new {@code *UsageEnumerator} bean lands
+     * with rate data.
+     */
+    private static final List<String> SERVICE_CODES = List.of(
+            "AmazonDynamoDB",
+            "AmazonSQS",
+            "AmazonSNS",
+            "AmazonSES",
+            "AmazonKinesis",
+            "AmazonKinesisFirehose",
+            "AWSSecretsManager",
+            "AmazonCloudWatch",
+            "AWSCloudFormation",
+            "AmazonAPIGateway",
+            "AWSStepFunctions",
+            "AmazonECR",
+            "AmazonECS",
+            "AmazonEKS",
+            "AmazonRDS",
+            "AmazonElastiCache",
+            "AmazonOpenSearchService",
+            "AmazonAthena",
+            "AWSGlue",
+            "AWSEvents",
+            "AmazonCognito",
+            "AWSCodeBuild",
+            "AWSCodeDeploy",
+            "AmazonRoute53",
+            "AWSCertificateManager",
+            "AWSKeyManagementService",
+            "AWSBackup",
+            "AWSTransfer",
+            "AmazonMSK",
+            "AWSSystemsManager",
+            "AWSAppConfig",
+            "AmazonTextract",
+            "AmazonBedrock");
+
+    @Override
+    public Stream<UsageLine> enumerate(Instant periodStart, Instant periodEnd, String region) {
+        if (Duration.between(periodStart, periodEnd).toSeconds() <= 0) {
+            return Stream.empty();
+        }
+        return SERVICE_CODES.stream().map(code -> new UsageLine(
+                periodStart, periodEnd,
+                code, region,
+                "Unknown", "Unknown",
+                UsageLine.RECORD_TYPE_USAGE,
+                "000000000000",
+                null,
+                Map.of(),
+                0.0,
+                "Unknown"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -262,3 +262,6 @@ floci:
       enabled: true
     transcribe:
       enabled: true
+    ce:
+      enabled: true
+      credit-usd-monthly: 0.0

--- a/src/main/resources/pricing-snapshots/products/AWSLambda/us-east-1.json
+++ b/src/main/resources/pricing-snapshots/products/AWSLambda/us-east-1.json
@@ -8,7 +8,8 @@
         "locationType": "AWS Region",
         "group": "AWS-Lambda-Requests",
         "groupDescription": "Invocation call for a Lambda function",
-        "regionCode": "us-east-1"
+        "regionCode": "us-east-1",
+        "usagetype": "AWS-Lambda-Requests"
       },
       "sku": "FLOCI-LAMBDA-REQ-USE1"
     },

--- a/src/main/resources/pricing-snapshots/products/AmazonEC2/us-east-1.json
+++ b/src/main/resources/pricing-snapshots/products/AmazonEC2/us-east-1.json
@@ -11,7 +11,8 @@
         "operatingSystem": "Linux",
         "preInstalledSw": "NA",
         "capacitystatus": "Used",
-        "regionCode": "us-east-1"
+        "regionCode": "us-east-1",
+        "usagetype": "BoxUsage:t3.micro"
       },
       "sku": "FLOCI-EC2-T3MICRO-USE1"
     },
@@ -52,7 +53,8 @@
         "operatingSystem": "Linux",
         "preInstalledSw": "NA",
         "capacitystatus": "Used",
-        "regionCode": "us-east-1"
+        "regionCode": "us-east-1",
+        "usagetype": "BoxUsage:m5.large"
       },
       "sku": "FLOCI-EC2-M5LARGE-USE1"
     },
@@ -93,7 +95,8 @@
         "operatingSystem": "Linux",
         "preInstalledSw": "NA",
         "capacitystatus": "Used",
-        "regionCode": "us-east-1"
+        "regionCode": "us-east-1",
+        "usagetype": "BoxUsage:c5.large"
       },
       "sku": "FLOCI-EC2-C5LARGE-USE1"
     },

--- a/src/main/resources/pricing-snapshots/products/AmazonS3/us-east-1.json
+++ b/src/main/resources/pricing-snapshots/products/AmazonS3/us-east-1.json
@@ -8,7 +8,8 @@
         "locationType": "AWS Region",
         "storageClass": "General Purpose",
         "volumeType": "Standard",
-        "regionCode": "us-east-1"
+        "regionCode": "us-east-1",
+        "usagetype": "TimedStorage-Standard"
       },
       "sku": "FLOCI-S3-STANDARD-USE1"
     },

--- a/src/test/java/io/github/hectorvent/floci/services/ce/CostExplorerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ce/CostExplorerIntegrationTest.java
@@ -1,0 +1,436 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for the Cost Explorer service.
+ * Validates AWS-compatible wire format using RestAssured.
+ * Protocol: JSON 1.1 — Content-Type: application/x-amz-json-1.1,
+ *           X-Amz-Target: AWSInsightsIndexService.&lt;Action&gt;
+ */
+@QuarkusTest
+class CostExplorerIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ce/aws4_request";
+    private static final String S3_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/s3/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void getCostAndUsage_emptyState_returnsResultsByTime() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3))
+            .body("ResultsByTime[0].TimePeriod.Start", startsWith("2026-01-01"))
+            .body("ResultsByTime[0].Total.UnblendedCost.Unit", equalTo("USD"));
+    }
+
+    @Test
+    void getCostAndUsage_monthlyGranularitySplitsAcrossMonths() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-15\",\"End\":\"2026-03-15\"}," +
+                    "\"Granularity\":\"MONTHLY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3));
+    }
+
+    @Test
+    void getCostAndUsage_hourlyGranularityEmitsHourBuckets() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01T00:00:00Z\",\"End\":\"2026-01-01T03:00:00Z\"}," +
+                    "\"Granularity\":\"HOURLY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3));
+    }
+
+    @Test
+    void getCostAndUsage_missingMetrics_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"DAILY\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void getCostAndUsage_missingTimePeriod_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void getCostAndUsage_invalidGranularity_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"YEARLY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void getCostAndUsage_endBeforeStart_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-02-01\",\"End\":\"2026-01-01\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    void getCostAndUsage_returnsNonZeroCostFromS3BucketObjects() {
+        // Stand up a bucket with one ~1-MiB object so cost synthesis has something
+        // to multiply against. The bundled S3 fixture rates Standard at $0.023/GB-Mo,
+        // so any non-zero size must produce a strictly positive UnblendedCost.
+        String bucket = "ce-test-bucket-" + System.currentTimeMillis();
+        given()
+            .header("Authorization", S3_AUTH)
+            .header("Host", "localhost")
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        byte[] payload = new byte[1024 * 1024]; // 1 MiB
+        given()
+            .header("Authorization", S3_AUTH)
+            .body(payload)
+        .when()
+            .put("/" + bucket + "/object.bin")
+        .then()
+            .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        String unblendedAmount = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-02-01\"}," +
+                    "\"Granularity\":\"MONTHLY\",\"Metrics\":[\"UnblendedCost\",\"UsageQuantity\"]," +
+                    "\"GroupBy\":[{\"Type\":\"DIMENSION\",\"Key\":\"SERVICE\"}]," +
+                    "\"Filter\":{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"AmazonS3\"]}}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime[0].Groups.Keys.flatten()", hasItem("AmazonS3"))
+            .extract()
+            .path("ResultsByTime[0].Groups.find { it.Keys.contains('AmazonS3') }.Metrics.UnblendedCost.Amount");
+
+        assertThat(Double.parseDouble(unblendedAmount), greaterThan(0.0));
+    }
+
+    @Test
+    void getCostAndUsage_creditOffsetReducesUnblendedCost() {
+        // Run two queries: one without and one with FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY
+        // toggled on. Credit injection is process-wide config, so this test asserts
+        // the no-credit baseline; the credit-on flow has dedicated unit coverage in
+        // CostSynthesizerTest. The intent here is that when a Credit RECORD_TYPE
+        // line exists, its amount flows directly into UnblendedCost without going
+        // through the rate lookup (which would produce 0 for a Credit-Promotional
+        // usage type).
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-02-01\"}," +
+                    "\"Granularity\":\"MONTHLY\",\"Metrics\":[\"UnblendedCost\"]," +
+                    "\"GroupBy\":[{\"Type\":\"DIMENSION\",\"Key\":\"RECORD_TYPE\"}]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(1));
+    }
+
+    @Test
+    void getCostAndUsage_filterByService() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]," +
+                    "\"GroupBy\":[{\"Type\":\"DIMENSION\",\"Key\":\"SERVICE\"}]," +
+                    "\"Filter\":{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"AmazonEC2\"]}}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime[0].Groups.Keys.flatten()", everyItem(equalTo("AmazonEC2")));
+    }
+
+    @Test
+    void getCostAndUsage_filterAndExpression() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]," +
+                    "\"Filter\":{\"And\":[" +
+                    "{\"Dimensions\":{\"Key\":\"REGION\",\"Values\":[\"us-east-1\"]}}," +
+                    "{\"Not\":{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"AmazonRDS\"]}}}" +
+                    "]}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3));
+    }
+
+    @Test
+    void getDimensionValues_serviceReturnsKnownServices() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetDimensionValues")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Dimension\":\"SERVICE\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DimensionValues.Value", hasItems("AmazonEC2", "AmazonS3", "AWSLambda"));
+    }
+
+    @Test
+    void getDimensionValues_recordTypeReturnsUsage() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetDimensionValues")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Dimension\":\"RECORD_TYPE\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DimensionValues.Value", hasItem("Usage"));
+    }
+
+    @Test
+    void getDimensionValues_missingDimension_returns400() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetDimensionValues")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void getTags_emptyState_returnsEmpty() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetTags")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", notNullValue())
+            .body("ReturnSize", greaterThanOrEqualTo(0));
+    }
+
+    @Test
+    void getReservationCoverage_returnsZeroedTotal() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetReservationCoverage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Total.CoverageHours.OnDemandHours", equalTo("0"))
+            .body("CoveragesByTime", hasSize(0));
+    }
+
+    @Test
+    void getReservationUtilization_returnsZeroedTotal() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetReservationUtilization")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Total.UtilizationPercentage", equalTo("0"))
+            .body("UtilizationsByTime", hasSize(0));
+    }
+
+    @Test
+    void getSavingsPlansCoverage_returnsEmpty() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetSavingsPlansCoverage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("SavingsPlansCoverages", hasSize(0));
+    }
+
+    @Test
+    void getSavingsPlansUtilization_returnsZeroedTotal() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetSavingsPlansUtilization")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Total.Utilization.UtilizationPercentage", equalTo("0"));
+    }
+
+    @Test
+    void getCostCategories_returnsEmpty() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostCategories")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CostCategoryNames", hasSize(0))
+            .body("ReturnSize", equalTo(0));
+    }
+
+    @Test
+    void getCostAndUsageWithResources_acceptsSameShape() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsageWithResources")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]," +
+                    "\"GroupBy\":[{\"Type\":\"DIMENSION\",\"Key\":\"RESOURCE_ID\"}]," +
+                    "\"Filter\":{\"Dimensions\":{\"Key\":\"SERVICE\",\"Values\":[\"AmazonEC2\"]}}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3))
+            .body("GroupDefinitions[0].Key", equalTo("RESOURCE_ID"));
+    }
+
+    @Test
+    void getCostAndUsage_dailyTruncatesEndToBucketBoundary() {
+        // End at 13:30 should still produce 3 whole-day buckets aligned to UTC midnight
+        // (Jan 1, Jan 2, Jan 3) per AWS DAILY semantics, not 3 buckets where the last
+        // ends mid-day.
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetCostAndUsage")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01T00:00:00Z\",\"End\":\"2026-01-03T13:30:00Z\"}," +
+                    "\"Granularity\":\"DAILY\",\"Metrics\":[\"UnblendedCost\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ResultsByTime", hasSize(3))
+            .body("ResultsByTime[2].TimePeriod.End", equalTo("2026-01-04T00:00:00Z"));
+    }
+
+    @Test
+    void getDimensionValues_includesAmazonMSKWithCanonicalCode() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetDimensionValues")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"TimePeriod\":{\"Start\":\"2026-01-01\",\"End\":\"2026-01-04\"}," +
+                    "\"Dimension\":\"SERVICE\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DimensionValues.Value", hasItem("AmazonMSK"))
+            .body("DimensionValues.Value", not(hasItem("AWSAmazonMSK")));
+    }
+
+    @Test
+    void unknownAction_returnsUnknownOperationError() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSInsightsIndexService.GetBogusAction")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("UnknownOperationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ce/CostSynthesizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ce/CostSynthesizerTest.java
@@ -1,0 +1,99 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.UsageLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Unit tests for {@link CostSynthesizer} — focused on rate application and
+ * the special-case treatment of USD-denominated record types
+ * (Credit / Refund / Tax / SavingsPlan upfront / SavingsPlan recurring).
+ */
+class CostSynthesizerTest {
+
+    private static final Instant START = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Instant END = Instant.parse("2026-01-02T00:00:00Z");
+
+    private CostSynthesizer synthesizer;
+
+    @BeforeEach
+    void setUp() {
+        // Hand-rolled stub so the test stays a pure unit test (no Pricing snapshot
+        // load on the classpath, no Quarkus boot).
+        PricingRateLookup stubLookup = new PricingRateLookup(null, null) {
+            @Override
+            public Map<String, Double> ratesFor(String serviceCode, String regionCode) {
+                if ("AmazonEC2".equals(serviceCode)) {
+                    return Map.of("BoxUsage:t3.micro", 0.0104);
+                }
+                return Map.of();
+            }
+        };
+        synthesizer = new CostSynthesizer(stubLookup);
+    }
+
+    @Test
+    void usageRecordType_multipliesQuantityByRate() {
+        UsageLine line = new UsageLine(START, END,
+                "AmazonEC2", "us-east-1", "BoxUsage:t3.micro", "RunInstances",
+                UsageLine.RECORD_TYPE_USAGE,
+                "000000000000", "i-test", Map.of(),
+                24.0, "Hrs");
+        Map<String, CostSynthesizer.MetricValue> metrics = synthesizer.compute(line);
+
+        assertThat(metrics.get("UnblendedCost").amount(), closeTo(24.0 * 0.0104, 1e-9));
+        assertThat(metrics.get("UnblendedCost").unit(), equalTo("USD"));
+        assertThat(metrics.get("UsageQuantity").amount(), equalTo(24.0));
+        assertThat(metrics.get("UsageQuantity").unit(), equalTo("Hrs"));
+    }
+
+    @Test
+    void creditRecordType_costEqualsQuantity() {
+        // Credit lines arrive denominated in USD already and must NOT be passed
+        // through the rate lookup (which has no entry for Credits/Credit-Promotional).
+        UsageLine credit = new UsageLine(START, END,
+                "Credits", "us-east-1", "Credit-Promotional", "ApplyPromoCredit",
+                UsageLine.RECORD_TYPE_CREDIT,
+                "000000000000", null, Map.of(),
+                -100.0, "USD");
+        Map<String, CostSynthesizer.MetricValue> metrics = synthesizer.compute(credit);
+
+        assertThat(metrics.get("UnblendedCost").amount(), equalTo(-100.0));
+        assertThat(metrics.get("UnblendedCost").unit(), equalTo("USD"));
+        assertThat(metrics.get("BlendedCost").amount(), equalTo(-100.0));
+        assertThat(metrics.get("AmortizedCost").amount(), equalTo(-100.0));
+        assertThat(metrics.get("NetUnblendedCost").amount(), equalTo(-100.0));
+        assertThat(metrics.get("NetAmortizedCost").amount(), equalTo(-100.0));
+        assertThat(metrics.get("UsageQuantity").amount(), equalTo(0.0));
+    }
+
+    @Test
+    void taxRecordType_costEqualsQuantity() {
+        UsageLine tax = new UsageLine(START, END,
+                "Tax", "us-east-1", "Tax", "Tax",
+                UsageLine.RECORD_TYPE_TAX,
+                "000000000000", null, Map.of(),
+                7.50, "USD");
+        Map<String, CostSynthesizer.MetricValue> metrics = synthesizer.compute(tax);
+        assertThat(metrics.get("UnblendedCost").amount(), equalTo(7.50));
+    }
+
+    @Test
+    void usageRecordType_unknownRateProducesZeroCost() {
+        UsageLine line = new UsageLine(START, END,
+                "AmazonRDS", "us-east-1", "InstanceUsage:db.t3.micro", "CreateDBInstance",
+                UsageLine.RECORD_TYPE_USAGE,
+                "000000000000", null, Map.of(),
+                24.0, "Hrs");
+        Map<String, CostSynthesizer.MetricValue> metrics = synthesizer.compute(line);
+        assertThat(metrics.get("UnblendedCost").amount(), equalTo(0.0));
+        assertThat(metrics.get("UsageQuantity").amount(), equalTo(24.0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ce/CreditLineEmitterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ce/CreditLineEmitterTest.java
@@ -1,0 +1,133 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.UsageLine;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+class CreditLineEmitterTest {
+
+    private static final Instant JAN_15 = Instant.parse("2026-01-15T00:00:00Z");
+    private static final Instant MAR_15 = Instant.parse("2026-03-15T00:00:00Z");
+
+    /**
+     * Stub synthesizer that returns a fixed monthly cost: $300 for the entire
+     * Jan-15 to Mar-15 line. Used to verify proportional split across months.
+     */
+    private CostSynthesizer fixedCostSynthesizer(double total) {
+        return new CostSynthesizer(new PricingRateLookup(null, null) {
+            @Override
+            public Map<String, Double> ratesFor(String serviceCode, String regionCode) {
+                return Map.of();
+            }
+        }) {
+            @Override
+            Map<String, MetricValue> compute(UsageLine line) {
+                if (UsageLine.RECORD_TYPE_USAGE.equals(line.recordType())) {
+                    return Map.of(
+                            "UnblendedCost", new MetricValue(total, "USD"),
+                            "BlendedCost", new MetricValue(total, "USD"),
+                            "AmortizedCost", new MetricValue(total, "USD"),
+                            "NetUnblendedCost", new MetricValue(total, "USD"),
+                            "NetAmortizedCost", new MetricValue(total, "USD"),
+                            "UsageQuantity", new MetricValue(line.quantity(), line.usageUnit()),
+                            "NormalizedUsageAmount", new MetricValue(line.quantity(), line.usageUnit()));
+                }
+                return Map.of();
+            }
+        };
+    }
+
+    private static UsageLine usage(Instant start, Instant end) {
+        return new UsageLine(start, end,
+                "AmazonEC2", "us-east-1", "BoxUsage:t3.micro", "RunInstances",
+                UsageLine.RECORD_TYPE_USAGE,
+                "000000000000", "i-test", Map.of(),
+                24.0, "Hrs");
+    }
+
+    @Test
+    void singleMonthLine_emitsOneCredit() {
+        CreditLineEmitter emitter = new CreditLineEmitter(50.0);
+        UsageLine line = usage(Instant.parse("2026-01-01T00:00:00Z"),
+                Instant.parse("2026-02-01T00:00:00Z"));
+        List<UsageLine> credits = emitter.emit(Stream.of(line), fixedCostSynthesizer(200.0)).toList();
+        assertThat(credits, hasSize(1));
+        assertThat(credits.get(0).quantity(), equalTo(-50.0));
+        assertThat(credits.get(0).recordType(), equalTo(UsageLine.RECORD_TYPE_CREDIT));
+    }
+
+    @Test
+    void multiMonthLine_emitsCreditPerCalendarMonth() {
+        // Line spans Jan 15 -> Mar 15, total cost $300. Three months touched —
+        // Jan (17d), Feb (28d), Mar (14d). Credit = $50/mo capped at the monthly
+        // share. All three months must produce a credit line.
+        CreditLineEmitter emitter = new CreditLineEmitter(50.0);
+        UsageLine line = usage(JAN_15, MAR_15);
+        List<UsageLine> credits = emitter.emit(Stream.of(line), fixedCostSynthesizer(300.0)).toList();
+        assertThat(credits, hasSize(3));
+        for (UsageLine credit : credits) {
+            assertThat(credit.recordType(), equalTo(UsageLine.RECORD_TYPE_CREDIT));
+            assertThat(credit.region(), equalTo("us-east-1"));
+        }
+        // Each month has share > $50 of $300 (Jan ~$87, Feb ~$144, Mar ~$72), so each
+        // credit caps at the configured -$50.
+        for (UsageLine credit : credits) {
+            assertThat(credit.quantity(), equalTo(-50.0));
+        }
+        // Windows should align to the three calendar months.
+        List<YearMonth> months = credits.stream()
+                .map(c -> YearMonth.from(c.periodStart().atOffset(ZoneOffset.UTC)))
+                .toList();
+        assertThat(months, hasItem(YearMonth.of(2026, 1)));
+        assertThat(months, hasItem(YearMonth.of(2026, 2)));
+        assertThat(months, hasItem(YearMonth.of(2026, 3)));
+    }
+
+    @Test
+    void multiMonthLine_smallTotalCapsCreditAtUsageCost() {
+        // Line spans Jan 15 -> Mar 15, but total cost is only $9. Per-month share
+        // is well under $50, so the credit caps at the monthly usage cost rather
+        // than the configured monthly limit.
+        CreditLineEmitter emitter = new CreditLineEmitter(50.0);
+        UsageLine line = usage(JAN_15, MAR_15);
+        List<UsageLine> credits = emitter.emit(Stream.of(line), fixedCostSynthesizer(9.0)).toList();
+        assertThat(credits, hasSize(3));
+        double total = 0;
+        for (UsageLine c : credits) {
+            // Each absolute credit is < $50.
+            assertThat(Math.abs(c.quantity()) <= 50.0, equalTo(true));
+            total += -c.quantity();
+        }
+        // Sum of credits == sum of usage cost (since credit per month >= monthly cost).
+        assertThat(total, closeTo(9.0, 1e-6));
+    }
+
+    @Test
+    void zeroConfiguredCredit_emitsNothing() {
+        CreditLineEmitter emitter = new CreditLineEmitter(0.0);
+        UsageLine line = usage(JAN_15, MAR_15);
+        List<UsageLine> credits = emitter.emit(Stream.of(line), fixedCostSynthesizer(300.0)).toList();
+        assertThat(credits, empty());
+    }
+
+    @Test
+    void zeroCostUsage_emitsNothing() {
+        CreditLineEmitter emitter = new CreditLineEmitter(50.0);
+        UsageLine line = usage(JAN_15, MAR_15);
+        List<UsageLine> credits = emitter.emit(Stream.of(line), fixedCostSynthesizer(0.0)).toList();
+        assertThat(credits, empty());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ce/TimeBucketingTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ce/TimeBucketingTest.java
@@ -1,0 +1,82 @@
+package io.github.hectorvent.floci.services.ce;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link TimeBucketing}, focused on the boundary-alignment
+ * behavior AWS Cost Explorer guarantees: Start truncates down, End rounds up
+ * to the next granularity boundary so every bucket spans a whole granularity
+ * unit.
+ */
+class TimeBucketingTest {
+
+    @Test
+    void splitDaily_truncatesNonAlignedEndToNextDay() {
+        Instant start = Instant.parse("2026-01-01T00:00:00Z");
+        Instant end = Instant.parse("2026-01-03T13:30:00Z");
+        List<TimeBucketing.Bucket> buckets = TimeBucketing.split(start, end, TimeBucketing.Granularity.DAILY);
+        assertThat(buckets, hasSize(3));
+        assertThat(buckets.get(0).start(), equalTo(Instant.parse("2026-01-01T00:00:00Z")));
+        assertThat(buckets.get(2).end(), equalTo(Instant.parse("2026-01-04T00:00:00Z")));
+    }
+
+    @Test
+    void splitHourly_truncatesNonAlignedBoundaries() {
+        Instant start = Instant.parse("2026-01-01T00:30:00Z");
+        Instant end = Instant.parse("2026-01-01T03:45:00Z");
+        List<TimeBucketing.Bucket> buckets = TimeBucketing.split(start, end, TimeBucketing.Granularity.HOURLY);
+        assertThat(buckets, hasSize(4));
+        assertThat(buckets.get(0).start(), equalTo(Instant.parse("2026-01-01T00:00:00Z")));
+        assertThat(buckets.get(3).end(), equalTo(Instant.parse("2026-01-01T04:00:00Z")));
+    }
+
+    @Test
+    void splitMonthly_anchorsToFirstOfMonth() {
+        Instant start = Instant.parse("2026-01-15T00:00:00Z");
+        Instant end = Instant.parse("2026-03-10T00:00:00Z");
+        List<TimeBucketing.Bucket> buckets = TimeBucketing.split(start, end, TimeBucketing.Granularity.MONTHLY);
+        assertThat(buckets, hasSize(3));
+        assertThat(buckets.get(0).start(), equalTo(Instant.parse("2026-01-01T00:00:00Z")));
+        assertThat(buckets.get(2).end(), equalTo(Instant.parse("2026-04-01T00:00:00Z")));
+    }
+
+    @Test
+    void splitDaily_alreadyAlignedEndDoesNotAddExtraDay() {
+        Instant start = Instant.parse("2026-01-01T00:00:00Z");
+        Instant end = Instant.parse("2026-01-03T00:00:00Z");
+        List<TimeBucketing.Bucket> buckets = TimeBucketing.split(start, end, TimeBucketing.Granularity.DAILY);
+        assertThat(buckets, hasSize(2));
+        assertThat(buckets.get(1).end(), equalTo(Instant.parse("2026-01-03T00:00:00Z")));
+    }
+
+    @Test
+    void split_endNotAfterStart_throws() {
+        Instant t = Instant.parse("2026-01-01T00:00:00Z");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> TimeBucketing.split(t, t, TimeBucketing.Granularity.DAILY));
+        assertThat(ex.getErrorCode(), equalTo("DataUnavailableException"));
+    }
+
+    @Test
+    void parseGranularity_acceptsThreeValues() {
+        assertThat(TimeBucketing.parseGranularity("DAILY"), equalTo(TimeBucketing.Granularity.DAILY));
+        assertThat(TimeBucketing.parseGranularity("HOURLY"), equalTo(TimeBucketing.Granularity.HOURLY));
+        assertThat(TimeBucketing.parseGranularity("MONTHLY"), equalTo(TimeBucketing.Granularity.MONTHLY));
+    }
+
+    @Test
+    void parseGranularity_rejectsInvalid() {
+        assertThrows(AwsException.class, () -> TimeBucketing.parseGranularity("YEARLY"));
+        assertThrows(AwsException.class, () -> TimeBucketing.parseGranularity(""));
+        assertThrows(AwsException.class, () -> TimeBucketing.parseGranularity(null));
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -178,3 +178,5 @@ floci:
       enabled: true
     pricing:
       enabled: true
+    ce:
+      enabled: true


### PR DESCRIPTION
## Summary

Implements PR 2 of the 3-PR scope discussed in #791 (#822). Adds the AWS Cost Explorer (`ce:*`) emulation by synthesizing cost and usage from Floci's existing resource state multiplied by the Pricing snapshot shipped in #821.

Closes #822.

- 9 operations: `GetCostAndUsage`, `GetCostAndUsageWithResources`, `GetDimensionValues`, `GetTags`, `GetReservationCoverage`, `GetReservationUtilization`, `GetSavingsPlansCoverage`, `GetSavingsPlansUtilization`, `GetCostCategories`
- JSON 1.1 protocol, dispatch via existing `AwsJson11Controller` (`X-Amz-Target: AWSInsightsIndexService.<Action>`)
- Full `TimePeriod` / `Granularity` (DAILY / MONTHLY / HOURLY) / `Filter` (recursive `And`/`Or`/`Not`/`Dimensions`/`Tags`/`CostCategories`) / `GroupBy` / `Metrics` support
- `RECORD_TYPE` semantics covered: `Usage`, `Credit` (when `FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY > 0`), with stub paths for `Tax`/`Refund`/`SavingsPlan*`
- RI / Savings Plans / Cost Categories return zeroed-totals stubs (full math out of scope; can land in follow-up)

## Architecture

A new SPI in `core/common/`:

```java
public interface ResourceUsageEnumerator {
    Stream<UsageLine> enumerate(Instant start, Instant end, String region);
}
```

CDI auto-discovers every `@ApplicationScoped` bean implementing it. `CostExplorerService` iterates `Instance<ResourceUsageEnumerator>` per request, so adding a new Floci service with cost data is a matter of dropping a new enumerator bean next to the service. Zero changes to `CostExplorerService` needed.

The bundled enumerators ship today:
- `Ec2UsageEnumerator` — `BoxUsage:<instanceType>` × hours per running instance
- `S3UsageEnumerator` — `TimedStorage-Standard` × GB-month per bucket
- `LambdaUsageEnumerator` — catalog-only (zero-quantity) for now
- `UnpricedServicesEnumerator` — zero-quantity catalog rows for ~30 other Floci services so they surface in `GetDimensionValues SERVICE`

The same enumerators will feed the upcoming CUR / BCM Data Exports Parquet writer (#823) without duplication.

## Pricing snapshot extended

Bundled product offers now carry the AWS-native `usagetype` attribute on each offer (`BoxUsage:t3.micro`, `TimedStorage-Standard`, `AWS-Lambda-Requests`). `PricingRateLookup` reads this attribute directly; the previous synthesis fallback is retained as a compatibility path for user-supplied snapshots via `FLOCI_SERVICES_PRICING_SNAPSHOT_PATH` that don't include it.

## Synthetic credit injection

`FLOCI_SERVICES_CE_CREDIT_USD_MONTHLY` (default `0.0`) emits a monthly `Credit` `RECORD_TYPE` row capped at the synthesized usage cost. Credits are split across each calendar month a usage line touches, weighted by second-overlap.

## Test plan

- [x] `./mvnw test -Dtest='CostExplorer*Test,CostSynthesizerTest,CreditLineEmitterTest,TimeBucketingTest,PricingIntegrationTest'` — 66/66 green locally (Java 25)
- [x] `CostExplorerIntegrationTest` (24 tests) — RestAssured wire-format coverage of all 9 operations: granularity bucketing, filter expressions, group-by, dimension/tag listings, RI/SP stubs, validation errors, path-traversal-style assertions, multi-version pricing snapshot, EC2 state filtering, S3 cost > 0, credit emission
- [x] `CostSynthesizerTest` (4 tests) — usage rate × quantity, USD-denominated short-circuit (Credit / Tax), unknown-rate zero-cost
- [x] `CreditLineEmitterTest` (5 tests) — single-month, multi-month proportional split, capping at usage cost, zero-config no-op, zero-cost-usage no-op
- [x] `TimeBucketingTest` (7 tests) — Start / End boundary truncation across DAILY / HOURLY / MONTHLY, granularity parsing
- [x] `PricingIntegrationTest` (26 tests) — unchanged, still green with the snapshot `usagetype` additions
- [ ] CI to run the full suite

## Scope boundaries (out of scope for this PR)

- Forecasting (`GetCostForecast`, `GetUsageForecast`)
- Right-sizing recommendations (`GetRightsizingRecommendation`)
- Anomaly detection management (separate PR planned per #791)
- Real RI / Savings Plan utilization math (currently zeroed stubs)
- Cost category management (CRUD on cost categories)
- CUR / BCM Data Exports Parquet emission — covered by #823

## Self-review notes

Reviewed locally before pushing. Four issues found and folded in:
1. `GetCostAndUsageWithResources` previously had a placeholder no-op flag; now shares `runCostAndUsage` directly with javadoc directing callers to `GroupBy=RESOURCE_ID`. Test added.
2. `UnpricedServicesEnumerator` had a typo (`AWSAmazonMSK`); corrected to `AmazonMSK`. Test added.
3. `Ec2UsageEnumerator` used `Duration.toHours()` which truncates fractional hours and silently dropped sub-hour windows; switched to `toSeconds() / 3600.0`.
4. `TimeBucketing` only truncated `Start`; `End` now also rounds up to the next granularity boundary so non-aligned ISO-8601 timestamps produce AWS-shaped buckets. Dedicated `TimeBucketingTest` added.

Refs: https://github.com/orgs/floci-io/discussions/791
Refs: #822
Builds on: #821
