### PR TITLE
feat(eventbridge): add UpdateEventBus action

### DIFF
--- a/docs/services/eventbridge.md
+++ b/docs/services/eventbridge.md
@@ -10,6 +10,7 @@
 | `CreateEventBus` | Create a custom event bus |
 | `DeleteEventBus` | Delete an event bus |
 | `DescribeEventBus` | Get event bus details |
+| `UpdateEventBus` | Update event bus description, KMS key, dead-letter config, or log config |
 | `ListEventBuses` | List all event buses |
 | `PutRule` | Create or update a rule with a schedule or event pattern |
 | `DeleteRule` | Delete a rule |

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -53,6 +53,7 @@ public class EventBridgeHandler {
                 case "CreateEventBus" -> handleCreateEventBus(request, region);
                 case "DeleteEventBus" -> handleDeleteEventBus(request, region);
                 case "DescribeEventBus" -> handleDescribeEventBus(request, region);
+                case "UpdateEventBus" -> handleUpdateEventBus(request, region);
                 case "ListEventBuses" -> handleListEventBuses(request, region);
                 case "PutRule" -> handlePutRule(request, region);
                 case "DeleteRule" -> handleDeleteRule(request, region);
@@ -114,6 +115,21 @@ public class EventBridgeHandler {
     private Response handleDescribeEventBus(JsonNode request, String region) {
         String name = request.path("Name").asText(null);
         EventBus bus = eventBridgeService.describeEventBus(name, region);
+        return Response.ok(buildBusNode(bus)).build();
+    }
+
+    private Response handleUpdateEventBus(JsonNode request, String region) {
+        String name = request.path("Name").asText(null);
+        String description = request.path("Description").asText(null);
+        String kmsKey = request.path("KmsKeyIdentifier").asText(null);
+        // Empty {} is treated as "no change", matching how omitted/null inputs flow.
+        // Only a populated object triggers a write to the bus's nested config field.
+        JsonNode dlqNode = request.path("DeadLetterConfig");
+        String dlq = (dlqNode.isObject() && !dlqNode.isEmpty()) ? dlqNode.toString() : null;
+        JsonNode logNode = request.path("LogConfig");
+        String logCfg = (logNode.isObject() && !logNode.isEmpty()) ? logNode.toString() : null;
+        EventBus bus = eventBridgeService.updateEventBus(
+                name, description, kmsKey, dlq, logCfg, region);
         return Response.ok(buildBusNode(bus)).build();
     }
 
@@ -505,6 +521,21 @@ public class EventBridgeHandler {
         }
         if (bus.getPolicy() != null) {
             node.put("Policy", bus.getPolicy());
+        }
+        if (bus.getKmsKeyIdentifier() != null) {
+            node.put("KmsKeyIdentifier", bus.getKmsKeyIdentifier());
+        }
+        // Stored as raw JSON strings; emitted as JSON objects so SDK clients
+        // can deserialize them as structs. Do NOT use node.put(...) here.
+        if (bus.getDeadLetterConfig() != null) {
+            try {
+                node.set("DeadLetterConfig", objectMapper.readTree(bus.getDeadLetterConfig()));
+            } catch (Exception ignored) { /* drop malformed stored config */ }
+        }
+        if (bus.getLogConfig() != null) {
+            try {
+                node.set("LogConfig", objectMapper.readTree(bus.getLogConfig()));
+            } catch (Exception ignored) { /* drop malformed stored config */ }
         }
         return node;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeHandler.java
@@ -530,12 +530,20 @@ public class EventBridgeHandler {
         if (bus.getDeadLetterConfig() != null) {
             try {
                 node.set("DeadLetterConfig", objectMapper.readTree(bus.getDeadLetterConfig()));
-            } catch (Exception ignored) { /* drop malformed stored config */ }
+            } catch (Exception e) {
+                LOG.warnv("Failed to parse stored DeadLetterConfig for bus {0} (arn={1}); "
+                        + "field omitted from response. Stored value: {2}. Error: {3}",
+                        bus.getName(), bus.getArn(), bus.getDeadLetterConfig(), e.getMessage());
+            }
         }
         if (bus.getLogConfig() != null) {
             try {
                 node.set("LogConfig", objectMapper.readTree(bus.getLogConfig()));
-            } catch (Exception ignored) { /* drop malformed stored config */ }
+            } catch (Exception e) {
+                LOG.warnv("Failed to parse stored LogConfig for bus {0} (arn={1}); "
+                        + "field omitted from response. Stored value: {2}. Error: {3}",
+                        bus.getName(), bus.getArn(), bus.getLogConfig(), e.getMessage());
+            }
         }
         return node;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -191,20 +191,26 @@ public class EventBridgeService {
                         .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                                 "EventBus not found: " + effectiveName, 404));
 
+        // Only mark dirty when a field is both non-blank AND different from
+        // the value currently on the bus — re-sending the same value is a no-op.
         boolean dirty = false;
-        if (description != null && !description.isBlank()) {
+        if (description != null && !description.isBlank()
+                && !description.equals(bus.getDescription())) {
             bus.setDescription(description);
             dirty = true;
         }
-        if (kmsKeyIdentifier != null && !kmsKeyIdentifier.isBlank()) {
+        if (kmsKeyIdentifier != null && !kmsKeyIdentifier.isBlank()
+                && !kmsKeyIdentifier.equals(bus.getKmsKeyIdentifier())) {
             bus.setKmsKeyIdentifier(kmsKeyIdentifier);
             dirty = true;
         }
-        if (deadLetterConfig != null && !deadLetterConfig.isBlank()) {
+        if (deadLetterConfig != null && !deadLetterConfig.isBlank()
+                && !deadLetterConfig.equals(bus.getDeadLetterConfig())) {
             bus.setDeadLetterConfig(deadLetterConfig);
             dirty = true;
         }
-        if (logConfig != null && !logConfig.isBlank()) {
+        if (logConfig != null && !logConfig.isBlank()
+                && !logConfig.equals(bus.getLogConfig())) {
             bus.setLogConfig(logConfig);
             dirty = true;
         }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -177,6 +177,46 @@ public class EventBridgeService {
                         "EventBus not found: " + effectiveName, 404));
     }
 
+    public EventBus updateEventBus(String name,
+                                   String description,
+                                   String kmsKeyIdentifier,
+                                   String deadLetterConfig,
+                                   String logConfig,
+                                   String region) {
+        // Name identifies the bus; never mutated (AWS does not support rename).
+        String effectiveName = name == null || name.isBlank() ? "default" : name;
+        EventBus bus = "default".equals(effectiveName)
+                ? getOrCreateDefaultBus(region)
+                : busStore.get(busKey(region, effectiveName))
+                        .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                                "EventBus not found: " + effectiveName, 404));
+
+        boolean dirty = false;
+        if (description != null && !description.isBlank()) {
+            bus.setDescription(description);
+            dirty = true;
+        }
+        if (kmsKeyIdentifier != null && !kmsKeyIdentifier.isBlank()) {
+            bus.setKmsKeyIdentifier(kmsKeyIdentifier);
+            dirty = true;
+        }
+        if (deadLetterConfig != null && !deadLetterConfig.isBlank()) {
+            bus.setDeadLetterConfig(deadLetterConfig);
+            dirty = true;
+        }
+        if (logConfig != null && !logConfig.isBlank()) {
+            bus.setLogConfig(logConfig);
+            dirty = true;
+        }
+
+        if (dirty) {
+            busStore.put(busKey(region, effectiveName), bus);
+            LOG.infov("Updated event bus: {0} (arn={1}) in region {2}",
+                    effectiveName, bus.getArn(), region);
+        }
+        return bus;
+    }
+
     public List<EventBus> listEventBuses(String namePrefix, String region) {
         getOrCreateDefaultBus(region);
         String storagePrefix = "bus:" + region + ":";

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/EventBus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/EventBus.java
@@ -15,6 +15,9 @@ public class EventBus {
     private Map<String, String> tags = new HashMap<>();
     private Instant createdTime;
     private String policy;
+    private String kmsKeyIdentifier;
+    private String deadLetterConfig;  // raw JSON: {"Arn":"..."}
+    private String logConfig;         // raw JSON: {"IncludeDetail":"...","Level":"..."}
 
     public EventBus() {}
 
@@ -42,4 +45,13 @@ public class EventBus {
 
     public String getPolicy() { return policy; }
     public void setPolicy(String policy) { this.policy = policy; }
+
+    public String getKmsKeyIdentifier() { return kmsKeyIdentifier; }
+    public void setKmsKeyIdentifier(String kmsKeyIdentifier) { this.kmsKeyIdentifier = kmsKeyIdentifier; }
+
+    public String getDeadLetterConfig() { return deadLetterConfig; }
+    public void setDeadLetterConfig(String deadLetterConfig) { this.deadLetterConfig = deadLetterConfig; }
+
+    public String getLogConfig() { return logConfig; }
+    public void setLogConfig(String logConfig) { this.logConfig = logConfig; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeUpdateEventBusIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeUpdateEventBusIntegrationTest.java
@@ -1,0 +1,276 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class EventBridgeUpdateEventBusIntegrationTest {
+
+    private static final String CT = "application/x-amz-json-1.1";
+    private static final String UPDATE = "AWSEvents.UpdateEventBus";
+    private static final String DESCRIBE = "AWSEvents.DescribeEventBus";
+    private static final String CREATE = "AWSEvents.CreateEventBus";
+    private static final String LIST = "AWSEvents.ListEventBuses";
+    private static final String PUT_PERM = "AWSEvents.PutPermission";
+
+    @BeforeAll
+    static void configure() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static void createBus(String name) {
+        given().contentType(CT).header("X-Amz-Target", CREATE)
+                .body("{\"Name\":\"" + name + "\"}")
+                .when().post("/")
+                .then().statusCode(200);
+    }
+
+    @Test
+    void updateDescriptionOnCustomBus() {
+        String bus = "update-test-bus-1";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\",\"Description\":\"hello world\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Name", equalTo(bus))
+                .body("Description", equalTo("hello world"))
+                .body("Arn", notNullValue());
+
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("hello world"));
+    }
+
+    @Test
+    void updateDefaultBus_nameOmitted() {
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Description\":\"default updated 1\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Name", equalTo("default"))
+                .body("Description", equalTo("default updated 1"));
+
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"default\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("default updated 1"));
+    }
+
+    @Test
+    void updateDefaultBus_nameExplicit() {
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"default\",\"Description\":\"default updated 2\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Name", equalTo("default"))
+                .body("Description", equalTo("default updated 2"));
+    }
+
+    @Test
+    void updateDefaultBus_autoMaterializes() {
+        // Send UpdateEventBus against default in a region/account state we haven't
+        // touched in this test. Should auto-materialize via getOrCreateDefaultBus.
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"default\",\"Description\":\"auto-materialized\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Name", equalTo("default"));
+    }
+
+    @Test
+    void updateNonExistentCustomBus_returns404() {
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"this-bus-was-never-created\",\"Description\":\"x\"}")
+                .when().post("/")
+                .then().statusCode(404)
+                .body("__type", containsString("ResourceNotFoundException"));
+    }
+
+    @Test
+    void updateKmsKeyIdentifier() {
+        String bus = "update-test-bus-kms";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"KmsKeyIdentifier\":\"arn:aws:kms:us-east-1:000000000000:key/test\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("KmsKeyIdentifier", equalTo("arn:aws:kms:us-east-1:000000000000:key/test"));
+
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("KmsKeyIdentifier", equalTo("arn:aws:kms:us-east-1:000000000000:key/test"));
+    }
+
+    @Test
+    void updateDeadLetterConfig_roundTripsAsObject() {
+        // Catches "emitted as string" bug: DeadLetterConfig must be a JSON object,
+        // not a stringified one. body("DeadLetterConfig.Arn", equalTo(...)) only
+        // resolves if the response field is a real object.
+        String bus = "update-test-bus-dlq";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"DeadLetterConfig\":{\"Arn\":\"arn:aws:sqs:us-east-1:000000000000:dlq\"}}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("DeadLetterConfig.Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:dlq"));
+
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("DeadLetterConfig.Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:dlq"));
+    }
+
+    @Test
+    void updateLogConfig_roundTripsAsObject() {
+        String bus = "update-test-bus-log";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"LogConfig\":{\"IncludeDetail\":\"FULL\",\"Level\":\"INFO\"}}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("LogConfig.IncludeDetail", equalTo("FULL"))
+                .body("LogConfig.Level", equalTo("INFO"));
+
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("LogConfig.IncludeDetail", equalTo("FULL"))
+                .body("LogConfig.Level", equalTo("INFO"));
+    }
+
+    @Test
+    void partialUpdateDoesNotClearOtherFields() {
+        String bus = "update-test-bus-partial";
+        createBus(bus);
+
+        // First update: set Description
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\",\"Description\":\"original desc\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        // Second update: only KmsKeyIdentifier — must not clear Description
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"KmsKeyIdentifier\":\"arn:aws:kms:us-east-1:000000000000:key/test\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("original desc"))
+                .body("KmsKeyIdentifier", equalTo("arn:aws:kms:us-east-1:000000000000:key/test"));
+    }
+
+    @Test
+    void allFieldsAbsent_isNoOp() {
+        String bus = "update-test-bus-noop";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\",\"Description\":\"keep me\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        // Update with only Name → returns 200, state unchanged
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("keep me"));
+    }
+
+    @Test
+    void policyUntouchedByUpdate() {
+        String bus = "update-test-bus-policy";
+        createBus(bus);
+
+        // Add a policy via PutPermission
+        given().contentType(CT).header("X-Amz-Target", PUT_PERM)
+                .body("{\"EventBusName\":\"" + bus + "\","
+                        + "\"Action\":\"events:PutEvents\","
+                        + "\"Principal\":\"222222222222\","
+                        + "\"StatementId\":\"AllowOtherAccount\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        // Now UpdateEventBus with only Description
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\",\"Description\":\"policy preserved\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        // Confirm policy is still present
+        given().contentType(CT).header("X-Amz-Target", DESCRIBE)
+                .body("{\"Name\":\"" + bus + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("Description", equalTo("policy preserved"))
+                .body("Policy", containsString("AllowOtherAccount"));
+    }
+
+    @Test
+    void listEventBusesReflectsUpdates() {
+        String bus = "update-test-bus-list";
+        createBus(bus);
+
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"Description\":\"listed\","
+                        + "\"KmsKeyIdentifier\":\"arn:aws:kms:us-east-1:000000000000:key/list-test\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        given().contentType(CT).header("X-Amz-Target", LIST)
+                .body("{\"NamePrefix\":\"update-test-bus-list\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("EventBuses.find { it.Name == '" + bus + "' }.Description",
+                        equalTo("listed"))
+                .body("EventBuses.find { it.Name == '" + bus + "' }.KmsKeyIdentifier",
+                        equalTo("arn:aws:kms:us-east-1:000000000000:key/list-test"));
+    }
+
+    @Test
+    void emptyNestedObjectIsNoOp() {
+        String bus = "update-test-bus-empty-obj";
+        createBus(bus);
+
+        // Set a DLQ config first
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"DeadLetterConfig\":{\"Arn\":\"arn:aws:sqs:us-east-1:000000000000:original-dlq\"}}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        // Send empty {} for DeadLetterConfig and LogConfig — should be no-op
+        given().contentType(CT).header("X-Amz-Target", UPDATE)
+                .body("{\"Name\":\"" + bus + "\","
+                        + "\"DeadLetterConfig\":{},"
+                        + "\"LogConfig\":{}}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("DeadLetterConfig.Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:original-dlq"))
+                .body("LogConfig", nullValue());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the AWS EventBridge [`UpdateEventBus`](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UpdateEventBus.html) API. Adds three persisted fields to `EventBus` (`kmsKeyIdentifier`, `deadLetterConfig`, `logConfig`) and round-trips them through `DescribeEventBus` and `ListEventBuses`.

- `DeadLetterConfig` and `LogConfig` are stored as raw JSON strings (mirroring how `Policy` is stored) and emitted as typed JSON objects on the wire so SDK clients deserialize cleanly.
- `Policy` is untouched — that's managed exclusively by `PutPermission` / `RemovePermission`, and is not an `UpdateEventBus` parameter per the AWS spec.
- `Name` is the bus identifier and is never mutated (AWS does not support renaming via this API).
- Default bus (`Name` omitted or `"default"`) is auto-materialized via the existing `getOrCreateDefaultBus` path.
- Skips storage write when no field actually changed — avoids WAL churn under repeated idempotent calls.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Action name (`UpdateEventBus`), request shape (`Name` / `Description` / `KmsKeyIdentifier` / `DeadLetterConfig` / `LogConfig`), and response shape per the [official AWS API reference](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_UpdateEventBus.html).

**SDK verified** end-to-end with `boto3 1.43.6`:
- All five inputs round-trip correctly through `update_event_bus` → `describe_event_bus`.
- `DeadLetterConfig` and `LogConfig` deserialize as native Python dicts (not stringified JSON).
- Non-existent bus surfaces as `client.exceptions.ResourceNotFoundException` (typed exception, mapped via the `__type` field in the response body).
- Empty `{}` for nested configs treated as no-change.

Plus 13 integration tests in `EventBridgeUpdateEventBusIntegrationTest`, all green. Full EventBridge package suite (146 tests) and full project suite (4,258 tests) also green.

## Checklist

- [x] `./mvnw test` passes locally (4258 tests, 0 failures, 0 errors)
- [x] New or updated integration test added (`EventBridgeUpdateEventBusIntegrationTest`, 13 cases)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)