### PR TITLE
fix: support EventBusName as ARN in EventBridge operations

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.eventbridge;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -154,7 +155,7 @@ public class EventBridgeService {
         if (name == null || name.isBlank()) {
             throw new AwsException("ValidationException", "EventBus name is required.", 400);
         }
-        String effectiveName = extractBusNameFromArn(name);
+        String effectiveName = resolvedBusName(name);
         if ("default".equals(effectiveName)) {
             throw new AwsException("ValidationException", "Cannot delete the default event bus.", 400);
         }
@@ -174,7 +175,7 @@ public class EventBridgeService {
 
     public EventBus describeEventBus(String name, String region) {
         // Handle both name and ARN format
-        String effectiveName = (name == null || name.isBlank()) ? "default" : extractBusNameFromArn(name);
+        String effectiveName = (name == null || name.isBlank()) ? "default" : resolvedBusName(name);
         if ("default".equals(effectiveName)) {
             return getOrCreateDefaultBus(region);
         }
@@ -888,7 +889,11 @@ public class EventBridgeService {
         }
         // Handle ARN format: arn:aws:events:region:account-id:event-bus/bus-name
         if (busName.startsWith("arn:aws:events:")) {
-            return extractBusNameFromArn(busName);
+            try {
+                return extractBusNameFromArn(busName);
+            } catch (IllegalArgumentException e) {
+                throw new AwsException("ValidationException", "Invalid EventBridge event bus ARN: " + busName, 400);
+            }
         }
         return busName;
     }
@@ -896,15 +901,15 @@ public class EventBridgeService {
     private static String extractBusNameFromArn(String arn) {
         // ARN format: arn:aws:events:region:account-id:event-bus/bus-name
         if (arn == null) return null;
-        if (!arn.startsWith("arn:aws:events:")) {
-            return arn;
+        AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+        if (!"events".equals(parsed.service())) {
+            throw new IllegalArgumentException("Expected EventBridge ARN but found service: " + parsed.service());
         }
         String prefix = "event-bus/";
-        int prefixIndex = arn.indexOf(prefix);
-        if (prefixIndex != -1) {
-            return arn.substring(prefixIndex + prefix.length());
+        if (parsed.resource() != null && parsed.resource().startsWith(prefix)) {
+            return parsed.resource().substring(prefix.length());
         }
-        return arn;
+        throw new IllegalArgumentException("Expected EventBridge event bus ARN but found resource: " + parsed.resource());
     }
 
     private static String busKey(String region, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -150,14 +150,16 @@ public class EventBridgeService {
     }
 
     public void deleteEventBus(String name, String region) {
-        if ("default".equals(name)) {
+        // Handle both name and ARN format
+        String effectiveName = extractBusNameFromArn(name);
+        if ("default".equals(effectiveName)) {
             throw new AwsException("ValidationException", "Cannot delete the default event bus.", 400);
         }
-        String key = busKey(region, name);
+        String key = busKey(region, effectiveName);
         busStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "EventBus not found: " + name, 404));
-        String rulePrefix = ruleKeyPrefix(region, name);
+        String rulePrefix = ruleKeyPrefix(region, effectiveName);
         boolean hasRules = ruleStore.keys().stream().anyMatch(k -> k.startsWith(rulePrefix));
         if (hasRules) {
             throw new AwsException("ValidationException",
@@ -168,13 +170,14 @@ public class EventBridgeService {
     }
 
     public EventBus describeEventBus(String name, String region) {
-        String effectiveName = name == null || name.isBlank() ? "default" : name;
+        // Handle both name and ARN format
+        String effectiveName = (name == null || name.isBlank()) ? "default" : extractBusNameFromArn(name);
         if ("default".equals(effectiveName)) {
             return getOrCreateDefaultBus(region);
         }
         return busStore.get(busKey(region, effectiveName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "EventBus not found: " + effectiveName, 404));
+                        "EventBus not found: " + name, 404));
     }
 
     public List<EventBus> listEventBuses(String namePrefix, String region) {
@@ -877,7 +880,27 @@ public class EventBridgeService {
     }
 
     private static String resolvedBusName(String busName) {
-        return (busName == null || busName.isBlank()) ? "default" : busName;
+        if (busName == null || busName.isBlank()) {
+            return "default";
+        }
+        // Handle ARN format: arn:aws:events:region:account-id:event-bus/bus-name
+        if (busName.startsWith("arn:aws:events:")) {
+            return extractBusNameFromArn(busName);
+        }
+        return busName;
+    }
+
+    private static String extractBusNameFromArn(String arn) {
+        // ARN format: arn:aws:events:region:account-id:event-bus/bus-name
+        if (!arn.startsWith("arn:aws:events:")) {
+            return arn;
+        }
+        String prefix = "event-bus/";
+        int prefixIndex = arn.indexOf(prefix);
+        if (prefixIndex != -1) {
+            return arn.substring(prefixIndex + prefix.length());
+        }
+        return arn;
     }
 
     private static String busKey(String region, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -150,7 +150,10 @@ public class EventBridgeService {
     }
 
     public void deleteEventBus(String name, String region) {
-        // Handle both name and ARN format
+        // Validate input and handle both name and ARN format
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "EventBus name is required.", 400);
+        }
         String effectiveName = extractBusNameFromArn(name);
         if ("default".equals(effectiveName)) {
             throw new AwsException("ValidationException", "Cannot delete the default event bus.", 400);
@@ -158,7 +161,7 @@ public class EventBridgeService {
         String key = busKey(region, effectiveName);
         busStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "EventBus not found: " + name, 404));
+                        "EventBus not found: " + effectiveName, 404));
         String rulePrefix = ruleKeyPrefix(region, effectiveName);
         boolean hasRules = ruleStore.keys().stream().anyMatch(k -> k.startsWith(rulePrefix));
         if (hasRules) {
@@ -892,6 +895,7 @@ public class EventBridgeService {
 
     private static String extractBusNameFromArn(String arn) {
         // ARN format: arn:aws:events:region:account-id:event-bus/bus-name
+        if (arn == null) return null;
         if (!arn.startsWith("arn:aws:events:")) {
             return arn;
         }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeArnIntegrationTest.java
@@ -1,0 +1,415 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+
+/**
+ * Integration tests for EventBridge ARN-based EventBusName support.
+ * AWS EventBridge APIs accept EventBusName as either a name OR an ARN.
+ * This test suite validates that Floci correctly handles both formats.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeArnIntegrationTest {
+
+    private static final String EVENT_BRIDGE_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String SQS_CONTENT_TYPE = "application/x-amz-json-1.0";
+
+    private static String customBusArn;
+    private static String customBusName;
+    private static String sinkQueueUrl;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void setup_createCustomEventBus() {
+        customBusName = "arn-test-bus";
+        customBusArn = given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"" + customBusName + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("EventBusArn", notNullValue())
+                .extract().jsonPath().getString("EventBusArn");
+    }
+
+    @Test
+    @Order(2)
+    void setup_createSinkQueue() {
+        sinkQueueUrl = given()
+                .contentType(SQS_CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"arn-test-sink-queue\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+    }
+
+    @Test
+    @Order(3)
+    void putRule_withArnAsEventBusName() {
+        // Create a rule using ARN as EventBusName instead of plain name
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                {
+                    "Name": "arn-test-rule",
+                    "EventBusName": "%s",
+                    "EventPattern": "{\\"source\\":[\\"test.event\\"]}",
+                    "State": "ENABLED"
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("RuleArn", notNullValue())
+                .body("RuleArn", containsString("arn-test-bus"));
+    }
+
+    @Test
+    @Order(4)
+    void describeRule_withArnAsEventBusName() {
+        // Describe the rule using ARN as EventBusName
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DescribeRule")
+                .body("""
+                {
+                    "Name": "arn-test-rule",
+                    "EventBusName": "%s"
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Name", equalTo("arn-test-rule"))
+                .body("EventBusName", equalTo(customBusName))
+                .body("State", equalTo("ENABLED"));
+    }
+
+    @Test
+    @Order(5)
+    void putTargets_withArnAsEventBusName() {
+        String queueArn = given()
+                .contentType(SQS_CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + sinkQueueUrl + "\",\"AttributeNames\":[\"All\"]}")
+                .when()
+                .post("/0000000000/arn-test-sink-queue")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutTargets")
+                .body("""
+                {
+                    "Rule": "arn-test-rule",
+                    "EventBusName": "%s",
+                    "Targets": [{
+                        "Id": "1",
+                        "Arn": "%s"
+                    }]
+                }
+                """.formatted(customBusArn, queueArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void listTargetsByRule_withArnAsEventBusName() {
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+                .body("""
+                {
+                    "Rule": "arn-test-rule",
+                    "EventBusName": "%s"
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Targets", hasSize(1))
+                .body("Targets[0].Id", equalTo("1"));
+    }
+
+    @Test
+    @Order(7)
+    void putEvents_withArnAsEventBusName() {
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutEvents")
+                .body("""
+                {
+                    "Entries": [{
+                        "Source": "test.event",
+                        "DetailType": "TestEvent",
+                        "Detail": "{\\"testKey\\":\\"testValue\\"}",
+                        "EventBusName": "%s"
+                    }]
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("FailedEntryCount", equalTo(0));
+    }
+
+    @Test
+    @Order(8)
+    void removeTargets_withArnAsEventBusName() {
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.RemoveTargets")
+                .body("""
+                {
+                    "Rule": "arn-test-rule",
+                    "EventBusName": "%s",
+                    "Ids": ["1"]
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(9)
+    void deleteRule_withArnAsEventBusName() {
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteRule")
+                .body("""
+                {
+                    "Name": "arn-test-rule",
+                    "EventBusName": "%s"
+                }
+                """.formatted(customBusArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(10)
+    void deleteEventBus_withArn() {
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+                .body("{\"Name\":\"" + customBusArn + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void describeEventBus_withArn() {
+        // Create another bus for this test
+        String busName = "describe-arn-test-bus";
+        String busArn = given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("EventBusArn");
+
+        // Describe using ARN
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+                .body("{\"Name\":\"" + busArn + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Name", equalTo(busName))
+                .body("Arn", equalTo(busArn));
+
+        // Cleanup
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/");
+    }
+
+    @Test
+    @Order(12)
+    void enableRule_withArnAsEventBusName() {
+        // Create a custom bus and rule for this test
+        String busName = "enable-rule-arn-test-bus";
+        String busArn = given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("EventBusArn");
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                {
+                    "Name": "enable-rule-test",
+                    "EventBusName": "%s",
+                    "EventPattern": "{\\"source\\":[\\"test\\"]}",
+                    "State": "DISABLED"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Enable rule using ARN as EventBusName
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.EnableRule")
+                .body("""
+                {
+                    "Name": "enable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Verify rule is enabled
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DescribeRule")
+                .body("""
+                {
+                    "Name": "enable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("State", equalTo("ENABLED"));
+
+        // Cleanup
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteRule")
+                .body("""
+                {
+                    "Name": "enable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/");
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/");
+    }
+
+    @Test
+    @Order(13)
+    void disableRule_withArnAsEventBusName() {
+        // Create a custom bus and rule for this test
+        String busName = "disable-rule-arn-test-bus";
+        String busArn = given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("EventBusArn");
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("""
+                {
+                    "Name": "disable-rule-test",
+                    "EventBusName": "%s",
+                    "EventPattern": "{\\"source\\":[\\"test\\"]}",
+                    "State": "ENABLED"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Disable rule using ARN as EventBusName
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DisableRule")
+                .body("""
+                {
+                    "Name": "disable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200);
+
+        // Verify rule is disabled
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DescribeRule")
+                .body("""
+                {
+                    "Name": "disable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("State", equalTo("DISABLED"));
+
+        // Cleanup
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteRule")
+                .body("""
+                {
+                    "Name": "disable-rule-test",
+                    "EventBusName": "%s"
+                }
+                """.formatted(busArn))
+                .when().post("/");
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/");
+    }
+}


### PR DESCRIPTION
This PR makes EventBridge operations accept an `EventBusName` supplied as a full EventBridge ARN
(for example: arn:aws:events:region:account-id:event-bus/my-bus), in addition to plain bus names.

Background
I noticed Floci treated the `EventBusName` parameter as a literal name only. When callers passed a full ARN,
the service tried to look up that ARN string as the bus name and failed with `ResourceNotFoundException`.
AWS accepts both plain names and ARNs for this parameter, so Floci should do the same.

What I changed
- Added a small helper `extractBusNameFromArn()` to detect EventBridge ARNs and extract the actual bus name.
- Updated `resolvedBusName()` and all code paths that accept `EventBusName` to use the helper.
- Allowed `describeEventBus()` and `deleteEventBus()` to accept ARNs in the `Name` parameter.
- Added `EventBridgeArnIntegrationTest` with 13 integration tests covering rule creation, description,
  targets, events, enable/disable, and deletion when `EventBusName` is an ARN.

Why this is safe
- Plain bus names continue to work exactly as before.
- ARN parsing only runs when the input starts with the EventBridge ARN prefix, so non-ARN behavior is unchanged.
- Null/empty `EventBusName` still resolves to the `default` bus (unchanged).

Testing
- 13 new integration tests for ARN scenarios — all pass.
- Existing EventBridge test suite (6 tests) — still passes; no regressions observed.

How to verify locally
1. Create a bus and note the ARN:
   `aws events create-event-bus --name test-bus`
2. Use the returned ARN in a `put-rule` or `put-events` call for `EventBusName` — the operations should succeed when using the ARN.

Impact
- Improves compatibility with AWS by accepting ARNs where AWS allows them.
- No breaking changes; behavior is additive and backwards compatible.

Fixes: https://github.com/floci-io/floci/issues/842